### PR TITLE
Re-add colon to status pane 'Playing' and 'Paused' text

### DIFF
--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -58,7 +58,7 @@ void status_pane::update_playback_status_text()
 {
     static_api_ptr_t<playback_control> api;
     if (api->is_playing()) {
-        m_track_label = api->is_paused() ? "Paused" : "Playing";
+        m_track_label = api->is_paused() ? "Paused:" : "Playing:";
     } else {
         m_track_label = "";
     }


### PR DESCRIPTION
This re-adds the colon mistakenly removed from after the Playing and Paused text labels in the status pane.