### PR TITLE
Fix toolbars misbehaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.0.0-alpha.2
+
+* Fixed a crash when adding a toolbar after the last toolbar and other potential misbehaviour in the toolbars. [[#130](https://github.com/reupen/columns_ui/pull/130)]
+
 ## 1.0.0-alpha.1
 
 ### Playlist view

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -369,8 +369,8 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
                 uie::window_ptr p_ext;
 
-                if (idx_hit >= 0 && gsl::narrow_cast<unsigned>(idx_hit) < g_rebar_window->m_bands.size())
-                    p_ext = g_rebar_window->m_bands[idx_hit].m_window;
+                if (idx_hit >= 0 && gsl::narrow_cast<unsigned>(idx_hit) < g_rebar_window->get_bands().size())
+                    p_ext = g_rebar_window->get_bands()[idx_hit].m_window;
 
                 pfc::refcounted_object_ptr_t<ui_extension::menu_hook_impl> extension_menu_nodes
                     = new ui_extension::menu_hook_impl;

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -81,7 +81,6 @@ private:
 
 public:
     HWND wnd_rebar{nullptr};
-    std::vector<RebarBandInfo> m_bands;
     band_cache cache;
 
     rebar_window() = default;
@@ -92,6 +91,9 @@ public:
     ~rebar_window() = default;
 
     HWND init();
+
+    void refresh_band_configs();
+    const std::vector<RebarBandInfo>& get_bands() const { return m_bands; }
 
     void add_band(
         const GUID& guid, unsigned width = 100, const ui_extension::window_ptr& p_ext = ui_extension::window_ptr_null);
@@ -126,6 +128,11 @@ public:
     {
         return std::find_if(std::begin(m_bands), std::end(m_bands), [&wnd](auto&& item) { return item.m_wnd == wnd; });
     }
+
+private:
+    std::vector<RebarBandInfo> m_bands;
+
+    friend class ui_ext_host_rebar;
 };
 
 ui_extension::window_host& get_rebar_host();

--- a/foo_ui_columns/rebar_band.cpp
+++ b/foo_ui_columns/rebar_band.cpp
@@ -97,34 +97,3 @@ void RebarBandInfo::read_extra(stream_reader* reader, abort_callback& aborter)
     reader->read_lendian_t(m_width.value, aborter);
     reader->read_lendian_t(m_width.dpi, aborter);
 }
-
-RebarBandInfo RebarBandInfo::clone() const
-{
-    RebarBandInfo band_info;
-    band_info.m_guid = m_guid;
-    band_info.m_width = m_width;
-    band_info.m_break_before_band = m_break_before_band;
-    band_info.m_config.set_size(0);
-    if (m_wnd && m_window.is_valid()) {
-        try {
-            abort_callback_dummy aborter;
-            stream_writer_memblock_ref writer(m_config);
-            m_config.set_size(0);
-            m_window->get_config(&writer, aborter);
-        } catch (const exception_io&) {
-        }
-    }
-    band_info.m_config.append_fromptr(m_config.get_ptr(), m_config.get_size());
-    return band_info;
-}
-
-RebarBandInfo& RebarBandInfo::operator=(const RebarBandInfo& band_info)
-{
-    *this = band_info.clone();
-    return *this;
-}
-
-RebarBandInfo::RebarBandInfo(const RebarBandInfo& band_info)
-{
-    *this = band_info.clone();
-}

--- a/foo_ui_columns/rebar_band.h
+++ b/foo_ui_columns/rebar_band.h
@@ -18,9 +18,8 @@ public:
     void write_extra(stream_writer* writer, abort_callback& aborter) const;
     void read_extra(stream_reader* reader, abort_callback& aborter);
 
-    RebarBandInfo clone() const;
     RebarBandInfo& operator=(RebarBandInfo&&) = default;
-    RebarBandInfo& operator=(const RebarBandInfo& band_info);
+    RebarBandInfo& operator=(const RebarBandInfo& band_info) = default;
     RebarBandInfo() = default;
     ~RebarBandInfo() = default;
 
@@ -31,5 +30,5 @@ public:
     }
 
     RebarBandInfo(RebarBandInfo&&) = default;
-    RebarBandInfo(const RebarBandInfo& band_info);
+    RebarBandInfo(const RebarBandInfo& band_info) = default;
 };


### PR DESCRIPTION
This fixes some misbehaviour (including a crash bug) in the toolbars due to the difference in behaviour of the RebarBandInfo copy and move constructors (and also the assignment operators).

Some more work is needed to move the run-time data out of RebarBandInfo but these changes will address the problems encountered.