### PR TITLE
Allow reverse sorting of Filter selection when added to a playlist

### DIFF
--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -334,6 +334,9 @@ public:
         const auto wnd_sort_string = GetDlgItem(wnd, IDC_SORT_STRING);
         uSetWindowText(wnd_sort_string, filter_panel::cfg_sort_string);
 
+        const auto wnd_autosend_reverse_sort = GetDlgItem(wnd, IDC_REVERSE_SORT_TRACKS);
+        Button_SetCheck(wnd_autosend_reverse_sort, filter_panel::cfg_reverse_sort_tracks ? BST_CHECKED : BST_UNCHECKED);
+
         const auto wnd_autosend = GetDlgItem(wnd, IDC_AUTOSEND);
         Button_SetCheck(wnd_autosend, filter_panel::cfg_autosend ? BST_CHECKED : BST_UNCHECKED);
 
@@ -357,6 +360,9 @@ public:
                 break;
             case IDC_AUTOSEND:
                 filter_panel::cfg_autosend = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
+                break;
+            case IDC_REVERSE_SORT_TRACKS:
+                filter_panel::cfg_reverse_sort_tracks = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
                 break;
             case IDC_FILTERS_ALLOW_SORTING:
                 filter_panel::cfg_allow_sorting = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -2,6 +2,7 @@
 #include "filter.h"
 #include "filter_config_var.h"
 #include "filter_search_bar.h"
+#include "filter_utils.h"
 
 namespace filter_panel {
 
@@ -463,11 +464,7 @@ bool filter_panel_t::do_drag_drop(WPARAM wp)
     metadb_handle_list_t<pfc::alloc_fast_aggressive> data;
     get_selection_handles(data);
     if (data.get_count() > 0) {
-        if (cfg_sort) {
-            service_ptr_t<titleformat_object> to;
-            static_api_ptr_t<titleformat_compiler>()->compile_safe(to, cfg_sort_string);
-            fbh::sort_metadb_handle_list_by_format(data, to, nullptr);
-        }
+        sort_tracks(data);
         static_api_ptr_t<playlist_incoming_item_filter> incoming_api;
         IDataObject* pDataObject = incoming_api->create_dataobject(data);
         if (pDataObject) {
@@ -578,11 +575,8 @@ void filter_panel_t::do_items_action(const pfc::bit_array& p_nodes, action_t act
         playlist_api->playlist_clear(index);
     }
 
-    if (cfg_sort) {
-        service_ptr_t<titleformat_object> to;
-        static_api_ptr_t<titleformat_compiler>()->compile_safe(to, cfg_sort_string);
-        fbh::sort_metadb_handle_list_by_format(handles, to, nullptr);
-    }
+    sort_tracks(handles);
+
     if (action != action_add_to_active)
         playlist_api->playlist_add_items(index, handles, pfc::bit_array_false());
     else {
@@ -645,13 +639,7 @@ void filter_panel_t::send_results_to_playlist(bool b_play)
             b_play ? "Filter Results (Playback)" : "Filter Results", pfc_infinite);
     playlist_api->playlist_clear(index);
 
-    if (cfg_sort) {
-        service_ptr_t<titleformat_object> to;
-        static_api_ptr_t<titleformat_compiler>()->compile_safe(to, cfg_sort_string);
-        {
-            fbh::sort_metadb_handle_list_by_format(handles, to, nullptr);
-        }
-    }
+    sort_tracks(handles);
     playlist_api->playlist_add_items(index, handles, pfc::bit_array_false());
 
     playlist_api->set_active_playlist(index);
@@ -709,11 +697,7 @@ void filter_panel_t::notify_on_kill_focus(HWND wnd_receiving)
 void node_t::ensure_handles_sorted()
 {
     if (!m_handles_sorted) {
-        if (cfg_sort) {
-            service_ptr_t<titleformat_object> to;
-            static_api_ptr_t<titleformat_compiler>()->compile_safe(to, cfg_sort_string);
-            fbh::sort_metadb_handle_list_by_format(m_handles, to, nullptr);
-        }
+        sort_tracks(m_handles);
         m_handles_sorted = true;
     }
 }

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -217,4 +217,5 @@ private:
     UINT_PTR m_contextmenu_manager_base{0};
     ui_status_text_override::ptr m_status_text_override;
 };
+
 }; // namespace filter_panel

--- a/foo_ui_columns/filter_config_var.cpp
+++ b/foo_ui_columns/filter_config_var.cpp
@@ -33,6 +33,8 @@ fbh::ConfigInt32DpiAware cfg_vertical_item_padding(g_guid_itempadding, 4);
 fbh::ConfigBool cfg_show_column_titles(g_guid_show_column_titles, true);
 fbh::ConfigBool cfg_allow_sorting(g_guid_allow_sorting, true);
 fbh::ConfigBool cfg_show_sort_indicators(g_guid_show_sort_indicators, true);
+fbh::ConfigBool cfg_reverse_sort_tracks(
+    GUID{0x1edc5277, 0x2dd6, 0x4276, {0x80, 0xb6, 0xda, 0xa4, 0x1e, 0xd4, 0x6e, 0xe5}}, false);
 
 cfg_bool cfg_showsearchclearbutton(g_guid_showsearchclearbutton, true);
 

--- a/foo_ui_columns/filter_config_var.h
+++ b/foo_ui_columns/filter_config_var.h
@@ -43,6 +43,6 @@ extern cfg_bool cfg_sort, cfg_autosend, cfg_orderedbysplitters, cfg_showemptyite
 extern cfg_int cfg_doubleclickaction, cfg_middleclickaction, cfg_edgestyle;
 extern cfg_fields_t cfg_field_list;
 extern fbh::ConfigInt32DpiAware cfg_vertical_item_padding;
-extern fbh::ConfigBool cfg_show_column_titles, cfg_allow_sorting, cfg_show_sort_indicators;
+extern fbh::ConfigBool cfg_show_column_titles, cfg_allow_sorting, cfg_show_sort_indicators, cfg_reverse_sort_tracks;
 
 } // namespace filter_panel

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -2,6 +2,7 @@
 
 #include "filter_search_bar.h"
 #include "filter_config_var.h"
