### PR TITLE
Always load full file info in Item details panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,27 +10,39 @@
 
 ### Other changes
 
-* Added the ability to close foobar2000 to the notification area [contributed by tuxzz, [#56](https://github.com/reupen/columns_ui/pull/56)].
+* Added the ability to close foobar2000 to the notification area. [Contributed by tuxzz, [#56](https://github.com/reupen/columns_ui/pull/56)]
 
-* The value of the 'Allow resizing of locked panels' setting is now available to other components.
+* Made the Item details panel load full metadata (including large fields such as lyrics) for selected items. (Previously, only playing items showed full metadata.) [[#68](https://github.com/reupen/columns_ui/issues/68)]
+
+* Right-clicking in empty space in NG playlist now correctly deselects all items and always displays a context menu. [[#75](https://github.com/reupen/columns_ui/issues/75)]
+
+* The value of the 'Allow resizing of locked panels' setting is now available to other components. [[#53](https://github.com/reupen/columns_ui/issues/53)]
+
+* Added a reliable mechanism for third-party splitter panels to store extra configuration data for child panels that persists through panel copy-and-paste operations. [[#52](https://github.com/reupen/columns_ui/issues/52)]
 
 * Corrected the status pane playback status when resume playback on start-up is enabled and foobar2000 is started when playback was previously paused.
 
+* Corrected the colour of text in the status pane when using high-contrast Windows themes. [Contributed by MAxonn, [#59](https://github.com/reupen/columns_ui/issues/59)]
+
 * Removed the ability to import FCS files.
 
-* Changed the syntax of CLI commands for importing configurations from FCL files. The commands now use the following syntax: `/columnsui:import <path>` and `/columnsui:import-quiet <path>`
+* Changed the syntax of CLI commands for importing configurations from FCL files. The commands now use the following syntax: `/columnsui:import <path>` and `/columnsui:import-quiet <path>`. [[#47](https://github.com/reupen/columns_ui/issues/47)]
 
-* Added CLI commands for exporting the current configuration to an FCL file. The added commands are `/columnsui:export <path>` and `/columnsui:export-quiet <path>`
+* Added CLI commands for exporting the current configuration to an FCL file. The added commands are `/columnsui:export <path>` and `/columnsui:export-quiet <path>`. [[#47](https://github.com/reupen/columns_ui/issues/47)]
 
-* Miscellaneous internal code refactoring.
+* Fixed a bug where pressing Enter or Return while editing an NG playlist grouping script would close the dialog box. [[#48](https://github.com/reupen/columns_ui/issues/48)]
 
 * Some minor changes to labels and layout in preferences and other configuration dialogs.
 
 * Renamed Columns playlist to legacy playlist. The columns/legacy will be completely removed in version 0.7.0 or later, anyone still using it is advised to switch to NG playlist.
 
-* Windows XP and Vista are no longer officially supported. Support will be completely removed in version 0.7.0 or later. Users of those operating systems are advised to stick with version 0.5.1.
+* Windows XP and Vista are no longer supported. Users of those operating systems are advised to stick with version 0.5.1.
 
-* Compiled with Visual Studio 2017 15.3.
+* Miscellaneous internal code refactoring.
+
+* Compiled with the foobar2000 1.4 SDK.
+
+* Compiled with Visual Studio 2017 15.6.
 
 ## 0.5.1
 

--- a/foo_ui_columns/file_info_reader.cpp
+++ b/foo_ui_columns/file_info_reader.cpp
@@ -1,0 +1,75 @@
+#include "stdafx.h"
+#include "file_info_reader.h"
+
+// See https://hydrogenaud.io/index.php/topic,101928.0.html
+
+namespace cui::helpers {
+
+std::shared_ptr<file_info_impl> FullFileInfoRequest::run()
+{
+    auto _ = gsl::finally([this] {
+        fb2k::inMainThread([callback = m_callback, self = shared_from_this()]() mutable { callback(std::move(self)); });
+    });
+    return read_info();
+}
+
+std::shared_ptr<file_info_impl> FullFileInfoRequest::read_info()
+{
+    m_aborter.check();
+    input_info_reader::ptr reader;
+    input_entry::g_open_for_info_read(reader, nullptr, m_track->get_path(), m_aborter);
+    auto info = std::make_shared<file_info_impl>();
+    reader->get_info(m_track->get_subsong_index(), *info, m_aborter);
+    return info;
+}
+
+void FullFileInfoRequest::queue()
+{
+    m_future = std::async(std::launch::async, [self = shared_from_this()] { return self->run(); });
+}
+
+void FullFileInfoRequest::abort()
+{
+    m_aborter.abort();
+}
+
+bool FullFileInfoRequest::is_ready() const
+{
+    return !m_future.valid() || m_future.wait_for(0ns) == std::future_status::ready;
+}
+
+void FullFileInfoRequest::wait() const
+{
+    if (m_future.valid())
+        m_future.wait();
+}
+
+std::shared_ptr<file_info_impl> FullFileInfoRequest::get()
+{
+    return m_future.get();
+}
+
+std::shared_ptr<file_info_impl> FullFileInfoRequest::get_safe(const char* requester_name)
+{
+    console::formatter formatter;
+    try {
+        return get();
+    } catch (const exception_aborted&) {
+    } catch (const std::exception& ex) {
+        pfc::string8 display_path;
+        filesystem::g_get_display_path(m_track->get_path(), display_path);
+        const char* error_message = ex.what();
+        if (error_message == nullptr) {
+            error_message = "Unknown error";
+        }
+        formatter << requester_name << u8": Error reading file info for track \"" << display_path << u8"\": "
+                  << error_message;
+    } catch (...) {
+        pfc::string8 display_path;
+        filesystem::g_get_display_path(m_track->get_path(), display_path);
+        formatter << requester_name << u8": Unknown error reading file info for track \"" << display_path << u8"\"";
+    }
+    return nullptr;
+}
+
+} // namespace cui::helpers

--- a/foo_ui_columns/file_info_reader.h
+++ b/foo_ui_columns/file_info_reader.h
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace cui::helpers {
+
+class FullFileInfoRequest : public std::enable_shared_from_this<FullFileInfoRequest> {
+public:
+    using CallbackFunction = void(std::shared_ptr<FullFileInfoRequest>);
+    FullFileInfoRequest(metadb_handle_ptr track, std::function<CallbackFunction> callback)
+        : m_track(std::move(track)), m_callback(std::move(callback))
+    {
+    }
+    void queue();
+    void abort();
+    bool is_ready() const;
+    void wait() const;
+    std::shared_ptr<file_info_impl> get();
+    std::shared_ptr<file_info_impl> get_safe(const char* requester_name);
+
+private:
+    std::shared_ptr<file_info_impl> run();
+    std::shared_ptr<file_info_impl> read_info();
+
+    metadb_handle_ptr m_track;
+    std::function<CallbackFunction> m_callback;
+    std::future<std::shared_ptr<file_info_impl>> m_future;
+    abort_callback_impl m_aborter;
+};
+
+} // namespace cui::helpers

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -304,6 +304,7 @@
     <ClCompile Include=".\prefs_utils.cpp" />
     <ClCompile Include=".\setup_dialog.cpp" />
     <ClCompile Include=".\sort.cpp" />
+    <ClCompile Include="file_info_reader.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\stdafx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\stdafx.h</PrecompiledHeaderFile>
@@ -464,6 +465,7 @@
     <ClInclude Include=".\playlist_view.h" />
     <ClInclude Include=".\setup_dialog.h" />
     <ClInclude Include=".\sort.h" />
+    <ClInclude Include="file_info_reader.h" />
     <ClInclude Include="ng_playlist\ng_playlist.h" />
     <ClInclude Include="ng_playlist\ng_playlist_groups.h" />
     <ClInclude Include="ng_playlist\ng_playlist_style.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -507,6 +507,7 @@
     <ClInclude Include="rebar_band.h" />
   </ItemGroup>
   <ItemGroup>
+    <None Include=".clang-format" />
     <None Include=".\buttons2.bmp" />
     <None Include=".\emptycoverdark.png" />
     <None Include=".\icons\star\left.ico" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -454,6 +454,9 @@
     <ClCompile Include="ng_playlist\ng_playlist_artwork.cpp">
       <Filter>Panels\NG Playlist</Filter>
     </ClCompile>
+    <ClCompile Include="file_info_reader.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include=".\cache.h">
@@ -624,6 +627,9 @@
     </ClInclude>
     <ClInclude Include="rebar_band.h">
       <Filter>Main Window</Filter>
+    </ClInclude>
+    <ClInclude Include="file_info_reader.h">
+      <Filter>Helpers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -741,6 +741,7 @@
     <None Include=".\up1.bmp">
       <Filter>Resources</Filter>
     </None>
+    <None Include=".clang-format" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include=".\foo_ui_columns.rc">

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "stdafx.h"
+#include "file_info_reader.h"
 
 extern const GUID g_guid_item_details;
 extern const GUID g_guid_item_details_tracking_mode;
@@ -356,7 +357,14 @@ private:
     void register_callback();
     void deregister_callback();
     void on_app_activate(bool b_activated);
-    void refresh_contents(bool b_new_track = true);
+
+    void set_handles(const metadb_handle_list& handles);
+    void refresh_contents(bool reset_scroll_position = true);
+    void request_full_file_info();
+    void on_full_file_info_request_completion(std::shared_ptr<cui::helpers::FullFileInfoRequest> request);
+    void release_aborted_full_file_info_requests();
+    void release_all_full_file_info_requests();
+
     void update_font_change_info();
     void reset_font_change_info();
     void update_display_info(HDC dc);
@@ -380,7 +388,12 @@ private:
     static std::vector<item_details_t*> g_windows;
 
     ui_selection_holder::ptr m_selection_holder;
-    metadb_handle_list m_handles, m_selection_handles;
+    metadb_handle_list m_handles;
+    metadb_handle_list m_selection_handles;
+    std::shared_ptr<file_info_impl> m_full_file_info;
+    std::shared_ptr<cui::helpers::FullFileInfoRequest> m_full_file_info_request;
+    std::vector<std::shared_ptr<cui::helpers::FullFileInfoRequest>> m_aborting_full_file_info_requests;
+    bool m_full_file_info_requested{};
     bool m_callback_registered{false};
     bool m_nowplaying_active{false}; //, m_update_scrollbar_range_in_progress;
     t_size m_tracking_mode;

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -139,7 +139,7 @@ public:
 };
 
 class menu_extension
-    : public ui_extension::containter_uie_window_t<uie::menu_window_v2>
+    : public ui_extension::container_uie_window_t<uie::menu_window_v2>
     , uih::MessageHook {
     static const TCHAR* class_name;
 

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <atomic>
 #include <complex>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <string_view>
@@ -54,3 +55,5 @@
 #include "config_vars.h"
 #include "config_defaults.h"
 #include "extern.h"
+
+using namespace std::chrono_literals;

--- a/vc15/columns_ui-public.sln
+++ b/vc15/columns_ui-public.sln
@@ -30,7 +30,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mmh", "..\mmh\mmh.vcxproj",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0FF158B9-F515-4DCF-B879-3D38EEC6DA2C}"
 	ProjectSection(SolutionItems) = preProject
-		..\.clang-format = ..\.clang-format
 		..\.gitignore = ..\.gitignore
 		..\.gitmodules = ..\.gitmodules
 		..\appveyor.yml = ..\appveyor.yml


### PR DESCRIPTION
Resolves #68

This makes the Item details panel load full file info (including large fields such as lyrics) when a selected item is being displayed. (Playing items already showed full file info.)