### PR TITLE
Use UpperCamelCase for class names (part 3)

### DIFF
--- a/foo_ui_columns/callbacks_config.cpp
+++ b/foo_ui_columns/callbacks_config.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "main_window.h"
 
-class config_object_notify_columns : public config_object_notify {
+class AlwaysOnTopNotifyReceiver : public config_object_notify {
     unsigned get_watched_object_count() override { return 1; }
     GUID get_watched_object(unsigned p_index) override { return standard_config_objects::bool_ui_always_on_top; };
     void on_watched_object_changed(const service_ptr_t<config_object>& p_object) override
@@ -29,5 +29,5 @@ class config_object_notify_columns : public config_object_notify {
 
 };*/
 
-service_factory_single_t<config_object_notify_columns> hj;
+service_factory_single_t<AlwaysOnTopNotifyReceiver> hj;
 // service_factory_single_t<titleformat_config_callback_columns> hjc;

--- a/foo_ui_columns/fcl_layout.cpp
+++ b/foo_ui_columns/fcl_layout.cpp
@@ -33,10 +33,10 @@ class LayoutDataSet : public cui::fcl::dataset_v2 {
         p_reader->read_lendian_t(active, p_abort);
         p_reader->read_lendian_t(pcount, p_abort);
 
-        pfc::list_t<cfg_layout_t::preset> presets;
+        pfc::list_t<ConfigLayout::preset> presets;
 
         for (t_uint32 j = 0; j < pcount; j++) {
-            cfg_layout_t::preset pres;
+            ConfigLayout::preset pres;
             if (!g_layout_window.import_config_to_object(p_reader, size, type, pres, panels, p_abort))
                 missingpanels = true;
             presets.add_item(pres);

--- a/foo_ui_columns/fcl_layout.cpp
+++ b/foo_ui_columns/fcl_layout.cpp
@@ -33,10 +33,10 @@ class LayoutDataSet : public cui::fcl::dataset_v2 {
         p_reader->read_lendian_t(active, p_abort);
         p_reader->read_lendian_t(pcount, p_abort);
 
-        pfc::list_t<ConfigLayout::preset> presets;
+        pfc::list_t<ConfigLayout::Preset> presets;
 
         for (t_uint32 j = 0; j < pcount; j++) {
-            ConfigLayout::preset pres;
+            ConfigLayout::Preset pres;
             if (!g_layout_window.import_config_to_object(p_reader, size, type, pres, panels, p_abort))
                 missingpanels = true;
             presets.add_item(pres);

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -471,6 +471,7 @@
     <ClInclude Include="filter_utils.h" />
     <ClInclude Include="font_utils.h" />
     <ClInclude Include="help.h" />
+    <ClInclude Include="menu_mnemonics.h" />
     <ClInclude Include="migrate.h" />
     <ClInclude Include="panel_menu_item.h" />
     <ClInclude Include="playlist_view_tfhooks.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -707,6 +707,9 @@
     <ClInclude Include="filter_config_var.h">
       <Filter>Filter</Filter>
     </ClInclude>
+    <ClInclude Include="menu_mnemonics.h">
+      <Filter>Menu toolbar</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".\buttons2.bmp">

--- a/foo_ui_columns/get_msg_hook.cpp
+++ b/foo_ui_columns/get_msg_hook.cpp
@@ -6,7 +6,7 @@
 
 extern rebar_window* g_rebar_window;
 
-bool get_msg_hook_t::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp)
+bool GetMsgHook::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp)
 {
     auto lpmsg = (LPMSG)lp;
     if ((lpmsg->message == WM_KEYUP || lpmsg->message == WM_SYSKEYDOWN || lpmsg->message == WM_KEYDOWN)
@@ -58,11 +58,11 @@ bool get_msg_hook_t::on_hooked_message(uih::MessageHookType p_type, int code, WP
     return false;
 }
 
-void get_msg_hook_t::register_hook()
+void GetMsgHook::register_hook()
 {
     uih::register_message_hook(uih::MessageHookType::type_get_message, this);
 }
-void get_msg_hook_t::deregister_hook()
+void GetMsgHook::deregister_hook()
 {
     uih::deregister_message_hook(uih::MessageHookType::type_get_message, this);
 }

--- a/foo_ui_columns/get_msg_hook.h
+++ b/foo_ui_columns/get_msg_hook.h
@@ -9,7 +9,7 @@
  * Class used for hooking message loops
  */
 
-class get_msg_hook_t : public uih::MessageHook {
+class GetMsgHook : public uih::MessageHook {
     bool on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp) override;
 
 public:

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -53,25 +53,25 @@ cfg_uint cfg_item_details_horizontal_alignment(g_guid_item_details_horizontal_al
 cfg_uint cfg_item_details_vertical_alignment(g_guid_item_details_vertical_alignment, uih::ALIGN_CENTRE);
 cfg_bool cfg_item_details_word_wrapping(g_guid_item_details_word_wrapping, true);
 
-void ItemDetails::menu_node_options::execute()
+void ItemDetails::MenuNodeOptions::execute()
 {
     if (p_this->m_wnd_config)
         SetActiveWindow(p_this->m_wnd_config);
     else {
-        auto p_dialog = new item_details_config_t(
+        auto p_dialog = new ItemDetailsConfig(
             p_this->m_script, p_this->m_edge_style, p_this->m_horizontal_alignment, p_this->m_vertical_alignment);
         p_dialog->run_modeless(GetAncestor(p_this->get_wnd(), GA_ROOT), p_this.get_ptr());
     }
 }
 
-ItemDetails::menu_node_options::menu_node_options(ItemDetails* p_wnd) : p_this(p_wnd) {}
+ItemDetails::MenuNodeOptions::MenuNodeOptions(ItemDetails* p_wnd) : p_this(p_wnd) {}
 
-bool ItemDetails::menu_node_options::get_description(pfc::string_base& p_out) const
+bool ItemDetails::MenuNodeOptions::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool ItemDetails::menu_node_options::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::MenuNodeOptions::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Options";
     p_displayflags = 0;
@@ -84,7 +84,7 @@ bool ItemDetails::have_config_popup() const
 }
 bool ItemDetails::show_config_popup(HWND wnd_parent)
 {
-    item_details_config_t dialog(m_script, m_edge_style, m_horizontal_alignment, m_vertical_alignment);
+    ItemDetailsConfig dialog(m_script, m_edge_style, m_horizontal_alignment, m_vertical_alignment);
     if (dialog.run_modal(wnd_parent)) {
         m_script = dialog.m_script;
         m_edge_style = dialog.m_edge_style;
@@ -141,27 +141,27 @@ void ItemDetails::get_config(stream_writer* p_writer, abort_callback& p_abort) c
 
 void ItemDetails::get_menu_items(ui_extension::menu_hook_t& p_hook)
 {
-    p_hook.add_node(ui_extension::menu_node_ptr(new menu_node_source_popup(this)));
+    p_hook.add_node(ui_extension::menu_node_ptr(new MenuNodeSourcePopup(this)));
     // p_node = new menu_node_alignment_popup(this);
     // p_hook.add_node(p_node);
-    ui_extension::menu_node_ptr p_node = new menu_node_hscroll(this);
+    ui_extension::menu_node_ptr p_node = new MenuNodeHorizontalScrolling(this);
     p_hook.add_node(p_node);
-    p_node = new menu_node_wwrap(this);
+    p_node = new MenuNodeWordWrap(this);
     p_hook.add_node(p_node);
-    p_node = new menu_node_options(this);
+    p_node = new MenuNodeOptions(this);
     p_hook.add_node(p_node);
 }
 
-ItemDetails::message_window_t ItemDetails::g_message_window;
+ItemDetails::MessageWindow ItemDetails::g_message_window;
 
 std::vector<ItemDetails*> ItemDetails::g_windows;
 
-ItemDetails::message_window_t::class_data& ItemDetails::message_window_t::get_class_data() const
+ItemDetails::MessageWindow::class_data& ItemDetails::MessageWindow::get_class_data() const
 {
     __implement_get_class_data_ex(_T("\r\n{6EB3EA81-7C5E-468d-B507-E5527F52361B}"), _T(""), false, 0, 0, 0, 0);
 }
 
-LRESULT ItemDetails::message_window_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT ItemDetails::MessageWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE:
@@ -428,7 +428,7 @@ void ItemDetails::refresh_contents(bool reset_scroll_position)
         LOGFONT lf;
         static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client, lf);
 
-        titleformat_hook_change_font tf_hook(lf);
+        TitleformatHookChangeFont tf_hook(lf);
         pfc::string8_fast_aggressive temp, temp2;
         temp.prealloc(2048);
         temp2.prealloc(2048);
@@ -754,7 +754,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         static_api_ptr_t<playlist_manager_v3>()->register_callback(this, playlist_callback_flags);
         static_api_ptr_t<metadb_io_v3>()->register_callback(this);
 
-        m_font_change_info.m_default_font = new font_t;
+        m_font_change_info.m_default_font = new Font;
         m_font_change_info.m_default_font->m_font
             = static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client);
         m_font_change_info.m_default_font->m_height = uGetFontHeight(m_font_change_info.m_default_font->m_font);
@@ -1149,9 +1149,9 @@ ItemDetails::class_data& ItemDetails::get_class_data() const
 
 uie::window_factory<ItemDetails> g_item_details;
 
-ItemDetails::menu_node_wwrap::menu_node_wwrap(ItemDetails* p_wnd) : p_this(p_wnd) {}
+ItemDetails::MenuNodeWordWrap::MenuNodeWordWrap(ItemDetails* p_wnd) : p_this(p_wnd) {}
 
-void ItemDetails::menu_node_wwrap::execute()
+void ItemDetails::MenuNodeWordWrap::execute()
 {
     p_this->m_word_wrapping = !p_this->m_word_wrapping;
     cfg_item_details_word_wrapping = p_this->m_word_wrapping;
@@ -1161,21 +1161,21 @@ void ItemDetails::menu_node_wwrap::execute()
     p_this->update_now();
 }
 
-bool ItemDetails::menu_node_wwrap::get_description(pfc::string_base& p_out) const
+bool ItemDetails::MenuNodeWordWrap::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool ItemDetails::menu_node_wwrap::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::MenuNodeWordWrap::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Word wrapping";
     p_displayflags = (p_this->m_word_wrapping) ? ui_extension::menu_node_t::state_checked : 0;
     return true;
 }
 
-ItemDetails::menu_node_hscroll::menu_node_hscroll(ItemDetails* p_wnd) : p_this(p_wnd) {}
+ItemDetails::MenuNodeHorizontalScrolling::MenuNodeHorizontalScrolling(ItemDetails* p_wnd) : p_this(p_wnd) {}
 
-void ItemDetails::menu_node_hscroll::execute()
+void ItemDetails::MenuNodeHorizontalScrolling::execute()
 {
     p_this->m_hscroll = !p_this->m_hscroll;
     cfg_item_details_hscroll = p_this->m_hscroll;
@@ -1185,36 +1185,36 @@ void ItemDetails::menu_node_hscroll::execute()
     p_this->update_now();
 }
 
-bool ItemDetails::menu_node_hscroll::get_description(pfc::string_base& p_out) const
+bool ItemDetails::MenuNodeHorizontalScrolling::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool ItemDetails::menu_node_hscroll::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::MenuNodeHorizontalScrolling::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Allow horizontal scrolling";
     p_displayflags = (p_this->m_hscroll) ? ui_extension::menu_node_t::state_checked : 0;
     return true;
 }
 
-ItemDetails::menu_node_alignment_popup::menu_node_alignment_popup(ItemDetails* p_wnd)
+ItemDetails::MenuNodeAlignmentPopup::MenuNodeAlignmentPopup(ItemDetails* p_wnd)
 {
-    m_items.add_item(new menu_node_alignment(p_wnd, 0));
-    m_items.add_item(new menu_node_alignment(p_wnd, 1));
-    m_items.add_item(new menu_node_alignment(p_wnd, 2));
+    m_items.add_item(new MenuNodeAlignment(p_wnd, 0));
+    m_items.add_item(new MenuNodeAlignment(p_wnd, 1));
+    m_items.add_item(new MenuNodeAlignment(p_wnd, 2));
 }
 
-void ItemDetails::menu_node_alignment_popup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
+void ItemDetails::MenuNodeAlignmentPopup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
 {
     p_out = m_items[p_index].get_ptr();
 }
 
-unsigned ItemDetails::menu_node_alignment_popup::get_children_count() const
+unsigned ItemDetails::MenuNodeAlignmentPopup::get_children_count() const
 {
     return m_items.get_count();
 }
 
-bool ItemDetails::menu_node_alignment_popup::get_display_data(
+bool ItemDetails::MenuNodeAlignmentPopup::get_display_data(
     pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Alignment";
@@ -1222,12 +1222,12 @@ bool ItemDetails::menu_node_alignment_popup::get_display_data(
     return true;
 }
 
-ItemDetails::menu_node_alignment::menu_node_alignment(ItemDetails* p_wnd, t_size p_value)
+ItemDetails::MenuNodeAlignment::MenuNodeAlignment(ItemDetails* p_wnd, t_size p_value)
     : p_this(p_wnd), m_type(p_value)
 {
 }
 
-void ItemDetails::menu_node_alignment::execute()
+void ItemDetails::MenuNodeAlignment::execute()
 {
     p_this->m_horizontal_alignment = m_type;
     cfg_item_details_horizontal_alignment = m_type;
@@ -1236,19 +1236,19 @@ void ItemDetails::menu_node_alignment::execute()
     p_this->update_now();
 }
 
-bool ItemDetails::menu_node_alignment::get_description(pfc::string_base& p_out) const
+bool ItemDetails::MenuNodeAlignment::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool ItemDetails::menu_node_alignment::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::MenuNodeAlignment::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = get_name(m_type);
     p_displayflags = (m_type == p_this->m_horizontal_alignment) ? ui_extension::menu_node_t::state_radiochecked : 0;
     return true;
 }
 
-const char* ItemDetails::menu_node_alignment::get_name(t_size source)
+const char* ItemDetails::MenuNodeAlignment::get_name(t_size source)
 {
     if (source == 0)
         return "Left";
@@ -1258,58 +1258,58 @@ const char* ItemDetails::menu_node_alignment::get_name(t_size source)
     return "Right";
 }
 
-ItemDetails::menu_node_source_popup::menu_node_source_popup(ItemDetails* p_wnd)
+ItemDetails::MenuNodeSourcePopup::MenuNodeSourcePopup(ItemDetails* p_wnd)
 {
-    m_items.add_item(new menu_node_track_mode(p_wnd, 3));
-    m_items.add_item(new menu_node_track_mode(p_wnd, 0));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, 3));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, 0));
     m_items.add_item(new uie::menu_node_separator_t());
-    m_items.add_item(new menu_node_track_mode(p_wnd, 2));
-    m_items.add_item(new menu_node_track_mode(p_wnd, 4));
-    m_items.add_item(new menu_node_track_mode(p_wnd, 1));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, 2));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, 4));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, 1));
 }
 
-void ItemDetails::menu_node_source_popup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
+void ItemDetails::MenuNodeSourcePopup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
 {
     p_out = m_items[p_index].get_ptr();
 }
 
-unsigned ItemDetails::menu_node_source_popup::get_children_count() const
+unsigned ItemDetails::MenuNodeSourcePopup::get_children_count() const
 {
     return m_items.get_count();
 }
 
-bool ItemDetails::menu_node_source_popup::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::MenuNodeSourcePopup::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Displayed track";
     p_displayflags = 0;
     return true;
 }
 
-ItemDetails::menu_node_track_mode::menu_node_track_mode(ItemDetails* p_wnd, t_size p_value)
+ItemDetails::MenuNodeTrackMode::MenuNodeTrackMode(ItemDetails* p_wnd, t_size p_value)
     : p_this(p_wnd), m_source(p_value)
 {
 }
 
-void ItemDetails::menu_node_track_mode::execute()
+void ItemDetails::MenuNodeTrackMode::execute()
 {
     p_this->m_tracking_mode = m_source;
     cfg_item_details_tracking_mode = m_source;
     p_this->on_tracking_mode_change();
 }
 
-bool ItemDetails::menu_node_track_mode::get_description(pfc::string_base& p_out) const
+bool ItemDetails::MenuNodeTrackMode::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool ItemDetails::menu_node_track_mode::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::MenuNodeTrackMode::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = get_name(m_source);
     p_displayflags = (m_source == p_this->m_tracking_mode) ? ui_extension::menu_node_t::state_radiochecked : 0;
     return true;
 }
 
-const char* ItemDetails::menu_node_track_mode::get_name(t_size source)
+const char* ItemDetails::MenuNodeTrackMode::get_name(t_size source)
 {
     if (source == track_playing)
         return "Playing item";

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -53,7 +53,7 @@ cfg_uint cfg_item_details_horizontal_alignment(g_guid_item_details_horizontal_al
 cfg_uint cfg_item_details_vertical_alignment(g_guid_item_details_vertical_alignment, uih::ALIGN_CENTRE);
 cfg_bool cfg_item_details_word_wrapping(g_guid_item_details_word_wrapping, true);
 
-void item_details_t::menu_node_options::execute()
+void ItemDetails::menu_node_options::execute()
 {
     if (p_this->m_wnd_config)
         SetActiveWindow(p_this->m_wnd_config);
@@ -64,25 +64,25 @@ void item_details_t::menu_node_options::execute()
     }
 }
 
-item_details_t::menu_node_options::menu_node_options(item_details_t* p_wnd) : p_this(p_wnd) {}
+ItemDetails::menu_node_options::menu_node_options(ItemDetails* p_wnd) : p_this(p_wnd) {}
 
-bool item_details_t::menu_node_options::get_description(pfc::string_base& p_out) const
+bool ItemDetails::menu_node_options::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool item_details_t::menu_node_options::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::menu_node_options::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Options";
     p_displayflags = 0;
     return true;
 }
 
-bool item_details_t::have_config_popup() const
+bool ItemDetails::have_config_popup() const
 {
     return true;
 }