+#include "filter_utils.h"
 
 namespace filter_panel {
 
@@ -32,13 +33,7 @@ void g_send_metadb_handles_to_playlist(tHandles& handles, bool b_play = false)
             b_play ? "Filter Results (Playback)" : "Filter Results", pfc_infinite);
     playlist_api->playlist_clear(index);
 
-    if (cfg_sort) {
-        service_ptr_t<titleformat_object> to;
-        static_api_ptr_t<titleformat_compiler>()->compile_safe(to, cfg_sort_string);
-        {
-            fbh::sort_metadb_handle_list_by_format(handles, to, nullptr);
-        }
-    }
+    sort_tracks(handles);
     playlist_api->playlist_add_items(index, handles, pfc::bit_array_false());
 
     playlist_api->set_active_playlist(index);

--- a/foo_ui_columns/filter_utils.h
+++ b/foo_ui_columns/filter_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <filter_config_var.h>
+
+namespace filter_panel {
+
+template <class Container>
+void sort_tracks(Container&& tracks)
+{
+    if (cfg_sort) {
+        service_ptr_t<titleformat_object> to;
+        static_api_ptr_t<titleformat_compiler>()->compile_safe(to, cfg_sort_string);
+        fbh::sort_metadb_handle_list_by_format(
+            std::forward<Container>(tracks), to, nullptr, false, cfg_reverse_sort_tracks);
+    }
+}
+
+} // namespace filter_panel

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -581,7 +581,7 @@ BEGIN
     LTEXT           "Behaviour",IDC_TITLE1,7,4,313,16
     CONTROL         "Sort tracks added when added to a playlist by:",IDC_SORT,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,30,169,10
-    EDITTEXT        IDC_SORT_STRING,7,42,313,14,ES_AUTOHSCROLL
+    EDITTEXT        IDC_SORT_STRING,7,42,247,14,ES_AUTOHSCROLL
     CONTROL         "Allow sorting using column titles",IDC_FILTERS_ALLOW_SORTING,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,68,124,10
     CONTROL         "Auto-send selection to playlist",IDC_AUTOSEND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,87,117,10
@@ -592,6 +592,7 @@ BEGIN
     COMBOBOX        IDC_DBLCLK,7,174,131,90,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     LTEXT           "Middle-click action",IDC_STATIC,7,199,65,8
     COMBOBOX        IDC_MIDDLE,7,210,131,90,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Reverse order",IDC_REVERSE_SORT_TRACKS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,258,44,62,10
 END
 
 IDD_PREFS_PVIEW_ARTWORK DIALOGEX 0, 0, 327, 271

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -467,6 +467,7 @@
     <ClInclude Include=".\menu_helpers.h" />
     <ClInclude Include=".\mw_drop_target.h" />
     <ClInclude Include="button_items.h" />
+    <ClInclude Include="filter_utils.h" />
     <ClInclude Include="font_utils.h" />
     <ClInclude Include="help.h" />
     <ClInclude Include="migrate.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -701,6 +701,9 @@
     <ClInclude Include=".\get_msg_hook.h">
       <Filter>Main window</Filter>
     </ClInclude>
+    <ClInclude Include="filter_utils.h">
+      <Filter>Filter</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".\buttons2.bmp">

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -84,6 +84,7 @@
 #define IDC_DROP_AT_END                 1017
 #define IDC_FCL_IMPORT                  1017
 #define IDC_FILTERS_SHOW_COLUMN_TITLES  1017
+#define IDC_REVERSE_SORT_TRACKS         1017
 #define IDC_VALUE                       1018
 #define IDC_FILTERS_ALLOW_SORTING       1018
 #define IDC_PLAYLIST_FILTER_STRING      1019


### PR DESCRIPTION
Resolves #171

This adds a new 'Reverse order' setting alongside the existing settings for controlling the sorting behaviour when tracks are added to a playlist from the Filter panel.