### PR TITLE
Improve list view keyboard shortcut handling

### DIFF
--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -482,11 +482,10 @@ bool filter_panel_t::do_drag_drop(WPARAM wp)
     return true;
 }
 
-bool filter_panel_t::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp, bool& b_processed)
+bool filter_panel_t::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
 {
     uie::window_ptr p_this = this;
     bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-    b_processed = ret;
     return ret;
 };
 

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -197,7 +197,7 @@ private:
     void notify_on_menu_select(WPARAM wp, LPARAM lp) override;
     bool notify_on_contextmenu(const POINT& pt, bool from_keyboard) override;
     void notify_sort_column(t_size index, bool b_descending, bool b_selection_only) override;
-    bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp, bool& b_processed) override;
+    bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp) override;
     bool do_drag_drop(WPARAM wp) override;
 
     t_size get_drag_item_count() override { return m_drag_item_count; }

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -780,11 +780,10 @@ void selection_properties_t::notify_on_column_size_change(t_size index, int new_
         m_column_field_width = new_width;
 }
 
-bool selection_properties_t::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp, bool& b_processed)
+bool selection_properties_t::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
 {
     uie::window_ptr p_this = this;
     bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-    b_processed = ret;
     return ret;
 }
 

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -193,7 +193,7 @@ public:
     void notify_on_set_focus(HWND wnd_lost) override;
     void notify_on_kill_focus(HWND wnd_receiving) override;
     bool notify_on_keyboard_keydown_copy() override;
-    bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp, bool& b_processed) override;
+    bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp) override;
     void notify_on_column_size_change(t_size index, int new_width) override;
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse) override;

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -986,11 +986,10 @@ t_size ng_playlist_view_t::get_highlight_item()
     return pfc_infinite;
 }
 
-bool ng_playlist_view_t::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp, bool& b_processed)
+bool ng_playlist_view_t::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
 {
     uie::window_ptr p_this = this;
     bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-    b_processed = ret;
     return ret;
 };
 bool ng_playlist_view_t::notify_on_keyboard_keydown_remove()

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -556,7 +556,7 @@ private:
     bool notify_on_middleclick(bool on_item, t_size index) override;
     bool notify_on_doubleleftclick_nowhere() override;
 
-    bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp, bool& b_processed) override;
+    bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp) override;
     bool notify_on_keyboard_keydown_remove() override;
 
     bool notify_on_keyboard_keydown_search() override;

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -133,11 +133,10 @@ public:
 
     bool notify_on_contextmenu(const POINT& pt, bool from_keyboard) override;
 
-    bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp, bool& b_processed) override
+    bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp) override
     {
         uie::window_ptr p_this = this;
         bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-        b_processed = ret;
         return ret;
     };
 


### PR DESCRIPTION
This updates ui_helpers to move handling of built-in character-based keyboard shortcuts to WM_KEYDOWN rather than WM_CHAR in list views.

This is to prevent double-handling if the same combination is assigned to a foobar2000 keyboard shortcut and the foobar2000 keyboard shortcut handler uses a modal message loop.