-bool item_details_t::show_config_popup(HWND wnd_parent)
+bool ItemDetails::show_config_popup(HWND wnd_parent)
 {
     item_details_config_t dialog(m_script, m_edge_style, m_horizontal_alignment, m_vertical_alignment);
     if (dialog.run_modal(wnd_parent)) {
@@ -106,7 +106,7 @@ bool item_details_t::show_config_popup(HWND wnd_parent)
     return false;
 }
 
-void item_details_t::set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
+void ItemDetails::set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
 {
     if (p_size) {
         t_size version;
@@ -127,7 +127,7 @@ void item_details_t::set_config(stream_reader* p_reader, t_size p_size, abort_ca
     }
 }
 
-void item_details_t::get_config(stream_writer* p_writer, abort_callback& p_abort) const
+void ItemDetails::get_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
     p_writer->write_lendian_t((t_size)stream_version_current, p_abort);
     p_writer->write_string(m_script, p_abort);
@@ -139,7 +139,7 @@ void item_details_t::get_config(stream_writer* p_writer, abort_callback& p_abort
     p_writer->write_lendian_t(m_vertical_alignment, p_abort);
 }
 
-void item_details_t::get_menu_items(ui_extension::menu_hook_t& p_hook)
+void ItemDetails::get_menu_items(ui_extension::menu_hook_t& p_hook)
 {
     p_hook.add_node(ui_extension::menu_node_ptr(new menu_node_source_popup(this)));
     // p_node = new menu_node_alignment_popup(this);
@@ -152,22 +152,22 @@ void item_details_t::get_menu_items(ui_extension::menu_hook_t& p_hook)
     p_hook.add_node(p_node);
 }
 
-item_details_t::message_window_t item_details_t::g_message_window;
+ItemDetails::message_window_t ItemDetails::g_message_window;
 
-std::vector<item_details_t*> item_details_t::g_windows;
+std::vector<ItemDetails*> ItemDetails::g_windows;
 
-item_details_t::message_window_t::class_data& item_details_t::message_window_t::get_class_data() const
+ItemDetails::message_window_t::class_data& ItemDetails::message_window_t::get_class_data() const
 {
     __implement_get_class_data_ex(_T("\r\n{6EB3EA81-7C5E-468d-B507-E5527F52361B}"), _T(""), false, 0, 0, 0, 0);
 }
 
-LRESULT item_details_t::message_window_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT ItemDetails::message_window_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE:
         break;
     case WM_ACTIVATEAPP:
-        item_details_t::g_on_app_activate(wp != 0);
+        ItemDetails::g_on_app_activate(wp != 0);
         break;
     case WM_DESTROY:
         break;
@@ -175,12 +175,12 @@ LRESULT item_details_t::message_window_t::on_message(HWND wnd, UINT msg, WPARAM 
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-void item_details_t::g_on_app_activate(bool b_activated)
+void ItemDetails::g_on_app_activate(bool b_activated)
 {
     for (auto& window : g_windows)
         window->on_app_activate(b_activated);
 }
-void item_details_t::on_app_activate(bool b_activated)
+void ItemDetails::on_app_activate(bool b_activated)
 {
     if (b_activated) {
         if (GetFocus() != get_wnd())
@@ -190,37 +190,37 @@ void item_details_t::on_app_activate(bool b_activated)
     }
 }
 
-const GUID& item_details_t::get_extension_guid() const
+const GUID& ItemDetails::get_extension_guid() const
 {
     return g_guid_item_details;
 }
-void item_details_t::get_name(pfc::string_base& p_out) const
+void ItemDetails::get_name(pfc::string_base& p_out) const
 {
     p_out = "Item details";
 }
-void item_details_t::get_category(pfc::string_base& p_out) const
+void ItemDetails::get_category(pfc::string_base& p_out) const
 {
     p_out = "Panels";
 }
-unsigned item_details_t::get_type() const
+unsigned ItemDetails::get_type() const
 {
     return uie::type_panel;
 }
 
-void item_details_t::register_callback()
+void ItemDetails::register_callback()
 {
     if (!m_callback_registered)
         g_ui_selection_manager_register_callback_no_now_playing_fallback(this);
     m_callback_registered = true;
 }
-void item_details_t::deregister_callback()
+void ItemDetails::deregister_callback()
 {
     if (m_callback_registered)
         static_api_ptr_t<ui_selection_manager>()->unregister_callback(this);
     m_callback_registered = false;
 }
 
-void item_details_t::update_scrollbar_range(bool b_set_pos)
+void ItemDetails::update_scrollbar_range(bool b_set_pos)
 {
     // if (m_update_scrollbar_range_in_progress) return;
 
@@ -352,7 +352,7 @@ void item_details_t::update_scrollbar_range(bool b_set_pos)
 #endif
 }
 
-void item_details_t::set_handles(const metadb_handle_list& handles)
+void ItemDetails::set_handles(const metadb_handle_list& handles)
 {
     const auto old_handles = std::move(m_handles);
     m_handles = handles;
@@ -367,7 +367,7 @@ void item_details_t::set_handles(const metadb_handle_list& handles)
     refresh_contents();
 }
 
-void item_details_t::request_full_file_info()
+void ItemDetails::request_full_file_info()
 {
     if (m_full_file_info_requested)
         return;
@@ -381,13 +381,13 @@ void item_details_t::request_full_file_info()
     if (filesystem::g_is_remote_or_unrecognized(handle->get_path()))
         return;
     m_full_file_info_request = std::make_unique<cui::helpers::FullFileInfoRequest>(
-        std::move(handle), [self = service_ptr_t<item_details_t>{this}](auto&& request) {
+        std::move(handle), [self = service_ptr_t<ItemDetails>{this}](auto&& request) {
             self->on_full_file_info_request_completion(std::forward<decltype(request)>(request));
         });
     m_full_file_info_request->queue();
 }
 
-void item_details_t::on_full_file_info_request_completion(std::shared_ptr<cui::helpers::FullFileInfoRequest> request)
+void ItemDetails::on_full_file_info_request_completion(std::shared_ptr<cui::helpers::FullFileInfoRequest> request)
 {
     if (m_full_file_info_request == request) {
         m_full_file_info_request.reset();
@@ -400,14 +400,14 @@ void item_details_t::on_full_file_info_request_completion(std::shared_ptr<cui::h
     release_aborted_full_file_info_requests();
 }
 
-void item_details_t::release_aborted_full_file_info_requests()
+void ItemDetails::release_aborted_full_file_info_requests()
 {
     const auto erase_iterator = std::remove_if(m_aborting_full_file_info_requests.begin(),
         m_aborting_full_file_info_requests.end(), [](auto&& item) { return item->is_ready(); });
     m_aborting_full_file_info_requests.erase(erase_iterator, m_aborting_full_file_info_requests.end());
 }
 
-void item_details_t::release_all_full_file_info_requests()
+void ItemDetails::release_all_full_file_info_requests()
 {
     if (m_full_file_info_request) {
         m_full_file_info_request->abort();
@@ -420,7 +420,7 @@ void item_details_t::release_all_full_file_info_requests()
     m_aborting_full_file_info_requests.clear();
 }
 
-void item_details_t::refresh_contents(bool reset_scroll_position)
+void ItemDetails::refresh_contents(bool reset_scroll_position)
 {
     // DisableRedrawing noRedraw(get_wnd());
     bool b_Update = true;
@@ -475,7 +475,7 @@ void item_details_t::refresh_contents(bool reset_scroll_position)
     }
 }
 
-void item_details_t::update_display_info(HDC dc)
+void ItemDetails::update_display_info(HDC dc)
 {
     if (!m_display_info_valid) {
         RECT rc;
@@ -490,7 +490,7 @@ void item_details_t::update_display_info(HDC dc)
     }
 }
 
-void item_details_t::update_display_info()
+void ItemDetails::update_display_info()
 {
     if (!m_display_info_valid) {
         HDC dc = GetDC(get_wnd());
@@ -500,7 +500,7 @@ void item_details_t::update_display_info()
         ReleaseDC(get_wnd(), dc);
     }
 }
-void item_details_t::reset_display_info()
+void ItemDetails::reset_display_info()
 {
     m_current_display_text.force_reset();
     m_display_line_info.remove_all();
@@ -508,7 +508,7 @@ void item_details_t::reset_display_info()
     m_display_info_valid = false;
 }
 
-void item_details_t::update_font_change_info()
+void ItemDetails::update_font_change_info()
 {
     if (!m_font_change_info_valid) {
         g_get_text_font_info(m_font_change_data, m_font_change_info);
@@ -517,14 +517,14 @@ void item_details_t::update_font_change_info()
     }
 }
 
-void item_details_t::reset_font_change_info()
+void ItemDetails::reset_font_change_info()
 {
     m_font_change_data.remove_all();
     m_font_change_info.reset();
     m_font_change_info_valid = false;
 }
 
-void item_details_t::on_playback_new_track(metadb_handle_ptr p_track)
+void ItemDetails::on_playback_new_track(metadb_handle_ptr p_track)
 {
     if (g_track_mode_includes_now_playing(m_tracking_mode)) {
         m_nowplaying_active = true;
@@ -532,38 +532,38 @@ void item_details_t::on_playback_new_track(metadb_handle_ptr p_track)
     }
 }
 
-void item_details_t::on_playback_seek(double p_time)
+void ItemDetails::on_playback_seek(double p_time)
 {
     if (m_nowplaying_active)
         refresh_contents(false);
 }
-void item_details_t::on_playback_pause(bool p_state)
+void ItemDetails::on_playback_pause(bool p_state)
 {
     if (m_nowplaying_active)
         refresh_contents(false);
 }
-void item_details_t::on_playback_edited(metadb_handle_ptr p_track)
+void ItemDetails::on_playback_edited(metadb_handle_ptr p_track)
 {
     if (m_nowplaying_active)
         refresh_contents(false);
 }
-void item_details_t::on_playback_dynamic_info(const file_info& p_info)
+void ItemDetails::on_playback_dynamic_info(const file_info& p_info)
 {
     if (m_nowplaying_active)
         refresh_contents(false);
 }
-void item_details_t::on_playback_dynamic_info_track(const file_info& p_info)
+void ItemDetails::on_playback_dynamic_info_track(const file_info& p_info)
 {
     if (m_nowplaying_active)
         refresh_contents(false);
 }
-void item_details_t::on_playback_time(double p_time)
+void ItemDetails::on_playback_time(double p_time)
 {
     if (m_nowplaying_active)
         refresh_contents(false);
 }
 
-void item_details_t::on_playback_stop(play_control::t_stop_reason p_reason)
+void ItemDetails::on_playback_stop(play_control::t_stop_reason p_reason)
 {
     if (g_track_mode_includes_now_playing(m_tracking_mode) && p_reason != play_control::stop_reason_starting_another
         && p_reason != play_control::stop_reason_shutting_down) {
@@ -579,7 +579,7 @@ void item_details_t::on_playback_stop(play_control::t_stop_reason p_reason)
     }
 }
 
-void item_details_t::on_playlist_switch()
+void ItemDetails::on_playlist_switch()
 {
     if (g_track_mode_includes_plalist(m_tracking_mode)
         && (!g_track_mode_includes_auto(m_tracking_mode) || !static_api_ptr_t<play_control>()->is_playing())) {
@@ -588,7 +588,7 @@ void item_details_t::on_playlist_switch()
         set_handles(handles);
     }
 }
-void item_details_t::on_items_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_state)
+void ItemDetails::on_items_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_state)
 {
     if (g_track_mode_includes_plalist(m_tracking_mode)
         && (!g_track_mode_includes_auto(m_tracking_mode) || !static_api_ptr_t<play_control>()->is_playing())) {
@@ -598,7 +598,7 @@ void item_details_t::on_items_selection_change(const pfc::bit_array& p_affected,
     }
 }
 
-void item_details_t::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook)
+void ItemDetails::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook)
 {
     if (!p_fromhook && !m_nowplaying_active) {
         bool b_refresh = false;
@@ -614,7 +614,7 @@ void item_details_t::on_changed_sorted(metadb_handle_list_cref p_items_sorted, b
     }
 }
 
-bool item_details_t::check_process_on_selection_changed()
+bool ItemDetails::check_process_on_selection_changed()
 {
     HWND wnd_focus = GetFocus();
     if (wnd_focus == nullptr)
@@ -625,7 +625,7 @@ bool item_details_t::check_process_on_selection_changed()
     return processid == GetCurrentProcessId();
 }
 
-void item_details_t::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection)
+void ItemDetails::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection)
 {
     if (check_process_on_selection_changed()) {
         if (g_ui_selection_manager_is_now_playing_fallback())
@@ -645,7 +645,7 @@ void item_details_t::on_selection_changed(const pfc::list_base_const_t<metadb_ha
     // console::formatter() << "Selection properties panel refreshed in: " << timer.query() << " seconds";
 }
 
-void item_details_t::on_tracking_mode_change()
+void ItemDetails::on_tracking_mode_change()
 {
     metadb_handle_list handles;
 
@@ -664,24 +664,24 @@ void item_details_t::on_tracking_mode_change()
     set_handles(handles);
 }
 
-void item_details_t::update_now()
+void ItemDetails::update_now()
 {
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_UPDATENOW);
 }
 
-void item_details_t::invalidate_all(bool b_update)
+void ItemDetails::invalidate_all(bool b_update)
 {
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | (b_update ? RDW_UPDATENOW : NULL));
 }
 
-void item_details_t::on_size()
+void ItemDetails::on_size()
 {
     RECT rc;
     GetClientRect(get_wnd(), &rc);
     on_size(RECT_CX(rc), RECT_CY(rc));
 }
 
-void item_details_t::on_size(t_size cx, t_size cy)
+void ItemDetails::on_size(t_size cx, t_size cy)
 {
     reset_display_info();
 
@@ -706,7 +706,7 @@ void item_details_t::on_size(t_size cx, t_size cy)
     }
 }
 
-void item_details_t::scroll(INT SB, int position, bool b_absolute)
+void ItemDetails::scroll(INT SB, int position, bool b_absolute)
 {
     SCROLLINFO si, si2;
     memset(&si, 0, sizeof(SCROLLINFO));
@@ -742,7 +742,7 @@ void item_details_t::scroll(INT SB, int position, bool b_absolute)
     }
 }
 
-LRESULT item_details_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE: {
@@ -976,21 +976,21 @@ LRESULT item_details_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-void item_details_t::g_on_font_change()
+void ItemDetails::g_on_font_change()
 {
     for (auto& window : g_windows) {
         window->on_font_change();
     }
 }
 
-void item_details_t::g_on_colours_change()
+void ItemDetails::g_on_colours_change()
 {
     for (auto& window : g_windows) {
         window->on_colours_change();
     }
 }
 
-void item_details_t::on_font_change()
+void ItemDetails::on_font_change()
 {
     m_font_change_info.m_default_font->m_font
         = static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client);
@@ -1001,12 +1001,12 @@ void item_details_t::on_font_change()
     update_now();
     */
 }
-void item_details_t::on_colours_change()
+void ItemDetails::on_colours_change()
 {
     invalidate_all();
 }
 
-item_details_t::item_details_t()
+ItemDetails::ItemDetails()
     : m_tracking_mode(cfg_item_details_tracking_mode)
     , m_script(cfg_item_details_script)
     , m_horizontal_alignment(cfg_item_details_horizontal_alignment)
@@ -1019,12 +1019,12 @@ item_details_t::item_details_t()
 {
 }
 
-void item_details_t::set_config_wnd(HWND wnd)
+void ItemDetails::set_config_wnd(HWND wnd)
 {
     m_wnd_config = wnd;
 }
 
-void item_details_t::set_script(const char* p_script)
+void ItemDetails::set_script(const char* p_script)
 {
     m_script = p_script;
 
@@ -1037,7 +1037,7 @@ void item_details_t::set_script(const char* p_script)
     }
 }
 
-void item_details_t::on_edge_style_change()
+void ItemDetails::on_edge_style_change()
 {
     long flags = 0;
 
@@ -1049,7 +1049,7 @@ void item_details_t::on_edge_style_change()
     SetWindowPos(get_wnd(), nullptr, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED);
 }
 
-void item_details_t::set_edge_style(t_size edge_style)
+void ItemDetails::set_edge_style(t_size edge_style)
 {
     m_edge_style = edge_style;
     if (get_wnd()) {
@@ -1057,7 +1057,7 @@ void item_details_t::set_edge_style(t_size edge_style)
     }
 }
 
-void item_details_t::set_vertical_alignment(t_size vertical_alignment)
+void ItemDetails::set_vertical_alignment(t_size vertical_alignment)
 {
     if (get_wnd()) {
         m_vertical_alignment = vertical_alignment;
@@ -1067,7 +1067,7 @@ void item_details_t::set_vertical_alignment(t_size vertical_alignment)
     }
 }
 
-void item_details_t::set_horizontal_alignment(t_size horizontal_alignment)
+void ItemDetails::set_horizontal_alignment(t_size horizontal_alignment)
 {
     if (get_wnd()) {
         m_horizontal_alignment = horizontal_alignment;
@@ -1077,65 +1077,65 @@ void item_details_t::set_horizontal_alignment(t_size horizontal_alignment)
     }
 }
 
-void item_details_t::on_playback_order_changed(t_size p_new_index) {}
+void ItemDetails::on_playback_order_changed(t_size p_new_index) {}
 
-void item_details_t::on_default_format_changed() {}
+void ItemDetails::on_default_format_changed() {}
 
-void item_details_t::on_playlist_locked(bool p_locked) {}
+void ItemDetails::on_playlist_locked(bool p_locked) {}
 
-void item_details_t::on_playlist_renamed(const char* p_new_name, t_size p_new_name_len) {}
+void ItemDetails::on_playlist_renamed(const char* p_new_name, t_size p_new_name_len) {}
 
-void item_details_t::on_item_ensure_visible(t_size p_idx) {}
+void ItemDetails::on_item_ensure_visible(t_size p_idx) {}
 
-void item_details_t::on_items_replaced(
+void ItemDetails::on_items_replaced(
     const pfc::bit_array& p_mask, const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data)
 {
 }
 
-void item_details_t::on_items_modified_fromplayback(const pfc::bit_array& p_mask, play_control::t_display_level p_level)
+void ItemDetails::on_items_modified_fromplayback(const pfc::bit_array& p_mask, play_control::t_display_level p_level)
 {
 }
 
-void item_details_t::on_items_modified(const pfc::bit_array& p_mask) {}
+void ItemDetails::on_items_modified(const pfc::bit_array& p_mask) {}
 
-void item_details_t::on_items_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) {}
+void ItemDetails::on_items_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) {}
 
-void item_details_t::on_items_removing(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) {}
+void ItemDetails::on_items_removing(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) {}
 
-void item_details_t::on_items_reordered(const t_size* p_order, t_size p_count) {}
+void ItemDetails::on_items_reordered(const t_size* p_order, t_size p_count) {}
 
-void item_details_t::on_items_added(
+void ItemDetails::on_items_added(
     t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const pfc::bit_array& p_selection)
 {
 }
 
-void item_details_t::on_item_focus_change(t_size p_from, t_size p_to) {}
+void ItemDetails::on_item_focus_change(t_size p_from, t_size p_to) {}
 
-void item_details_t::on_volume_change(float p_new_val) {}
+void ItemDetails::on_volume_change(float p_new_val) {}
 
-void item_details_t::on_playback_starting(play_control::t_track_command p_command, bool p_paused) {}
+void ItemDetails::on_playback_starting(play_control::t_track_command p_command, bool p_paused) {}
 
-bool item_details_t::g_track_mode_includes_selection(t_size mode)
+bool ItemDetails::g_track_mode_includes_selection(t_size mode)
 {
     return mode == track_auto_selection_playing || mode == track_selection;
 }
 
-bool item_details_t::g_track_mode_includes_auto(t_size mode)
+bool ItemDetails::g_track_mode_includes_auto(t_size mode)
 {
     return mode == track_auto_playlist_playing || mode == track_auto_selection_playing;
 }
 
-bool item_details_t::g_track_mode_includes_plalist(t_size mode)
+bool ItemDetails::g_track_mode_includes_plalist(t_size mode)
 {
     return mode == track_auto_playlist_playing || mode == track_playlist;
 }
 
-bool item_details_t::g_track_mode_includes_now_playing(t_size mode)
+bool ItemDetails::g_track_mode_includes_now_playing(t_size mode)
 {
     return mode == track_auto_playlist_playing || mode == track_auto_selection_playing || mode == track_playing;
 }
 
-item_details_t::class_data& item_details_t::get_class_data() const
+ItemDetails::class_data& ItemDetails::get_class_data() const
 {
     DWORD flags = 0;
     if (m_edge_style == 1)
@@ -1147,11 +1147,11 @@ item_details_t::class_data& item_details_t::get_class_data() const
     //__implement_get_class_data(L"", false);
 }
 
-uie::window_factory<item_details_t> g_item_details;
+uie::window_factory<ItemDetails> g_item_details;
 
-item_details_t::menu_node_wwrap::menu_node_wwrap(item_details_t* p_wnd) : p_this(p_wnd) {}
+ItemDetails::menu_node_wwrap::menu_node_wwrap(ItemDetails* p_wnd) : p_this(p_wnd) {}
 
-void item_details_t::menu_node_wwrap::execute()
+void ItemDetails::menu_node_wwrap::execute()
 {
     p_this->m_word_wrapping = !p_this->m_word_wrapping;
     cfg_item_details_word_wrapping = p_this->m_word_wrapping;
@@ -1161,21 +1161,21 @@ void item_details_t::menu_node_wwrap::execute()
     p_this->update_now();
 }
 
-bool item_details_t::menu_node_wwrap::get_description(pfc::string_base& p_out) const
+bool ItemDetails::menu_node_wwrap::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool item_details_t::menu_node_wwrap::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::menu_node_wwrap::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Word wrapping";
     p_displayflags = (p_this->m_word_wrapping) ? ui_extension::menu_node_t::state_checked : 0;
     return true;
 }
 
