### PR TITLE
Update Azure Pipelines configuration

### DIFF
--- a/azure/job-build.yml
+++ b/azure/job-build.yml
@@ -27,7 +27,7 @@ jobs:
     submodules: recursive
   - powershell: |
       choco install llvm
-      svn checkout -r351731 https://github.com/llvm/llvm-project/trunk/llvm/tools/msbuild
+      svn checkout -r322941 https://github.com/llvm/llvm-project/trunk/llvm/tools/msbuild
       ((Get-Content -path msbuild\install.bat -Raw) -replace '2017\\Professional\\Common7\\IDE\\VC\\VCTargets','2019\Enterprise\MSBuild\Microsoft\VC\v160') | Set-Content -Path msbuild\install-enterprise.bat
       cmd /c msbuild\install-enterprise.bat
     condition: variables.installLlvm

--- a/azure/job-build.yml
+++ b/azure/job-build.yml
@@ -2,7 +2,6 @@ parameters:
   name: ''
   displayName: ''
   installLlvm: ''
-  installVcpkg: ''
   matrix: {}
   msBuildArgs: ''
   platform: ''
@@ -16,7 +15,6 @@ jobs:
     vmImage: ${{ parameters.vmImage }}
   variables:
     installLlvm: ${{ parameters.installLlvm }}
-    installVcpkg: ${{ parameters.installVcpkg }}
     msBuildArgs: ${{ parameters.msBuildArgs }}
     platform: ${{ parameters.platform }}
     solution: ${{ parameters.solution }}
@@ -34,15 +32,9 @@ jobs:
       cmd /c msbuild\install-enterprise.bat
     condition: variables.installLlvm
     displayName: Install LLVM
-  - script: |
-      git clone https://github.com/Microsoft/vcpkg.git
-      vcpkg\bootstrap-vcpkg.bat
-    condition: variables.installVcpkg
-    displayName: Install Vcpkg
   - powershell: |
-      $vcpkgPath = If ('$(installVcpkg)') { '.\vcpkg\vcpkg' } Else { 'vcpkg' }
-      & $vcpkgPath integrate install
-      & $vcpkgPath install $(vcpkgPackages)
+      vcpkg integrate install
+      vcpkg install $(vcpkgPackages)
     condition: variables.vcpkgPackages
     displayName: Install dependencies
   - task: VSBuild@1

--- a/azure/pipeline.yml
+++ b/azure/pipeline.yml
@@ -6,7 +6,6 @@ jobs:
 - template: job-build.yml
   parameters:
     displayName: VS 2019
-    installVcpkg: 'true'
     matrix:
       LLVM Debug:
         configuration: Debug

--- a/azure/pipeline.yml
+++ b/azure/pipeline.yml
@@ -5,21 +5,28 @@ variables:
 jobs:
 - template: job-build.yml
   parameters:
-    displayName: VS 2019
+    displayName: VS 2019 LLVM
+    installLlvm: 'true'
     matrix:
-      LLVM Debug:
+      Debug:
         configuration: Debug
-        installLlvm: 'true'
-        msBuildArgs: ${{ variables.llvmMsBuildArgs }}
-      LLVM Release:
+      Release:
         configuration: Release
-        installLlvm: 'true'
-        msBuildArgs: ${{ variables.llvmMsBuildArgs }}
-      v142 Debug:
+    msBuildArgs: ${{ variables.llvmMsBuildArgs }}
+    name: vs2019_llvm
+    platform: Win32
+    solution: ${{ variables.solution }}
+    vcpkgPackages: ${{ variables.vcpkgPackages }}
+    vmImage: windows-2019
+- template: job-build.yml
+  parameters:
+    displayName: VS 2019 v142
+    matrix:
+      Debug:
         configuration: Debug
-      v142 Release:
+      Release:
         configuration: Release
-    name: vs2019
+    name: vs2019_v142
     platform: Win32
     solution: ${{ variables.solution }}
     vcpkgPackages: ${{ variables.vcpkgPackages }}


### PR DESCRIPTION
This:

- splits the config into two jobs as this seems to be the only way to get each matrix line reported separately on GitHub
- removes the install Vcpkg step as Vcpkg is now pre-installed in the VS 2019 Azure Pipelines image
- gets the LLVM build running again (but not working, there's now a `/SUBSYSTEM:WINDOWS: no such file or directory` error from `llvm-lib.exe`)