### PR TITLE
Fix tab order in the toolbars

### DIFF
--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -130,6 +130,12 @@ public:
     }
 
 private:
+    /**
+     * For some reason, the z-order gets messed up after adding bands to the rebar control.
+     * This makes sure that the z-order for bands goes from top to bottom.
+     */
+    void fix_z_order();
+
     std::vector<RebarBandInfo> m_bands;
 
     friend class ui_ext_host_rebar;


### PR DESCRIPTION
For some reason the z-order is getting messed up when bands are initially added to the rebar.

This isn't the nicest of fixes, but is the only reliable one I could find that covers reordering and adding bands at run-time as well.