### PR TITLE
Improve Item properties column-width DPI handling

### DIFF
--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -247,7 +247,7 @@ private:
     bool m_show_column_titles, m_show_group_titles;
 
     bool m_autosizing_columns{true};
-    uih::IntegerAndDpi<int32_t> m_column_name_width{75};
+    uih::IntegerAndDpi<int32_t> m_column_name_width{80};
     uih::IntegerAndDpi<int32_t> m_column_field_width{125};
 
     t_size m_edge_style;

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -145,7 +145,7 @@ public:
     void get_category(pfc::string_base& out) const override;
     unsigned get_type() const override;
 
-    enum { config_version_current = 4 };
+    enum { config_version_current = 5 };
     void set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort) override;
     void get_config(stream_writer* p_writer, abort_callback& p_abort) const override;
 
@@ -247,7 +247,8 @@ private:
     bool m_show_column_titles, m_show_group_titles;
 
     bool m_autosizing_columns{true};
-    t_size m_column_name_width{75}, m_column_field_width{125};
+    uih::IntegerAndDpi<int32_t> m_column_name_width{75};
+    uih::IntegerAndDpi<int32_t> m_column_field_width{125};
 
     t_size m_edge_style;
     t_size m_edit_column, m_edit_index;


### PR DESCRIPTION
Resolves #138

This makes the column widths have an associated DPI, so that they are restored correctly if the DPI changes (between foobar2000 launches) and also so that the default column widths are scaled appropriately.