-item_details_t::menu_node_hscroll::menu_node_hscroll(item_details_t* p_wnd) : p_this(p_wnd) {}
+ItemDetails::menu_node_hscroll::menu_node_hscroll(ItemDetails* p_wnd) : p_this(p_wnd) {}
 
-void item_details_t::menu_node_hscroll::execute()
+void ItemDetails::menu_node_hscroll::execute()
 {
     p_this->m_hscroll = !p_this->m_hscroll;
     cfg_item_details_hscroll = p_this->m_hscroll;
@@ -1185,36 +1185,36 @@ void item_details_t::menu_node_hscroll::execute()
     p_this->update_now();
 }
 
-bool item_details_t::menu_node_hscroll::get_description(pfc::string_base& p_out) const
+bool ItemDetails::menu_node_hscroll::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool item_details_t::menu_node_hscroll::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::menu_node_hscroll::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Allow horizontal scrolling";
     p_displayflags = (p_this->m_hscroll) ? ui_extension::menu_node_t::state_checked : 0;
     return true;
 }
 
-item_details_t::menu_node_alignment_popup::menu_node_alignment_popup(item_details_t* p_wnd)
+ItemDetails::menu_node_alignment_popup::menu_node_alignment_popup(ItemDetails* p_wnd)
 {
     m_items.add_item(new menu_node_alignment(p_wnd, 0));
     m_items.add_item(new menu_node_alignment(p_wnd, 1));
     m_items.add_item(new menu_node_alignment(p_wnd, 2));
 }
 
-void item_details_t::menu_node_alignment_popup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
+void ItemDetails::menu_node_alignment_popup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
 {
     p_out = m_items[p_index].get_ptr();
 }
 
-unsigned item_details_t::menu_node_alignment_popup::get_children_count() const
+unsigned ItemDetails::menu_node_alignment_popup::get_children_count() const
 {
     return m_items.get_count();
 }
 
-bool item_details_t::menu_node_alignment_popup::get_display_data(
+bool ItemDetails::menu_node_alignment_popup::get_display_data(
     pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Alignment";
@@ -1222,12 +1222,12 @@ bool item_details_t::menu_node_alignment_popup::get_display_data(
     return true;
 }
 
-item_details_t::menu_node_alignment::menu_node_alignment(item_details_t* p_wnd, t_size p_value)
+ItemDetails::menu_node_alignment::menu_node_alignment(ItemDetails* p_wnd, t_size p_value)
     : p_this(p_wnd), m_type(p_value)
 {
 }
 
-void item_details_t::menu_node_alignment::execute()
+void ItemDetails::menu_node_alignment::execute()
 {
     p_this->m_horizontal_alignment = m_type;
     cfg_item_details_horizontal_alignment = m_type;
@@ -1236,19 +1236,19 @@ void item_details_t::menu_node_alignment::execute()
     p_this->update_now();
 }
 
-bool item_details_t::menu_node_alignment::get_description(pfc::string_base& p_out) const
+bool ItemDetails::menu_node_alignment::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool item_details_t::menu_node_alignment::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::menu_node_alignment::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = get_name(m_type);
     p_displayflags = (m_type == p_this->m_horizontal_alignment) ? ui_extension::menu_node_t::state_radiochecked : 0;
     return true;
 }
 
-const char* item_details_t::menu_node_alignment::get_name(t_size source)
+const char* ItemDetails::menu_node_alignment::get_name(t_size source)
 {
     if (source == 0)
         return "Left";
@@ -1258,7 +1258,7 @@ const char* item_details_t::menu_node_alignment::get_name(t_size source)
     return "Right";
 }
 
-item_details_t::menu_node_source_popup::menu_node_source_popup(item_details_t* p_wnd)
+ItemDetails::menu_node_source_popup::menu_node_source_popup(ItemDetails* p_wnd)
 {
     m_items.add_item(new menu_node_track_mode(p_wnd, 3));
     m_items.add_item(new menu_node_track_mode(p_wnd, 0));
@@ -1268,48 +1268,48 @@ item_details_t::menu_node_source_popup::menu_node_source_popup(item_details_t* p
     m_items.add_item(new menu_node_track_mode(p_wnd, 1));
 }
 
-void item_details_t::menu_node_source_popup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
+void ItemDetails::menu_node_source_popup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
 {
     p_out = m_items[p_index].get_ptr();
 }
 
-unsigned item_details_t::menu_node_source_popup::get_children_count() const
+unsigned ItemDetails::menu_node_source_popup::get_children_count() const
 {
     return m_items.get_count();
 }
 
-bool item_details_t::menu_node_source_popup::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::menu_node_source_popup::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Displayed track";
     p_displayflags = 0;
     return true;
 }
 
-item_details_t::menu_node_track_mode::menu_node_track_mode(item_details_t* p_wnd, t_size p_value)
+ItemDetails::menu_node_track_mode::menu_node_track_mode(ItemDetails* p_wnd, t_size p_value)
     : p_this(p_wnd), m_source(p_value)
 {
 }
 
-void item_details_t::menu_node_track_mode::execute()
+void ItemDetails::menu_node_track_mode::execute()
 {
     p_this->m_tracking_mode = m_source;
     cfg_item_details_tracking_mode = m_source;
     p_this->on_tracking_mode_change();
 }
 
-bool item_details_t::menu_node_track_mode::get_description(pfc::string_base& p_out) const
+bool ItemDetails::menu_node_track_mode::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool item_details_t::menu_node_track_mode::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
+bool ItemDetails::menu_node_track_mode::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = get_name(m_source);
     p_displayflags = (m_source == p_this->m_tracking_mode) ? ui_extension::menu_node_t::state_radiochecked : 0;
     return true;
 }
 
