### PR TITLE
Fix volume bar misbehaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fixed a crash when adding a toolbar after the last toolbar and other potential misbehaviour in the toolbars. [[#130](https://github.com/reupen/columns_ui/pull/130)]
 
+* Fixed misbehaviour when using the mouse wheel with the volume bar and the volume bar misreporting the current volume in some cases. [[#131](https://github.com/reupen/columns_ui/pull/131)]
+
 ## 1.0.0-alpha.1
 
 ### Playlist view

--- a/foo_ui_columns/component_impl.cpp
+++ b/foo_ui_columns/component_impl.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 
-#define VERSION "1.0.0-alpha.1"
+#define VERSION "1.0.0-alpha.2"
 
 #ifndef __clang__
 #define DATE ", Date "__DATE__


### PR DESCRIPTION
Fixes misbehaviour when using the mouse wheel to change the volume using the volume bar, and the volume bar misreporting the current volume in some cases.

This was due to an incorrect calculation being used when converting a volume to a volume bar position.