### PR TITLE
Add context menu item to open preferences in certain toolbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@
 
 * Added an output device toolbar (for foobar2000 1.4 and newer only). [[#105](https://github.com/reupen/columns_ui/pull/105)]
 
-* Added a ReplayGain source mode toolbar (for foobar2000 1.4 and newer only). [[#106](https://github.com/reupen/columns_ui/pull/106)]
+* Added a ReplayGain source mode toolbar (for foobar2000 1.4 and newer only). [[#106](https://github.com/reupen/columns_ui/pull/106), [#116](https://github.com/reupen/columns_ui/pull/116)]
 
-* Added a DSP preset toolbar (for foobar2000 1.4 and newer only). [[#115](https://github.com/reupen/columns_ui/pull/115)]
+* Added a DSP preset toolbar (for foobar2000 1.4 and newer only). [[#115](https://github.com/reupen/columns_ui/pull/115), [#116](https://github.com/reupen/columns_ui/pull/116)]
 
 * Added a live layout editing button to the default buttons toolbar configuration. [[#99](https://github.com/reupen/columns_ui/pull/99)]
 

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -25,6 +25,7 @@ public:
     void get_name(pfc::string_base& out) const override { out = ToolbarArgs::name; }
     void get_category(pfc::string_base& out) const override { out.set_string("Toolbars"); }
     bool is_available(const uie::window_host_ptr& p_host) const override { return ToolbarArgs::is_available(); }
+    void get_menu_items(uie::menu_hook_t& p_hook) override { ToolbarArgs::get_menu_items(p_hook); }
     class_data& get_class_data() const override
     {
         __implement_get_class_data_child_ex(ToolbarArgs::class_name, false, false);

--- a/foo_ui_columns/dsp_preset.cpp
+++ b/foo_ui_columns/dsp_preset.cpp
@@ -1,6 +1,10 @@
 #include "stdafx.h"
 
 #include "drop_down_list_toolbar.h"
+#include "panel_menu_item.h"
+
+// Not exposed in the foobar2000 SDK
+constexpr GUID dsp_manager_page_id{0xEB1878C9, 0x4B31, 0x46E3, {0x95, 0x2B, 0x6F, 0x7E, 0x1F, 0xD3, 0x63, 0xDD}};
 
 struct DspPresetToolbarArgs {
     using ID = size_t;
@@ -36,6 +40,11 @@ struct DspPresetToolbarArgs {
 
         auto api = dsp_config_manager_v2::get();
         api->select_preset(id);
+    }
+    static void get_menu_items(uie::menu_hook_t& p_hook)
+    {
+        p_hook.add_node(new cui::panel_helpers::CommandMenuNode{
+            "DSP Manager", [] { ui_control::get()->show_preferences(dsp_manager_page_id); }});
     }
     static constexpr void on_first_window_created() {}
     static constexpr void on_last_window_destroyed() {}

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -459,6 +459,7 @@
     <ClInclude Include=".\mw_drop_target.h" />
     <ClInclude Include="button_items.h" />
     <ClInclude Include="migrate.h" />
+    <ClInclude Include="panel_menu_item.h" />
     <ClInclude Include="playlist_view_tfhooks.h" />
     <ClInclude Include=".\setup_dialog.h" />
     <ClInclude Include="file_info_reader.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -637,6 +637,9 @@
     <ClInclude Include="drop_down_list_toolbar.h">
       <Filter>Toolbars</Filter>
     </ClInclude>
+    <ClInclude Include="panel_menu_item.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".\buttons2.bmp">

--- a/foo_ui_columns/order_dropdown.cpp
+++ b/foo_ui_columns/order_dropdown.cpp
@@ -35,6 +35,7 @@ struct PlaybackOrderToolbarArgs {
             api->playback_order_set_active(iter - items.begin());
     }
 
+    static void get_menu_items(uie::menu_hook_t& p_hook) {}
     static constexpr void on_first_window_created() {}
     static constexpr void on_last_window_destroyed() {}
     static constexpr bool is_available() { return true; }

--- a/foo_ui_columns/output_device.cpp
+++ b/foo_ui_columns/output_device.cpp
@@ -45,6 +45,7 @@ struct OutputDeviceToolbarArgs {
             api->setCoreConfigDevice(output_id, device_id);
         }
     }
+    static void get_menu_items(uie::menu_hook_t& p_hook) {}
     static void on_first_window_created()
     {
         if (!is_available())

--- a/foo_ui_columns/panel_menu_item.h
+++ b/foo_ui_columns/panel_menu_item.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace cui::panel_helpers {
+
+class CommandMenuNode : public uie::menu_node_command_t {
+public:
+    bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override
+    {
+        p_out = m_title;
+        p_displayflags = 0;
+        return true;
+    }
+    bool get_description(pfc::string_base& p_out) const override { return false; }
+    void execute() override { m_execute_callback(); }
+    CommandMenuNode(const char* title, std::function<void()> execute_callback)
+        : m_title(title), m_execute_callback{std::move(execute_callback)}
+    {
+    }
+
+private:
+    pfc::string8 m_title;
+    std::function<void()> m_execute_callback;
+};
+
+} // namespace cui::panel_helpers

--- a/foo_ui_columns/replaygain_mode.cpp
+++ b/foo_ui_columns/replaygain_mode.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include "drop_down_list_toolbar.h"
+#include "panel_menu_item.h"
 
 class ReplayGainCoreSettingsNotifyLambda : public replaygain_core_settings_notify {
 public:
@@ -50,6 +51,11 @@ struct ReplayGainModeToolbarArgs {
 
         auto playback_api = playback_control_v3::get();
         playback_api->restart();
+    }
+    static void get_menu_items(uie::menu_hook_t& p_hook)
+    {
+        p_hook.add_node(new cui::panel_helpers::CommandMenuNode{
+            "ReplayGain options", [] { ui_control::get()->show_preferences(preferences_page::guid_playback); }});
     }
     static void on_first_window_created()
     {


### PR DESCRIPTION
Adds items to the context menus for the DSP preset and ReplayGain mode toolbars to open the DSP Manager and Playback preference pages respectively.