-const char* item_details_t::menu_node_track_mode::get_name(t_size source)
+const char* ItemDetails::menu_node_track_mode::get_name(t_size source)
 {
     if (source == track_playing)
         return "Playing item";

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -21,31 +21,31 @@ extern cfg_uint cfg_item_details_horizontal_alignment;
 extern cfg_uint cfg_item_details_vertical_alignment;
 extern cfg_bool cfg_item_details_word_wrapping;
 
-class line_info_t {
+class LineInfo {
 public:
     t_size m_bytes{NULL};
     t_size m_raw_bytes{NULL};
 
-    line_info_t() = default;
+    LineInfo() = default;
 };
 
-class display_line_info_t : public line_info_t {
+class DisplayLineInfo : public LineInfo {
 public:
     t_size m_width{0};
     t_size m_height{0};
 
-    display_line_info_t() = default;
+    DisplayLineInfo() = default;
 };
 
-class font_data_t {
+class FontData {
 public:
     pfc::string8 m_face;
     t_size m_point{10};
     bool m_bold{false}, m_underline{false}, m_italic{false};
 
-    font_data_t() = default;
+    FontData() = default;
 
-    static int g_compare(const font_data_t& item1, const font_data_t& item2)
+    static int g_compare(const FontData& item1, const FontData& item2)
     {
         int ret = stricmp_utf8(item1.m_face, item2.m_face);
         if (ret == 0)
@@ -60,51 +60,51 @@ public:
     }
 };
 
-bool operator==(const font_data_t& item1, const font_data_t& item2);
+bool operator==(const FontData& item1, const FontData& item2);
 
-class font_change_data_t {
+class FontChangeData {
 public:
-    font_data_t m_font_data;
+    FontData m_font_data;
     bool m_reset{false};
     t_size m_character_index{NULL};
 
-    font_change_data_t() = default;
+    FontChangeData() = default;
 };
 
-using font_change_data_list_t = pfc::list_t<font_change_data_t, pfc::alloc_fast_aggressive>;
+using font_change_data_list_t = pfc::list_t<FontChangeData, pfc::alloc_fast_aggressive>;
 
-using line_info_list_t = pfc::list_t<line_info_t, pfc::alloc_fast_aggressive>;
-using display_line_info_list_t = pfc::list_t<display_line_info_t, pfc::alloc_fast_aggressive>;
+using line_info_list_t = pfc::list_t<LineInfo, pfc::alloc_fast_aggressive>;
+using display_line_info_list_t = pfc::list_t<DisplayLineInfo, pfc::alloc_fast_aggressive>;
 
-void g_parse_font_format_string(const char* str, t_size len, font_data_t& p_out);
+void g_parse_font_format_string(const char* str, t_size len, FontData& p_out);
 void g_get_text_font_data(const char* p_text, pfc::string8_fast_aggressive& p_new_text, font_change_data_list_t& p_out);
 
-class font_t : public pfc::refcounted_object_root {
+class Font : public pfc::refcounted_object_root {
 public:
-    using ptr_t = pfc::refcounted_object_ptr_t<font_t>;
+    using ptr_t = pfc::refcounted_object_ptr_t<Font>;
 
-    font_data_t m_data;
+    FontData m_data;
 
     gdi_object_t<HFONT>::ptr_t m_font;
     t_size m_height{};
     // font_t (const font_t & p_font) : m_font(p_font.m_font), m_height(p_font.m_height), m_data(p_font.m_data) {};
 };
 
-using font_list_t = pfc::list_t<font_t::ptr_t>;
+using font_list_t = pfc::list_t<Font::ptr_t>;
 
-class font_change_info_t {
+class FontChangeNotify {
 public:
     class font_change_entry_t {
     public:
         t_size m_text_index{};
-        font_t::ptr_t m_font;
+        Font::ptr_t m_font;
     };
 
     font_list_t m_fonts;
     pfc::array_t<font_change_entry_t> m_font_changes;
-    font_t::ptr_t m_default_font;
+    Font::ptr_t m_default_font;
 
-    bool find_font(const font_data_t& p_font, t_size& index);
+    bool find_font(const FontData& p_font, t_size& index);
 
     void reset(bool bKeepHandles = false);
 };
@@ -112,25 +112,25 @@ public:
 // void get_multiline_text_dimensions(HDC dc, pfc::string8_fast_aggressive & text, line_info_list_t & indices, t_size
 // line_height, SIZE & sz, bool b_word_wrapping = false, t_size max_width = pfc_infinite);
 void g_get_multiline_text_dimensions(HDC dc, pfc::string8_fast_aggressive& text_new, const line_info_list_t& rawLines,
-    display_line_info_list_t& displayLines, const font_change_info_t& p_font_data, t_size line_height, SIZE& sz,
+    display_line_info_list_t& displayLines, const FontChangeNotify& p_font_data, t_size line_height, SIZE& sz,
     bool b_word_wrapping = false, t_size max_width = pfc_infinite);
 // void get_multiline_text_dimensions_const(HDC dc, const char * text, const line_info_list_t & indices, t_size
 // line_height, SIZE & sz, bool b_word_wrapping = false, t_size max_width = pfc_infinite);
 void g_get_multiline_text_dimensions_const(HDC dc, const char* text, const line_info_list_t& indices,
-    const font_change_info_t& p_font_data, t_size line_height, SIZE& sz, bool b_word_wrapping = false,
+    const FontChangeNotify& p_font_data, t_size line_height, SIZE& sz, bool b_word_wrapping = false,
     t_size max_width = pfc_infinite);
 void g_get_text_multiline_data(const char* text, pfc::string8_fast_aggressive& p_out,
-    pfc::list_t<line_info_t, pfc::alloc_fast_aggressive>& indices);
+    pfc::list_t<LineInfo, pfc::alloc_fast_aggressive>& indices);
 
-void g_parse_font_format_string(const char* str, t_size len, font_data_t& p_out);
+void g_parse_font_format_string(const char* str, t_size len, FontData& p_out);
 void g_get_text_font_data(const char* p_text, pfc::string8_fast_aggressive& p_new_text, font_change_data_list_t& p_out);
-void g_get_text_font_info(const font_change_data_list_t& p_data, font_change_info_t& p_info);
+void g_get_text_font_info(const font_change_data_list_t& p_data, FontChangeNotify& p_info);
 
 void g_text_out_multiline_font(HDC dc, const RECT& rc_topleft, t_size line_height, const char* text,
-    const font_change_info_t& p_font_data, const display_line_info_list_t& newLineDataWrapped, const SIZE& sz,
+    const FontChangeNotify& p_font_data, const display_line_info_list_t& newLineDataWrapped, const SIZE& sz,
     COLORREF cr_text, uih::alignment align, bool b_hscroll, bool word_wrapping);
 
-class titleformat_hook_change_font : public titleformat_hook {
+class TitleformatHookChangeFont : public titleformat_hook {
 public:
     bool process_field(
         titleformat_text_out* p_out, const char* p_name, unsigned p_name_length, bool& p_found_flag) override;
@@ -138,18 +138,18 @@ public:
     bool process_function(titleformat_text_out* p_out, const char* p_name, unsigned p_name_length,
         titleformat_hook_function_params* p_params, bool& p_found_flag) override;
 
-    titleformat_hook_change_font(const LOGFONT& lf);
+    TitleformatHookChangeFont(const LOGFONT& lf);
 
 private:
     pfc::string8 m_default_font_face;
     t_size m_default_font_size;
 };
 
-class font_code_generator_t {
-    class string_font_code : private pfc::string8_fast_aggressive {
+class FontCodeGenerator {
+    class StringFontCode : private pfc::string8_fast_aggressive {
     public:
         operator const char*() const;
-        string_font_code(const LOGFONT& lf);
+        StringFontCode(const LOGFONT& lf);
     };
 
 public:
@@ -166,12 +166,12 @@ class ItemDetails
     , public play_callback
     , public playlist_callback_single
     , public metadb_io_callback_dynamic {
-    class message_window_t : public ui_helpers::container_window {
+    class MessageWindow : public ui_helpers::container_window {
         class_data& get_class_data() const override;
         LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     };
 
-    static message_window_t g_message_window;
+    static MessageWindow g_message_window;
 
     enum {
         MSG_REFRESH = WM_USER + 2,
@@ -196,7 +196,7 @@ public:
 
     bool g_track_mode_includes_selection(t_size mode);
 
-    class menu_node_track_mode : public ui_extension::menu_node_command_t {
+    class MenuNodeTrackMode : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemDetails> p_this;
         t_size m_source;
 
@@ -205,22 +205,22 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_track_mode(ItemDetails* p_wnd, t_size p_value);
+        MenuNodeTrackMode(ItemDetails* p_wnd, t_size p_value);
         ;
     };
 
-    class menu_node_source_popup : public ui_extension::menu_node_popup_t {
+    class MenuNodeSourcePopup : public ui_extension::menu_node_popup_t {
         pfc::list_t<ui_extension::menu_node_ptr> m_items;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
-        menu_node_source_popup(ItemDetails* p_wnd);
+        MenuNodeSourcePopup(ItemDetails* p_wnd);
         ;
     };
 
-    class menu_node_alignment : public ui_extension::menu_node_command_t {
+    class MenuNodeAlignment : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemDetails> p_this;
         t_size m_type;
 
@@ -229,50 +229,50 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_alignment(ItemDetails* p_wnd, t_size p_value);
+        MenuNodeAlignment(ItemDetails* p_wnd, t_size p_value);
         ;
     };
 
-    class menu_node_alignment_popup : public ui_extension::menu_node_popup_t {
+    class MenuNodeAlignmentPopup : public ui_extension::menu_node_popup_t {
         pfc::list_t<ui_extension::menu_node_ptr> m_items;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
-        menu_node_alignment_popup(ItemDetails* p_wnd);
+        MenuNodeAlignmentPopup(ItemDetails* p_wnd);
         ;
     };
 
-    class menu_node_options : public ui_extension::menu_node_command_t {
+    class MenuNodeOptions : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemDetails> p_this;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_options(ItemDetails* p_wnd);
+        MenuNodeOptions(ItemDetails* p_wnd);
         ;
     };
-    class menu_node_hscroll : public ui_extension::menu_node_command_t {
+    class MenuNodeHorizontalScrolling : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemDetails> p_this;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_hscroll(ItemDetails* p_wnd);
+        MenuNodeHorizontalScrolling(ItemDetails* p_wnd);
         ;
     };
 
-    class menu_node_wwrap : public ui_extension::menu_node_command_t {
+    class MenuNodeWordWrap : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemDetails> p_this;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_wwrap(ItemDetails* p_wnd);
+        MenuNodeWordWrap(ItemDetails* p_wnd);
         ;
     };
 
@@ -399,7 +399,7 @@ private:
     t_size m_tracking_mode;
 
     bool m_font_change_info_valid{false};
-    font_change_info_t m_font_change_info;
+    FontChangeNotify m_font_change_info;
     font_change_data_list_t m_font_change_data;
 
     line_info_list_t m_line_info;
@@ -424,13 +424,13 @@ private:
     // HWND m_wnd_richedit;
 };
 
-class item_details_config_t {
+class ItemDetailsConfig {
 public:
     pfc::string8 m_script;
     uint32_t m_edge_style{};
     uint32_t m_horizontal_alignment{};
     uint32_t m_vertical_alignment{};
-    font_code_generator_t m_font_code_generator;
+    FontCodeGenerator m_font_code_generator;
     bool m_modal{};
     bool m_timer_active{};
     service_ptr_t<ItemDetails> m_this;
@@ -439,7 +439,7 @@ public:
     enum { timer_id = 100 };
 
     static BOOL CALLBACK g_DialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    item_details_config_t(const char* p_text, uint32_t edge_style, uint32_t halign, uint32_t valign);
+    ItemDetailsConfig(const char* p_text, uint32_t edge_style, uint32_t halign, uint32_t valign);
 
     bool run_modal(HWND wnd);
     void run_modeless(HWND wnd, ItemDetails* p_this);

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -160,7 +160,7 @@ private:
     LOGFONT m_lf{};
 };
 
-class item_details_t
+class ItemDetails
     : public uie::container_ui_extension
     , public ui_selection_callback
     , public play_callback
@@ -197,7 +197,7 @@ public:
     bool g_track_mode_includes_selection(t_size mode);
 
     class menu_node_track_mode : public ui_extension::menu_node_command_t {
-        service_ptr_t<item_details_t> p_this;
+        service_ptr_t<ItemDetails> p_this;
         t_size m_source;
 
     public:
@@ -205,7 +205,7 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_track_mode(item_details_t* p_wnd, t_size p_value);
+        menu_node_track_mode(ItemDetails* p_wnd, t_size p_value);
         ;
     };
 
@@ -216,12 +216,12 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
-        menu_node_source_popup(item_details_t* p_wnd);
+        menu_node_source_popup(ItemDetails* p_wnd);
         ;
     };
 
     class menu_node_alignment : public ui_extension::menu_node_command_t {
-        service_ptr_t<item_details_t> p_this;
+        service_ptr_t<ItemDetails> p_this;
         t_size m_type;
 
     public:
@@ -229,7 +229,7 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_alignment(item_details_t* p_wnd, t_size p_value);
+        menu_node_alignment(ItemDetails* p_wnd, t_size p_value);
         ;
     };
 
@@ -240,39 +240,39 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
-        menu_node_alignment_popup(item_details_t* p_wnd);
+        menu_node_alignment_popup(ItemDetails* p_wnd);
         ;
     };
 
     class menu_node_options : public ui_extension::menu_node_command_t {
-        service_ptr_t<item_details_t> p_this;
+        service_ptr_t<ItemDetails> p_this;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_options(item_details_t* p_wnd);
+        menu_node_options(ItemDetails* p_wnd);
         ;
     };
     class menu_node_hscroll : public ui_extension::menu_node_command_t {
-        service_ptr_t<item_details_t> p_this;
+        service_ptr_t<ItemDetails> p_this;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_hscroll(item_details_t* p_wnd);
+        menu_node_hscroll(ItemDetails* p_wnd);
         ;
     };
 
     class menu_node_wwrap : public ui_extension::menu_node_command_t {
-        service_ptr_t<item_details_t> p_this;
+        service_ptr_t<ItemDetails> p_this;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_wwrap(item_details_t* p_wnd);
+        menu_node_wwrap(ItemDetails* p_wnd);
         ;
     };
 
@@ -349,7 +349,7 @@ public:
 
     void set_config_wnd(HWND wnd);
 
-    item_details_t();
+    ItemDetails();
 
 private:
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
@@ -385,7 +385,7 @@ private:
     void on_font_change();
     void on_colours_change();
 
-    static std::vector<item_details_t*> g_windows;
+    static std::vector<ItemDetails*> g_windows;
 
     ui_selection_holder::ptr m_selection_holder;
     metadb_handle_list m_handles;
@@ -433,7 +433,7 @@ public:
     font_code_generator_t m_font_code_generator;
     bool m_modal{};
     bool m_timer_active{};
-    service_ptr_t<item_details_t> m_this;
+    service_ptr_t<ItemDetails> m_this;
     HWND m_wnd{};
 
     enum { timer_id = 100 };
@@ -442,7 +442,7 @@ public:
     item_details_config_t(const char* p_text, uint32_t edge_style, uint32_t halign, uint32_t valign);
 
     bool run_modal(HWND wnd);
-    void run_modeless(HWND wnd, item_details_t* p_this);
+    void run_modeless(HWND wnd, ItemDetails* p_this);
 
 private:
     void kill_timer();

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -174,7 +174,7 @@ void item_details_config_t::kill_timer()
     }
 }
 
-void item_details_config_t::run_modeless(HWND wnd, item_details_t* p_this)
+void item_details_config_t::run_modeless(HWND wnd, ItemDetails* p_this)
 {
     m_modal = false;
     m_this = p_this;

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -2,7 +2,7 @@
 #include "item_details.h"
 #include "config.h"
 
-BOOL CALLBACK item_details_config_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+BOOL CALLBACK ItemDetailsConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
         /*case DM_GETDEFID:
@@ -152,13 +152,13 @@ BOOL CALLBACK item_details_config_t::on_message(HWND wnd, UINT msg, WPARAM wp, L
     return FALSE;
 }
 
-void item_details_config_t::on_timer()
+void ItemDetailsConfig::on_timer()
 {
     m_this->set_script(m_script);
     kill_timer();
 }
 
-void item_details_config_t::start_timer()
+void ItemDetailsConfig::start_timer()
 {
     kill_timer();
 
@@ -166,7 +166,7 @@ void item_details_config_t::start_timer()
     m_timer_active = true;
 }
 
-void item_details_config_t::kill_timer()
+void ItemDetailsConfig::kill_timer()
 {
     if (m_timer_active) {
         KillTimer(m_wnd, timer_id);
@@ -174,7 +174,7 @@ void item_details_config_t::kill_timer()
     }
 }
 
-void item_details_config_t::run_modeless(HWND wnd, ItemDetails* p_this)
+void ItemDetailsConfig::run_modeless(HWND wnd, ItemDetails* p_this)
 {
     m_modal = false;
     m_this = p_this;
@@ -182,24 +182,24 @@ void item_details_config_t::run_modeless(HWND wnd, ItemDetails* p_this)
         delete this;
 }
 
-bool item_details_config_t::run_modal(HWND wnd)
+bool ItemDetailsConfig::run_modal(HWND wnd)
 {
     m_modal = true;
     return uDialogBox(IDD_ITEM_DETAILS_OPTIONS, wnd, g_DialogProc, (LPARAM)this) != 0;
 }
 
-item_details_config_t::item_details_config_t(const char* p_text, uint32_t edge_style, uint32_t halign, uint32_t valign)
+ItemDetailsConfig::ItemDetailsConfig(const char* p_text, uint32_t edge_style, uint32_t halign, uint32_t valign)
     : m_script(p_text), m_edge_style(edge_style), m_horizontal_alignment(halign), m_vertical_alignment(valign)
 {
 }
 
-BOOL CALLBACK item_details_config_t::g_DialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+BOOL CALLBACK ItemDetailsConfig::g_DialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
-    item_details_config_t* p_data = nullptr;
+    ItemDetailsConfig* p_data = nullptr;
     if (msg == WM_INITDIALOG) {
-        p_data = reinterpret_cast<item_details_config_t*>(lp);
+        p_data = reinterpret_cast<ItemDetailsConfig*>(lp);
         SetWindowLongPtr(wnd, DWLP_USER, lp);
     } else
-        p_data = reinterpret_cast<item_details_config_t*>(GetWindowLongPtr(wnd, DWLP_USER));
+        p_data = reinterpret_cast<ItemDetailsConfig*>(GetWindowLongPtr(wnd, DWLP_USER));
     return p_data ? p_data->on_message(wnd, msg, wp, lp) : FALSE;
 }

--- a/foo_ui_columns/item_details_font.cpp
+++ b/foo_ui_columns/item_details_font.cpp
@@ -2,19 +2,19 @@
 #include "item_details.h"
 #include "config.h"
 
-bool operator==(const font_data_t& item1, const font_data_t& item2)
+bool operator==(const FontData& item1, const FontData& item2)
 {
-    return !font_data_t::g_compare(item1, item2);
+    return !FontData::g_compare(item1, item2);
 }
 
-void font_change_info_t::reset(bool bKeepHandles /*= false*/)
+void FontChangeNotify::reset(bool bKeepHandles /*= false*/)
 {
     if (!bKeepHandles)
         m_fonts.set_size(0);
     m_font_changes.set_size(0);
 }
 
-bool font_change_info_t::find_font(const font_data_t& p_font, t_size& index)
+bool FontChangeNotify::find_font(const FontData& p_font, t_size& index)
 {
     t_size count = m_fonts.get_count();
     for (t_size i = 0; i < count; i++) {
@@ -27,7 +27,7 @@ bool font_change_info_t::find_font(const font_data_t& p_font, t_size& index)
     return false;
 }
 
-titleformat_hook_change_font::titleformat_hook_change_font(const LOGFONT& lf)
+TitleformatHookChangeFont::TitleformatHookChangeFont(const LOGFONT& lf)
 {
     HDC dc = GetDC(nullptr);
     m_default_font_size = -MulDiv(lf.lfHeight, 72, GetDeviceCaps(dc, LOGPIXELSY));
@@ -36,7 +36,7 @@ titleformat_hook_change_font::titleformat_hook_change_font(const LOGFONT& lf)
     m_default_font_face = pfc::stringcvt::string_utf8_from_wide(lf.lfFaceName, tabsize(lf.lfFaceName));
 }
 
-bool titleformat_hook_change_font::process_function(titleformat_text_out* p_out, const char* p_name,
+bool TitleformatHookChangeFont::process_function(titleformat_text_out* p_out, const char* p_name,
     unsigned p_name_length, titleformat_hook_function_params* p_params, bool& p_found_flag)
 {
     p_found_flag = false;
@@ -82,7 +82,7 @@ bool titleformat_hook_change_font::process_function(titleformat_text_out* p_out,
     return false;
 }
 
-bool titleformat_hook_change_font::process_field(
+bool TitleformatHookChangeFont::process_field(
     titleformat_text_out* p_out, const char* p_name, unsigned p_name_length, bool& p_found_flag)
 {
     p_found_flag = false;
@@ -99,21 +99,21 @@ bool titleformat_hook_change_font::process_field(
     return false;
 }
 
-void font_code_generator_t::initialise(const LOGFONT& p_lf_default, HWND parent, UINT edit)
+void FontCodeGenerator::initialise(const LOGFONT& p_lf_default, HWND parent, UINT edit)
 {
     m_lf = p_lf_default;
-    uSendDlgItemMessageText(parent, edit, WM_SETTEXT, 0, string_font_code(m_lf));
+    uSendDlgItemMessageText(parent, edit, WM_SETTEXT, 0, StringFontCode(m_lf));
 }
 
-void font_code_generator_t::run(HWND parent, UINT edit)
+void FontCodeGenerator::run(HWND parent, UINT edit)
 {
     if (auto font_description = cui::fonts::select_font(parent, m_lf); font_description) {
         m_lf = font_description->log_font;
-        uSendDlgItemMessageText(parent, edit, WM_SETTEXT, 0, string_font_code(m_lf));
+        uSendDlgItemMessageText(parent, edit, WM_SETTEXT, 0, StringFontCode(m_lf));
     }
 }
 
-font_code_generator_t::string_font_code::string_font_code(const LOGFONT& lf)
+FontCodeGenerator::StringFontCode::StringFontCode(const LOGFONT& lf)
 {
     prealloc(64);
     HDC dc = GetDC(nullptr);
@@ -132,12 +132,12 @@ font_code_generator_t::string_font_code::string_font_code(const LOGFONT& lf)
     add_string(")");
 }
 
-font_code_generator_t::string_font_code::operator const char*() const
+FontCodeGenerator::StringFontCode::operator const char*() const
 {
     return get_ptr();
 }
 
-void g_parse_font_format_string(const char* str, t_size len, font_data_t& p_out)
+void g_parse_font_format_string(const char* str, t_size len, FontData& p_out)
 {
     t_size ptr = 0;
     while (ptr < len) {

--- a/foo_ui_columns/item_details_font.cpp
+++ b/foo_ui_columns/item_details_font.cpp
@@ -178,7 +178,7 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { item_details_t::g_on_font_change(); }
+    void on_font_changed() const override { ItemDetails::g_on_font_change(); }
 };
 
 class colour_client_item_details : public cui::colours::client {
@@ -195,7 +195,7 @@ public:
     bool get_themes_supported() const override { return false; };
 
     void on_bool_changed(t_size mask) const override{};
-    void on_colour_changed(t_size mask) const override { item_details_t::g_on_colours_change(); };
+    void on_colour_changed(t_size mask) const override { ItemDetails::g_on_colours_change(); };
 };
 
 namespace {

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -22,7 +22,7 @@ void g_get_text_font_data(const char* p_text, pfc::string8_fast_aggressive& p_ne
             bool b_tab = false;
 
             if ((b_tab = *ptr == '\t') || *ptr == '\x7') {
-                font_change_data_t temp;
+                FontChangeData temp;
                 t_size count = ptr - start;
                 ptr++;
 
@@ -58,7 +58,7 @@ void g_get_text_font_data(const char* p_text, pfc::string8_fast_aggressive& p_ne
     }
 }
 
-void g_get_text_font_info(const font_change_data_list_t& p_data, font_change_info_t& p_info)
+void g_get_text_font_info(const font_change_data_list_t& p_data, FontChangeNotify& p_info)
 {
     t_size count = p_data.get_count();
     if (count) {
@@ -96,7 +96,7 @@ void g_get_text_font_info(const font_change_data_list_t& p_data, font_change_inf
                     if (index < maskKeepFonts.get_count())
                         maskKeepFonts[index] = true;
                 } else {
-                    font_t::ptr_t font = new font_t;
+                    Font::ptr_t font = new Font;
                     font->m_font = CreateFontIndirect(&lf);
                     font->m_height = uGetFontHeight(font->m_font);
                     font->m_data = p_data[i].m_font_data;
@@ -152,7 +152,7 @@ bool g_text_ptr_skip_font_change(const char*& ptr)
 }
 
 void g_get_text_multiline_data(const char* text, pfc::string8_fast_aggressive& p_out,
-    pfc::list_t<line_info_t, pfc::alloc_fast_aggressive>& indices)
+    pfc::list_t<LineInfo, pfc::alloc_fast_aggressive>& indices)
 {
     indices.remove_all();
     p_out.prealloc(strlen(text));
@@ -169,7 +169,7 @@ void g_get_text_multiline_data(const char* text, pfc::string8_fast_aggressive& p
             }
         }
 
-        line_info_t temp;
+        LineInfo temp;
         temp.m_raw_bytes = counter;
         // if (*ptr)
         indices.add_item(temp /*p_out.get_length()*/);
@@ -318,7 +318,7 @@ bool text_ptr_find_break(
 #define ELLIPSIS_LEN 3
 
 void g_get_multiline_text_dimensions(HDC dc, pfc::string8_fast_aggressive& text_new, const line_info_list_t& rawLines,
-    display_line_info_list_t& displayLines, const font_change_info_t& p_font_data, t_size line_height, SIZE& sz,
+    display_line_info_list_t& displayLines, const FontChangeNotify& p_font_data, t_size line_height, SIZE& sz,
     bool b_word_wrapping, t_size max_width)
 {
     const int half_padding_size = uih::scale_dpi_value(2);
@@ -538,7 +538,7 @@ void g_get_multiline_text_dimensions(HDC dc, pfc::string8_fast_aggressive& text_
                     // inc--;
                 }
 
-                display_line_info_t temp;
+                DisplayLineInfo temp;
                 temp.m_raw_bytes = inc;
                 temp.m_bytes = temp.m_raw_bytes;
                 if (b_skipped) {
@@ -664,7 +664,7 @@ void get_multiline_text_dimensions_const(HDC dc, const char * text, const line_i
 #endif
 
 void g_get_multiline_text_dimensions_const(HDC dc, const char* text, const line_info_list_t& newLineData,
-    const font_change_info_t& p_font_data, t_size line_height, SIZE& sz, bool b_word_wrapping, t_size width)
+    const FontChangeNotify& p_font_data, t_size line_height, SIZE& sz, bool b_word_wrapping, t_size width)
 {
     pfc::string8_fast_aggressive rawText = text;
     display_line_info_list_t newLineDataWrapped;
@@ -673,7 +673,7 @@ void g_get_multiline_text_dimensions_const(HDC dc, const char* text, const line_
 }
 
 void g_text_out_multiline_font(HDC dc, const RECT& rc_topleft, t_size line_height, const char* text,
-    const font_change_info_t& p_font_data, const display_line_info_list_t& newLineDataWrapped, const SIZE& sz,
+    const FontChangeNotify& p_font_data, const display_line_info_list_t& newLineDataWrapped, const SIZE& sz,
     COLORREF cr_text, uih::alignment align, bool b_hscroll, bool word_wrapping)
 {
     pfc::string8_fast_aggressive rawText = text;

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -81,9 +81,9 @@ public:
 };
 #endif
 
-selection_properties_t::message_window_t selection_properties_t::g_message_window;
+ItemProperties::message_window_t ItemProperties::g_message_window;
 
-std::vector<selection_properties_t*> selection_properties_t::g_windows;
+std::vector<ItemProperties*> ItemProperties::g_windows;
 
 // {862F8A37-16E0-4a74-B27E-2B73DB567D0F}
 const GUID appearance_client_selection_properties_impl::g_guid
@@ -93,24 +93,24 @@ namespace {
 cui::colours::client::factory<appearance_client_selection_properties_impl> g_appearance_client_impl;
 };
 
-void selection_properties_t::g_redraw_all()
+void ItemProperties::g_redraw_all()
 {
     for (auto& window : g_windows)
         window->invalidate_all();
 }
 
-selection_properties_t::message_window_t::class_data& selection_properties_t::message_window_t::get_class_data() const
+ItemProperties::message_window_t::class_data& ItemProperties::message_window_t::get_class_data() const
 {
     __implement_get_class_data_ex(_T("{9D0A0408-59AC-4a96-A3EF-FF26B7B7C118}"), _T(""), false, 0, 0, 0, 0);
 }
 
-LRESULT selection_properties_t::message_window_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT ItemProperties::message_window_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE:
         break;
     case WM_ACTIVATEAPP:
-        selection_properties_t::g_on_app_activate(wp != 0);
+        ItemProperties::g_on_app_activate(wp != 0);
         break;
     case WM_DESTROY:
         break;
@@ -118,12 +118,12 @@ LRESULT selection_properties_t::message_window_t::on_message(HWND wnd, UINT msg,
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-void selection_properties_t::g_on_app_activate(bool b_activated)
+void ItemProperties::g_on_app_activate(bool b_activated)
 {
     for (auto& window : g_windows)
         window->on_app_activate(b_activated);
 }
-void selection_properties_t::on_app_activate(bool b_activated)
+void ItemProperties::on_app_activate(bool b_activated)
 {
     if (b_activated) {
         if (GetFocus() != get_wnd())
@@ -133,24 +133,24 @@ void selection_properties_t::on_app_activate(bool b_activated)
     }
 }
 
-const GUID& selection_properties_t::get_extension_guid() const
+const GUID& ItemProperties::get_extension_guid() const
 {
     return g_guid_selection_properties;
 }
-void selection_properties_t::get_name(pfc::string_base& p_out) const
+void ItemProperties::get_name(pfc::string_base& p_out) const
 {
     p_out = "Item properties";
 }
-void selection_properties_t::get_category(pfc::string_base& p_out) const
+void ItemProperties::get_category(pfc::string_base& p_out) const
 {
     p_out = "Panels";
 }
-unsigned selection_properties_t::get_type() const
+unsigned ItemProperties::get_type() const
 {
     return uie::type_panel;
 }
 
-void selection_properties_t::set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
+void ItemProperties::set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
 {
     if (!p_size)
         return;
@@ -196,7 +196,7 @@ void selection_properties_t::set_config(stream_reader* p_reader, t_size p_size, 
     p_reader->read_lendian_t(m_column_field_width.dpi, p_abort);
 }
 
-void selection_properties_t::get_config(stream_writer* p_writer, abort_callback& p_abort) const
+void ItemProperties::get_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
     p_writer->write_lendian_t(t_size(config_version_current), p_abort);
     t_size count = m_fields.get_count();
@@ -219,7 +219,7 @@ void selection_properties_t::get_config(stream_writer* p_writer, abort_callback&
     p_writer->write_lendian_t(m_column_field_width.dpi, p_abort);
 }
 
-void selection_properties_t::notify_on_initialisation()
+void ItemProperties::notify_on_initialisation()
 {
     set_autosize(m_autosizing_columns);
     LOGFONT lf;
@@ -233,7 +233,7 @@ void selection_properties_t::notify_on_initialisation()
     set_show_header(m_show_column_titles);
     set_group_level_indentation_enabled(false);
 }
-void selection_properties_t::notify_on_create()
+void ItemProperties::notify_on_create()
 {
     pfc::list_t<Column> columns;
     columns.add_item(Column("Field", m_column_name_width, 0));
@@ -251,7 +251,7 @@ void selection_properties_t::notify_on_create()
         g_message_window.create(nullptr);
     g_windows.push_back(this);
 }
-void selection_properties_t::notify_on_destroy()
+void ItemProperties::notify_on_destroy()
 {
     g_windows.erase(std::remove(g_windows.begin(), g_windows.end(), this), g_windows.end());
     if (g_windows.empty())
@@ -266,13 +266,13 @@ void selection_properties_t::notify_on_destroy()
     m_selection_holder.release();
 }
 
-void selection_properties_t::notify_on_set_focus(HWND wnd_lost)
+void ItemProperties::notify_on_set_focus(HWND wnd_lost)
 {
     deregister_callback();
     m_selection_holder = static_api_ptr_t<ui_selection_manager>()->acquire();
     m_selection_holder->set_selection(m_handles);
 }
-void selection_properties_t::notify_on_kill_focus(HWND wnd_receiving)
+void ItemProperties::notify_on_kill_focus(HWND wnd_receiving)
 {
     m_selection_holder.release();
     register_callback();
@@ -288,13 +288,13 @@ void selection_properties_t::notify_on_kill_focus(HWND wnd_receiving)
     }*/
 }
 
-void selection_properties_t::register_callback()
+void ItemProperties::register_callback()
 {
     if (!m_callback_registered)
         g_ui_selection_manager_register_callback_no_now_playing_fallback(this);
     m_callback_registered = true;
 }
-void selection_properties_t::deregister_callback()
+void ItemProperties::deregister_callback()
 {
     if (m_callback_registered)
         static_api_ptr_t<ui_selection_manager>()->unregister_callback(this);
@@ -409,7 +409,7 @@ public:
 private:
 };
 
-void selection_properties_t::refresh_contents()
+void ItemProperties::refresh_contents()
 {
     bool b_redraw = disable_redrawing();
 
@@ -491,7 +491,7 @@ void selection_properties_t::refresh_contents()
         enable_redrawing();
 }
 
-void selection_properties_t::on_playback_new_track(metadb_handle_ptr p_track)
+void ItemProperties::on_playback_new_track(metadb_handle_ptr p_track)
 {
     if (m_tracking_mode == track_nowplaying || m_tracking_mode == track_automatic) {
         m_handles.remove_all();
@@ -500,7 +500,7 @@ void selection_properties_t::on_playback_new_track(metadb_handle_ptr p_track)
     }
 }
 
-void selection_properties_t::on_playback_stop(play_control::t_stop_reason p_reason)
+void ItemProperties::on_playback_stop(play_control::t_stop_reason p_reason)
 {
     if (p_reason != play_control::stop_reason_starting_another && p_reason != play_control::stop_reason_shutting_down) {
         if (m_tracking_mode == track_nowplaying || m_tracking_mode == track_automatic) {
@@ -513,7 +513,7 @@ void selection_properties_t::on_playback_stop(play_control::t_stop_reason p_reas
     }
 }
 
-void selection_properties_t::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook)
+void ItemProperties::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook)
 {
     if (!p_fromhook) {
         bool b_refresh = false;
@@ -529,7 +529,7 @@ void selection_properties_t::on_changed_sorted(metadb_handle_list_cref p_items_s
     }
 }
 
-bool selection_properties_t::check_process_on_selection_changed()
+bool ItemProperties::check_process_on_selection_changed()
 {
     HWND wnd_focus = GetFocus();
     if (wnd_focus == nullptr)
@@ -540,7 +540,7 @@ bool selection_properties_t::check_process_on_selection_changed()
     return processid == GetCurrentProcessId();
 }
 
-void selection_properties_t::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection)
+void ItemProperties::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection)
 {
     if (check_process_on_selection_changed()) {
         if (g_ui_selection_manager_is_now_playing_fallback())
@@ -562,7 +562,7 @@ void selection_properties_t::on_selection_changed(const pfc::list_base_const_t<m
     // console::formatter() << "Selection properties panel refreshed in: " << timer.query() << " seconds";
 }
 
-void selection_properties_t::on_tracking_mode_change()
+void ItemProperties::on_tracking_mode_change()
 {
     m_handles.remove_all();
     if (m_tracking_mode == track_selection
@@ -584,7 +584,7 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { selection_properties_t::g_on_font_items_change(); }
+    void on_font_changed() const override { ItemProperties::g_on_font_items_change(); }
 };
 
 class font_header_client_selection_properties : public cui::fonts::client {
@@ -594,7 +594,7 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { selection_properties_t::g_on_font_header_change(); }
+    void on_font_changed() const override { ItemProperties::g_on_font_header_change(); }
 };
 
 class font_group_client_selection_properties : public cui::fonts::client {
@@ -604,9 +604,9 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { selection_properties_t::g_on_font_groups_change(); }
+    void on_font_changed() const override { ItemProperties::g_on_font_groups_change(); }
 };
-void selection_properties_t::g_on_font_items_change()
+void ItemProperties::g_on_font_items_change()
 {
     LOGFONT lf;
     static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
@@ -615,7 +615,7 @@ void selection_properties_t::g_on_font_items_change()
     }
 }
 
-void selection_properties_t::g_on_font_groups_change()
+void ItemProperties::g_on_font_groups_change()
 {
     LOGFONT lf;
     static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
@@ -624,7 +624,7 @@ void selection_properties_t::g_on_font_groups_change()
     }
 }
 
-void selection_properties_t::g_on_font_header_change()
+void ItemProperties::g_on_font_header_change()
 {
     LOGFONT lf;
     static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
@@ -633,7 +633,7 @@ void selection_properties_t::g_on_font_header_change()
     }
 }
 
-selection_properties_t::selection_properties_t()
+ItemProperties::ItemProperties()
     : m_tracking_mode(cfg_selection_properties_tracking_mode)
     , m_info_sections_mask(cfg_selection_properties_info_sections)
     , m_show_column_titles(cfg_selection_poperties_show_column_titles)
@@ -657,7 +657,7 @@ selection_properties_t::selection_properties_t()
     m_fields.add_item(field_t("Comment", "COMMENT"));
 }
 
-void selection_properties_t::notify_save_inline_edit(const char* value)
+void ItemProperties::notify_save_inline_edit(const char* value)
 {
     static_api_ptr_t<metadb_io_v2> tagger_api;
     if (strcmp(value, "<mixed values>") != 0) {
@@ -722,7 +722,7 @@ void selection_properties_t::notify_save_inline_edit(const char* value)
     m_edit_handles.remove_all();
 }
 
-bool selection_properties_t::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
+bool ItemProperties::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
     pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
 {
     t_size indices_count = indices.get_count();
@@ -756,7 +756,7 @@ bool selection_properties_t::notify_create_inline_edit(const pfc::list_base_cons
     return false;
 }
 
-void selection_properties_t::g_print_field(const char* field, const file_info& p_info, pfc::string_base& p_out)
+void ItemProperties::g_print_field(const char* field, const file_info& p_info, pfc::string_base& p_out)
 {
     t_size meta_index = p_info.meta_find(field);
     if (meta_index != pfc_infinite) {
@@ -766,13 +766,13 @@ void selection_properties_t::g_print_field(const char* field, const file_info& p
     }
 }
 
-bool selection_properties_t::notify_before_create_inline_edit(
+bool ItemProperties::notify_before_create_inline_edit(
     const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse)
 {
     return m_handles.get_count() && column == 1 && indices.get_count() == 1 && indices[0] < m_fields.get_count();
 }
 
-void selection_properties_t::notify_on_column_size_change(t_size index, int new_width)
+void ItemProperties::notify_on_column_size_change(t_size index, int new_width)
 {
     if (index == 0)
         m_column_name_width = new_width;
@@ -780,20 +780,20 @@ void selection_properties_t::notify_on_column_size_change(t_size index, int new_
         m_column_field_width = new_width;
 }
 
-bool selection_properties_t::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
+bool ItemProperties::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
 {
     uie::window_ptr p_this = this;
     bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
     return ret;
 }
 
-bool selection_properties_t::notify_on_keyboard_keydown_copy()
+bool ItemProperties::notify_on_keyboard_keydown_copy()
 {
     copy_selected_items_as_text(1);
     return true;
 }
 
-void selection_properties_t::get_menu_items(ui_extension::menu_hook_t& p_hook)
+void ItemProperties::get_menu_items(ui_extension::menu_hook_t& p_hook)
 {
     ui_extension::menu_node_ptr p_node = new menu_node_source_popup(this);
     p_hook.add_node(p_node);
@@ -803,7 +803,7 @@ void selection_properties_t::get_menu_items(ui_extension::menu_hook_t& p_hook)
     p_hook.add_node(p_node);
 }
 
-bool selection_properties_t::show_config_popup(HWND wnd_parent)
+bool ItemProperties::show_config_popup(HWND wnd_parent)
 {
     selection_properties_config_t dialog(
         m_fields, m_edge_style, m_info_sections_mask, m_show_column_titles, m_show_group_titles);
@@ -835,7 +835,7 @@ bool selection_properties_t::show_config_popup(HWND wnd_parent)
     return false;
 }
 
-bool selection_properties_t::have_config_popup() const
+bool ItemProperties::have_config_popup() const
 {
     return true;
 }
@@ -847,9 +847,9 @@ font_header_client_selection_properties::factory<font_header_client_selection_pr
 font_group_client_selection_properties::factory<font_group_client_selection_properties>
     g_font_group_client_selection_properties;
 } // namespace
-uie::window_factory<selection_properties_t> g_selection_properties;
+uie::window_factory<ItemProperties> g_selection_properties;
 
-selection_properties_t::menu_node_source_popup::menu_node_source_popup(selection_properties_t* p_wnd)
+ItemProperties::menu_node_source_popup::menu_node_source_popup(ItemProperties* p_wnd)
 {
     m_items.add_item(new menu_node_track_mode(p_wnd, 2));
     m_items.add_item(new menu_node_track_mode(p_wnd, 0));
@@ -858,17 +858,17 @@ selection_properties_t::menu_node_source_popup::menu_node_source_popup(selection
     m_items.add_item(new menu_node_track_mode(p_wnd, 1));
 }
 
-void selection_properties_t::menu_node_source_popup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
+void ItemProperties::menu_node_source_popup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
 {
     p_out = m_items[p_index].get_ptr();
 }
 
-unsigned selection_properties_t::menu_node_source_popup::get_children_count() const
+unsigned ItemProperties::menu_node_source_popup::get_children_count() const
 {
     return m_items.get_count();
 }
 
-bool selection_properties_t::menu_node_source_popup::get_display_data(
+bool ItemProperties::menu_node_source_popup::get_display_data(
     pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Tracking mode";
@@ -876,20 +876,20 @@ bool selection_properties_t::menu_node_source_popup::get_display_data(
     return true;
 }
 
-selection_properties_t::menu_node_autosize::menu_node_autosize(selection_properties_t* p_wnd) : p_this(p_wnd) {}
+ItemProperties::menu_node_autosize::menu_node_autosize(ItemProperties* p_wnd) : p_this(p_wnd) {}
 
-void selection_properties_t::menu_node_autosize::execute()
+void ItemProperties::menu_node_autosize::execute()
 {
     p_this->m_autosizing_columns = !p_this->m_autosizing_columns;
     p_this->set_autosize(p_this->m_autosizing_columns);
 }
 
-bool selection_properties_t::menu_node_autosize::get_description(pfc::string_base& p_out) const
+bool ItemProperties::menu_node_autosize::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool selection_properties_t::menu_node_autosize::get_display_data(
+bool ItemProperties::menu_node_autosize::get_display_data(
     pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Auto-sizing columns";
@@ -897,24 +897,24 @@ bool selection_properties_t::menu_node_autosize::get_display_data(
     return true;
 }
 
-selection_properties_t::menu_node_track_mode::menu_node_track_mode(selection_properties_t* p_wnd, t_size p_value)
+ItemProperties::menu_node_track_mode::menu_node_track_mode(ItemProperties* p_wnd, t_size p_value)
     : p_this(p_wnd), m_source(p_value)
 {
 }
 
-void selection_properties_t::menu_node_track_mode::execute()
+void ItemProperties::menu_node_track_mode::execute()
 {
     p_this->m_tracking_mode = m_source;
     cfg_selection_properties_tracking_mode = m_source;
     p_this->on_tracking_mode_change();
 }
 
-bool selection_properties_t::menu_node_track_mode::get_description(pfc::string_base& p_out) const
+bool ItemProperties::menu_node_track_mode::get_description(pfc::string_base& p_out) const
 {
     return false;
 }
 
-bool selection_properties_t::menu_node_track_mode::get_display_data(
+bool ItemProperties::menu_node_track_mode::get_display_data(
     pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = get_name(m_source);
@@ -922,7 +922,7 @@ bool selection_properties_t::menu_node_track_mode::get_display_data(
     return true;
 }
 
-const char* selection_properties_t::menu_node_track_mode::get_name(t_size source)
+const char* ItemProperties::menu_node_track_mode::get_name(t_size source)
 {
     if (source == track_nowplaying)
         return "Playing item";
@@ -975,5 +975,5 @@ int track_property_callback_itemproperties::track_property_t::g_compare(self_t c
 
 void appearance_client_selection_properties_impl::on_colour_changed(t_size mask) const
 {
-    selection_properties_t::g_redraw_all();
+    ItemProperties::g_redraw_all();
 }

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -117,7 +117,7 @@ private:
     fields_list_view_t m_field_list;
 };
 
-class selection_properties_t
+class ItemProperties
     : public t_list_view_panel<appearance_client_selection_properties_impl, uie::window>
     , public ui_selection_callback
     , public play_callback
@@ -152,7 +152,7 @@ public:
     bool have_config_popup() const override;
     bool show_config_popup(HWND wnd_parent) override;
     class menu_node_track_mode : public ui_extension::menu_node_command_t {
-        service_ptr_t<selection_properties_t> p_this;
+        service_ptr_t<ItemProperties> p_this;
         t_size m_source;
 
     public:
@@ -160,17 +160,17 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_track_mode(selection_properties_t* p_wnd, t_size p_value);
+        menu_node_track_mode(ItemProperties* p_wnd, t_size p_value);
         ;
     };
     class menu_node_autosize : public ui_extension::menu_node_command_t {
-        service_ptr_t<selection_properties_t> p_this;
+        service_ptr_t<ItemProperties> p_this;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_autosize(selection_properties_t* p_wnd);
+        menu_node_autosize(ItemProperties* p_wnd);
         ;
     };
     class menu_node_source_popup : public ui_extension::menu_node_popup_t {
@@ -180,7 +180,7 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
-        menu_node_source_popup(selection_properties_t* p_wnd);
+        menu_node_source_popup(ItemProperties* p_wnd);
         ;
     };
 
@@ -225,7 +225,7 @@ public:
     static void g_on_font_header_change();
     static void g_on_font_groups_change();
 
-    selection_properties_t();
+    ItemProperties();
 
 private:
     void register_callback();
@@ -235,7 +235,7 @@ private:
     void on_tracking_mode_change();
     bool check_process_on_selection_changed();
 
-    static std::vector<selection_properties_t*> g_windows;
+    static std::vector<ItemProperties*> g_windows;
 
     ui_selection_holder::ptr m_selection_holder;
     metadb_handle_list m_handles, m_selection_handles;

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -2,26 +2,26 @@
 
 #include "list_view_panel.h"
 
-struct info_section_t {
+struct InfoSection {
     t_uint32 id;
     const char* name;
-    info_section_t(t_uint32 p_id, const char* p_name) : id(p_id), name(p_name){};
+    InfoSection(t_uint32 p_id, const char* p_name) : id(p_id), name(p_name){};
 };
 
-class field_t {
+class Field {
 public:
     pfc::string8 m_name;
     pfc::string8 m_name_friendly;
 
-    field_t(const char* friendly, const char* field) : m_name(field), m_name_friendly(friendly){};
-    field_t() = default;
+    Field(const char* friendly, const char* field) : m_name(field), m_name_friendly(friendly){};
+    Field() = default;
 };
 
-class fields_list_view_t : public uih::ListView {
+class FieldsList : public uih::ListView {
 public:
     t_size m_edit_index, m_edit_column;
-    pfc::list_t<field_t>& m_fields;
-    fields_list_view_t(pfc::list_t<field_t>& p_fields);
+    pfc::list_t<Field>& m_fields;
+    FieldsList(pfc::list_t<Field>& p_fields);
 
     void get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& items);
     void notify_on_create() override;
@@ -37,9 +37,9 @@ private:
 t_size g_get_info_secion_index_by_name(const char* p_name);
 t_size g_get_info_secion_index_by_id(t_size id);
 
-extern const info_section_t g_info_sections[5];
+extern const InfoSection g_info_sections[5];
 
-class track_property_callback_itemproperties : public track_property_callback_v2 {
+class ItemPropertiesTrackPropertyCallback : public track_property_callback_v2 {
 public:
     class track_property_t {
     public:
@@ -72,11 +72,11 @@ public:
     bool is_group_wanted(const char* p_group) override;
     void sort();
 
-    track_property_callback_itemproperties();
+    ItemPropertiesTrackPropertyCallback();
     pfc::array_staticsize_t<pfc::list_t<track_property_t>> m_values;
 };
 
-class appearance_client_selection_properties_impl : public cui::colours::client {
+class ItemPropertiesColoursClient : public cui::colours::client {
 public:
     static const GUID g_guid;
 
@@ -97,16 +97,16 @@ public:
     void on_bool_changed(t_size mask) const override{};
 };
 
-class selection_properties_config_t {
+class ItemPropertiesConfig {
 public:
-    pfc::list_t<field_t> m_fields;
+    pfc::list_t<Field> m_fields;
     t_size m_edge_style;
     t_uint32 m_info_sections_mask;
     bool m_show_columns, m_show_groups;
 
     bool m_initialising;
     static BOOL CALLBACK g_DialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    selection_properties_config_t(pfc::list_t<field_t> p_fields, t_size edge_style, t_uint32 info_sections_mask,
+    ItemPropertiesConfig(pfc::list_t<Field> p_fields, t_size edge_style, t_uint32 info_sections_mask,
         bool b_show_columns, bool b_show_groups);
 
     bool run_modal(HWND wnd);
@@ -114,27 +114,27 @@ public:
 private:
     BOOL CALLBACK on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
-    fields_list_view_t m_field_list;
+    FieldsList m_field_list;
 };
 
 class ItemProperties
-    : public t_list_view_panel<appearance_client_selection_properties_impl, uie::window>
+    : public t_list_view_panel<ItemPropertiesColoursClient, uie::window>
     , public ui_selection_callback
     , public play_callback
     , public metadb_io_callback_dynamic {
-    class message_window_t : public ui_helpers::container_window {
+    class MessageWindow : public ui_helpers::container_window {
         class_data& get_class_data() const override;
         LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     };
 
-    static message_window_t g_message_window;
+    static MessageWindow g_message_window;
 
     enum {
         MSG_REFRESH = WM_USER + 2,
     };
 
 public:
-    enum tracking_mode_t {
+    enum TrackingMode {
         track_selection,
         track_nowplaying,
         track_automatic,
@@ -151,7 +151,7 @@ public:
 
     bool have_config_popup() const override;
     bool show_config_popup(HWND wnd_parent) override;
-    class menu_node_track_mode : public ui_extension::menu_node_command_t {
+    class MenuNodeTrackMode : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemProperties> p_this;
         t_size m_source;
 
@@ -160,27 +160,27 @@ public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_track_mode(ItemProperties* p_wnd, t_size p_value);
+        MenuNodeTrackMode(ItemProperties* p_wnd, t_size p_value);
         ;
     };
-    class menu_node_autosize : public ui_extension::menu_node_command_t {
+    class ModeNodeAutosize : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemProperties> p_this;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        menu_node_autosize(ItemProperties* p_wnd);
+        ModeNodeAutosize(ItemProperties* p_wnd);
         ;
     };
-    class menu_node_source_popup : public ui_extension::menu_node_popup_t {
+    class MenuNodeSourcePopup : public ui_extension::menu_node_popup_t {
         pfc::list_t<ui_extension::menu_node_ptr> m_items;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
-        menu_node_source_popup(ItemProperties* p_wnd);
+        MenuNodeSourcePopup(ItemProperties* p_wnd);
         ;
     };
 
@@ -239,7 +239,7 @@ private:
 
     ui_selection_holder::ptr m_selection_holder;
     metadb_handle_list m_handles, m_selection_handles;
-    pfc::list_t<field_t> m_fields;
+    pfc::list_t<Field> m_fields;
     bool m_callback_registered{false};
     t_size m_tracking_mode;
 

--- a/foo_ui_columns/item_properties_config.cpp
+++ b/foo_ui_columns/item_properties_config.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "item_properties.h"
 
-BOOL CALLBACK selection_properties_config_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_INITDIALOG: {
@@ -118,7 +118,7 @@ BOOL CALLBACK selection_properties_config_t::on_message(HWND wnd, UINT msg, WPAR
             }
         } break;
         case IDC_NEW: {
-            field_t temp;
+            Field temp;
             temp.m_name_friendly = "<enter name here>";
             temp.m_name = "<ENTER FIELD HERE>";
             t_size index = m_fields.add_item(temp);
@@ -161,12 +161,12 @@ BOOL CALLBACK selection_properties_config_t::on_message(HWND wnd, UINT msg, WPAR
     return FALSE;
 }
 
-bool selection_properties_config_t::run_modal(HWND wnd)
+bool ItemPropertiesConfig::run_modal(HWND wnd)
 {
     return uDialogBox(IDD_ITEM_PROPS_OPTIONS, wnd, g_DialogProc, (LPARAM)this) != 0;
 }
 
-selection_properties_config_t::selection_properties_config_t(pfc::list_t<field_t> p_fields, t_size edge_style,
+ItemPropertiesConfig::ItemPropertiesConfig(pfc::list_t<Field> p_fields, t_size edge_style,
     t_uint32 info_sections_mask, bool b_show_columns, bool b_show_groups)
     : m_fields(std::move(p_fields))
     , m_edge_style(edge_style)
@@ -178,13 +178,13 @@ selection_properties_config_t::selection_properties_config_t(pfc::list_t<field_t
 {
 }
 
-BOOL CALLBACK selection_properties_config_t::g_DialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+BOOL CALLBACK ItemPropertiesConfig::g_DialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
-    selection_properties_config_t* p_data = nullptr;
+    ItemPropertiesConfig* p_data = nullptr;
     if (msg == WM_INITDIALOG) {
-        p_data = reinterpret_cast<selection_properties_config_t*>(lp);
+        p_data = reinterpret_cast<ItemPropertiesConfig*>(lp);
         SetWindowLongPtr(wnd, DWLP_USER, lp);
     } else
-        p_data = reinterpret_cast<selection_properties_config_t*>(GetWindowLongPtr(wnd, DWLP_USER));
+        p_data = reinterpret_cast<ItemPropertiesConfig*>(GetWindowLongPtr(wnd, DWLP_USER));
     return p_data ? p_data->on_message(wnd, msg, wp, lp) : FALSE;
 }

--- a/foo_ui_columns/item_properties_config_list_view.cpp
+++ b/foo_ui_columns/item_properties_config_list_view.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "item_properties.h"
 
-void fields_list_view_t::notify_save_inline_edit(const char* value)
+void FieldsList::notify_save_inline_edit(const char* value)
 {
     if (m_edit_index < m_fields.get_count()) {
         (m_edit_column ? m_fields[m_edit_index].m_name : m_fields[m_edit_index].m_name_friendly) = value;
@@ -15,7 +15,7 @@ void fields_list_view_t::notify_save_inline_edit(const char* value)
     m_edit_index = pfc_infinite;
 }
 
-bool fields_list_view_t::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
+bool FieldsList::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
     pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
 {
     t_size indices_count = indices.get_count();
@@ -33,13 +33,13 @@ bool fields_list_view_t::notify_create_inline_edit(const pfc::list_base_const_t<
     return false;
 }
 
-bool fields_list_view_t::notify_before_create_inline_edit(
+bool FieldsList::notify_before_create_inline_edit(
     const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse)
 {
     return column <= 1 && indices.get_count() == 1;
 }
 
-void fields_list_view_t::notify_on_create()
+void FieldsList::notify_on_create()
 {
     set_single_selection(true);
     pfc::list_t<Column> columns;
@@ -56,7 +56,7 @@ void fields_list_view_t::notify_on_create()
     insert_items(0, count, items.get_ptr());
 }
 
-void fields_list_view_t::get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& items)
+void FieldsList::get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& items)
 {
     items.set_count(count);
     for (t_size i = 0; i < count; i++) {
@@ -66,7 +66,7 @@ void fields_list_view_t::get_insert_items(t_size base, t_size count, pfc::list_t
     }
 }
 
-fields_list_view_t::fields_list_view_t(pfc::list_t<field_t>& p_fields)
+FieldsList::FieldsList(pfc::list_t<Field>& p_fields)
     : m_edit_index(pfc_infinite), m_edit_column(pfc_infinite), m_fields(p_fields)
 {
 }

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -9,7 +9,7 @@ static const GUID g_guid_layout = {0x755971a7, 0x109b, 0x41dc, {0xbe, 0xd9, 0x5a
 
 ConfigLayout cfg_layout(g_guid_layout);
 
-class window_host_layout : public ui_extension::window_host {
+class LayoutWindowHost : public ui_extension::window_host {
 public:
     const GUID& get_host_guid() const override
     {
@@ -52,7 +52,7 @@ public:
     void relinquish_ownership(HWND wnd) override { g_layout_window.relinquish_child(); }
 };
 
-ui_extension::window_host_factory_single<window_host_layout> g_window_host_layout_factory;
+ui_extension::window_host_factory_single<LayoutWindowHost> g_window_host_layout_factory;
 
 bool LayoutWindow::set_focus()
 {
@@ -527,9 +527,9 @@ void LayoutWindow::run_live_edit_base_delayed(HWND wnd, POINT pt, pfc::list_t<ui
     PostMessage(get_wnd(), MSG_EDIT_PANEL, NULL, NULL);
 }
 
-class panel_list_t : public pfc::list_t<uie::window::ptr> {
+class PanelList : public pfc::list_t<uie::window::ptr> {
 public:
-    panel_list_t()
+    PanelList()
     {
         service_enum_t<ui_extension::window> e;
         uie::window_ptr l;
@@ -559,7 +559,7 @@ void g_get_panels_info(const pfc::list_t<uie::window::ptr>& p_panels, uie::windo
     p_out.sort_by_category_and_name();
 }
 
-void LayoutWindow::run_live_edit_base(const live_edit_data_t& p_data)
+void LayoutWindow::run_live_edit_base(const LiveEditData& p_data)
 {
     if (m_trans_fill.get_wnd())
         return;
@@ -591,7 +591,7 @@ void LayoutWindow::run_live_edit_base(const live_edit_data_t& p_data)
     ShowWindow(wnd_over, SW_SHOWNOACTIVATE);
 
     HMENU menu = CreatePopupMenu();
-    panel_list_t panel_list;
+    PanelList panel_list;
     pfc::list_t<uie::window::ptr> supported_panels(panel_list);
     pfc::bit_array_bittable mask_remove(supported_panels.get_count());
     if (p_container_v2.is_valid())

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -54,18 +54,18 @@ public:
 
 ui_extension::window_host_factory_single<window_host_layout> g_window_host_layout_factory;
 
-bool layout_window::set_focus()
+bool LayoutWindow::set_focus()
 {
     return __set_focus_recur(m_child);
 }
 
-void layout_window::show_window()
+void LayoutWindow::show_window()
 {
     ShowWindow(m_child_wnd, SW_SHOWNORMAL);
     ShowWindow(get_wnd(), SW_SHOWNORMAL);
 }
 
-bool layout_window::__set_focus_recur(const uie::window_ptr& p_wnd)
+bool LayoutWindow::__set_focus_recur(const uie::window_ptr& p_wnd)
 {
     service_ptr_t<uie::playlist_window> p_playlist_wnd;
     service_ptr_t<uie::splitter_window> p_splitter_wnd;
@@ -90,12 +90,12 @@ bool layout_window::__set_focus_recur(const uie::window_ptr& p_wnd)
     return false;
 }
 
-void layout_window::show_menu_access_keys()
+void LayoutWindow::show_menu_access_keys()
 {
     return __show_menu_access_keys_recur(m_child);
 }
 
-void layout_window::__show_menu_access_keys_recur(const uie::window_ptr& p_wnd)
+void LayoutWindow::__show_menu_access_keys_recur(const uie::window_ptr& p_wnd)
 {
     service_ptr_t<uie::menu_window> p_menu_wnd;
     service_ptr_t<uie::splitter_window> p_splitter_wnd;
@@ -114,17 +114,17 @@ void layout_window::__show_menu_access_keys_recur(const uie::window_ptr& p_wnd)
     }
 }
 
-void layout_window::hide_menu_access_keys()
+void LayoutWindow::hide_menu_access_keys()
 {
     __hide_menu_access_keys_recur(m_child);
 }
 
-bool layout_window::on_menu_char(unsigned short c)
+bool LayoutWindow::on_menu_char(unsigned short c)
 {
     return __on_menu_char_recur(m_child, c);
 }
 
-bool layout_window::__on_menu_char_recur(const uie::window_ptr& p_wnd, unsigned short c)
+bool LayoutWindow::__on_menu_char_recur(const uie::window_ptr& p_wnd, unsigned short c)
 {
     service_ptr_t<uie::menu_window> p_menu_wnd;
     service_ptr_t<uie::splitter_window> p_splitter_wnd;
@@ -145,12 +145,12 @@ bool layout_window::__on_menu_char_recur(const uie::window_ptr& p_wnd, unsigned 
     return false;
 }
 
-bool layout_window::set_menu_focus()
+bool LayoutWindow::set_menu_focus()
 {
     return __set_menu_focus_recur(m_child);
 }
 
-bool layout_window::__set_menu_focus_recur(const uie::window_ptr& p_wnd)
+bool LayoutWindow::__set_menu_focus_recur(const uie::window_ptr& p_wnd)
 {
     bool ret = false;
     service_ptr_t<uie::menu_window> p_menu_wnd;
@@ -180,7 +180,7 @@ bool layout_window::__set_menu_focus_recur(const uie::window_ptr& p_wnd)
     return ret;
 }
 
-void layout_window::set_layout_editing_active(bool b_val)
+void LayoutWindow::set_layout_editing_active(bool b_val)
 {
     if (b_val) {
         if (!m_layout_editing_active)
@@ -192,12 +192,12 @@ void layout_window::set_layout_editing_active(bool b_val)
         m_layout_editing_active = false;
     }
 }
-bool layout_window::get_layout_editing_active()
+bool LayoutWindow::get_layout_editing_active()
 {
     return m_layout_editing_active;
 }
 
-void layout_window::enter_layout_editing_mode()
+void LayoutWindow::enter_layout_editing_mode()
 {
     if (get_wnd()) {
         uih::register_message_hook(uih::MessageHookType::type_get_message, this);
@@ -206,19 +206,19 @@ void layout_window::enter_layout_editing_mode()
     //__enter_layout_editing_mode_recur(m_child);
 }
 
-void layout_window::exit_layout_editing_mode()
+void LayoutWindow::exit_layout_editing_mode()
 {
     uih::deregister_message_hook(uih::MessageHookType::type_get_message, this);
     uih::deregister_message_hook(uih::MessageHookType::type_mouse, this);
     //__exit_layout_editing_mode_recur(m_child);
 }
 
-bool layout_window::is_menu_focused()
+bool LayoutWindow::is_menu_focused()
 {
     return __is_menu_focused_recur(m_child);
 }
 
-bool layout_window::__is_menu_focused_recur(const uie::window_ptr& p_wnd)
+bool LayoutWindow::__is_menu_focused_recur(const uie::window_ptr& p_wnd)
 {
     service_ptr_t<uie::menu_window> p_menu_wnd;
     service_ptr_t<uie::splitter_window> p_splitter_wnd;
@@ -241,14 +241,14 @@ bool layout_window::__is_menu_focused_recur(const uie::window_ptr& p_wnd)
     return false;
 }
 
-HWND layout_window::get_previous_menu_focus_window() const
+HWND LayoutWindow::get_previous_menu_focus_window() const
 {
     HWND ret = nullptr;
     __get_previous_menu_focus_window_recur(m_child, ret);
     return ret;
 }
 
-bool layout_window::__get_previous_menu_focus_window_recur(const uie::window_ptr& p_wnd, HWND& wnd_previous) const
+bool LayoutWindow::__get_previous_menu_focus_window_recur(const uie::window_ptr& p_wnd, HWND& wnd_previous) const
 {
     service_ptr_t<uie::menu_window_v2> p_menu_wnd;
     service_ptr_t<uie::splitter_window> p_splitter_wnd;
@@ -273,7 +273,7 @@ bool layout_window::__get_previous_menu_focus_window_recur(const uie::window_ptr
     return false;
 }
 
-void layout_window::__hide_menu_access_keys_recur(const uie::window_ptr& p_wnd)
+void LayoutWindow::__hide_menu_access_keys_recur(const uie::window_ptr& p_wnd)
 {
     service_ptr_t<uie::menu_window> p_menu_wnd;
     service_ptr_t<uie::splitter_window> p_splitter_wnd;
@@ -292,7 +292,7 @@ void layout_window::__hide_menu_access_keys_recur(const uie::window_ptr& p_wnd)
     }
 }
 
-void layout_window::get_child(uie::splitter_item_ptr& p_out)
+void LayoutWindow::get_child(uie::splitter_item_ptr& p_out)
 {
     p_out = new uie::splitter_item_simple_t;
     p_out->set_panel_guid(m_child_guid);
@@ -304,7 +304,7 @@ void layout_window::get_child(uie::splitter_item_ptr& p_out)
     } else
         p_out->set_panel_config_from_ptr(m_child_data.get_ptr(), m_child_data.get_size());
 }
-void layout_window::set_child(const uie::splitter_item_t* item)
+void LayoutWindow::set_child(const uie::splitter_item_t* item)
 {
     if (get_wnd()) {
         SendMessage(get_wnd(), WM_SETREDRAW, FALSE, 0);
@@ -355,7 +355,7 @@ void __get_panel_list_recur(const uie::window_ptr& p_wnd, pfc::list_base_t<GUID>
     }
 }
 
-bool layout_window::import_config_to_object(stream_reader* p_reader, t_size psize, t_uint32 mode,
+bool LayoutWindow::import_config_to_object(stream_reader* p_reader, t_size psize, t_uint32 mode,
     cfg_layout_t::preset& p_out, pfc::list_base_t<GUID>& panels, abort_callback& p_abort)
 {
     // uie::splitter_item_ptr item = new uie::splitter_item_simple_t;
@@ -407,7 +407,7 @@ bool layout_window::import_config_to_object(stream_reader* p_reader, t_size psiz
     // p_out.set(item);
 }
 
-void layout_window::export_config(
+void LayoutWindow::export_config(
     stream_writer* p_out, t_uint32 mode, pfc::list_base_t<GUID>& panels, abort_callback& p_abort)
 {
     enum { stream_version = 0 };
@@ -469,7 +469,7 @@ void layout_window::export_config(
     }
 }
 
-void layout_window::create_child()
+void LayoutWindow::create_child()
 {
     RECT rc;
     GetClientRect(get_wnd(), &rc);
@@ -489,7 +489,7 @@ void layout_window::create_child()
         }
     }
 }
-void layout_window::destroy_child()
+void LayoutWindow::destroy_child()
 {
     if (m_child_wnd && m_child.is_valid()) {
         abort_callback_dummy p_abort;
@@ -499,14 +499,14 @@ void layout_window::destroy_child()
     }
 }
 
-void layout_window::relinquish_child()
+void LayoutWindow::relinquish_child()
 {
     m_child_wnd = nullptr;
     m_child.release();
     m_child_data.set_size(0);
 }
 
-void layout_window::refresh_child()
+void LayoutWindow::refresh_child()
 {
     uie::splitter_item_ptr item;
     cfg_layout.get_active_preset_for_use(item);
@@ -519,7 +519,7 @@ void layout_window::refresh_child()
     }
 }
 
-void layout_window::run_live_edit_base_delayed(HWND wnd, POINT pt, pfc::list_t<uie::window::ptr>& p_hierarchy)
+void LayoutWindow::run_live_edit_base_delayed(HWND wnd, POINT pt, pfc::list_t<uie::window::ptr>& p_hierarchy)
 {
     m_live_edit_data.m_hierarchy = p_hierarchy;
     m_live_edit_data.m_wnd = wnd;
@@ -559,7 +559,7 @@ void g_get_panels_info(const pfc::list_t<uie::window::ptr>& p_panels, uie::windo
     p_out.sort_by_category_and_name();
 }
 
-void layout_window::run_live_edit_base(const live_edit_data_t& p_data)
+void LayoutWindow::run_live_edit_base(const live_edit_data_t& p_data)
 {
     if (m_trans_fill.get_wnd())
         return;
@@ -798,7 +798,7 @@ void layout_window::run_live_edit_base(const live_edit_data_t& p_data)
     }
 }
 
-bool layout_window::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp)
+bool LayoutWindow::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp)
 {
     if (p_type == uih::MessageHookType::type_get_message) {
         auto* lpmsg = (LPMSG)lp;
@@ -865,7 +865,7 @@ bool layout_window::on_hooked_message(uih::MessageHookType p_type, int code, WPA
     return false;
 }
 
-LRESULT layout_window::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT LayoutWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE:

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -356,7 +356,7 @@ void __get_panel_list_recur(const uie::window_ptr& p_wnd, pfc::list_base_t<GUID>
 }
 
 bool LayoutWindow::import_config_to_object(stream_reader* p_reader, t_size psize, t_uint32 mode,
-    ConfigLayout::preset& p_out, pfc::list_base_t<GUID>& panels, abort_callback& p_abort)
+    ConfigLayout::Preset& p_out, pfc::list_base_t<GUID>& panels, abort_callback& p_abort)
 {
     // uie::splitter_item_ptr item = new uie::splitter_item_simple_t;
     GUID guid;

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -7,7 +7,7 @@
 // {755971A7-109B-41dc-BED9-5A05CC07C905}
 static const GUID g_guid_layout = {0x755971a7, 0x109b, 0x41dc, {0xbe, 0xd9, 0x5a, 0x5, 0xcc, 0x7, 0xc9, 0x5}};
 
-cfg_layout_t cfg_layout(g_guid_layout);
+ConfigLayout cfg_layout(g_guid_layout);
 
 class window_host_layout : public ui_extension::window_host {
 public:
@@ -356,7 +356,7 @@ void __get_panel_list_recur(const uie::window_ptr& p_wnd, pfc::list_base_t<GUID>
 }
 
 bool LayoutWindow::import_config_to_object(stream_reader* p_reader, t_size psize, t_uint32 mode,
-    cfg_layout_t::preset& p_out, pfc::list_base_t<GUID>& panels, abort_callback& p_abort)
+    ConfigLayout::preset& p_out, pfc::list_base_t<GUID>& panels, abort_callback& p_abort)
 {
     // uie::splitter_item_ptr item = new uie::splitter_item_simple_t;
     GUID guid;

--- a/foo_ui_columns/layout.h
+++ b/foo_ui_columns/layout.h
@@ -60,7 +60,7 @@ private:
     // bool m_initialised;
 };
 
-class layout_window
+class LayoutWindow
     : public ui_helpers::container_window
     , private uih::MessageHook {
 public:
@@ -91,7 +91,7 @@ public:
     void set_layout_editing_active(bool b_val);
     bool get_layout_editing_active();
 
-    layout_window() = default;
+    LayoutWindow() = default;
 
 private:
     class live_edit_data_t {
@@ -136,5 +136,5 @@ private:
     live_edit_data_t m_live_edit_data;
 };
 
-extern layout_window g_layout_window;
+extern LayoutWindow g_layout_window;
 extern cfg_layout_t cfg_layout;

--- a/foo_ui_columns/layout.h
+++ b/foo_ui_columns/layout.h
@@ -9,7 +9,7 @@
  * Classes used for hosting panels in the main area of the UI
  */
 
-class cfg_layout_t : public cfg_var {
+class ConfigLayout : public cfg_var {
 public:
     class preset {
     public:
@@ -48,7 +48,7 @@ public:
 
     void reset_presets(); // needs services
 
-    cfg_layout_t(const GUID& p_guid);
+    ConfigLayout(const GUID& p_guid);
 
 private:
     enum { stream_version_current = 0 };
@@ -66,7 +66,7 @@ class LayoutWindow
 public:
     enum { MSG_LAYOUT_SET_FOCUS = WM_USER + 2, MSG_EDIT_PANEL };
 
-    static void g_get_default_presets(pfc::list_t<cfg_layout_t::preset>& p_out);
+    static void g_get_default_presets(pfc::list_t<ConfigLayout::preset>& p_out);
 
     void refresh_child();
     void relinquish_child();
@@ -78,7 +78,7 @@ public:
     void show_window();
 
     void export_config(stream_writer* p_out, t_uint32 mode, pfc::list_base_t<GUID>& panels, abort_callback& p_abort);
-    bool import_config_to_object(stream_reader* p_reader, t_size size, t_uint32 mode, cfg_layout_t::preset& p_out,
+    bool import_config_to_object(stream_reader* p_reader, t_size size, t_uint32 mode, ConfigLayout::preset& p_out,
         pfc::list_base_t<GUID>& panels, abort_callback& p_abort);
 
     void show_menu_access_keys();
@@ -137,4 +137,4 @@ private:
 };
 
 extern LayoutWindow g_layout_window;
-extern cfg_layout_t cfg_layout;
+extern ConfigLayout cfg_layout;

--- a/foo_ui_columns/layout.h
+++ b/foo_ui_columns/layout.h
@@ -94,7 +94,7 @@ public:
     LayoutWindow() = default;
 
 private:
-    class live_edit_data_t {
+    class LiveEditData {
     public:
         pfc::list_t<uie::window::ptr> m_hierarchy;
         POINT m_point;
@@ -107,7 +107,7 @@ private:
     void exit_layout_editing_mode();
     uih::TranslucentFillWindow m_trans_fill;
     void run_live_edit_base_delayed(HWND wnd, POINT pt, pfc::list_t<uie::window::ptr>& p_hierarchy);
-    void run_live_edit_base(const live_edit_data_t& p_data);
+    void run_live_edit_base(const LiveEditData& p_data);
     bool on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp) override;
 
     class_data& get_class_data() const override
@@ -133,7 +133,7 @@ private:
     pfc::array_t<t_uint8> m_child_data;
     HWND m_child_wnd{nullptr};
     bool m_layout_editing_active{false};
-    live_edit_data_t m_live_edit_data;
+    LiveEditData m_live_edit_data;
 };
 
 extern LayoutWindow g_layout_window;

--- a/foo_ui_columns/layout.h
+++ b/foo_ui_columns/layout.h
@@ -11,7 +11,7 @@
 
 class ConfigLayout : public cfg_var {
 public:
-    class preset {
+    class Preset {
     public:
         pfc::array_t<t_uint8> m_val;
         GUID m_guid{};
@@ -26,7 +26,7 @@ public:
     unsigned get_active() { return m_active; }
 
     /** from configuration, not from ui */
-    const pfc::list_base_const_t<preset>& get_presets() const;
+    const pfc::list_base_const_t<Preset>& get_presets() const;
 
     void get_preset(t_size index, uie::splitter_item_ptr& p_out);
     void set_preset(t_size index, const uie::splitter_item_t* item);
@@ -37,11 +37,11 @@ public:
     t_size delete_preset(t_size index);
 
     t_size add_preset(const char* p_name, t_size len = pfc_infinite);
-    t_size add_preset(const preset& item);
+    t_size add_preset(const Preset& item);
     void set_active_preset(t_size index);
     void save_active_preset();
 
-    void set_presets(const pfc::list_base_const_t<preset>& presets, t_size active);
+    void set_presets(const pfc::list_base_const_t<Preset>& presets, t_size active);
     void get_data_raw(stream_writer* out, abort_callback& p_abort) override;
 
     void set_data_raw(stream_reader*, unsigned p_sizehint, abort_callback& p_abort) override;
@@ -53,7 +53,7 @@ public:
 private:
     enum { stream_version_current = 0 };
 
-    pfc::list_t<preset> m_presets;
+    pfc::list_t<Preset> m_presets;
 
     unsigned m_active;
 
@@ -66,7 +66,7 @@ class LayoutWindow
 public:
     enum { MSG_LAYOUT_SET_FOCUS = WM_USER + 2, MSG_EDIT_PANEL };
 
-    static void g_get_default_presets(pfc::list_t<ConfigLayout::preset>& p_out);
+    static void g_get_default_presets(pfc::list_t<ConfigLayout::Preset>& p_out);
 
     void refresh_child();
     void relinquish_child();
@@ -78,7 +78,7 @@ public:
     void show_window();
 
     void export_config(stream_writer* p_out, t_uint32 mode, pfc::list_base_t<GUID>& panels, abort_callback& p_abort);
-    bool import_config_to_object(stream_reader* p_reader, t_size size, t_uint32 mode, ConfigLayout::preset& p_out,
+    bool import_config_to_object(stream_reader* p_reader, t_size size, t_uint32 mode, ConfigLayout::Preset& p_out,
         pfc::list_base_t<GUID>& panels, abort_callback& p_abort);
 
     void show_menu_access_keys();

--- a/foo_ui_columns/layout_config.cpp
+++ b/foo_ui_columns/layout_config.cpp
@@ -314,7 +314,7 @@ void cfg_layout_t::set_presets(const pfc::list_base_const_t<preset>& presets, t_
     }
 }
 
-void layout_window::g_get_default_presets(pfc::list_t<cfg_layout_t::preset>& p_out)
+void LayoutWindow::g_get_default_presets(pfc::list_t<cfg_layout_t::preset>& p_out)
 {
     for (auto&& preset : cui::default_presets::quick_setup_presets)
         p_out.add_item(preset_to_config_preset(preset));

--- a/foo_ui_columns/layout_config.cpp
+++ b/foo_ui_columns/layout_config.cpp
@@ -190,12 +190,12 @@ uie::window::ptr node_to_window(Node node)
     return window;
 }
 
-ConfigLayout::preset preset_to_config_preset(Preset preset)
+ConfigLayout::Preset preset_to_config_preset(Preset preset)
 {
     const auto window = node_to_window(preset.node);
     abort_callback_dummy aborter;
 
-    ConfigLayout::preset preset_default;
+    ConfigLayout::Preset preset_default;
     preset_default.m_name.set_string(preset.name.data(), preset.name.size());
     preset_default.m_guid = preset.node.guid;
     stream_writer_memblock_ref conf(preset_default.m_val, true);
@@ -210,14 +210,14 @@ ConfigLayout::ConfigLayout(const GUID& p_guid)
     , m_active(0) //, m_initialised(false)
     {};
 
-void ConfigLayout::preset::write(stream_writer* out, abort_callback& p_abort)
+void ConfigLayout::Preset::write(stream_writer* out, abort_callback& p_abort)
 {
     out->write_lendian_t(m_guid, p_abort);
     out->write_string(m_name.get_ptr(), p_abort);
     out->write_lendian_t(m_val.get_size(), p_abort);
     out->write(m_val.get_ptr(), m_val.get_size(), p_abort);
 }
-void ConfigLayout::preset::read(stream_reader* stream, abort_callback& p_abort)
+void ConfigLayout::Preset::read(stream_reader* stream, abort_callback& p_abort)
 {
     stream->read_lendian_t(m_guid, p_abort);
     pfc::string8 temp;
@@ -229,14 +229,14 @@ void ConfigLayout::preset::read(stream_reader* stream, abort_callback& p_abort)
     stream->read(m_val.get_ptr(), m_val.get_size(), p_abort);
 }
 
-void ConfigLayout::preset::get(uie::splitter_item_ptr& p_out)
+void ConfigLayout::Preset::get(uie::splitter_item_ptr& p_out)
 {
     p_out = new uie::splitter_item_simple_t;
     p_out->set_panel_guid(m_guid);
     p_out->set_panel_config_from_ptr(m_val.get_ptr(), m_val.get_size());
 }
 
-void ConfigLayout::preset::set(const uie::splitter_item_t* item)
+void ConfigLayout::Preset::set(const uie::splitter_item_t* item)
 {
     m_guid = item->get_panel_guid();
     item->get_panel_config_to_array(m_val, true);
@@ -261,13 +261,13 @@ void ConfigLayout::set_preset(t_size index, const uie::splitter_item_t* item)
     }
 }
 
-t_size ConfigLayout::add_preset(const preset& item)
+t_size ConfigLayout::add_preset(const Preset& item)
 {
     return m_presets.add_item(item);
 }
 t_size ConfigLayout::add_preset(const char* p_name, t_size len)
 {
-    preset temp;
+    Preset temp;
     temp.m_name.set_string(p_name, len);
     temp.m_guid = columns_ui::panels::guid_playlist_view_v2;
     return m_presets.add_item(temp);
@@ -304,7 +304,7 @@ t_size ConfigLayout::delete_preset(t_size index)
     return m_presets.get_count();
 }
 
-void ConfigLayout::set_presets(const pfc::list_base_const_t<preset>& presets, t_size active)
+void ConfigLayout::set_presets(const pfc::list_base_const_t<Preset>& presets, t_size active)
 {
     if (presets.get_count()) {
         m_presets.remove_all();
@@ -314,7 +314,7 @@ void ConfigLayout::set_presets(const pfc::list_base_const_t<preset>& presets, t_
     }
 }
 
-void LayoutWindow::g_get_default_presets(pfc::list_t<ConfigLayout::preset>& p_out)
+void LayoutWindow::g_get_default_presets(pfc::list_t<ConfigLayout::Preset>& p_out)
 {
     for (auto&& preset : cui::default_presets::quick_setup_presets)
         p_out.add_item(preset_to_config_preset(preset));
@@ -348,7 +348,7 @@ void ConfigLayout::set_preset_name(t_size index, const char* ptr, t_size len)
     }
 }
 
-const pfc::list_base_const_t<ConfigLayout::preset>& ConfigLayout::get_presets() const
+const pfc::list_base_const_t<ConfigLayout::Preset>& ConfigLayout::get_presets() const
 {
     return m_presets;
 }
@@ -385,7 +385,7 @@ void ConfigLayout::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, ab
         unsigned count;
         p_reader->read_lendian_t(count, p_abort);
         for (unsigned n = 0; n < count; n++) {
-            preset temp;
+            Preset temp;
             temp.read(p_reader, p_abort);
             m_presets.add_item(temp);
         }

--- a/foo_ui_columns/layout_config.cpp
+++ b/foo_ui_columns/layout_config.cpp
@@ -190,12 +190,12 @@ uie::window::ptr node_to_window(Node node)
     return window;
 }
 
-cfg_layout_t::preset preset_to_config_preset(Preset preset)
+ConfigLayout::preset preset_to_config_preset(Preset preset)
 {
     const auto window = node_to_window(preset.node);
     abort_callback_dummy aborter;
 
-    cfg_layout_t::preset preset_default;
+    ConfigLayout::preset preset_default;
     preset_default.m_name.set_string(preset.name.data(), preset.name.size());
     preset_default.m_guid = preset.node.guid;
     stream_writer_memblock_ref conf(preset_default.m_val, true);
@@ -205,19 +205,19 @@ cfg_layout_t::preset preset_to_config_preset(Preset preset)
 
 } // namespace cui::default_presets
 
-cfg_layout_t::cfg_layout_t(const GUID& p_guid)
+ConfigLayout::ConfigLayout(const GUID& p_guid)
     : cfg_var(p_guid)
     , m_active(0) //, m_initialised(false)
     {};
 
-void cfg_layout_t::preset::write(stream_writer* out, abort_callback& p_abort)
+void ConfigLayout::preset::write(stream_writer* out, abort_callback& p_abort)
 {
     out->write_lendian_t(m_guid, p_abort);
     out->write_string(m_name.get_ptr(), p_abort);
     out->write_lendian_t(m_val.get_size(), p_abort);
     out->write(m_val.get_ptr(), m_val.get_size(), p_abort);
 }
-void cfg_layout_t::preset::read(stream_reader* stream, abort_callback& p_abort)
+void ConfigLayout::preset::read(stream_reader* stream, abort_callback& p_abort)
 {
     stream->read_lendian_t(m_guid, p_abort);
     pfc::string8 temp;
@@ -229,20 +229,20 @@ void cfg_layout_t::preset::read(stream_reader* stream, abort_callback& p_abort)
     stream->read(m_val.get_ptr(), m_val.get_size(), p_abort);
 }
 
-void cfg_layout_t::preset::get(uie::splitter_item_ptr& p_out)
+void ConfigLayout::preset::get(uie::splitter_item_ptr& p_out)
 {
     p_out = new uie::splitter_item_simple_t;
     p_out->set_panel_guid(m_guid);
     p_out->set_panel_config_from_ptr(m_val.get_ptr(), m_val.get_size());
 }
 
-void cfg_layout_t::preset::set(const uie::splitter_item_t* item)
+void ConfigLayout::preset::set(const uie::splitter_item_t* item)
 {
     m_guid = item->get_panel_guid();
     item->get_panel_config_to_array(m_val, true);
 }
 
-void cfg_layout_t::get_preset(t_size index, uie::splitter_item_ptr& p_out)
+void ConfigLayout::get_preset(t_size index, uie::splitter_item_ptr& p_out)
 {
     if (index == m_active && g_layout_window.get_wnd()) {
         g_layout_window.get_child(p_out);
@@ -251,7 +251,7 @@ void cfg_layout_t::get_preset(t_size index, uie::splitter_item_ptr& p_out)
     }
 }
 
-void cfg_layout_t::set_preset(t_size index, const uie::splitter_item_t* item)
+void ConfigLayout::set_preset(t_size index, const uie::splitter_item_t* item)
 {
     if (index == m_active && g_layout_window.get_wnd()) {
         g_layout_window.set_child(item);
@@ -261,18 +261,18 @@ void cfg_layout_t::set_preset(t_size index, const uie::splitter_item_t* item)
     }
 }
 
-t_size cfg_layout_t::add_preset(const preset& item)
+t_size ConfigLayout::add_preset(const preset& item)
 {
     return m_presets.add_item(item);
 }
-t_size cfg_layout_t::add_preset(const char* p_name, t_size len)
+t_size ConfigLayout::add_preset(const char* p_name, t_size len)
 {
     preset temp;
     temp.m_name.set_string(p_name, len);
     temp.m_guid = columns_ui::panels::guid_playlist_view_v2;
     return m_presets.add_item(temp);
 }
-void cfg_layout_t::save_active_preset()
+void ConfigLayout::save_active_preset()
 {
     if (m_active < m_presets.get_count() && g_layout_window.get_wnd()) {
         uie::splitter_item_ptr ptr;
@@ -281,7 +281,7 @@ void cfg_layout_t::save_active_preset()
     }
 }
 
-void cfg_layout_t::set_active_preset(t_size index)
+void ConfigLayout::set_active_preset(t_size index)
 {
     if (index < m_presets.get_count() && m_active != index) {
         m_active = index;
@@ -292,7 +292,7 @@ void cfg_layout_t::set_active_preset(t_size index)
     }
 }
 
-t_size cfg_layout_t::delete_preset(t_size index)
+t_size ConfigLayout::delete_preset(t_size index)
 {
     if (index < m_presets.get_count()) {
         if (index == m_active)
@@ -304,7 +304,7 @@ t_size cfg_layout_t::delete_preset(t_size index)
     return m_presets.get_count();
 }
 
-void cfg_layout_t::set_presets(const pfc::list_base_const_t<preset>& presets, t_size active)
+void ConfigLayout::set_presets(const pfc::list_base_const_t<preset>& presets, t_size active)
 {
     if (presets.get_count()) {
         m_presets.remove_all();
@@ -314,13 +314,13 @@ void cfg_layout_t::set_presets(const pfc::list_base_const_t<preset>& presets, t_
     }
 }
 
-void LayoutWindow::g_get_default_presets(pfc::list_t<cfg_layout_t::preset>& p_out)
+void LayoutWindow::g_get_default_presets(pfc::list_t<ConfigLayout::preset>& p_out)
 {
     for (auto&& preset : cui::default_presets::quick_setup_presets)
         p_out.add_item(preset_to_config_preset(preset));
 }
 
-void cfg_layout_t::reset_presets()
+void ConfigLayout::reset_presets()
 {
     if (core_api::are_services_available()) {
         const auto preset = preset_to_config_preset(cui::default_presets::default_preset);
@@ -335,25 +335,25 @@ void cfg_layout_t::reset_presets()
     }
 }
 
-void cfg_layout_t::get_preset_name(t_size index, pfc::string_base& p_out)
+void ConfigLayout::get_preset_name(t_size index, pfc::string_base& p_out)
 {
     if (index < m_presets.get_count()) {
         p_out = m_presets[index].m_name;
     }
 }
-void cfg_layout_t::set_preset_name(t_size index, const char* ptr, t_size len)
+void ConfigLayout::set_preset_name(t_size index, const char* ptr, t_size len)
 {
     if (index < m_presets.get_count()) {
         m_presets[index].m_name.set_string(ptr, len);
     }
 }
 
-const pfc::list_base_const_t<cfg_layout_t::preset>& cfg_layout_t::get_presets() const
+const pfc::list_base_const_t<ConfigLayout::preset>& ConfigLayout::get_presets() const
 {
     return m_presets;
 }
 
-void cfg_layout_t::get_data_raw(stream_writer* out, abort_callback& p_abort)
+void ConfigLayout::get_data_raw(stream_writer* out, abort_callback& p_abort)
 {
     out->write_lendian_t(t_uint32(stream_version_current), p_abort);
     out->write_lendian_t(m_active, p_abort);
@@ -375,7 +375,7 @@ void cfg_layout_t::get_data_raw(stream_writer* out, abort_callback& p_abort)
     }
 }
 
-void cfg_layout_t::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort)
+void ConfigLayout::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort)
 {
     t_uint32 version;
     p_reader->read_lendian_t(version, p_abort);
@@ -400,7 +400,7 @@ void cfg_layout_t::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, ab
     }
 }
 
-void cfg_layout_t::get_active_preset_for_use(uie::splitter_item_ptr& p_out)
+void ConfigLayout::get_active_preset_for_use(uie::splitter_item_ptr& p_out)
 {
     if (!m_presets.get_count())
         reset_presets();

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -15,7 +15,7 @@
 #include "migrate.h"
 
 rebar_window* g_rebar_window = nullptr;
-layout_window g_layout_window;
+LayoutWindow g_layout_window;
 cui::MainWindow cui::main_window;
 status_pane g_status_pane;
 

--- a/foo_ui_columns/menu_mnemonics.h
+++ b/foo_ui_columns/menu_mnemonics.h
@@ -1,0 +1,109 @@
+#pragma once
+
+/**
+ * This class is borrowed from menu_manager.cpp in the foobar2000 SDK.
+ *
+ * The following licence applies:
+ *
+ * foobar2000 1.4 SDK
+ * Copyright (c) 2001-2018, Peter Pawlowski
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ * disclaimer.
+ *
+ * Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+class MnemonicManager {
+    pfc::string8_fast_aggressive used;
+    bool is_used(unsigned c)
+    {
+        char temp[8];
+        temp[pfc::utf8_encode_char(uCharLower(c), temp)] = 0;
+        return !!strstr(used, temp);
+    }
+
+    static bool is_alphanumeric(char c)
+    {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+    }
+
+    void insert(const char* src, unsigned idx, pfc::string_base& out)
+    {
+        out.reset();
+        out.add_string(src, idx);
+        out.add_string("&");
+        out.add_string(src + idx);
+        used.add_char(uCharLower(src[idx]));
+    }
+
+public:
+    bool check_string(const char* src)
+    { // check for existing mnemonics
+        const char* ptr = src;
+        while (ptr = strchr(ptr, '&')) {
+            if (ptr[1] == '&')
+                ptr += 2;
+            else {
+                unsigned c = 0;
+                if (pfc::utf8_decode_char(ptr + 1, c) > 0) {
+                    if (!is_used(c))
+                        used.add_char(uCharLower(c));
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+    bool process_string(const char* src, pfc::string_base& out) // returns if changed
+    {
+        if (check_string(src)) {
+            out = src;
+            return false;
+        }
+        unsigned idx = 0;
+        while (src[idx] == ' ')
+            idx++;
+        while (src[idx]) {
+            if (is_alphanumeric(src[idx]) && !is_used(src[idx])) {
+                insert(src, idx, out);
+                return true;
+            }
+
+            while (src[idx] && src[idx] != ' ' && src[idx] != '\t')
+                idx++;
+            if (src[idx] == '\t')
+                break;
+            while (src[idx] == ' ')
+                idx++;
+        }
+
+        // no success picking first letter of one of words
+        idx = 0;
+        while (src[idx]) {
+            if (src[idx] == '\t')
+                break;
+            if (is_alphanumeric(src[idx]) && !is_used(src[idx])) {
+                insert(src, idx, out);
+                return true;
+            }
+            idx++;
+        }
+
+        // giving up
+        out = src;
+        return false;
+    }
+};

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "menu_mnemonics.h"
 
 cfg_int cfg_fullsizemenu(GUID{0xe880f267, 0x73de, 0x7952, {0x5b, 0x79, 0xb5, 0xda, 0x77, 0x28, 0x6d, 0xb6}}, 0);
 
@@ -9,89 +10,6 @@ enum {
     MSG_SHOW_MENUACC = WM_USER + 2,
     MSG_CREATE_MENU = WM_USER + 3,
     MSG_SIZE_LIMIT_CHANGE
-};
-
-// from menu_manager.cpp
-class MnemonicManager {
-    pfc::string8_fast_aggressive used;
-    bool is_used(unsigned c)
-    {
-        char temp[8];
-        temp[pfc::utf8_encode_char(uCharLower(c), temp)] = 0;
-        return !!strstr(used, temp);
-    }
-
-    static bool is_alphanumeric(char c)
-    {
-        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
-    }
-
-    void insert(const char* src, unsigned idx, pfc::string_base& out)
-    {
-        out.reset();
-        out.add_string(src, idx);
-        out.add_string("&");
-        out.add_string(src + idx);
-        used.add_char(uCharLower(src[idx]));
-    }
-
-public:
-    bool check_string(const char* src)
-    { // check for existing mnemonics
-        const char* ptr = src;
-        while (ptr = strchr(ptr, '&')) {
-            if (ptr[1] == '&')
-                ptr += 2;
-            else {
-                unsigned c = 0;
-                if (pfc::utf8_decode_char(ptr + 1, c) > 0) {
-                    if (!is_used(c))
-                        used.add_char(uCharLower(c));
-                }
-                return true;
-            }
-        }
-        return false;
-    }
-    bool process_string(const char* src, pfc::string_base& out) // returns if changed
-    {
-        if (check_string(src)) {
-            out = src;
-            return false;
-        }
-        unsigned idx = 0;
-        while (src[idx] == ' ')
-            idx++;
-        while (src[idx]) {
-            if (is_alphanumeric(src[idx]) && !is_used(src[idx])) {
-                insert(src, idx, out);
-                return true;
-            }
-
-            while (src[idx] && src[idx] != ' ' && src[idx] != '\t')
-                idx++;
-            if (src[idx] == '\t')
-                break;
-            while (src[idx] == ' ')
-                idx++;
-        }
-
-        // no success picking first letter of one of words
-        idx = 0;
-        while (src[idx]) {
-            if (src[idx] == '\t')
-                break;
-            if (is_alphanumeric(src[idx]) && !is_used(src[idx])) {
-                insert(src, idx, out);
-                return true;
-            }
-            idx++;
-        }
-
-        // giving up
-        out = src;
-        return false;
-    }
 };
 
 class MainMenuRootGroup {

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -138,7 +138,7 @@ public:
     }
 };
 
-class menu_extension
+class MenuToolbar
     : public ui_extension::container_uie_window_t<uie::menu_window_v2>
     , uih::MessageHook {
     static const TCHAR* class_name;
@@ -199,35 +199,35 @@ public:
     bool is_menu_focused() const override;
     HWND get_previous_focus_window() const override;
 
-    menu_extension();
-    ~menu_extension();
+    MenuToolbar();
+    ~MenuToolbar();
 };
 
-bool menu_extension::hooked = false;
+bool MenuToolbar::hooked = false;
 
-menu_extension::menu_extension() : p_manager(nullptr){};
+MenuToolbar::MenuToolbar() : p_manager(nullptr){};
 
-menu_extension::~menu_extension() = default;
+MenuToolbar::~MenuToolbar() = default;
 
-const TCHAR* menu_extension::class_name = _T("{76E6DB50-0DE3-4f30-A7E4-93FD628B1401}");
+const TCHAR* MenuToolbar::class_name = _T("{76E6DB50-0DE3-4f30-A7E4-93FD628B1401}");
 
-bool menu_extension::is_menu_focused() const
+bool MenuToolbar::is_menu_focused() const
 {
     return GetFocus() == wnd_menu;
 }
 
-HWND menu_extension::get_previous_focus_window() const
+HWND MenuToolbar::get_previous_focus_window() const
 {
     return wnd_prev_focus;
 }
 
-LRESULT WINAPI menu_extension::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI MenuToolbar::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
-    auto p_this = reinterpret_cast<menu_extension*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
+    auto p_this = reinterpret_cast<MenuToolbar*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
     return p_this ? p_this->hook(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
 }
 
-LRESULT menu_extension::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE: {
@@ -422,7 +422,7 @@ LRESULT menu_extension::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-LRESULT WINAPI menu_extension::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI MenuToolbar::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_KILLFOCUS: {
@@ -473,12 +473,12 @@ LRESULT WINAPI menu_extension::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     return uCallWindowProc(menuproc, wnd, msg, wp, lp);
 }
 
-void menu_extension::make_menu(unsigned idx)
+void MenuToolbar::make_menu(unsigned idx)
 {
     if (idx == actual_active || hooked || idx < 1 || idx > m_buttons.get_count())
         return;
 
-    service_ptr_t<menu_extension> dummy = this; // menu command may delete us
+    service_ptr_t<MenuToolbar> dummy = this; // menu command may delete us
 
     actual_active = idx;
 
@@ -583,7 +583,7 @@ void menu_extension::make_menu(unsigned idx)
     actual_active = 0;
 }
 
-bool menu_extension::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp)
+bool MenuToolbar::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp)
 {
     static POINT last_pt;
 
@@ -667,28 +667,28 @@ bool menu_extension::on_hooked_message(uih::MessageHookType p_type, int code, WP
     return false;
 }
 
-void menu_extension::get_name(pfc::string_base& out) const
+void MenuToolbar::get_name(pfc::string_base& out) const
 {
     out.set_string("Menu");
 }
-void menu_extension::get_category(pfc::string_base& out) const
+void MenuToolbar::get_category(pfc::string_base& out) const
 {
     out.set_string("Toolbars");
 }
 
-void menu_extension::set_focus()
+void MenuToolbar::set_focus()
 {
     {
         SetFocus(wnd_menu);
     }
 }
-void menu_extension::show_accelerators()
+void MenuToolbar::show_accelerators()
 {
     {
         show_menu_acc();
     }
 }
-void menu_extension::hide_accelerators()
+void MenuToolbar::hide_accelerators()
 {
     {
         if (GetFocus() != wnd_menu)
@@ -696,7 +696,7 @@ void menu_extension::hide_accelerators()
     }
 }
 
-bool menu_extension::on_menuchar(unsigned short chr)
+bool MenuToolbar::on_menuchar(unsigned short chr)
 {
     {
         UINT id;
@@ -709,7 +709,7 @@ bool menu_extension::on_menuchar(unsigned short chr)
 }
 
 // {76E6DB50-0DE3-4f30-A7E4-93FD628B1401}
-const GUID menu_extension::extension_guid
+const GUID MenuToolbar::extension_guid
     = {0x76e6db50, 0xde3, 0x4f30, {0xa7, 0xe4, 0x93, 0xfd, 0x62, 0x8b, 0x14, 0x1}};
 
-ui_extension::window_factory<menu_extension> blah;
+ui_extension::window_factory<MenuToolbar> blah;

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -12,7 +12,7 @@ enum {
 };
 
 // from menu_manager.cpp
-class mnemonic_manager {
+class MnemonicManager {
     pfc::string8_fast_aggressive used;
     bool is_used(unsigned c)
     {
@@ -94,23 +94,23 @@ public:
     }
 };
 
-class mainmenu_root_group {
+class MainMenuRootGroup {
 public:
     pfc::string8 m_name;
     pfc::array_t<TCHAR> m_name_with_accelerators;
     GUID m_guid{};
     t_uint32 m_sort_priority{NULL};
 
-    mainmenu_root_group() = default;
+    MainMenuRootGroup() = default;
 
-    static t_size g_compare(const mainmenu_root_group& p_item1, const mainmenu_root_group& p_item2)
+    static t_size g_compare(const MainMenuRootGroup& p_item1, const MainMenuRootGroup& p_item2)
     {
         return pfc::compare_t(p_item1.m_sort_priority, p_item2.m_sort_priority);
     }
-    static void g_get_root_items(pfc::list_base_t<mainmenu_root_group>& p_out)
+    static void g_get_root_items(pfc::list_base_t<MainMenuRootGroup>& p_out)
     {
         p_out.remove_all();
-        mnemonic_manager mnemonics;
+        MnemonicManager mnemonics;
 
         service_enum_t<mainmenu_group> e;
         service_ptr_t<mainmenu_group> ptr;
@@ -119,7 +119,7 @@ public:
         while (e.next(ptr)) {
             if (ptr->get_parent() == pfc::guid_null) {
                 if (ptr->service_query_t(ptrp)) {
-                    mainmenu_root_group item;
+                    MainMenuRootGroup item;
                     pfc::string8 name;
                     ptrp->get_display_string(name);
                     item.m_guid = ptrp->get_guid();
@@ -165,7 +165,7 @@ public:
 
     HWND wnd_menu{nullptr};
     HWND wnd_prev_focus{nullptr};
-    pfc::list_t<mainmenu_root_group> m_buttons;
+    pfc::list_t<MainMenuRootGroup> m_buttons;
 
     LRESULT WINAPI hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     static LRESULT WINAPI main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
@@ -233,7 +233,7 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CREATE: {
         initialised = true;
 
-        mainmenu_root_group::g_get_root_items(m_buttons);
+        MainMenuRootGroup::g_get_root_items(m_buttons);
         t_size button_count = m_buttons.get_count();
 
         pfc::array_t<TBBUTTON> tbb;

--- a/foo_ui_columns/mw_drop_target.cpp
+++ b/foo_ui_columns/mw_drop_target.cpp
@@ -7,12 +7,12 @@ extern HWND g_status;
 
 bool g_last_rmb = false;
 
-drop_handler_interface::drop_handler_interface()
+MainWindowDropTarget::MainWindowDropTarget()
 {
     m_DropTargetHelper.instantiate(CLSID_DragDropHelper, nullptr, CLSCTX_INPROC_SERVER);
 }
 
-bool drop_handler_interface::check_window_allowed(HWND wnd)
+bool MainWindowDropTarget::check_window_allowed(HWND wnd)
 {
     return wnd
         && (wnd == cui::main_window.get_wnd() || wnd == g_rebar || (g_rebar && IsChild(g_rebar, wnd))
@@ -20,7 +20,7 @@ bool drop_handler_interface::check_window_allowed(HWND wnd)
                || wnd == g_status);
 }
 
-HRESULT STDMETHODCALLTYPE drop_handler_interface::Drop(
+HRESULT STDMETHODCALLTYPE MainWindowDropTarget::Drop(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -85,7 +85,7 @@ HRESULT STDMETHODCALLTYPE drop_handler_interface::Drop(
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE drop_handler_interface::DragLeave()
+HRESULT STDMETHODCALLTYPE MainWindowDropTarget::DragLeave()
 {
     if (m_DropTargetHelper.is_valid())
         m_DropTargetHelper->DragLeave();
@@ -97,7 +97,7 @@ HRESULT STDMETHODCALLTYPE drop_handler_interface::DragLeave()
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE drop_handler_interface::DragOver(DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
+HRESULT STDMETHODCALLTYPE MainWindowDropTarget::DragOver(DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
     if (m_DropTargetHelper.is_valid())
@@ -129,7 +129,7 @@ HRESULT STDMETHODCALLTYPE drop_handler_interface::DragOver(DWORD grfKeyState, PO
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE drop_handler_interface::DragEnter(
+HRESULT STDMETHODCALLTYPE MainWindowDropTarget::DragEnter(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -161,7 +161,7 @@ HRESULT STDMETHODCALLTYPE drop_handler_interface::DragEnter(
     return S_OK; //??
 }
 
-ULONG STDMETHODCALLTYPE drop_handler_interface::Release()
+ULONG STDMETHODCALLTYPE MainWindowDropTarget::Release()
 {
     LONG rv = InterlockedDecrement(&drop_ref_count);
     if (!rv) {
@@ -173,12 +173,12 @@ ULONG STDMETHODCALLTYPE drop_handler_interface::Release()
     return rv;
 }
 
-ULONG STDMETHODCALLTYPE drop_handler_interface::AddRef()
+ULONG STDMETHODCALLTYPE MainWindowDropTarget::AddRef()
 {
     return InterlockedIncrement(&drop_ref_count);
 }
 
-HRESULT STDMETHODCALLTYPE drop_handler_interface::QueryInterface(REFIID riid, LPVOID FAR* ppvObject)
+HRESULT STDMETHODCALLTYPE MainWindowDropTarget::QueryInterface(REFIID riid, LPVOID FAR* ppvObject)
 {
     if (ppvObject == nullptr)
         return E_INVALIDARG;

--- a/foo_ui_columns/mw_drop_target.h
+++ b/foo_ui_columns/mw_drop_target.h
@@ -9,7 +9,7 @@
  * Class used for handling drag and drop operations on the main window (drop target only)
  */
 
-class drop_handler_interface : public IDropTarget {
+class MainWindowDropTarget : public IDropTarget {
 public:
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID FAR* ppvObject) override;
     ULONG STDMETHODCALLTYPE AddRef() override;
@@ -23,7 +23,7 @@ public:
     HRESULT STDMETHODCALLTYPE DragLeave() override;
 
     HRESULT STDMETHODCALLTYPE Drop(IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect) override;
-    drop_handler_interface();
+    MainWindowDropTarget();
 
 private:
     static bool check_window_allowed(HWND wnd);

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -34,7 +34,7 @@ service_ptr_t<mainmenu_manager> g_menu_playback;
 service_ptr_t<contextmenu_manager> g_main_nowplaying;
 } // namespace systray_contextmenus
 
-get_msg_hook_t g_get_msg_hook;
+GetMsgHook g_get_msg_hook;
 static HWND wnd_last;
 
 LRESULT cui::MainWindow::s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -167,7 +167,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             create_systray_icon();
 
         HRESULT hr = OleInitialize(nullptr);
-        pfc::com_ptr_t<drop_handler_interface> drop_handler = new drop_handler_interface;
+        pfc::com_ptr_t<MainWindowDropTarget> drop_handler = new MainWindowDropTarget;
         RegisterDragDrop(m_wnd, drop_handler.get_ptr());
 
         create_child_windows();

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -57,7 +57,7 @@ BOOL setup_dialog_t::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         cfg_layout.get_preset(cfg_layout.get_active(), m_previous_layout);
 
-        layout_window::g_get_default_presets(m_presets);
+        LayoutWindow::g_get_default_presets(m_presets);
 
         LVITEM lvi;
         memset(&lvi, 0, sizeof(LVITEM));

--- a/foo_ui_columns/setup_dialog.h
+++ b/foo_ui_columns/setup_dialog.h
@@ -12,7 +12,7 @@
 #include "layout.h"
 
 class setup_dialog_t : public pfc::refcounted_object_root {
-    pfc::list_t<cfg_layout_t::preset> m_presets;
+    pfc::list_t<ConfigLayout::preset> m_presets;
     uie::splitter_item_ptr m_previous_layout;
     cui::colours::colour_mode_t m_previous_colour_mode{columns_ui::colours::colour_mode_themed};
     bool m_previous_show_artwork{};

--- a/foo_ui_columns/setup_dialog.h
+++ b/foo_ui_columns/setup_dialog.h
@@ -12,7 +12,7 @@
 #include "layout.h"
 
 class setup_dialog_t : public pfc::refcounted_object_root {
-    pfc::list_t<ConfigLayout::preset> m_presets;
+    pfc::list_t<ConfigLayout::Preset> m_presets;
     uie::splitter_item_ptr m_previous_layout;
     cui::colours::colour_mode_t m_previous_colour_mode{columns_ui::colours::colour_mode_themed};
     bool m_previous_show_artwork{};

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -662,7 +662,7 @@ BOOL LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             cfg_layout.get_preset_name(m_active_preset, param.m_text);
             param.m_text << " (copy)";
             if (uDialogBox(IDD_RENAME_PLAYLIST, wnd, RenameProc, reinterpret_cast<LPARAM>(&param))) {
-                cfg_layout_t::preset preset;
+                ConfigLayout::preset preset;
                 preset.m_name = param.m_text;
                 preset.set(m_node_root->m_item->get_ptr());
                 auto preset_index = cfg_layout.add_preset(preset);

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -662,7 +662,7 @@ BOOL LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             cfg_layout.get_preset_name(m_active_preset, param.m_text);
             param.m_text << " (copy)";
             if (uDialogBox(IDD_RENAME_PLAYLIST, wnd, RenameProc, reinterpret_cast<LPARAM>(&param))) {
-                ConfigLayout::preset preset;
+                ConfigLayout::Preset preset;
                 preset.m_name = param.m_text;
                 preset.set(m_node_root->m_item->get_ptr());
                 auto preset_index = cfg_layout.add_preset(preset);


### PR DESCRIPTION
There is a [documented naming convention to use UpperCamelCase for class names](https://github.com/reupen/columns_ui/blob/master/CONTRIBUTING.md). 

However, many existing class names are non-compliant. This renames several existing class names to make them compliant.