### PR TITLE
Add range-v3 as a dependency and add range-based for helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ This repo makes use of Git submodules. If you're not familiar with them, [check 
 
 ## Build instructions
 
-Visual Studio 2017 15.8 is required to build Columns UI. You can use the [free community edition](https://www.visualstudio.com/downloads/).
+Visual Studio 2017 15.9 is required to build Columns UI. You can use the [free community edition](https://www.visualstudio.com/downloads/).
 
 You'll need Windows 10 SDK version 10.0.16299.0 (an installation option in Visual Studio).
 
-### Installing the Microsoft Guideline Support Library (GSL)
+### Installing external dependencies
 
-The Microsoft Guideline Support Library (GSL) is required to build Columns UI.
+The Microsoft Guideline Support Library (GSL) and range-v3 are required to build Columns UI.
 
-Currently, the recommended way to install it is using [vcpkg](https://github.com/Microsoft/vcpkg).
+The recommended way to install them is using [vcpkg](https://github.com/Microsoft/vcpkg).
 
 You can set up vcpkg, and install Microsoft GSL, using the following commands (run outside of the Columns UI source tree):
 
@@ -31,7 +31,7 @@ git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
 .\bootstrap-vcpkg.bat
 .\vcpkg integrate install
-.\vcpkg install ms-gsl
+.\vcpkg install ms-gsl range-v3
 ```
 
 ### Building using the Visual Studio IDE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
 install:
 - cmd: |
-    vcpkg install ms-gsl
+    vcpkg install ms-gsl range-v3
     git submodule update --init --recursive
 build_script:
 - ps: |

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -47,6 +47,7 @@
 #include "../ui_helpers/stdafx.h"
 #include "../mmh/stdafx.h"
 #include "../fbh/stdafx.h"
+#include "../pfc/range_based_for.h"
 
 #include "resource.h"
 #include "utf8api.h"

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -24,6 +24,7 @@
 #include <share.h>
 
 #include <gsl/gsl>
+#include <range/v3/all.hpp>
 
 // Included before windows.h, because pfc.h includes winsock2.h
 #include "../pfc/pfc.h"


### PR DESCRIPTION
This:
- adds range-v3 as a dependency
- adds an include for a helper header added to https://github.com/reupen/pfc that adds basic range-based for support to `pfc::list_t<>` and `pfc::array_t<>`