### PR TITLE
Make list view header height vary with vertical item padding setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 * The default vertical item padding of the playlist view and playlist switcher was increased.
 
+* The height of the playlist view and filter panel column titles now varies with the vertical item padding setting.
+
+* The scroll position is now preserved when adjusting playlist view, playlist switcher and filter panel settings that affect the vertical height and/or position of items.
+
 * Compiled with the foobar2000 1.4 SDK.
 
 ## 1.0.0


### PR DESCRIPTION
This makes the height of the playlist view and other list view column titles vary with the configured vertical item padding.

It also preserves the scroll position in list views when adjusting certain settings (such as vertical item padding).