### PR TITLE
Use UpperCamelCase for class names (part 4)

### DIFF
--- a/foo_ui_columns/columns_v2.cpp
+++ b/foo_ui_columns/columns_v2.cpp
@@ -2,7 +2,7 @@
 #include "playlist_view_tfhooks.h"
 #include "columns_v2.h"
 
-void column_t::read(stream_reader* reader, abort_callback& abortCallback)
+void PlaylistViewColumn::read(stream_reader* reader, abort_callback& abortCallback)
 {
     width.dpi = uih::get_system_dpi_cached().cx;
     reader->read_string(name, abortCallback);
@@ -20,14 +20,14 @@ void column_t::read(stream_reader* reader, abort_callback& abortCallback)
     reader->read_string(edit_field, abortCallback);
 }
 
-void column_t::read_extra(stream_reader* reader, ColumnStreamVersion streamVersion, abort_callback& abortCallback)
+void PlaylistViewColumn::read_extra(stream_reader* reader, ColumnStreamVersion streamVersion, abort_callback& abortCallback)
 {
     if (streamVersion >= ColumnStreamVersion::streamVersion1) {
         reader->read_lendian_t(width.dpi, abortCallback);
     }
 }
 
-void column_t::write(stream_writer* out, abort_callback& abortCallback) const
+void PlaylistViewColumn::write(stream_writer* out, abort_callback& abortCallback) const
 {
     out->write_string(name.get_ptr(), abortCallback);
     out->write_string(spec.get_ptr(), abortCallback);
@@ -44,12 +44,12 @@ void column_t::write(stream_writer* out, abort_callback& abortCallback) const
     out->write_string(edit_field, abortCallback);
 }
 
-void column_t::write_extra(stream_writer* out, abort_callback& abortCallback) const
+void PlaylistViewColumn::write_extra(stream_writer* out, abort_callback& abortCallback) const
 {
     out->write_lendian_t(width.dpi, abortCallback);
 }
 
-bool column_list_t::move_up(t_size idx)
+bool ColumnList::move_up(t_size idx)
 {
     unsigned count = get_count();
     if (idx > 0 && idx < count) {
@@ -61,7 +61,7 @@ bool column_list_t::move_up(t_size idx)
     return false;
 }
 
-bool column_list_t::move(t_size from, t_size to)
+bool ColumnList::move(t_size from, t_size to)
 {
     unsigned count = get_count();
     unsigned n = from;
@@ -88,7 +88,7 @@ bool column_list_t::move(t_size from, t_size to)
     return rv;
 }
 
-bool column_list_t::move_down(t_size idx)
+bool ColumnList::move_down(t_size idx)
 {
     unsigned count = get_count();
     if (idx >= 0 && idx < (count - 1)) {
@@ -100,7 +100,7 @@ bool column_list_t::move_down(t_size idx)
     return false;
 }
 
-void cfg_columns_t::get_data_raw(stream_writer* out, abort_callback& p_abort)
+void ConfigColumns::get_data_raw(stream_writer* out, abort_callback& p_abort)
 {
     // if (!cfg_nohscroll) playlist_view::g_save_columns(); FIXME
 
@@ -122,15 +122,15 @@ void cfg_columns_t::get_data_raw(stream_writer* out, abort_callback& p_abort)
     }
 }
 
-void cfg_columns_t::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort)
+void ConfigColumns::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort)
 {
-    pfc::list_t<column_t::ptr> items;
+    pfc::list_t<PlaylistViewColumn::ptr> items;
     ColumnStreamVersion streamVersion = ColumnStreamVersion::streamVersion0;
 
     t_uint32 num;
     p_reader->read_lendian_t(num, p_abort);
     for (t_size i = 0; i < num; i++) {
-        column_t::ptr item = new column_t;
+        PlaylistViewColumn::ptr item = new PlaylistViewColumn;
         item->read(p_reader, p_abort);
         items.add_item(item);
     }
@@ -156,23 +156,23 @@ void cfg_columns_t::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, a
     set_entries_ref(items);
 }
 
-void cfg_columns_t::reset()
+void ConfigColumns::reset()
 {
     remove_all();
-    add_item(new column_t(
+    add_item(new PlaylistViewColumn(
         "Artist", "[%artist%]", false, "", false, "", 180, ALIGN_LEFT, FILTER_NONE, "", 180, true, "ARTIST"));
-    add_item(new column_t(
+    add_item(new PlaylistViewColumn(
         "#", "[%tracknumber%]", false, "", false, "", 18, ALIGN_RIGHT, FILTER_NONE, "", 18, true, "TRACKNUMBER"));
     add_item(
-        new column_t("Title", "[%title%]", false, "", false, "", 300, ALIGN_LEFT, FILTER_NONE, "", 300, true, "TITLE"));
+        new PlaylistViewColumn("Title", "[%title%]", false, "", false, "", 300, ALIGN_LEFT, FILTER_NONE, "", 300, true, "TITLE"));
     add_item(
-        new column_t("Album", "[%album%]", false, "", false, "", 200, ALIGN_LEFT, FILTER_NONE, "", 200, true, "ALBUM"));
-    add_item(new column_t("Date", "[%date%]", false, "", false, "", 60, ALIGN_LEFT, FILTER_NONE, "", 60, true, "DATE"));
-    add_item(new column_t("Length", "[%_time_elapsed% / ]%_length%", false, "", true, "$num(%_length_seconds%,6)", 60,
+        new PlaylistViewColumn("Album", "[%album%]", false, "", false, "", 200, ALIGN_LEFT, FILTER_NONE, "", 200, true, "ALBUM"));
+    add_item(new PlaylistViewColumn("Date", "[%date%]", false, "", false, "", 60, ALIGN_LEFT, FILTER_NONE, "", 60, true, "DATE"));
+    add_item(new PlaylistViewColumn("Length", "[%_time_elapsed% / ]%_length%", false, "", true, "$num(%_length_seconds%,6)", 60,
         ALIGN_RIGHT, FILTER_NONE, "", 60, true, ""));
 }
 
-cfg_columns_t::cfg_columns_t(const GUID& p_guid, ColumnStreamVersion streamVersion) : cfg_var(p_guid)
+ConfigColumns::ConfigColumns(const GUID& p_guid, ColumnStreamVersion streamVersion) : cfg_var(p_guid)
 {
     reset();
 }

--- a/foo_ui_columns/columns_v2.h
+++ b/foo_ui_columns/columns_v2.h
@@ -1,8 +1,8 @@
 #ifndef _COLUMNS_2_H_
 #define _COLUMNS_2_H_
 
-class column_base_t : public pfc::refcounted_object_root {
-    using self_t = column_base_t;
+class PlaylistViewColumnBase : public pfc::refcounted_object_root {
+    using self_t = PlaylistViewColumnBase;
 
 public:
     using ptr = pfc::refcounted_object_ptr_t<self_t>;
@@ -21,9 +21,9 @@ public:
     bool show{true};
     pfc::string8 edit_field;
 
-    column_base_t() = default;
+    PlaylistViewColumnBase() = default;
 
-    column_base_t(const char* pname, const char* pspec, bool b_use_custom_colour, const char* p_colour_spec,
+    PlaylistViewColumnBase(const char* pname, const char* pspec, bool b_use_custom_colour, const char* p_colour_spec,
         bool b_use_custom_sort, const char* p_sort_spec, int p_width, alignment p_align,
         playlist_filter_type p_filter_type, const char* p_filter_string, unsigned p_parts, bool b_show,
         const char* p_edit_field)
@@ -49,8 +49,8 @@ enum class ColumnStreamVersion {
 
 };
 
-class column_t : public column_base_t {
-    using self_t = column_t;
+class PlaylistViewColumn : public PlaylistViewColumnBase {
+    using self_t = PlaylistViewColumn;
 
 public:
     using ptr = pfc::refcounted_object_ptr_t<self_t>;
@@ -62,22 +62,22 @@ public:
     void read_extra(stream_reader* reader, ColumnStreamVersion streamVersion, abort_callback& abortCallback);
     void write_extra(stream_writer* writer, abort_callback& abortCallback) const;
 
-    column_t() = default;
+    PlaylistViewColumn() = default;
 
-    column_t(const char* pname, const char* pspec, bool b_use_custom_colour, const char* p_colour_spec,
+    PlaylistViewColumn(const char* pname, const char* pspec, bool b_use_custom_colour, const char* p_colour_spec,
         bool b_use_custom_sort, const char* p_sort_spec, unsigned p_width, alignment p_align,
         playlist_filter_type p_filter_type, const char* p_filter_string, unsigned p_parts, bool b_show,
         const char* p_edit_field)
-        : column_base_t(pname, pspec, b_use_custom_colour, p_colour_spec, b_use_custom_sort, p_sort_spec, p_width,
+        : PlaylistViewColumnBase(pname, pspec, b_use_custom_colour, p_colour_spec, b_use_custom_sort, p_sort_spec, p_width,
               p_align, p_filter_type, p_filter_string, p_parts, b_show, p_edit_field)
     {
     }
 
-    column_t(const column_t&) = default;
-    column_t& operator=(const column_t&) = default;
-    column_t(column_t&&) = default;
-    column_t& operator=(column_t&&) = default;
-    ~column_t() = default;
+    PlaylistViewColumn(const PlaylistViewColumn&) = default;
+    PlaylistViewColumn& operator=(const PlaylistViewColumn&) = default;
+    PlaylistViewColumn(PlaylistViewColumn&&) = default;
+    PlaylistViewColumn& operator=(PlaylistViewColumn&&) = default;
+    ~PlaylistViewColumn() = default;
 
 private:
     service_ptr_t<titleformat_object> to_display;
@@ -85,30 +85,30 @@ private:
     service_ptr_t<titleformat_object> to_sort;
 };
 
-using column_list_cref_t = const pfc::list_base_const_t<column_t::ptr>&;
+using ColumnListCRef = const pfc::list_base_const_t<PlaylistViewColumn::ptr>&;
 
-class column_list_t : public pfc::list_t<column_t::ptr> {
+class ColumnList : public pfc::list_t<PlaylistViewColumn::ptr> {
 public:
-    void set_entries_ref(column_list_cref_t entries)
+    void set_entries_ref(ColumnListCRef entries)
     {
         remove_all();
         add_items(entries);
     }
 
-    void set_entries_copy(column_list_cref_t entries, bool keep_reference_to_source_items = false)
+    void set_entries_copy(ColumnListCRef entries, bool keep_reference_to_source_items = false)
     {
         // remove_all();
         t_size count = entries.get_count();
         set_count(count);
         for (t_size i = 0; i < count; i++) {
-            column_t::ptr item = new column_t(*entries[i].get_ptr());
+            PlaylistViewColumn::ptr item = new PlaylistViewColumn(*entries[i].get_ptr());
             if (keep_reference_to_source_items)
                 item->source_item = entries[i];
             (*this)[i] = item;
         }
     }
 
-    void set_widths(column_list_cref_t entries)
+    void set_widths(ColumnListCRef entries)
     {
         // remove_all();
         t_size count = get_count();
@@ -131,19 +131,19 @@ public:
     bool move(t_size from, t_size to);
 };
 
-class cfg_columns_t
+class ConfigColumns
     : public cfg_var
-    , public column_list_t {
+    , public ColumnList {
 public:
     void reset();
 
-    cfg_columns_t(const GUID& p_guid, ColumnStreamVersion streamVersion);
+    ConfigColumns(const GUID& p_guid, ColumnStreamVersion streamVersion);
 
 protected:
     void get_data_raw(stream_writer* out, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort) override;
 };
 
-extern cfg_columns_t g_columns;
+extern ConfigColumns g_columns;
 
 #endif

--- a/foo_ui_columns/config.h
+++ b/foo_ui_columns/config.h
@@ -92,7 +92,7 @@ public:
         }
     }
 };
-void speedtest(column_list_cref_t columns, bool b_global);
+void speedtest(ColumnListCRef columns, bool b_global);
 
 extern EditorFontNotify g_editor_font_notify;
 extern cfg_uint g_last_colour;

--- a/foo_ui_columns/config_artwork.cpp
+++ b/foo_ui_columns/config_artwork.cpp
@@ -151,7 +151,7 @@ public:
         {
             if (m_changed) {
                 artwork_panel::g_on_repository_change();
-                pvt::ng_playlist_view_t::g_on_artwork_repositories_change();
+                pvt::PlaylistView::g_on_artwork_repositories_change();
                 m_changed = false;
             }
         }

--- a/foo_ui_columns/config_columns.cpp
+++ b/foo_ui_columns/config_columns.cpp
@@ -42,7 +42,7 @@ void double_to_string(double blah, pfc::string_base& p_out, int points = 10, boo
     }
 }
 
-void speedtest(column_list_cref_t columns, bool b_global)
+void speedtest(ColumnListCRef columns, bool b_global)
 {
     static_api_ptr_t<playlist_manager> playlist_api;
     static_api_ptr_t<titleformat_compiler> titleformat_api;

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -20,18 +20,18 @@ struct ColumnTimes {
 
 class edit_column_window_options : public ColumnTab {
 public:
-    void get_column(column_t::ptr& p_out) override { p_out = m_column; };
+    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
     using self_t = edit_column_window_options;
     HWND create(HWND wnd) override { return uCreateDialog(IDD_COLUMN_OPTIONS, wnd, g_on_message, (LPARAM)this); }
     // virtual const char * get_name()=0;
-    edit_column_window_options(column_t::ptr column)
+    edit_column_window_options(PlaylistViewColumn::ptr column)
         : initialising(false), editproc(nullptr), m_wnd(nullptr), m_column(std::move(column)){};
 
     bool initialising;
     WNDPROC editproc;
     HWND m_wnd;
 
-    column_t::ptr m_column;
+    PlaylistViewColumn::ptr m_column;
 
     void set_detail_enabled(HWND wnd, BOOL show)
     {
@@ -82,7 +82,7 @@ public:
         set_detail_enabled(wnd, m_column.is_valid());
     }
 
-    void set_column(const column_t::ptr& column) override
+    void set_column(const PlaylistViewColumn::ptr& column) override
     {
         if (m_column.get_ptr() != column.get_ptr()) {
             m_column = column;
@@ -227,14 +227,14 @@ class DisplayScriptTab : public ColumnTab {
 public:
     using SelfType = DisplayScriptTab;
 
-    void get_column(column_t::ptr& p_out) override { p_out = m_column; };
+    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
 
     HWND create(HWND wnd) override
     {
         return uCreateDialog(IDD_COLUMN_DISPLAY_SCRIPT, wnd, s_on_message, reinterpret_cast<LPARAM>(this));
     }
 
-    void set_column(const column_t::ptr& column) override
+    void set_column(const PlaylistViewColumn::ptr& column) override
     {
         if (m_column.get_ptr() != column.get_ptr()) {
             m_column = column;
@@ -242,7 +242,7 @@ public:
         }
     }
 
-    explicit DisplayScriptTab(column_t::ptr col) : m_wnd(nullptr), initialising(false), m_column(std::move(col)) {}
+    explicit DisplayScriptTab(PlaylistViewColumn::ptr col) : m_wnd(nullptr), initialising(false), m_column(std::move(col)) {}
 
 private:
     static BOOL CALLBACK s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -305,21 +305,21 @@ private:
     cui::prefs::EditControlSelectAllHook m_edit_control_hook;
     HWND m_wnd;
     bool initialising;
-    column_t::ptr m_column;
+    PlaylistViewColumn::ptr m_column;
 };
 
 class StyleScriptTab : public ColumnTab {
 public:
     using SelfType = StyleScriptTab;
 
-    void get_column(column_t::ptr& p_out) override { p_out = m_column; };
+    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
 
     HWND create(HWND wnd) override
     {
         return uCreateDialog(IDD_COLUMN_STYLE_SCRIPT, wnd, s_on_message, reinterpret_cast<LPARAM>(this));
     }
 
-    void set_column(const column_t::ptr& column) override
+    void set_column(const PlaylistViewColumn::ptr& column) override
     {
         if (m_column.get_ptr() != column.get_ptr()) {
             m_column = column;
@@ -327,7 +327,7 @@ public:
         }
     }
 
-    explicit StyleScriptTab(column_t::ptr col) : m_wnd(nullptr), initialising(false), m_column(std::move(col)) {}
+    explicit StyleScriptTab(PlaylistViewColumn::ptr col) : m_wnd(nullptr), initialising(false), m_column(std::move(col)) {}
 
 private:
     static BOOL CALLBACK s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -399,21 +399,21 @@ private:
     cui::prefs::EditControlSelectAllHook m_edit_control_hook;
     HWND m_wnd;
     bool initialising;
-    column_t::ptr m_column;
+    PlaylistViewColumn::ptr m_column;
 };
 
 class SortingScriptTab : public ColumnTab {
 public:
     using SelfType = SortingScriptTab;
 
-    void get_column(column_t::ptr& p_out) override { p_out = m_column; };
+    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
 
     HWND create(HWND wnd) override
     {
         return uCreateDialog(IDD_COLUMN_SORTING_SCRIPT, wnd, s_on_message, reinterpret_cast<LPARAM>(this));
     }
 
-    void set_column(const column_t::ptr& column) override
+    void set_column(const PlaylistViewColumn::ptr& column) override
     {
         if (m_column.get_ptr() != column.get_ptr()) {
             m_column = column;
@@ -421,7 +421,7 @@ public:
         }
     }
 
-    explicit SortingScriptTab(column_t::ptr col) : m_wnd(nullptr), initialising(false), m_column(std::move(col)) {}
+    explicit SortingScriptTab(PlaylistViewColumn::ptr col) : m_wnd(nullptr), initialising(false), m_column(std::move(col)) {}
 
 private:
     static BOOL CALLBACK s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -490,7 +490,7 @@ private:
     cui::prefs::EditControlSelectAllHook m_edit_control_hook;
     HWND m_wnd;
     bool initialising;
-    column_t::ptr m_column;
+    PlaylistViewColumn::ptr m_column;
 };
 
 // {0A7A2845-06A4-4c15-B09F-A6EBEE86335D}
@@ -524,7 +524,7 @@ void TabColumns::make_child()
     if (cfg_child_column < count && cfg_child_column >= 0) {
         int item = ListView_GetNextItem(GetDlgItem(m_wnd, IDC_COLUMNS), -1, LVNI_SELECTED);
 
-        column_t::ptr column;
+        PlaylistViewColumn::ptr column;
         if (item != -1)
             column = m_columns[item];
 
@@ -630,7 +630,7 @@ BOOL TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     int& idx = item;
                     auto wnd_lv = HWND(wp);
                     if (cmd == ID_NEW) {
-                        column_t::ptr temp = new column_t;
+                        PlaylistViewColumn::ptr temp = new PlaylistViewColumn;
                         temp->name = "New Column";
                         t_size insert = m_columns.insert_item(
                             temp, idx >= 0 && (t_size)idx < m_columns.get_count() ? idx : m_columns.get_count());
@@ -692,7 +692,7 @@ BOOL TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case MSG_SELECTION_CHANGED: {
         int item = (ListView_GetNextItem(GetDlgItem(m_wnd, IDC_COLUMNS), -1, LVNI_SELECTED));
         m_child->set_column(
-            item != -1 && item >= 0 && (t_size)item < m_columns.get_count() ? m_columns[item] : column_t::ptr());
+            item != -1 && item >= 0 && (t_size)item < m_columns.get_count() ? m_columns[item] : PlaylistViewColumn::ptr());
     }
         return 0;
     case MSG_COLUMN_NAME_CHANGED: {
@@ -772,7 +772,7 @@ BOOL TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             int idx = ListView_GetNextItem(wnd_lv, -1, LVNI_SELECTED);
             // if (true)
             {
-                column_t::ptr temp = new column_t;
+                PlaylistViewColumn::ptr temp = new PlaylistViewColumn;
                 temp->name = "New Column";
                 t_size insert = m_columns.insert_item(
                     temp, idx >= 0 && (t_size)idx < m_columns.get_count() ? idx : m_columns.get_count());

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -853,7 +853,7 @@ void TabColumns::apply()
     g_columns.set_entries_copy(m_columns);
     for (size_t i = 0, count = m_columns.get_count(); i < count; i++)
         m_columns[i]->source_item = g_columns[i];
-    pvt::ng_playlist_view_t::g_on_columns_change();
+    pvt::PlaylistView::g_on_columns_change();
 }
 
 void TabColumns::show_column(size_t index)

--- a/foo_ui_columns/config_columns_v2.h
+++ b/foo_ui_columns/config_columns_v2.h
@@ -7,8 +7,8 @@ public:
     virtual HWND create(HWND wnd) = 0;
     // virtual void destroy(HWND wnd)=0;
     // virtual const char * get_name()=0;
-    virtual void set_column(const column_t::ptr& column) = 0;
-    virtual void get_column(column_t::ptr& p_out) = 0;
+    virtual void set_column(const PlaylistViewColumn::ptr& column) = 0;
+    virtual void get_column(PlaylistViewColumn::ptr& p_out) = 0;
 };
 
 class TabColumns : public PreferencesTab {
@@ -49,6 +49,6 @@ private:
     TabColumns() = default;
 
     cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
-    column_list_t m_columns;
+    ColumnList m_columns;
     bool initialising{false};
 };

--- a/foo_ui_columns/config_vars.cpp
+++ b/foo_ui_columns/config_vars.cpp
@@ -151,7 +151,7 @@ cfg_string cfg_playlist_switcher_tagz(
 // {F006EC50-7F52-4037-9D48-7447BBF742AA}
 static const GUID guid_columns = {0xf006ec50, 0x7f52, 0x4037, {0x9d, 0x48, 0x74, 0x47, 0xbb, 0xf7, 0x42, 0xaa}};
 
-cfg_columns_t g_columns(guid_columns, ColumnStreamVersion::streamVersion0);
+ConfigColumns g_columns(guid_columns, ColumnStreamVersion::streamVersion0);
 
 ConfigWindowPlacement cfg_window_placement_columns(
     GUID{0x8bdb3caa, 0x6544, 0x07a6, {0x89, 0x67, 0xf8, 0x13, 0x3a, 0x80, 0x75, 0xbb}});

--- a/foo_ui_columns/fcl_titles.cpp
+++ b/foo_ui_columns/fcl_titles.cpp
@@ -72,7 +72,7 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
         fbh::fcl::Reader reader(p_reader, stream_size, p_abort);
         t_size count;
         reader.read_item(count);
-        column_list_t newcolumns;
+        ColumnList newcolumns;
         for (t_size i = 0; i < count; i++) {
             t_uint32 column_id;
             t_uint32 column_size;
@@ -80,7 +80,7 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
             reader.read_item(column_id);
             reader.read_item(column_size);
 
-            column_t::ptr item = new column_t;
+            PlaylistViewColumn::ptr item = new PlaylistViewColumn;
 
             fbh::fcl::Reader reader2(reader, column_size, p_abort);
 

--- a/foo_ui_columns/fcl_titles.cpp
+++ b/foo_ui_columns/fcl_titles.cpp
@@ -153,7 +153,7 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
         }
 
         g_columns.set_entries_ref(newcolumns);
-        pvt::ng_playlist_view_t::g_on_columns_change();
+        pvt::PlaylistView::g_on_columns_change();
     }
 };
 
@@ -295,7 +295,7 @@ class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
 
         if (b_groups_set)
             pvt::g_groups.set_groups(newgroups, false);
-        pvt::ng_playlist_view_t::g_on_groups_change();
+        pvt::PlaylistView::g_on_groups_change();
         // pvt::ng_playlist_view_t::g_on_show_artwork_change();
         // pvt::ng_playlist_view_t::g_on_artwork_width_change();
     }
@@ -370,10 +370,10 @@ class PlaylistViewMiscDataSet : public cui::fcl::dataset {
             }
         }
 
-        pvt::ng_playlist_view_t::g_on_autosize_change();
-        pvt::ng_playlist_view_t::g_on_vertical_item_padding_change();
-        pvt::ng_playlist_view_t::g_on_show_header_change();
-        pvt::ng_playlist_view_t::g_update_all_items();
+        pvt::PlaylistView::g_on_autosize_change();
+        pvt::PlaylistView::g_on_vertical_item_padding_change();
+        pvt::PlaylistView::g_on_show_header_change();
+        pvt::PlaylistView::g_update_all_items();
     }
 };
 

--- a/foo_ui_columns/menu_items.cpp
+++ b/foo_ui_columns/menu_items.cpp
@@ -47,7 +47,7 @@ static const MainMenuCommand activate_now_playing{activate_now_playing_id, "Acti
 static const MainMenuCommand show_groups{show_groups_id, "Show groups", "Shows or hides playlist view groups.",
     [] {
         pvt::cfg_grouping = !pvt::cfg_grouping;
-        pvt::ng_playlist_view_t::g_on_groups_change();
+        pvt::PlaylistView::g_on_groups_change();
     },
     [] { return static_cast<bool>(pvt::cfg_grouping); }};
 

--- a/foo_ui_columns/ng_playlist/config_object_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/config_object_callbacks.cpp
@@ -8,7 +8,7 @@ public:
     void on_watched_object_changed(const service_ptr_t<config_object>& p_object) override
     {
         const auto val = p_object->get_data_bool_simple(false);
-        pvt::ng_playlist_view_t::g_on_playback_follows_cursor_change(val);
+        pvt::PlaylistView::g_on_playback_follows_cursor_change(val);
     }
 };
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -36,8 +36,8 @@ const GUID g_artwork_lowpriority = {0xcb1c1c5d, 0x4f99, 0x4c24, {0xb2, 0x39, 0xa
 // {A28CC736-2B8B-484c-B7A9-4CC312DBD357}
 const GUID g_guid_grouping = {0xa28cc736, 0x2b8b, 0x484c, {0xb7, 0xa9, 0x4c, 0xc3, 0x12, 0xdb, 0xd3, 0x57}};
 
-std::vector<ng_playlist_view_t*> ng_playlist_view_t::g_windows;
-ng_playlist_view_t::ng_global_mesage_window ng_playlist_view_t::g_global_mesage_window;
+std::vector<PlaylistView*> PlaylistView::g_windows;
+PlaylistView::ng_global_mesage_window PlaylistView::g_global_mesage_window;
 
 cfg_groups_t g_groups(g_groups_guid);
 
@@ -50,18 +50,18 @@ fbh::ConfigUint32DpiAware cfg_artwork_width(g_artwork_width_guid, 100);
 void cfg_groups_t::swap(t_size index1, t_size index2)
 {
     m_groups.swap_items(index1, index2);
-    ng_playlist_view_t::g_on_groups_change();
+    PlaylistView::g_on_groups_change();
 }
 void cfg_groups_t::replace_group(t_size index, const group_t& p_group)
 {
     m_groups.replace_item(index, p_group);
-    ng_playlist_view_t::g_on_groups_change();
+    PlaylistView::g_on_groups_change();
 }
 t_size cfg_groups_t::add_group(const group_t& p_group, bool notify_playlist_views)
 {
     t_size ret = m_groups.add_item(p_group);
     if (notify_playlist_views)
-        ng_playlist_view_t::g_on_groups_change();
+        PlaylistView::g_on_groups_change();
     return ret;
 }
 
@@ -70,13 +70,13 @@ void cfg_groups_t::set_groups(const pfc::list_base_const_t<group_t>& p_groups, b
     m_groups.remove_all();
     m_groups.add_items(p_groups);
     if (b_update_views)
-        ng_playlist_view_t::g_on_groups_change();
+        PlaylistView::g_on_groups_change();
 }
 
 void cfg_groups_t::remove_group(t_size index)
 {
     m_groups.remove_by_idx(index);
-    ng_playlist_view_t::g_on_groups_change();
+    PlaylistView::g_on_groups_change();
 }
 
 void set_font_size(bool up)
@@ -90,17 +90,17 @@ void set_font_size(bool up)
     api->set_font(pvt::g_guid_items_font, lf_ng);
 }
 
-ng_playlist_view_t::ng_playlist_view_t() : m_dragging_initial_playlist(pfc_infinite){};
+PlaylistView::PlaylistView() : m_dragging_initial_playlist(pfc_infinite){};
 
-ng_playlist_view_t::~ng_playlist_view_t() = default;
+PlaylistView::~PlaylistView() = default;
 
-void ng_playlist_view_t::populate_list()
+void PlaylistView::populate_list()
 {
     metadb_handle_list_t<pfc::alloc_fast_aggressive> data;
     m_playlist_api->activeplaylist_get_all_items(data);
     on_items_added(0, data, pfc::bit_array_false());
 }
-void ng_playlist_view_t::refresh_groups(bool b_update_columns)
+void PlaylistView::refresh_groups(bool b_update_columns)
 {
     static_api_ptr_t<titleformat_compiler> p_compiler;
     service_ptr_t<titleformat_object> p_script, p_script_group;
@@ -134,7 +134,7 @@ void ng_playlist_view_t::refresh_groups(bool b_update_columns)
     set_group_count(used_count, b_update_columns);
 }
 
-t_size ng_playlist_view_t::column_index_display_to_actual(t_size display_index)
+t_size PlaylistView::column_index_display_to_actual(t_size display_index)
 {
     t_size count = m_column_mask.get_count(), counter = 0;
     for (t_size i = 0; i < count; i++) {
@@ -145,7 +145,7 @@ t_size ng_playlist_view_t::column_index_display_to_actual(t_size display_index)
     throw pfc::exception_bug_check();
 }
 
-t_size ng_playlist_view_t::column_index_actual_to_display(t_size actual_index)
+t_size PlaylistView::column_index_actual_to_display(t_size actual_index)
 {
     t_size count = m_column_mask.get_count(), counter = 0;
     for (t_size i = 0; i < count; i++) {
@@ -158,7 +158,7 @@ t_size ng_playlist_view_t::column_index_actual_to_display(t_size actual_index)
     return pfc_infinite;
     // throw pfc::exception_bug_check();
 }
-void ng_playlist_view_t::on_column_widths_change()
+void PlaylistView::on_column_widths_change()
 {
     t_size count = m_column_mask.get_count();
     pfc::list_t<int> widths;
@@ -168,13 +168,13 @@ void ng_playlist_view_t::on_column_widths_change()
     set_column_widths(widths);
 }
 
-void ng_playlist_view_t::g_on_column_widths_change(const ng_playlist_view_t* p_skip)
+void PlaylistView::g_on_column_widths_change(const PlaylistView* p_skip)
 {
     for (auto& window : g_windows)
         if (window != p_skip)
             window->on_column_widths_change();
 }
-void ng_playlist_view_t::refresh_columns()
+void PlaylistView::refresh_columns()
 {
     static_api_ptr_t<titleformat_compiler> p_compiler;
     service_ptr_t<titleformat_object> p_script, p_script_group;
@@ -231,12 +231,12 @@ void ng_playlist_view_t::refresh_columns()
     set_columns(columns);
 }
 
-void ng_playlist_view_t::g_on_groups_change()
+void PlaylistView::g_on_groups_change()
 {
     for (auto& window : g_windows)
         window->on_groups_change();
 }
-void ng_playlist_view_t::on_groups_change()
+void PlaylistView::on_groups_change()
 {
     if (get_wnd()) {
         clear_all_items();
@@ -245,7 +245,7 @@ void ng_playlist_view_t::on_groups_change()
     }
 }
 
-void ng_playlist_view_t::update_all_items(bool b_update_display)
+void PlaylistView::update_all_items(bool b_update_display)
 {
     static_api_ptr_t<titleformat_compiler> p_compiler;
     service_ptr_t<titleformat_object> p_script, p_script_group;
@@ -259,12 +259,12 @@ void ng_playlist_view_t::update_all_items(bool b_update_display)
 
     refresh_all_items_text(b_update_display);
 }
-void ng_playlist_view_t::refresh_all_items_text(bool b_update_display)
+void PlaylistView::refresh_all_items_text(bool b_update_display)
 {
     update_items(0, get_item_count(), false);
     invalidate_all();
 }
-void ng_playlist_view_t::update_items(t_size index, t_size count, bool b_update_display)
+void PlaylistView::update_items(t_size index, t_size count, bool b_update_display)
 {
     for (t_size i = 0; i < count; i++) {
         t_size cg = get_item(i + index)->get_group_count();
@@ -274,22 +274,22 @@ void ng_playlist_view_t::update_items(t_size index, t_size count, bool b_update_
     }
     uih::ListView::update_items(index, count, b_update_display);
 }
-void ng_playlist_view_t::g_on_autosize_change()
+void PlaylistView::g_on_autosize_change()
 {
     for (auto& window : g_windows)
         window->set_autosize(cfg_nohscroll != 0);
 }
-void ng_playlist_view_t::g_on_show_artwork_change()
+void PlaylistView::g_on_show_artwork_change()
 {
     for (auto& window : g_windows)
         window->set_show_group_info_area(cfg_show_artwork);
 }
-void ng_playlist_view_t::g_on_alternate_selection_change()
+void PlaylistView::g_on_alternate_selection_change()
 {
     for (auto& window : g_windows)
         window->set_alternate_selection_model(cfg_alternative_sel != 0);
 }
-void ng_playlist_view_t::g_on_artwork_width_change(const ng_playlist_view_t* p_skip)
+void PlaylistView::g_on_artwork_width_change(const PlaylistView* p_skip)
 {
     for (auto& window : g_windows) {
         if (window != p_skip) {
@@ -299,7 +299,7 @@ void ng_playlist_view_t::g_on_artwork_width_change(const ng_playlist_view_t* p_s
         }
     }
 }
-void ng_playlist_view_t::g_flush_artwork(bool b_redraw, const ng_playlist_view_t* p_skip)
+void PlaylistView::g_flush_artwork(bool b_redraw, const PlaylistView* p_skip)
 {
     for (auto& window : g_windows) {
         if (window != p_skip) {
@@ -309,7 +309,7 @@ void ng_playlist_view_t::g_flush_artwork(bool b_redraw, const ng_playlist_view_t
         }
     }
 }
-void ng_playlist_view_t::g_on_artwork_repositories_change()
+void PlaylistView::g_on_artwork_repositories_change()
 {
     for (auto& window : g_windows) {
         if (window->m_artwork_manager.is_valid()) {
@@ -317,80 +317,80 @@ void ng_playlist_view_t::g_on_artwork_repositories_change()
         }
     }
 }
-void ng_playlist_view_t::g_on_vertical_item_padding_change()
+void PlaylistView::g_on_vertical_item_padding_change()
 {
     for (auto& window : g_windows)
         window->set_vertical_item_padding(settings::playlist_view_item_padding);
 }
-void ng_playlist_view_t::g_on_font_change()
+void PlaylistView::g_on_font_change()
 {
     LOGFONT lf;
     static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_items_font, lf);
     for (auto& window : g_windows)
         window->set_font(&lf);
 }
-void ng_playlist_view_t::g_on_header_font_change()
+void PlaylistView::g_on_header_font_change()
 {
     LOGFONT lf;
     static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_header_font, lf);
     for (auto& window : g_windows)
         window->set_header_font(&lf);
 }
-void ng_playlist_view_t::g_on_group_header_font_change()
+void PlaylistView::g_on_group_header_font_change()
 {
     LOGFONT lf;
     static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_group_header_font, lf);
     for (auto& window : g_windows)
         window->set_group_font(&lf);
 }
-void ng_playlist_view_t::g_update_all_items()
+void PlaylistView::g_update_all_items()
 {
     for (auto& window : g_windows)
         window->update_all_items();
 }
-void ng_playlist_view_t::g_on_show_header_change()
+void PlaylistView::g_on_show_header_change()
 {
     for (auto& window : g_windows)
         window->set_show_header(cfg_header != 0);
 }
-void ng_playlist_view_t::g_on_sorting_enabled_change()
+void PlaylistView::g_on_sorting_enabled_change()
 {
     for (auto& window : g_windows)
         window->set_sorting_enabled(cfg_header_hottrack != 0);
 }
-void ng_playlist_view_t::g_on_show_sort_indicators_change()
+void PlaylistView::g_on_show_sort_indicators_change()
 {
     for (auto& window : g_windows)
         window->set_show_sort_indicators(cfg_show_sort_arrows != 0);
 }
-void ng_playlist_view_t::g_on_edge_style_change()
+void PlaylistView::g_on_edge_style_change()
 {
     for (auto& window : g_windows)
         window->set_edge_style(cfg_frame);
 }
-void ng_playlist_view_t::g_on_time_change()
+void PlaylistView::g_on_time_change()
 {
     for (auto& window : g_windows)
         window->on_time_change();
 }
-void ng_playlist_view_t::g_on_show_tooltips_change()
+void PlaylistView::g_on_show_tooltips_change()
 {
     for (auto& window : g_windows) {
         window->set_show_tooltips(cfg_tooltip != 0);
         window->set_limit_tooltips_to_clipped_items(cfg_tooltips_clipped != 0);
     }
 }
-void ng_playlist_view_t::g_on_playback_follows_cursor_change(bool b_val)
+void PlaylistView::g_on_playback_follows_cursor_change(bool b_val)
 {
     for (auto& window : g_windows)
         window->set_always_show_focus(b_val);
 }
-void ng_playlist_view_t::g_on_columns_change()
+void PlaylistView::g_on_columns_change()
 {
     for (auto& window : g_windows)
         window->on_columns_change();
 }
-void ng_playlist_view_t::on_columns_change()
+void PlaylistView::on_columns_change()
 {
     if (get_wnd()) {
         clear_all_items();
@@ -399,7 +399,7 @@ void ng_playlist_view_t::on_columns_change()
     }
 }
 
-void ng_playlist_view_t::s_redraw_all()
+void PlaylistView::s_redraw_all()
 {
     for (auto&& window : g_windows)
         RedrawWindow(window->get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
@@ -409,7 +409,7 @@ int g_compare_wchar(const pfc::array_t<WCHAR>& a, const pfc::array_t<WCHAR>& b)
 {
     return StrCmpLogicalW(a.get_ptr(), b.get_ptr());
 }
-void ng_playlist_view_t::notify_sort_column(t_size index, bool b_descending, bool b_selection_only)
+void PlaylistView::notify_sort_column(t_size index, bool b_descending, bool b_selection_only)
 {
     unsigned active_playlist = m_playlist_api->get_active_playlist();
     if (active_playlist != -1
@@ -506,7 +506,7 @@ void ng_playlist_view_t::notify_sort_column(t_size index, bool b_descending, boo
         }
     }
 }
-void ng_playlist_view_t::notify_on_initialisation()
+void PlaylistView::notify_on_initialisation()
 {
     set_group_info_area_size(
         cfg_artwork_width, cfg_artwork_width + (cfg_artwork_reflection ? (cfg_artwork_width * 3) / 11 : 0));
@@ -545,7 +545,7 @@ void ng_playlist_view_t::notify_on_initialisation()
     refresh_columns();
     refresh_groups();
 }
-void ng_playlist_view_t::notify_on_create()
+void PlaylistView::notify_on_create()
 {
     pfc::hires_timer timer;
     timer.start();
@@ -567,7 +567,7 @@ void ng_playlist_view_t::notify_on_create()
     formatter << "Playlist view initialised in: " << pfc::format_float(timer.query(), 0, 3) << " s";
 }
 
-void ng_playlist_view_t::notify_on_destroy()
+void PlaylistView::notify_on_destroy()
 {
     g_windows.erase(std::remove(g_windows.begin(), g_windows.end(), this), g_windows.end());
     if (g_windows.empty())
@@ -595,16 +595,16 @@ void ng_playlist_view_t::notify_on_destroy()
     }
 }
 
-void ng_playlist_view_t::notify_on_set_focus(HWND wnd_lost)
+void PlaylistView::notify_on_set_focus(HWND wnd_lost)
 {
     m_selection_holder = static_api_ptr_t<ui_selection_manager>()->acquire();
     m_selection_holder->set_playlist_selection_tracking();
 }
-void ng_playlist_view_t::notify_on_kill_focus(HWND wnd_receiving)
+void PlaylistView::notify_on_kill_focus(HWND wnd_receiving)
 {
     m_selection_holder.release();
 }
-bool ng_playlist_view_t::notify_on_contextmenu_header(const POINT& pt, const HDHITTESTINFO& hittest)
+bool PlaylistView::notify_on_contextmenu_header(const POINT& pt, const HDHITTESTINFO& hittest)
 {
     uie::window_ptr p_this_temp = this;
     enum {
@@ -695,21 +695,21 @@ bool ng_playlist_view_t::notify_on_contextmenu_header(const POINT& pt, const HDH
         TabColumns::get_instance().show_column(column_index_display_to_actual(index));
     } else if (cmd == IDM_AUTOSIZE) {
         cfg_nohscroll = cfg_nohscroll == 0;
-        pvt::ng_playlist_view_t::g_on_autosize_change();
+        pvt::PlaylistView::g_on_autosize_change();
     } else if (cmd == IDM_PREFS) {
         static_api_ptr_t<ui_control>()->show_preferences(columns::config_get_playlist_view_guid());
     } else if (cmd == IDM_ARTWORK) {
         cfg_show_artwork = !cfg_show_artwork;
-        pvt::ng_playlist_view_t::g_on_show_artwork_change();
+        pvt::PlaylistView::g_on_show_artwork_change();
     } else if (cmd >= IDM_CUSTOM_BASE) {
         if (t_size(cmd - IDM_CUSTOM_BASE) < g_columns.get_count()) {
             g_columns[cmd - IDM_CUSTOM_BASE]->show = !g_columns[cmd - IDM_CUSTOM_BASE]->show; // g_columns
-            pvt::ng_playlist_view_t::g_on_columns_change();
+            pvt::PlaylistView::g_on_columns_change();
         }
     }
     return true;
 }
-void ng_playlist_view_t::notify_on_menu_select(WPARAM wp, LPARAM lp)
+void PlaylistView::notify_on_menu_select(WPARAM wp, LPARAM lp)
 {
     if (HIWORD(wp) & MF_POPUP) {
         m_status_text_override.release();
@@ -743,7 +743,7 @@ void ng_playlist_view_t::notify_on_menu_select(WPARAM wp, LPARAM lp)
     }
 }
 
-bool ng_playlist_view_t::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
+bool PlaylistView::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
 {
     enum {
         ID_PLAY = 1,
@@ -827,7 +827,7 @@ bool ng_playlist_view_t::notify_on_contextmenu(const POINT& pt, bool from_keyboa
     return true;
 }
 
-void ng_playlist_view_t::notify_update_item_data(t_size index)
+void PlaylistView::notify_update_item_data(t_size index)
 {
     string_array& p_out = get_item_subitems(index);
     item_ng_t* p_item = get_item(index);
@@ -919,25 +919,25 @@ void ng_playlist_view_t::notify_update_item_data(t_size index)
     }
 }
 
-const style_data_t& ng_playlist_view_t::get_style_data(t_size index)
+const style_data_t& PlaylistView::get_style_data(t_size index)
 {
     if (get_item(index)->m_style_data.get_count() != get_column_count()) {
         notify_update_item_data(index);
     }
     return get_item(index)->m_style_data;
 }
-bool ng_playlist_view_t::notify_on_middleclick(bool on_item, t_size index)
+bool PlaylistView::notify_on_middleclick(bool on_item, t_size index)
 {
     return cui::playlist_item_helpers::mclick_action::run(cfg_playlist_middle_action, on_item, index);
 }
-bool ng_playlist_view_t::notify_on_doubleleftclick_nowhere()
+bool PlaylistView::notify_on_doubleleftclick_nowhere()
 {
     if (cfg_playlist_double.get_value().m_command != pfc::guid_null)
         return mainmenu_commands::g_execute(cfg_playlist_double.get_value().m_command);
     return false;
 }
 
-void ng_playlist_view_t::get_insert_items(
+void PlaylistView::get_insert_items(
     /*t_size p_playlist, */ t_size start, t_size count, InsertItemsContainer& items)
 {
     items.set_count(count);
@@ -961,13 +961,13 @@ void ng_playlist_view_t::get_insert_items(
     });
 }
 
-void ng_playlist_view_t::flush_items()
+void PlaylistView::flush_items()
 {
     InsertItemsContainer items;
     get_insert_items(0, m_playlist_api->activeplaylist_get_item_count(), items);
     replace_items(0, items);
 }
-void ng_playlist_view_t::reset_items()
+void PlaylistView::reset_items()
 {
     clear_all_items();
     InsertItemsContainer items;
@@ -975,7 +975,7 @@ void ng_playlist_view_t::reset_items()
     insert_items(0, items.get_size(), items.get_ptr());
 }
 
-t_size ng_playlist_view_t::get_highlight_item()
+t_size PlaylistView::get_highlight_item()
 {
     if (static_api_ptr_t<play_control>()->is_playing()) {
         t_size playing_index, playing_playlist;
@@ -986,61 +986,61 @@ t_size ng_playlist_view_t::get_highlight_item()
     return pfc_infinite;
 }
 
-bool ng_playlist_view_t::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
+bool PlaylistView::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
 {
     uie::window_ptr p_this = this;
     bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
     return ret;
 };
-bool ng_playlist_view_t::notify_on_keyboard_keydown_remove()
+bool PlaylistView::notify_on_keyboard_keydown_remove()
 {
     m_playlist_api->activeplaylist_undo_backup();
     m_playlist_api->activeplaylist_remove_selection();
     return true;
 };
 
-bool ng_playlist_view_t::notify_on_keyboard_keydown_search()
+bool PlaylistView::notify_on_keyboard_keydown_search()
 {
     return standard_commands::main_playlist_search();
 };
 
-bool ng_playlist_view_t::notify_on_keyboard_keydown_undo()
+bool PlaylistView::notify_on_keyboard_keydown_undo()
 {
     m_playlist_api->activeplaylist_undo_restore();
     return true;
 };
-bool ng_playlist_view_t::notify_on_keyboard_keydown_redo()
+bool PlaylistView::notify_on_keyboard_keydown_redo()
 {
     m_playlist_api->activeplaylist_redo_restore();
     return true;
 };
-bool ng_playlist_view_t::notify_on_keyboard_keydown_cut()
+bool PlaylistView::notify_on_keyboard_keydown_cut()
 {
     return playlist_utils::cut();
 };
-bool ng_playlist_view_t::notify_on_keyboard_keydown_copy()
+bool PlaylistView::notify_on_keyboard_keydown_copy()
 {
     return playlist_utils::copy();
 };
-bool ng_playlist_view_t::notify_on_keyboard_keydown_paste()
+bool PlaylistView::notify_on_keyboard_keydown_paste()
 {
     return playlist_utils::paste_at_focused_item(get_wnd());
 };
 
-t_size ng_playlist_view_t::storage_get_focus_item()
+t_size PlaylistView::storage_get_focus_item()
 {
     return static_api_ptr_t<playlist_manager>()->activeplaylist_get_focus_item();
 }
-void ng_playlist_view_t::storage_set_focus_item(t_size index)
+void PlaylistView::storage_set_focus_item(t_size index)
 {
     pfc::vartoggle_t<bool> tog(m_ignore_callback, true);
     static_api_ptr_t<playlist_manager>()->activeplaylist_set_focus_item(index);
 }
-void ng_playlist_view_t::storage_get_selection_state(pfc::bit_array_var& out)
+void PlaylistView::storage_get_selection_state(pfc::bit_array_var& out)
 {
     static_api_ptr_t<playlist_manager>()->activeplaylist_get_selection_mask(out);
 }
-bool ng_playlist_view_t::storage_set_selection_state(
+bool PlaylistView::storage_set_selection_state(
     const pfc::bit_array& p_affected, const pfc::bit_array& p_status, pfc::bit_array_var* p_changed)
 {
     pfc::vartoggle_t<bool> tog(m_ignore_callback, true);
@@ -1066,16 +1066,16 @@ bool ng_playlist_view_t::storage_set_selection_state(
     api->activeplaylist_set_selection(p_affected, p_status);
     return b_changed;
 }
-bool ng_playlist_view_t::storage_get_item_selected(t_size index)
+bool PlaylistView::storage_get_item_selected(t_size index)
 {
     return static_api_ptr_t<playlist_manager>()->activeplaylist_is_item_selected(index);
 }
-t_size ng_playlist_view_t::storage_get_selection_count(t_size max)
+t_size PlaylistView::storage_get_selection_count(t_size max)
 {
     return static_api_ptr_t<playlist_manager>()->activeplaylist_get_selection_count(max);
 }
 
-void ng_playlist_view_t::execute_default_action(t_size index, t_size column, bool b_keyboard, bool b_ctrl)
+void PlaylistView::execute_default_action(t_size index, t_size column, bool b_keyboard, bool b_ctrl)
 {
     if (b_keyboard && b_ctrl) {
         t_size active = m_playlist_api->get_active_playlist();
@@ -1085,40 +1085,40 @@ void ng_playlist_view_t::execute_default_action(t_size index, t_size column, boo
         m_playlist_api->activeplaylist_execute_default_action(index);
     }
 };
-void ng_playlist_view_t::move_selection(int delta)
+void PlaylistView::move_selection(int delta)
 {
     m_playlist_api->activeplaylist_undo_backup();
     m_playlist_api->activeplaylist_move_selection(delta);
 }
 
-const GUID& ng_playlist_view_t::get_extension_guid() const
+const GUID& PlaylistView::get_extension_guid() const
 {
     return g_extension_guid;
 }
 
-void ng_playlist_view_t::get_name(pfc::string_base& out) const
+void PlaylistView::get_name(pfc::string_base& out) const
 {
     out.set_string("Playlist view");
 }
-bool ng_playlist_view_t::get_short_name(pfc::string_base& out) const
+bool PlaylistView::get_short_name(pfc::string_base& out) const
 {
     out.set_string("Playlist");
     return true;
 }
-void ng_playlist_view_t::get_category(pfc::string_base& out) const
+void PlaylistView::get_category(pfc::string_base& out) const
 {
     out.set_string("Playlist Views");
 }
-unsigned ng_playlist_view_t::get_type() const
+unsigned PlaylistView::get_type() const
 {
     return uie::type_panel | uie::type_playlist;
 }
 
 // {FB059406-5F14-4bd0-8A11-4242854CBBA5}
-const GUID ng_playlist_view_t::g_extension_guid
+const GUID PlaylistView::g_extension_guid
     = {0xfb059406, 0x5f14, 0x4bd0, {0x8a, 0x11, 0x42, 0x42, 0x85, 0x4c, 0xbb, 0xa5}};
 
-uie::window_factory<ng_playlist_view_t> g_pvt;
+uie::window_factory<PlaylistView> g_pvt;
 
 // {C882D3AC-C014-44df-9C7E-2DADF37645A0}
 const GUID appearance_client_ngpv_impl::g_guid
@@ -1141,7 +1141,7 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { ng_playlist_view_t::g_on_font_change(); }
+    void on_font_changed() const override { PlaylistView::g_on_font_change(); }
 };
 
 class font_header_client_ngpv : public cui::fonts::client {
@@ -1151,7 +1151,7 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { ng_playlist_view_t::g_on_header_font_change(); }
+    void on_font_changed() const override { PlaylistView::g_on_header_font_change(); }
 };
 
 class font_group_header_client_ngpv : public cui::fonts::client {
@@ -1161,7 +1161,7 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { ng_playlist_view_t::g_on_group_header_font_change(); }
+    void on_font_changed() const override { PlaylistView::g_on_group_header_font_change(); }
 };
 
 font_client_ngpv::factory<font_client_ngpv> g_font_client_ngpv;
@@ -1171,8 +1171,8 @@ font_group_header_client_ngpv::factory<font_group_header_client_ngpv> g_font_gro
 void appearance_client_ngpv_impl::on_colour_changed(t_size mask) const
 {
     if (cfg_show_artwork && cfg_artwork_reflection && (mask & (cui::colours::colour_flag_background)))
-        ng_playlist_view_t::g_flush_artwork();
-    ng_playlist_view_t::g_update_all_items();
+        PlaylistView::g_flush_artwork();
+    PlaylistView::g_update_all_items();
 }
 
 } // namespace pvt

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -195,7 +195,7 @@ void PlaylistView::refresh_columns()
     t_size count = g_columns.get_count();
     m_column_mask.set_size(count);
     for (t_size i = 0; i < count; i++) {
-        column_t* source = g_columns[i].get_ptr();
+        PlaylistViewColumn* source = g_columns[i].get_ptr();
         bool b_valid = false;
         if (source->show) {
             switch (source->filter_type) {

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -312,7 +312,7 @@ public:
     void on_bool_changed(t_size mask) const override{};
 };
 
-class ng_playlist_view_t
+class PlaylistView
     : public t_list_view_panel<appearance_client_ngpv_impl, uie::playlist_window>
     , playlist_callback_single
     , playlist_callback_base {
@@ -330,7 +330,7 @@ class ng_playlist_view_t
             case WM_CREATE:
                 break;
             case WM_TIMECHANGE:
-                ng_playlist_view_t::g_on_time_change();
+                PlaylistView::g_on_time_change();
                 break;
             case WM_DESTROY:
                 break;
@@ -340,21 +340,21 @@ class ng_playlist_view_t
     };
 
 public:
-    ng_playlist_view_t();
-    ~ng_playlist_view_t();
+    PlaylistView();
+    ~PlaylistView();
 
-    static std::vector<ng_playlist_view_t*> g_windows;
+    static std::vector<PlaylistView*> g_windows;
     static ng_global_mesage_window g_global_mesage_window;
 
     static void g_on_groups_change();
     static void g_on_columns_change();
-    static void g_on_column_widths_change(const ng_playlist_view_t* p_skip = nullptr);
+    static void g_on_column_widths_change(const PlaylistView* p_skip = nullptr);
     static void g_update_all_items();
     static void g_on_autosize_change();
     static void g_on_show_artwork_change();
     static void g_on_alternate_selection_change();
-    static void g_on_artwork_width_change(const ng_playlist_view_t* p_skip = nullptr);
-    static void g_flush_artwork(bool b_redraw = false, const ng_playlist_view_t* p_skip = nullptr);
+    static void g_on_artwork_width_change(const PlaylistView* p_skip = nullptr);
+    static void g_flush_artwork(bool b_redraw = false, const PlaylistView* p_skip = nullptr);
     static void g_on_artwork_repositories_change();
     static void g_on_vertical_item_padding_change();
     static void g_on_show_header_change();
@@ -466,7 +466,7 @@ private:
         }
 
         item_group_ng_t::ptr m_group;
-        service_ptr_t<ng_playlist_view_t> m_window;
+        service_ptr_t<PlaylistView> m_window;
 
     private:
     };
@@ -581,7 +581,7 @@ private:
         t_size act_from = column_index_display_to_actual(index_from);
         t_size act_to = column_index_display_to_actual(index_to);
         g_columns.move(act_from, act_to);
-        pvt::ng_playlist_view_t::g_on_columns_change();
+        pvt::PlaylistView::g_on_columns_change();
     }
 
     bool notify_on_timer(UINT_PTR timerid) override
@@ -688,7 +688,7 @@ public:
     HRESULT STDMETHODCALLTYPE DragOver(DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
     HRESULT STDMETHODCALLTYPE DragLeave() override;
     HRESULT STDMETHODCALLTYPE Drop(IDataObject* pDataObj, DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
-    IDropTarget_playlist(ng_playlist_view_t* playlist);
+    IDropTarget_playlist(PlaylistView* playlist);
 
 private:
     HRESULT UpdateDropDescription(IDataObject* pDataObj, DWORD pdwEffect);
@@ -696,14 +696,14 @@ private:
     long drop_ref_count;
     bool last_rmb;
     bool m_is_accepted_type;
-    service_ptr_t<ng_playlist_view_t> p_playlist;
+    service_ptr_t<PlaylistView> p_playlist;
     pfc::com_ptr_t<IDataObject> m_DataObject;
     mmh::ComPtr<IDropTargetHelper> m_DropTargetHelper;
 };
 
 class IDropSource_playlist : public IDropSource {
     long refcount;
-    service_ptr_t<ng_playlist_view_t> p_playlist;
+    service_ptr_t<PlaylistView> p_playlist;
     DWORD m_initial_key_state;
 
 public:
@@ -712,7 +712,7 @@ public:
     ULONG STDMETHODCALLTYPE Release() override;
     HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState) override;
     HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD dwEffect) override;
-    IDropSource_playlist(ng_playlist_view_t* playlist, DWORD initial_key_state);
+    IDropSource_playlist(PlaylistView* playlist, DWORD initial_key_state);
 };
 
 class preferences_tab_impl : public PreferencesTab {

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -407,7 +407,7 @@ HBITMAP g_create_hbitmap_from_data(
     return ret;
 }
 
-HBITMAP ng_playlist_view_t::request_group_artwork(t_size index_item, t_size item_group_count)
+HBITMAP PlaylistView::request_group_artwork(t_size index_item, t_size item_group_count)
 {
     t_size group_count = m_scripts.get_count();
     HBITMAP ret = nullptr;

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -2,7 +2,7 @@
 #include "ng_playlist.h"
 
 namespace pvt {
-void ng_playlist_view_t::on_items_added(/*unsigned p_playlist, */ unsigned start,
+void PlaylistView::on_items_added(/*unsigned p_playlist, */ unsigned start,
     const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const pfc::bit_array& p_selection)
 {
     /*(if (p_playlist == 0)*/
@@ -16,7 +16,7 @@ void ng_playlist_view_t::on_items_added(/*unsigned p_playlist, */ unsigned start
         // reset_items();
     }
 }
-void ng_playlist_view_t::on_items_reordered(/*t_size p_playlist, */ const t_size* p_order, t_size p_count){
+void PlaylistView::on_items_reordered(/*t_size p_playlist, */ const t_size* p_order, t_size p_count){
     /*(if (p_playlist ==0)*/
     {clear_sort_column();
         for (t_size i = 0; i < p_count; i++) {
@@ -35,7 +35,7 @@ void ng_playlist_view_t::on_items_reordered(/*t_size p_playlist, */ const t_size
 ; // changes selection too; doesnt actually change set of items that are selected or item having focus, just changes
   // their order
 
-void ng_playlist_view_t::on_items_removed(/*t_size p_playlist, */ const pfc::bit_array& p_mask, t_size p_old_count,
+void PlaylistView::on_items_removed(/*t_size p_playlist, */ const pfc::bit_array& p_mask, t_size p_old_count,
     t_size p_new_count){/*(if (p_playlist == 0)*/
     {clear_sort_column();
 remove_items(p_mask, false);
@@ -45,7 +45,7 @@ invalidate_all();
 }
 }
 ;
-void ng_playlist_view_t::on_items_selection_change(
+void PlaylistView::on_items_selection_change(
     /*t_size p_playlist, */ const pfc::bit_array& p_affected, const pfc::bit_array& p_state)
 {
     /*(if (p_playlist == 0)*/
@@ -53,7 +53,7 @@ void ng_playlist_view_t::on_items_selection_change(
         RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
     }
 };
-void ng_playlist_view_t::on_item_focus_change(/*t_size p_playlist, */ t_size p_from, t_size p_to)
+void PlaylistView::on_item_focus_change(/*t_size p_playlist, */ t_size p_from, t_size p_to)
 {
     // if (p_playlist==0)
     if (!m_ignore_callback) {
@@ -61,7 +61,7 @@ void ng_playlist_view_t::on_item_focus_change(/*t_size p_playlist, */ t_size p_f
     }
 }; // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
 
-void ng_playlist_view_t::on_items_modified(/*t_size p_playlist, */ const pfc::bit_array& p_mask){// if (p_playlist==0)
+void PlaylistView::on_items_modified(/*t_size p_playlist, */ const pfc::bit_array& p_mask){// if (p_playlist==0)
     {clear_sort_column();
 t_size count = m_playlist_api->activeplaylist_get_item_count();
 
@@ -79,7 +79,7 @@ for (t_size i = 0; i < count; i++) {
 }
 }
 ;
-void ng_playlist_view_t::on_items_modified_fromplayback(
+void PlaylistView::on_items_modified_fromplayback(
     /*t_size p_playlist, */ const pfc::bit_array& p_mask, play_control::t_display_level p_level)
 {
     if (!core_api::is_shutting_down()) {
@@ -97,19 +97,19 @@ void ng_playlist_view_t::on_items_modified_fromplayback(
     }
 };
 
-void ng_playlist_view_t::on_items_replaced(/*t_size p_playlist, */ const pfc::bit_array& p_mask,
+void PlaylistView::on_items_replaced(/*t_size p_playlist, */ const pfc::bit_array& p_mask,
     const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data)
 {
     on_items_modified(p_mask);
 };
 
-void ng_playlist_view_t::on_item_ensure_visible(/*t_size p_playlist, */ t_size p_idx){// if (p_playlist==0)
+void PlaylistView::on_item_ensure_visible(/*t_size p_playlist, */ t_size p_idx){// if (p_playlist==0)
     {ensure_visible(p_idx);
 }
 }
 ;
 
-void ng_playlist_view_t::on_playlist_switch()
+void PlaylistView::on_playlist_switch()
 {
     clear_sort_column();
     clear_all_items();
@@ -144,7 +144,7 @@ void ng_playlist_view_t::on_playlist_switch()
     if (!b_scrolled && focus != pfc_infinite)
         ensure_visible(focus);
 };
-void ng_playlist_view_t::on_playlist_renamed(const char* p_new_name, t_size p_new_name_len)
+void PlaylistView::on_playlist_renamed(const char* p_new_name, t_size p_new_name_len)
 {
     clear_sort_column();
     clear_all_items();

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -112,7 +112,7 @@ BOOL preferences_tab_impl::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         switch (wp) {
         case IDC_GROUPING: {
             cfg_grouping = Button_GetCheck(HWND(lp)) == BST_CHECKED;
-            ng_playlist_view_t::g_on_groups_change();
+            PlaylistView::g_on_groups_change();
         } break;
         case IDC_GROUP_UP: {
             HWND list = uGetDlgItem(wnd, IDC_GROUPS);

--- a/foo_ui_columns/ng_playlist/ng_playlist_dropsource.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_dropsource.cpp
@@ -2,7 +2,7 @@
 #include "ng_playlist.h"
 
 namespace pvt {
-bool ng_playlist_view_t::do_drag_drop(WPARAM wp)
+bool PlaylistView::do_drag_drop(WPARAM wp)
 {
     metadb_handle_list_t<pfc::alloc_fast_aggressive> data;
     m_playlist_api->activeplaylist_get_selected_items(data);
@@ -77,7 +77,7 @@ HRESULT STDMETHODCALLTYPE IDropSource_playlist::GiveFeedback(DWORD dwEffect)
     return DRAGDROP_S_USEDEFAULTCURSORS;
 }
 
-IDropSource_playlist::IDropSource_playlist(ng_playlist_view_t* playlist, DWORD initial_key_state)
+IDropSource_playlist::IDropSource_playlist(PlaylistView* playlist, DWORD initial_key_state)
     : refcount(0), p_playlist(playlist), m_initial_key_state(initial_key_state){};
 
 } // namespace pvt

--- a/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
@@ -284,7 +284,7 @@ HRESULT STDMETHODCALLTYPE IDropTarget_playlist::Drop(
                 class delayed_drop_target_processer_t : public process_locations_notify {
                 public:
                     playlist_position_reference_tracker m_insertIndexTracker;
-                    service_ptr_t<ng_playlist_view_t> p_playlist;
+                    service_ptr_t<PlaylistView> p_playlist;
 
                     void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) override
                     {
@@ -321,7 +321,7 @@ HRESULT STDMETHODCALLTYPE IDropTarget_playlist::Drop(
 
     return S_OK;
 }
-IDropTarget_playlist::IDropTarget_playlist(ng_playlist_view_t* playlist)
+IDropTarget_playlist::IDropTarget_playlist(PlaylistView* playlist)
     : drop_ref_count(0), last_rmb(false), m_is_accepted_type(false), p_playlist(playlist)
 {
     m_DropTargetHelper.instantiate(CLSID_DragDropHelper, nullptr, CLSCTX_INPROC_SERVER);

--- a/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
@@ -2,13 +2,13 @@
 #include "ng_playlist.h"
 
 namespace pvt {
-bool ng_playlist_view_t::notify_before_create_inline_edit(
+bool PlaylistView::notify_before_create_inline_edit(
     const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse)
 {
     return (!b_source_mouse || main_window::config_get_inline_metafield_edit_mode() != main_window::mode_disabled)
         && column < m_edit_fields.get_count() && strlen(m_edit_fields[column]);
 };
-bool ng_playlist_view_t::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
+bool PlaylistView::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
     pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
 {
     t_size indices_count = indices.get_count();
@@ -49,7 +49,7 @@ bool ng_playlist_view_t::notify_create_inline_edit(const pfc::list_base_const_t<
     }
     return true;
 };
-void ng_playlist_view_t::notify_save_inline_edit(const char* value)
+void PlaylistView::notify_save_inline_edit(const char* value)
 {
     static_api_ptr_t<metadb_io_v2> tagger_api;
     if (strcmp(value, "<multiple values>") != 0) {
@@ -82,7 +82,7 @@ void ng_playlist_view_t::notify_save_inline_edit(const char* value)
         }
     }
 };
-void ng_playlist_view_t::notify_exit_inline_edit()
+void PlaylistView::notify_exit_inline_edit()
 {
     m_edit_field.reset();
     m_edit_handles.remove_all();

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -3,7 +3,7 @@
 
 namespace pvt {
 
-void ng_playlist_view_t::render_group_info(HDC dc, t_size index, t_size group_count, const RECT& rc2)
+void PlaylistView::render_group_info(HDC dc, t_size index, t_size group_count, const RECT& rc2)
 {
     if (!m_gdiplus_initialised)
         return;
@@ -42,7 +42,7 @@ void ng_playlist_view_t::render_group_info(HDC dc, t_size index, t_size group_co
     }
 }
 
-void ng_playlist_view_t::render_item(HDC dc, t_size index, int indentation, bool b_selected, bool b_window_focused,
+void PlaylistView::render_item(HDC dc, t_size index, int indentation, bool b_selected, bool b_window_focused,
     bool b_highlight, bool should_hide_focus, bool b_focused, const RECT* rc_outter_item)
 {
     cui::colours::helper p_helper(appearance_client_ngpv_impl::g_guid);
@@ -149,7 +149,7 @@ void ng_playlist_view_t::render_item(HDC dc, t_size index, int indentation, bool
     }
 }
 
-void ng_playlist_view_t::render_group(
+void PlaylistView::render_group(
     HDC dc, t_size index, t_size group, const char* text, int indentation, t_size level, const RECT& rc)
 {
     cui::colours::helper p_helper(appearance_client_ngpv_impl::g_guid);

--- a/foo_ui_columns/playlist_switcher.cpp
+++ b/foo_ui_columns/playlist_switcher.cpp
@@ -23,12 +23,12 @@ public:
 font_client_switcher::factory<font_client_switcher> g_font_client_switcher;
 
 // {EB38A997-3B5F-4126-8746-262AA9C1F94B}
-const GUID appearance_client_ps_impl::g_guid
+const GUID PlaylistSwitcherColoursClient::g_guid
     = {0xeb38a997, 0x3b5f, 0x4126, {0x87, 0x46, 0x26, 0x2a, 0xa9, 0xc1, 0xf9, 0x4b}};
 
-appearance_client_ps_impl::factory<appearance_client_ps_impl> g_appearance_client_ps_impl;
+PlaylistSwitcherColoursClient::factory<PlaylistSwitcherColoursClient> g_appearance_client_ps_impl;
 
-void appearance_client_ps_impl::on_colour_changed(t_size mask) const
+void PlaylistSwitcherColoursClient::on_colour_changed(t_size mask) const
 {
     PlaylistSwitcher::g_redraw_all();
 }

--- a/foo_ui_columns/playlist_switcher.cpp
+++ b/foo_ui_columns/playlist_switcher.cpp
@@ -17,7 +17,7 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { playlist_switcher_t::g_on_font_items_change(); }
+    void on_font_changed() const override { PlaylistSwitcher::g_on_font_items_change(); }
 };
 
 font_client_switcher::factory<font_client_switcher> g_font_client_switcher;
@@ -30,5 +30,5 @@ appearance_client_ps_impl::factory<appearance_client_ps_impl> g_appearance_clien
 
 void appearance_client_ps_impl::on_colour_changed(t_size mask) const
 {
-    playlist_switcher_t::g_redraw_all();
+    PlaylistSwitcher::g_redraw_all();
 }

--- a/foo_ui_columns/playlist_switcher.h
+++ b/foo_ui_columns/playlist_switcher.h
@@ -1,7 +1,7 @@
 #ifndef _COLUMNS_UI_PLAYLIST_SWITCHER_H_
 #define _COLUMNS_UI_PLAYLIST_SWITCHER_H_
 
-class appearance_client_ps_impl : public cui::colours::client {
+class PlaylistSwitcherColoursClient : public cui::colours::client {
 public:
     static const GUID g_guid;
 

--- a/foo_ui_columns/playlist_switcher_callbacks.cpp
+++ b/foo_ui_columns/playlist_switcher_callbacks.cpp
@@ -1,29 +1,29 @@
 #include "stdafx.h"
 #include "playlist_switcher_v2.h"
 
-void playlist_switcher_t::on_items_added(t_size p_playlist, t_size p_start,
+void PlaylistSwitcher::on_items_added(t_size p_playlist, t_size p_start,
     const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const pfc::bit_array& p_selection)
 {
     refresh_items(p_playlist, 1);
 }
-void playlist_switcher_t::on_items_removed(
+void PlaylistSwitcher::on_items_removed(
     t_size p_playlist, const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count)
 {
     refresh_items(p_playlist, 1);
 }
 
-void playlist_switcher_t::on_items_modified(t_size p_playlist, const pfc::bit_array& p_mask)
+void PlaylistSwitcher::on_items_modified(t_size p_playlist, const pfc::bit_array& p_mask)
 {
     refresh_items(p_playlist, 1);
 }
 
-void playlist_switcher_t::on_items_replaced(
+void PlaylistSwitcher::on_items_replaced(
     t_size p_playlist, const pfc::bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
 {
     refresh_items(p_playlist, 1);
 }
 
-void playlist_switcher_t::on_playlist_activate(t_size p_old, t_size p_new)
+void PlaylistSwitcher::on_playlist_activate(t_size p_old, t_size p_new)
 {
     if (p_old != pfc_infinite && p_old < get_item_count())
         refresh_items(p_old, 1, false);
@@ -34,12 +34,12 @@ void playlist_switcher_t::on_playlist_activate(t_size p_old, t_size p_new)
     } else
         set_selection_state(pfc::bit_array_true(), pfc::bit_array_false(), false);
 };
-void playlist_switcher_t::on_playlist_created(t_size p_index, const char* p_name, t_size p_name_len)
+void PlaylistSwitcher::on_playlist_created(t_size p_index, const char* p_name, t_size p_name_len)
 {
     refresh_playing_playlist();
     add_items(p_index, 1);
 };
-void playlist_switcher_t::on_playlists_reorder(const t_size* p_order, t_size p_count)
+void PlaylistSwitcher::on_playlists_reorder(const t_size* p_order, t_size p_count)
 {
     refresh_playing_playlist();
     t_size start = 0;
@@ -54,30 +54,30 @@ void playlist_switcher_t::on_playlists_reorder(const t_size* p_order, t_size p_c
     if (index != pfc_infinite)
         set_item_selected_single(index, false);
 };
-void playlist_switcher_t::on_playlists_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count)
+void PlaylistSwitcher::on_playlists_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count)
 {
     refresh_playing_playlist();
     remove_items(p_mask);
 }
-void playlist_switcher_t::on_playlist_renamed(t_size p_index, const char* p_new_name, t_size p_new_name_len)
+void PlaylistSwitcher::on_playlist_renamed(t_size p_index, const char* p_new_name, t_size p_new_name_len)
 {
     refresh_items(p_index, 1);
 };
 
-void playlist_switcher_t::on_playlist_locked(t_size p_playlist, bool p_locked)
+void PlaylistSwitcher::on_playlist_locked(t_size p_playlist, bool p_locked)
 {
     refresh_items(p_playlist, 1);
 };
 
-void playlist_switcher_t::on_playback_starting(play_control::t_track_command p_command, bool p_paused)
+void PlaylistSwitcher::on_playback_starting(play_control::t_track_command p_command, bool p_paused)
 {
     on_playing_playlist_change(get_playing_playlist());
 };
-void playlist_switcher_t::on_playback_new_track(metadb_handle_ptr p_track)
+void PlaylistSwitcher::on_playback_new_track(metadb_handle_ptr p_track)
 {
     on_playing_playlist_change(get_playing_playlist());
 };
-void playlist_switcher_t::on_playback_stop(play_control::t_stop_reason p_reason)
+void PlaylistSwitcher::on_playback_stop(play_control::t_stop_reason p_reason)
 {
     if (p_reason != play_control::stop_reason_shutting_down)
         on_playing_playlist_change(get_playing_playlist());

--- a/foo_ui_columns/playlist_switcher_drop_source.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_source.cpp
@@ -23,7 +23,7 @@ bool PlaylistSwitcher::do_drag_drop(WPARAM wp)
     return true;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::QueryInterface(REFIID iid, void** ppvObject)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropSource::QueryInterface(REFIID iid, void** ppvObject)
 {
     if (ppvObject == nullptr)
         return E_INVALIDARG;
@@ -40,11 +40,11 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::QueryInterface(REFIID
     }
     return E_NOINTERFACE;
 }
-ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::AddRef()
+ULONG STDMETHODCALLTYPE PlaylistSwitcher::DropSource::AddRef()
 {
     return InterlockedIncrement(&refcount);
 }
-ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::Release()
+ULONG STDMETHODCALLTYPE PlaylistSwitcher::DropSource::Release()
 {
     LONG rv = InterlockedDecrement(&refcount);
     if (!rv) {
@@ -53,7 +53,7 @@ ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::Release()
     return rv;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropSource::QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState)
 {
     if (fEscapePressed || ((m_initial_key_state & MK_LBUTTON) && (grfKeyState & MK_RBUTTON))) {
         return DRAGDROP_S_CANCEL;
@@ -65,10 +65,10 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::QueryContinueDrag(BOO
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::GiveFeedback(DWORD dwEffect)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropSource::GiveFeedback(DWORD dwEffect)
 {
     return DRAGDROP_S_USEDEFAULTCURSORS;
 }
 
-PlaylistSwitcher::IDropSource_t::IDropSource_t(PlaylistSwitcher* p_window, DWORD initial_key_state)
+PlaylistSwitcher::DropSource::DropSource(PlaylistSwitcher* p_window, DWORD initial_key_state)
     : refcount(0), m_window(p_window), m_initial_key_state(initial_key_state){};

--- a/foo_ui_columns/playlist_switcher_drop_source.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_source.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "playlist_switcher_v2.h"
 
-bool playlist_switcher_t::do_drag_drop(WPARAM wp)
+bool PlaylistSwitcher::do_drag_drop(WPARAM wp)
 {
     pfc::bit_array_bittable mask(get_item_count());
     get_selection_state(mask);
@@ -23,7 +23,7 @@ bool playlist_switcher_t::do_drag_drop(WPARAM wp)
     return true;
 }
 
-HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropSource_t::QueryInterface(REFIID iid, void** ppvObject)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::QueryInterface(REFIID iid, void** ppvObject)
 {
     if (ppvObject == nullptr)
         return E_INVALIDARG;
@@ -40,11 +40,11 @@ HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropSource_t::QueryInterface(REF
     }
     return E_NOINTERFACE;
 }
-ULONG STDMETHODCALLTYPE playlist_switcher_t::IDropSource_t::AddRef()
+ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::AddRef()
 {
     return InterlockedIncrement(&refcount);
 }
-ULONG STDMETHODCALLTYPE playlist_switcher_t::IDropSource_t::Release()
+ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::Release()
 {
     LONG rv = InterlockedDecrement(&refcount);
     if (!rv) {
@@ -53,7 +53,7 @@ ULONG STDMETHODCALLTYPE playlist_switcher_t::IDropSource_t::Release()
     return rv;
 }
 
-HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropSource_t::QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState)
 {
     if (fEscapePressed || ((m_initial_key_state & MK_LBUTTON) && (grfKeyState & MK_RBUTTON))) {
         return DRAGDROP_S_CANCEL;
@@ -65,10 +65,10 @@ HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropSource_t::QueryContinueDrag(
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropSource_t::GiveFeedback(DWORD dwEffect)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropSource_t::GiveFeedback(DWORD dwEffect)
 {
     return DRAGDROP_S_USEDEFAULTCURSORS;
 }
 
-playlist_switcher_t::IDropSource_t::IDropSource_t(playlist_switcher_t* p_window, DWORD initial_key_state)
+PlaylistSwitcher::IDropSource_t::IDropSource_t(PlaylistSwitcher* p_window, DWORD initial_key_state)
     : refcount(0), m_window(p_window), m_initial_key_state(initial_key_state){};

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -55,7 +55,7 @@ bool g_get_folder_name(IDataObject* pDataObj, pfc::string8& p_out)
     return ret;
 }
 
-HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::QueryInterface(REFIID riid, LPVOID FAR* ppvObject)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::QueryInterface(REFIID riid, LPVOID FAR* ppvObject)
 {
     if (ppvObject == nullptr)
         return E_INVALIDARG;
@@ -73,12 +73,12 @@ HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::QueryInterface(REF
     return E_NOINTERFACE;
 }
 
-ULONG STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::AddRef()
+ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::AddRef()
 {
     return InterlockedIncrement(&drop_ref_count);
 }
 
-ULONG STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::Release()
+ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::Release()
 {
     LONG rv = InterlockedDecrement(&drop_ref_count);
     if (!rv) {
@@ -87,7 +87,7 @@ ULONG STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::Release()
     return rv;
 }
 
-HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::DragEnter(
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragEnter(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -121,7 +121,7 @@ HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::DragEnter(
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::DragOver(DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragOver(DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
     bool isAltDown = (grfKeyState & MK_ALT) != 0;
@@ -234,7 +234,7 @@ HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::DragOver(DWORD grf
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::DragLeave()
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragLeave()
 {
     if (m_DropTargetHelper.is_valid())
         m_DropTargetHelper->DragLeave();
@@ -257,7 +257,7 @@ HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::DragLeave()
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::Drop(
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::Drop(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -398,7 +398,7 @@ HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::Drop(
                     class delayed_drop_target_processer_t : public process_locations_notify {
                     public:
                         playlist_position_reference_tracker m_insertIndexTracker;
-                        service_ptr_t<playlist_switcher_t> m_window;
+                        service_ptr_t<PlaylistSwitcher> m_window;
                         bool m_new_playlist{false};
                         pfc::string8 m_playlist_name;
 
@@ -457,7 +457,7 @@ HRESULT STDMETHODCALLTYPE playlist_switcher_t::IDropTarget_t::Drop(
     return S_OK;
 }
 
-playlist_switcher_t::IDropTarget_t::IDropTarget_t(playlist_switcher_t* p_window)
+PlaylistSwitcher::IDropTarget_t::IDropTarget_t(PlaylistSwitcher* p_window)
     : drop_ref_count(0), m_last_rmb(false), m_is_playlists(false), m_is_accepted_type(false), m_window(p_window)
 {
     m_ole_api = standard_api_create_t<ole_interaction_v2>();

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -55,7 +55,7 @@ bool g_get_folder_name(IDataObject* pDataObj, pfc::string8& p_out)
     return ret;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::QueryInterface(REFIID riid, LPVOID FAR* ppvObject)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::QueryInterface(REFIID riid, LPVOID FAR* ppvObject)
 {
     if (ppvObject == nullptr)
         return E_INVALIDARG;
@@ -73,12 +73,12 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::QueryInterface(REFIID
     return E_NOINTERFACE;
 }
 
-ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::AddRef()
+ULONG STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::AddRef()
 {
     return InterlockedIncrement(&drop_ref_count);
 }
 
-ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::Release()
+ULONG STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Release()
 {
     LONG rv = InterlockedDecrement(&drop_ref_count);
     if (!rv) {
@@ -87,7 +87,7 @@ ULONG STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::Release()
     return rv;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragEnter(
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::DragEnter(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -121,7 +121,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragEnter(
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragOver(DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::DragOver(DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
     bool isAltDown = (grfKeyState & MK_ALT) != 0;
@@ -234,7 +234,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragOver(DWORD grfKey
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragLeave()
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::DragLeave()
 {
     if (m_DropTargetHelper.is_valid())
         m_DropTargetHelper->DragLeave();
@@ -257,7 +257,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::DragLeave()
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::Drop(
+HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -395,7 +395,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::Drop(
                         playlist_name.replace_char('_', ' ', 0);
 
                 {
-                    class delayed_drop_target_processer_t : public process_locations_notify {
+                    class DelayedDropTargetProcesser : public process_locations_notify {
                     public:
                         playlist_position_reference_tracker m_insertIndexTracker;
                         service_ptr_t<PlaylistSwitcher> m_window;
@@ -431,11 +431,11 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::Drop(
                         }
                         void on_aborted() override {}
 
-                        delayed_drop_target_processer_t() : m_insertIndexTracker(false){};
+                        DelayedDropTargetProcesser() : m_insertIndexTracker(false){};
                     };
 
-                    service_ptr_t<delayed_drop_target_processer_t> ptr
-                        = new service_impl_t<delayed_drop_target_processer_t>;
+                    service_ptr_t<DelayedDropTargetProcesser> ptr
+                        = new service_impl_t<DelayedDropTargetProcesser>;
                     ptr->m_window = m_window;
                     ptr->m_insertIndexTracker.m_playlist = idx;
                     ptr->m_new_playlist = create_new;
@@ -457,7 +457,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::IDropTarget_t::Drop(
     return S_OK;
 }
 
-PlaylistSwitcher::IDropTarget_t::IDropTarget_t(PlaylistSwitcher* p_window)
+PlaylistSwitcher::DropTarget::DropTarget(PlaylistSwitcher* p_window)
     : drop_ref_count(0), m_last_rmb(false), m_is_playlists(false), m_is_accepted_type(false), m_window(p_window)
 {
     m_ole_api = standard_api_create_t<ole_interaction_v2>();

--- a/foo_ui_columns/playlist_switcher_inline_edit.cpp
+++ b/foo_ui_columns/playlist_switcher_inline_edit.cpp
@@ -1,12 +1,12 @@
 #include "stdafx.h"
 #include "playlist_switcher_v2.h"
 
-bool playlist_switcher_t::notify_before_create_inline_edit(
+bool PlaylistSwitcher::notify_before_create_inline_edit(
     const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse)
 {
     return column == 0 && indices.get_count() == 1;
 };
-bool playlist_switcher_t::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
+bool PlaylistSwitcher::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
     pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
 {
     t_size indices_count = indices.get_count();
@@ -18,7 +18,7 @@ bool playlist_switcher_t::notify_create_inline_edit(const pfc::list_base_const_t
     }
     return false;
 };
-void playlist_switcher_t::notify_save_inline_edit(const char* value)
+void PlaylistSwitcher::notify_save_inline_edit(const char* value)
 {
     if (m_edit_playlist.is_valid() && m_edit_playlist->m_playlist != pfc_infinite) {
         pfc::string8 current;

--- a/foo_ui_columns/playlist_switcher_shortcut_menu.cpp
+++ b/foo_ui_columns/playlist_switcher_shortcut_menu.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "playlist_switcher_v2.h"
 
-bool playlist_switcher_t::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
+bool PlaylistSwitcher::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
 {
     uie::window_ptr p_this_temp = this;
     HMENU menu = CreatePopupMenu();

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -2,12 +2,12 @@
 #include "playlist_switcher_v2.h"
 
 // {70A5C273-67AB-4bb6-B61C-F7975A6871FD}
-const GUID playlist_switcher_t::g_guid_font
+const GUID PlaylistSwitcher::g_guid_font
     = {0x70a5c273, 0x67ab, 0x4bb6, {0xb6, 0x1c, 0xf7, 0x97, 0x5a, 0x68, 0x71, 0xfd}};
 
-std::vector<playlist_switcher_t*> playlist_switcher_t::g_windows;
+std::vector<PlaylistSwitcher*> PlaylistSwitcher::g_windows;
 
-void playlist_switcher_t::get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& p_out)
+void PlaylistSwitcher::get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& p_out)
 {
     p_out.set_count(count);
 
@@ -19,7 +19,7 @@ void playlist_switcher_t::get_insert_items(t_size base, t_size count, pfc::list_
     }
 }
 
-void playlist_switcher_t::refresh_all_items()
+void PlaylistSwitcher::refresh_all_items()
 {
     remove_items(pfc::bit_array_true(), false);
 
@@ -30,26 +30,26 @@ void playlist_switcher_t::refresh_all_items()
         set_item_selected_single(index, false);
 }
 
-void playlist_switcher_t::refresh_items(t_size base, t_size count, bool b_update)
+void PlaylistSwitcher::refresh_items(t_size base, t_size count, bool b_update)
 {
     pfc::list_t<uih::ListView::InsertItem> items_insert;
     get_insert_items(base, count, items_insert);
     replace_items(base, items_insert, b_update);
 }
 
-void playlist_switcher_t::add_items(t_size base, t_size count)
+void PlaylistSwitcher::add_items(t_size base, t_size count)
 {
     pfc::list_t<uih::ListView::InsertItem> items_insert;
     get_insert_items(base, count, items_insert);
     insert_items(base, items_insert.get_count(), items_insert.get_ptr());
 }
 
-void playlist_switcher_t::refresh_columns()
+void PlaylistSwitcher::refresh_columns()
 {
     set_columns(pfc::list_single_ref_t<Column>(Column("Name", 100)));
 }
 
-void playlist_switcher_t::move_selection(int delta)
+void PlaylistSwitcher::move_selection(int delta)
 {
     t_size count = m_playlist_api->get_playlist_count();
     order_helper order(count);
@@ -77,29 +77,29 @@ void playlist_switcher_t::move_selection(int delta)
         }
     }
 }
-void playlist_switcher_t::g_on_edgestyle_change()
+void PlaylistSwitcher::g_on_edgestyle_change()
 {
     for (auto& window : g_windows) {
         window->set_edge_style(cfg_plistframe);
     }
 }
-void playlist_switcher_t::g_on_vertical_item_padding_change()
+void PlaylistSwitcher::g_on_vertical_item_padding_change()
 {
     for (auto& window : g_windows) {
         window->set_vertical_item_padding(settings::playlist_switcher_item_padding);
     }
 }
-void playlist_switcher_t::g_redraw_all()
+void PlaylistSwitcher::g_redraw_all()
 {
     for (auto& window : g_windows)
         RedrawWindow(window->get_wnd(), nullptr, nullptr, RDW_UPDATENOW | RDW_INVALIDATE);
 }
-void playlist_switcher_t::g_refresh_all_items()
+void PlaylistSwitcher::g_refresh_all_items()
 {
     for (auto& window : g_windows)
         window->refresh_all_items();
 }
-void playlist_switcher_t::g_on_font_items_change()
+void PlaylistSwitcher::g_on_font_items_change()
 {
     LOGFONT lf;
     static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_font, lf);
@@ -107,7 +107,7 @@ void playlist_switcher_t::g_on_font_items_change()
         window->set_font(&lf);
     }
 }
-void playlist_switcher_t::notify_on_initialisation()
+void PlaylistSwitcher::notify_on_initialisation()
 {
     set_autosize(true);
     set_single_selection(true);
@@ -119,7 +119,7 @@ void playlist_switcher_t::notify_on_initialisation()
     static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_font, lf);
     set_font(&lf);
 };
-void playlist_switcher_t::notify_on_create()
+void PlaylistSwitcher::notify_on_create()
 {
     m_playlist_api = standard_api_create_t<playlist_manager_v3>();
     m_playback_api = standard_api_create_t<playback_control>();
@@ -138,7 +138,7 @@ void playlist_switcher_t::notify_on_create()
 
     g_windows.push_back(this);
 }
-void playlist_switcher_t::notify_on_destroy()
+void PlaylistSwitcher::notify_on_destroy()
 {
     m_selection_holder.release();
 
@@ -153,5 +153,5 @@ void playlist_switcher_t::notify_on_destroy()
 }
 
 namespace {
-uie::window_factory<playlist_switcher_t> g_playlist_switcher;
+uie::window_factory<PlaylistSwitcher> g_playlist_switcher;
 }

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -133,7 +133,7 @@ void PlaylistSwitcher::notify_on_create()
     m_playlist_api->register_callback(this, playlist_callback::flag_all);
     standard_api_create_t<play_callback_manager>()->register_callback(this, play_callback::flag_on_playback_all, false);
 
-    pfc::com_ptr_t<IDropTarget_t> drop_target = new IDropTarget_t(this);
+    pfc::com_ptr_t<DropTarget> drop_target = new DropTarget(this);
     RegisterDragDrop(get_wnd(), drop_target.get_ptr());
 
     g_windows.push_back(this);

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -5,7 +5,7 @@
 #include "list_view_panel.h"
 
 class PlaylistSwitcher
-    : public t_list_view_panel<appearance_client_ps_impl, uie::window>
+    : public t_list_view_panel<PlaylistSwitcherColoursClient, uie::window>
     , private playlist_callback
     , private play_callback {
     enum {
@@ -29,7 +29,7 @@ class PlaylistSwitcher
 
     enum { TIMER_SWITCH = TIMER_BASE };
 
-    class IDropSource_t : public IDropSource {
+    class DropSource : public IDropSource {
         long refcount;
         service_ptr_t<PlaylistSwitcher> m_window;
         DWORD m_initial_key_state;
@@ -40,10 +40,10 @@ class PlaylistSwitcher
         ULONG STDMETHODCALLTYPE Release() override;
         HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState) override;
         HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD dwEffect) override;
-        IDropSource_t(PlaylistSwitcher* p_window, DWORD initial_key_state);
+        DropSource(PlaylistSwitcher* p_window, DWORD initial_key_state);
     };
 
-    class IDropTarget_t : public IDropTarget {
+    class DropTarget : public IDropTarget {
     public:
         HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID FAR* ppvObject) override;
         ULONG STDMETHODCALLTYPE AddRef() override;
@@ -54,7 +54,7 @@ class PlaylistSwitcher
         HRESULT STDMETHODCALLTYPE DragLeave() override;
         HRESULT STDMETHODCALLTYPE Drop(IDataObject* pDataObj, DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
 
-        IDropTarget_t(PlaylistSwitcher* p_window);
+        DropTarget(PlaylistSwitcher* p_window);
 
     private:
         long drop_ref_count;

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -4,7 +4,7 @@
 #include "playlist_switcher.h"
 #include "list_view_panel.h"
 
-class playlist_switcher_t
+class PlaylistSwitcher
     : public t_list_view_panel<appearance_client_ps_impl, uie::window>
     , private playlist_callback
     , private play_callback {
@@ -31,7 +31,7 @@ class playlist_switcher_t
 
     class IDropSource_t : public IDropSource {
         long refcount;
-        service_ptr_t<playlist_switcher_t> m_window;
+        service_ptr_t<PlaylistSwitcher> m_window;
         DWORD m_initial_key_state;
 
     public:
@@ -40,7 +40,7 @@ class playlist_switcher_t
         ULONG STDMETHODCALLTYPE Release() override;
         HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL fEscapePressed, DWORD grfKeyState) override;
         HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD dwEffect) override;
-        IDropSource_t(playlist_switcher_t* p_window, DWORD initial_key_state);
+        IDropSource_t(PlaylistSwitcher* p_window, DWORD initial_key_state);
     };
 
     class IDropTarget_t : public IDropTarget {
@@ -54,14 +54,14 @@ class playlist_switcher_t
         HRESULT STDMETHODCALLTYPE DragLeave() override;
         HRESULT STDMETHODCALLTYPE Drop(IDataObject* pDataObj, DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
 
-        IDropTarget_t(playlist_switcher_t* p_window);
+        IDropTarget_t(PlaylistSwitcher* p_window);
 
     private:
         long drop_ref_count;
         bool m_last_rmb;
         bool m_is_playlists;
         bool m_is_accepted_type;
-        service_ptr_t<playlist_switcher_t> m_window;
+        service_ptr_t<PlaylistSwitcher> m_window;
         pfc::com_ptr_t<IDataObject> m_DataObject;
         service_ptr_t<ole_interaction_v2> m_ole_api;
         service_ptr_t<playlist_manager_v4> m_playlist_api;
@@ -306,7 +306,7 @@ public:
     }
     unsigned get_type() const override { return uie::type_panel; }
 
-    playlist_switcher_t() : m_playing_playlist(pfc_infinite){};
+    PlaylistSwitcher() : m_playing_playlist(pfc_infinite){};
 
 private:
     contextmenu_manager::ptr m_contextmenu_manager;
@@ -326,5 +326,5 @@ private:
     service_ptr_t<playback_control> m_playback_api;
 
     static const GUID g_guid_font;
-    static std::vector<playlist_switcher_t*> g_windows;
+    static std::vector<PlaylistSwitcher*> g_windows;
 };

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -22,25 +22,25 @@ void remove_playlist_helper(t_size index)
     api->remove_playlist_switch(index);
 }
 
-ui_extension::window_factory<playlists_tabs_extension> blah;
-ui_extension::window_host_factory<playlists_tabs_extension::window_host_impl> g_tab_host;
+ui_extension::window_factory<PlaylistTabs> blah;
+ui_extension::window_host_factory<PlaylistTabs::window_host_impl> g_tab_host;
 
-HFONT playlists_tabs_extension::g_font = nullptr;
+HFONT PlaylistTabs::g_font = nullptr;
 
-void playlists_tabs_extension::get_supported_panels(
+void PlaylistTabs::get_supported_panels(
     const pfc::list_base_const_t<uie::window::ptr>& p_windows, pfc::bit_array_var& p_mask_unsupported)
 {
     service_ptr_t<service_base> temp;
     g_tab_host.instance_create(temp);
     uie::window_host_ptr ptr;
     if (temp->service_query_t(ptr))
-        (static_cast<playlists_tabs_extension::window_host_impl*>(ptr.get_ptr()))->set_this(this);
+        (static_cast<PlaylistTabs::window_host_impl*>(ptr.get_ptr()))->set_this(this);
     t_size count = p_windows.get_count();
     for (t_size i = 0; i < count; i++)
         p_mask_unsupported.set(i, !p_windows[i]->is_available(ptr));
 }
 
-bool playlists_tabs_extension::is_point_ours(
+bool PlaylistTabs::is_point_ours(
     HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<uie::window::ptr>& p_hierarchy)
 {
     if (wnd_point == get_wnd() || IsChild(get_wnd(), wnd_point)) {
@@ -69,7 +69,7 @@ bool playlists_tabs_extension::is_point_ours(
     return false;
 };
 
-void playlists_tabs_extension::on_font_change()
+void PlaylistTabs::on_font_change()
 {
     if (g_font != nullptr) {
         unsigned count = list_wnd.get_count();
@@ -94,9 +94,9 @@ void playlists_tabs_extension::on_font_change()
     }
 }
 
-pfc::ptr_list_t<playlists_tabs_extension> playlists_tabs_extension::list_wnd;
+pfc::ptr_list_t<PlaylistTabs> PlaylistTabs::list_wnd;
 
-void playlists_tabs_extension::kill_switch_timer()
+void PlaylistTabs::kill_switch_timer()
 {
     if (m_switch_timer) {
         m_switch_timer = false;
@@ -104,7 +104,7 @@ void playlists_tabs_extension::kill_switch_timer()
     }
 }
 
-void playlists_tabs_extension::switch_to_playlist_delayed2(unsigned idx)
+void PlaylistTabs::switch_to_playlist_delayed2(unsigned idx)
 {
     // if have a timer already and idxs re same dont bother
     if (!(m_switch_timer && idx == m_switch_playlist)) {
@@ -116,15 +116,15 @@ void playlists_tabs_extension::switch_to_playlist_delayed2(unsigned idx)
     }
 }
 
-playlists_tabs_extension::~playlists_tabs_extension() = default;
+PlaylistTabs::~PlaylistTabs() = default;
 
-LRESULT WINAPI playlists_tabs_extension::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI PlaylistTabs::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
-    auto p_this = reinterpret_cast<playlists_tabs_extension*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
+    auto p_this = reinterpret_cast<PlaylistTabs*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
     return p_this ? p_this->hook(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
 }
 
-void playlists_tabs_extension::create_child()
+void PlaylistTabs::create_child()
 {
     destroy_child();
     if (m_host.is_valid()) {
@@ -151,7 +151,7 @@ void playlists_tabs_extension::create_child()
     }
 }
 
-void playlists_tabs_extension::destroy_child()
+void PlaylistTabs::destroy_child()
 {
     if (m_child.is_valid()) {
         m_child->destroy_window();
@@ -163,7 +163,7 @@ void playlists_tabs_extension::destroy_child()
     }
 }
 
-bool playlists_tabs_extension::create_tabs()
+bool PlaylistTabs::create_tabs()
 {
     bool rv = false;
     bool force_close = false;
@@ -230,30 +230,30 @@ bool playlists_tabs_extension::create_tabs()
     return rv;
 }
 
-const GUID& playlists_tabs_extension::get_extension_guid() const
+const GUID& PlaylistTabs::get_extension_guid() const
 {
     return extension_guid;
 }
 
-void playlists_tabs_extension::get_name(pfc::string_base& out) const
+void PlaylistTabs::get_name(pfc::string_base& out) const
 {
     out.set_string("Playlist tabs");
 }
-void playlists_tabs_extension::get_category(pfc::string_base& out) const
+void PlaylistTabs::get_category(pfc::string_base& out) const
 {
     out.set_string("Splitters");
 }
-bool playlists_tabs_extension::get_short_name(pfc::string_base& out) const
+bool PlaylistTabs::get_short_name(pfc::string_base& out) const
 {
     out.set_string("Playlist tabs");
     return true;
 }
 
 // {ABB72D0D-DBF0-4bba-8C68-3357EBE07A4D}
-const GUID playlists_tabs_extension::extension_guid
+const GUID PlaylistTabs::extension_guid
     = {0xabb72d0d, 0xdbf0, 0x4bba, {0x8c, 0x68, 0x33, 0x57, 0xeb, 0xe0, 0x7a, 0x4d}};
 
-LRESULT WINAPI playlists_tabs_extension::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_GETDLGCODE:
@@ -402,7 +402,7 @@ LRESULT WINAPI playlists_tabs_extension::hook(HWND wnd, UINT msg, WPARAM wp, LPA
     return uCallWindowProc(tabproc, wnd, msg, wp, lp);
 }
 
-void playlists_tabs_extension::on_child_position_change()
+void PlaylistTabs::on_child_position_change()
 {
     reset_size_limits();
     get_host()->on_size_limit_change(get_wnd(),
@@ -411,7 +411,7 @@ void playlists_tabs_extension::on_child_position_change()
     // on_size();
 }
 
-void playlists_tabs_extension::get_config(stream_writer* out, abort_callback& p_abort) const
+void PlaylistTabs::get_config(stream_writer* out, abort_callback& p_abort) const
 {
     out->write_lendian_t(m_child_guid, p_abort);
     if (m_child.is_valid()) {
@@ -427,7 +427,7 @@ void playlists_tabs_extension::get_config(stream_writer* out, abort_callback& p_
     }
 }
 
-void playlists_tabs_extension::set_config(stream_reader* config, t_size p_size, abort_callback& p_abort)
+void PlaylistTabs::set_config(stream_reader* config, t_size p_size, abort_callback& p_abort)
 {
     if (p_size) {
         config->read_lendian_t(m_child_guid, p_abort);
@@ -439,7 +439,7 @@ void playlists_tabs_extension::set_config(stream_reader* config, t_size p_size, 
     }
 }
 
-void playlists_tabs_extension::export_config(stream_writer* p_writer, abort_callback& p_abort) const
+void PlaylistTabs::export_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
     abort_callback_dummy abortCallback;
     p_writer->write_lendian_t(m_child_guid, p_abort);
@@ -461,7 +461,7 @@ void playlists_tabs_extension::export_config(stream_writer* p_writer, abort_call
     p_writer->write(data.get_ptr(), data.get_size(), p_abort);
 }
 
-void playlists_tabs_extension::import_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
+void PlaylistTabs::import_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
 {
     if (p_size) {
         p_reader->read_lendian_t(m_child_guid, p_abort);
@@ -484,7 +484,7 @@ void playlists_tabs_extension::import_config(stream_reader* p_reader, t_size p_s
     }
 }
 
-uie::splitter_item_t* playlists_tabs_extension::get_panel(unsigned index) const
+uie::splitter_item_t* PlaylistTabs::get_panel(unsigned index) const
 {
     auto ptr = new uie::splitter_item_simple_t;
     ptr->set_panel_guid(m_child_guid);
@@ -498,17 +498,17 @@ uie::splitter_item_t* playlists_tabs_extension::get_panel(unsigned index) const
     return ptr;
 }
 
-unsigned playlists_tabs_extension::get_maximum_panel_count() const
+unsigned PlaylistTabs::get_maximum_panel_count() const
 {
     return 1;
 }
 
-unsigned playlists_tabs_extension::get_panel_count() const
+unsigned PlaylistTabs::get_panel_count() const
 {
     return m_child_guid != pfc::guid_null ? 1 : 0;
 }
 
-void playlists_tabs_extension::replace_panel(unsigned index, const uie::splitter_item_t* p_item)
+void PlaylistTabs::replace_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
     if (index == 0 && m_child_guid != pfc::guid_null) {
         if (initialised)
@@ -524,7 +524,7 @@ void playlists_tabs_extension::replace_panel(unsigned index, const uie::splitter
     }
 }
 
-void playlists_tabs_extension::remove_panel(unsigned index)
+void PlaylistTabs::remove_panel(unsigned index)
 {
     if (index == 0 && m_child_guid != pfc::guid_null) {
         if (initialised)
@@ -538,7 +538,7 @@ void playlists_tabs_extension::remove_panel(unsigned index)
     }
 }
 
-void playlists_tabs_extension::insert_panel(unsigned index, const uie::splitter_item_t* p_item)
+void PlaylistTabs::insert_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
     if (index == 0 && m_child_guid == pfc::guid_null) {
         if (initialised)
@@ -554,12 +554,12 @@ void playlists_tabs_extension::insert_panel(unsigned index, const uie::splitter_
     }
 }
 
-unsigned playlists_tabs_extension::get_type() const
+unsigned PlaylistTabs::get_type() const
 {
     return ui_extension::type_layout | uie::type_splitter;
 }
 
-void playlists_tabs_extension::on_size(unsigned cx, unsigned cy)
+void PlaylistTabs::on_size(unsigned cx, unsigned cy)
 {
     if (wnd_tabs) {
         SetWindowPos(wnd_tabs, nullptr, 0, 0, cx, cy, SWP_NOZORDER);
@@ -578,14 +578,14 @@ void playlists_tabs_extension::on_size(unsigned cx, unsigned cy)
     }
 }
 
-void playlists_tabs_extension::on_size()
+void PlaylistTabs::on_size()
 {
     RECT rc;
     GetWindowRect(get_wnd(), &rc);
     on_size(rc.right - rc.left, rc.bottom - rc.top);
 }
 
-void playlists_tabs_extension::adjust_rect(bool b_larger, RECT* rc)
+void PlaylistTabs::adjust_rect(bool b_larger, RECT* rc)
 {
     if (b_larger) {
         RECT rc_child = *rc;
@@ -600,7 +600,7 @@ void playlists_tabs_extension::adjust_rect(bool b_larger, RECT* rc)
     }
 }
 
-void playlists_tabs_extension::reset_size_limits()
+void PlaylistTabs::reset_size_limits()
 {
     memset(&mmi, 0, sizeof(mmi));
     if (m_child_wnd) {
@@ -652,7 +652,7 @@ void playlists_tabs_extension::reset_size_limits()
     }
 }
 
-void playlists_tabs_extension::set_styles(bool visible /*= true*/)
+void PlaylistTabs::set_styles(bool visible /*= true*/)
 {
     if (wnd_tabs) {
         long flags = WS_CHILD | TCS_HOTTRACK | TCS_TABS
@@ -665,40 +665,40 @@ void playlists_tabs_extension::set_styles(bool visible /*= true*/)
     }
 }
 
-void playlists_tabs_extension::on_playlist_locked(unsigned int, bool) {}
+void PlaylistTabs::on_playlist_locked(unsigned int, bool) {}
 
-void playlists_tabs_extension::on_playback_order_changed(unsigned int) {}
+void PlaylistTabs::on_playback_order_changed(unsigned int) {}
 
-void playlists_tabs_extension::on_default_format_changed() {}
+void PlaylistTabs::on_default_format_changed() {}
 
-void playlists_tabs_extension::on_playlists_removing(const pfc::bit_array&, unsigned int, unsigned int) {}
+void PlaylistTabs::on_playlists_removing(const pfc::bit_array&, unsigned int, unsigned int) {}
 
-void playlists_tabs_extension::on_item_ensure_visible(unsigned int, unsigned int) {}
+void PlaylistTabs::on_item_ensure_visible(unsigned int, unsigned int) {}
 
-void playlists_tabs_extension::on_items_replaced(
+void PlaylistTabs::on_items_replaced(
     unsigned int, const pfc::bit_array&, const pfc::list_base_const_t<t_on_items_replaced_entry>&)
 {
 }
 
-void playlists_tabs_extension::on_items_modified_fromplayback(
+void PlaylistTabs::on_items_modified_fromplayback(
     unsigned int, const pfc::bit_array&, play_control::t_display_level)
 {
 }
 
-void playlists_tabs_extension::on_items_modified(unsigned int, const pfc::bit_array&) {}
+void PlaylistTabs::on_items_modified(unsigned int, const pfc::bit_array&) {}
 
-void playlists_tabs_extension::on_item_focus_change(unsigned int, unsigned int, unsigned int) {}
+void PlaylistTabs::on_item_focus_change(unsigned int, unsigned int, unsigned int) {}
 
-void playlists_tabs_extension::on_items_selection_change(unsigned int, const pfc::bit_array&, const pfc::bit_array&) {}
+void PlaylistTabs::on_items_selection_change(unsigned int, const pfc::bit_array&, const pfc::bit_array&) {}
 
-void playlists_tabs_extension::on_items_reordered(unsigned int, const unsigned int*, unsigned int) {}
+void PlaylistTabs::on_items_reordered(unsigned int, const unsigned int*, unsigned int) {}
 
-void playlists_tabs_extension::on_items_added(
+void PlaylistTabs::on_items_added(
     unsigned int, unsigned int, const pfc::list_base_const_t<metadb_handle_ptr>&, const pfc::bit_array&)
 {
 }
 
-void playlists_tabs_extension::on_playlist_renamed(unsigned p_index, const char* p_new_name, unsigned p_new_name_len)
+void PlaylistTabs::on_playlist_renamed(unsigned p_index, const char* p_new_name, unsigned p_new_name_len)
 {
     if (wnd_tabs) {
         uTabCtrl_InsertItemText(wnd_tabs, p_index, pfc::string8(p_new_name, p_new_name_len), false);
@@ -707,7 +707,7 @@ void playlists_tabs_extension::on_playlist_renamed(unsigned p_index, const char*
     }
 }
 
-void playlists_tabs_extension::on_playlists_removed(
+void PlaylistTabs::on_playlists_removed(
     const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count)
 {
     bool need_move = false;
@@ -730,7 +730,7 @@ void playlists_tabs_extension::on_playlists_removed(
         on_size();
 }
 
-void playlists_tabs_extension::on_playlist_created(unsigned p_index, const char* p_name, unsigned p_name_len)
+void PlaylistTabs::on_playlist_created(unsigned p_index, const char* p_name, unsigned p_name_len)
 {
     if (wnd_tabs) {
         uTabCtrl_InsertItemText(wnd_tabs, p_index, pfc::string8(p_name, p_name_len));
@@ -741,7 +741,7 @@ void playlists_tabs_extension::on_playlist_created(unsigned p_index, const char*
         on_size();
 }
 
-void playlists_tabs_extension::on_playlists_reorder(const unsigned* p_order, unsigned p_count)
+void PlaylistTabs::on_playlists_reorder(const unsigned* p_order, unsigned p_count)
 {
     if (wnd_tabs) {
         static_api_ptr_t<playlist_manager> playlist_api;
@@ -759,24 +759,24 @@ void playlists_tabs_extension::on_playlists_reorder(const unsigned* p_order, uns
     }
 }
 
-void playlists_tabs_extension::on_playlist_activate(unsigned p_old, unsigned p_new)
+void PlaylistTabs::on_playlist_activate(unsigned p_old, unsigned p_new)
 {
     if (wnd_tabs) {
         TabCtrl_SetCurSel(wnd_tabs, p_new);
     }
 }
 
-void FB2KAPI playlists_tabs_extension::on_items_removed(
+void FB2KAPI PlaylistTabs::on_items_removed(
     unsigned p_playlist, const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count)
 {
 }
 
-void FB2KAPI playlists_tabs_extension::on_items_removing(
+void FB2KAPI PlaylistTabs::on_items_removing(
     unsigned p_playlist, const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count)
 {
 }
 
-playlists_tabs_extension::class_data& playlists_tabs_extension::get_class_data() const
+PlaylistTabs::class_data& PlaylistTabs::get_class_data() const
 {
     __implement_get_class_data_ex(_T("{ABB72D0D-DBF0-4bba-8C68-3357EBE07A4D}"), _T(""), false, 0,
         WS_CHILD | WS_CLIPCHILDREN, WS_EX_CONTROLPARENT, CS_DBLCLKS);
@@ -784,17 +784,17 @@ playlists_tabs_extension::class_data& playlists_tabs_extension::get_class_data()
 
 void g_on_autohide_tabs_change()
 {
-    unsigned count = playlists_tabs_extension::list_wnd.get_count();
+    unsigned count = PlaylistTabs::list_wnd.get_count();
     for (unsigned n = 0; n < count; n++) {
-        playlists_tabs_extension::list_wnd[n]->create_tabs();
+        PlaylistTabs::list_wnd[n]->create_tabs();
     }
 }
 
 void g_on_multiline_tabs_change()
 {
-    unsigned count = playlists_tabs_extension::list_wnd.get_count();
+    unsigned count = PlaylistTabs::list_wnd.get_count();
     for (unsigned n = 0; n < count; n++) {
-        playlists_tabs_extension* p_tabs = playlists_tabs_extension::list_wnd[n];
+        PlaylistTabs* p_tabs = PlaylistTabs::list_wnd[n];
         p_tabs->set_styles();
         p_tabs->on_size();
     }
@@ -802,7 +802,7 @@ void g_on_multiline_tabs_change()
 
 void g_on_tabs_font_change()
 {
-    playlists_tabs_extension::on_font_change();
+    PlaylistTabs::on_font_change();
 }
 
 class font_client_switcher_tabs : public cui::fonts::client {
@@ -812,17 +812,17 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_labels; }
 
-    void on_font_changed() const override { playlists_tabs_extension::on_font_change(); }
+    void on_font_changed() const override { PlaylistTabs::on_font_change(); }
 };
 
 font_client_switcher_tabs::factory<font_client_switcher_tabs> g_font_client_switcher_tabs;
 
-void playlists_tabs_extension::window_host_impl::set_this(playlists_tabs_extension* ptr)
+void PlaylistTabs::window_host_impl::set_this(PlaylistTabs* ptr)
 {
     m_this = ptr;
 }
 
-void playlists_tabs_extension::window_host_impl::relinquish_ownership(HWND wnd)
+void PlaylistTabs::window_host_impl::relinquish_ownership(HWND wnd)
 {
     m_this->m_child_wnd = nullptr;
     m_this->m_host.release();
@@ -830,51 +830,51 @@ void playlists_tabs_extension::window_host_impl::relinquish_ownership(HWND wnd)
     m_this->reset_size_limits();
 }
 
-bool playlists_tabs_extension::window_host_impl::override_status_text_create(
+bool PlaylistTabs::window_host_impl::override_status_text_create(
     service_ptr_t<ui_status_text_override>& p_out)
 {
     static_api_ptr_t<ui_control> api;
     return m_this->get_host()->override_status_text_create(p_out);
 }
 
-const GUID& playlists_tabs_extension::window_host_impl::get_host_guid() const
+const GUID& PlaylistTabs::window_host_impl::get_host_guid() const
 {
     // {20789B52-4998-43ae-9B20-CCFD3BFBEEBD}
     static const GUID guid = {0x20789b52, 0x4998, 0x43ae, {0x9b, 0x20, 0xcc, 0xfd, 0x3b, 0xfb, 0xee, 0xbd}};
     return guid;
 }
 
-void playlists_tabs_extension::window_host_impl::on_size_limit_change(HWND wnd, unsigned flags)
+void PlaylistTabs::window_host_impl::on_size_limit_change(HWND wnd, unsigned flags)
 {
     m_this->on_child_position_change();
 }
 
-bool playlists_tabs_extension::window_host_impl::get_show_shortcuts() const
+bool PlaylistTabs::window_host_impl::get_show_shortcuts() const
 {
     return m_this->get_host()->get_keyboard_shortcuts_enabled();
 }
 
-bool playlists_tabs_extension::window_host_impl::get_keyboard_shortcuts_enabled() const
+bool PlaylistTabs::window_host_impl::get_keyboard_shortcuts_enabled() const
 {
     return m_this->get_host()->get_keyboard_shortcuts_enabled();
 }
 
-bool playlists_tabs_extension::window_host_impl::set_window_visibility(HWND wnd, bool visibility)
+bool PlaylistTabs::window_host_impl::set_window_visibility(HWND wnd, bool visibility)
 {
     return false;
 }
 
-bool playlists_tabs_extension::window_host_impl::is_visibility_modifiable(HWND wnd, bool desired_visibility) const
+bool PlaylistTabs::window_host_impl::is_visibility_modifiable(HWND wnd, bool desired_visibility) const
 {
     return false;
 }
 
-bool playlists_tabs_extension::window_host_impl::is_visible(HWND wnd) const
+bool PlaylistTabs::window_host_impl::is_visible(HWND wnd) const
 {
     return true;
 }
 
-bool playlists_tabs_extension::window_host_impl::request_resize(
+bool PlaylistTabs::window_host_impl::request_resize(
     HWND wnd, unsigned flags, unsigned width, unsigned height)
 {
     if (flags == ui_extension::size_height && is_resize_supported(wnd)) {
@@ -892,7 +892,7 @@ bool playlists_tabs_extension::window_host_impl::request_resize(
     return false;
 }
 
-unsigned playlists_tabs_extension::window_host_impl::is_resize_supported(HWND wnd) const
+unsigned PlaylistTabs::window_host_impl::is_resize_supported(HWND wnd) const
 {
     // We won't support ui_extension::size_width since we can't reliably detect multiline tab shit
     return (m_this->get_host()->is_resize_supported(m_this->get_wnd()) & ui_extension::size_height);

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -15,7 +15,7 @@ class PlaylistTabs
     , public playlist_callback {
 public:
     enum : uint32_t { MSG_RESET_SIZE_LIMITS = WM_USER + 3 };
-    class window_host_impl : public ui_extension::window_host {
+    class WindowHost : public ui_extension::window_host {
     public:
         unsigned is_resize_supported(HWND wnd) const override;
 
@@ -75,7 +75,7 @@ public:
 
     ~PlaylistTabs();
 
-    class playlists_tabs_drop_target : public IDropTarget {
+    class PlaylistTabsDropTarget : public IDropTarget {
     public:
         HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID FAR* ppvObject) override;
         ULONG STDMETHODCALLTYPE AddRef() override;
@@ -85,7 +85,7 @@ public:
         HRESULT STDMETHODCALLTYPE DragOver(DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
         HRESULT STDMETHODCALLTYPE DragLeave() override;
         HRESULT STDMETHODCALLTYPE Drop(IDataObject* pDataObj, DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
-        playlists_tabs_drop_target(PlaylistTabs* p_wnd);
+        PlaylistTabsDropTarget(PlaylistTabs* p_wnd);
 
     private:
         bool m_last_rmb{};
@@ -180,7 +180,7 @@ private:
 
     GUID m_child_guid{};
     pfc::array_t<t_uint8> m_child_data;
-    service_ptr_t<window_host_impl> m_host;
+    service_ptr_t<WindowHost> m_host;
     ui_extension::window_ptr m_child;
     HWND m_child_wnd{nullptr};
     HWND m_host_wnd{nullptr};
@@ -190,6 +190,6 @@ private:
     MINMAXINFO mmi{};
 };
 
-extern ui_extension::window_host_factory<PlaylistTabs::window_host_impl> g_tab_host;
+extern ui_extension::window_host_factory<PlaylistTabs::WindowHost> g_tab_host;
 
 #endif

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -10,7 +10,7 @@ void g_on_tabs_font_change();
 void remove_playlist_helper(t_size index);
 constexpr unsigned SWITCH_TIMER_ID = 670u;
 
-class playlists_tabs_extension
+class PlaylistTabs
     : public uie::container_ui_extension_t<ui_helpers::container_window, uie::splitter_window_v2>
     , public playlist_callback {
 public:
@@ -37,10 +37,10 @@ public:
 
         void relinquish_ownership(HWND wnd) override;
         ;
-        void set_this(playlists_tabs_extension* ptr);
+        void set_this(PlaylistTabs* ptr);
 
     private:
-        service_ptr_t<playlists_tabs_extension> m_this;
+        service_ptr_t<PlaylistTabs> m_this;
     };
 
 private:
@@ -65,15 +65,15 @@ private:
     class_data& get_class_data() const override;
 
 public:
-    static pfc::ptr_list_t<playlists_tabs_extension> list_wnd;
+    static pfc::ptr_list_t<PlaylistTabs> list_wnd;
 
     HWND wnd_tabs{nullptr};
     LRESULT WINAPI hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     static LRESULT WINAPI main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
-    playlists_tabs_extension() = default;
+    PlaylistTabs() = default;
 
-    ~playlists_tabs_extension();
+    ~PlaylistTabs();
 
     class playlists_tabs_drop_target : public IDropTarget {
     public:
@@ -85,14 +85,14 @@ public:
         HRESULT STDMETHODCALLTYPE DragOver(DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
         HRESULT STDMETHODCALLTYPE DragLeave() override;
         HRESULT STDMETHODCALLTYPE Drop(IDataObject* pDataObj, DWORD grfKeyState, POINTL pt, DWORD* pdwEffect) override;
-        playlists_tabs_drop_target(playlists_tabs_extension* p_wnd);
+        playlists_tabs_drop_target(PlaylistTabs* p_wnd);
 
     private:
         bool m_last_rmb{};
         bool m_is_accepted_type{};
         long drop_ref_count{};
         POINTL last_over{};
-        service_ptr_t<playlists_tabs_extension> p_list;
+        service_ptr_t<PlaylistTabs> p_list;
         pfc::com_ptr_t<IDataObject> m_DataObject;
         mmh::ComPtr<IDropTargetHelper> m_DropTargetHelper;
     };
@@ -190,6 +190,6 @@ private:
     MINMAXINFO mmi{};
 };
 
-extern ui_extension::window_host_factory<playlists_tabs_extension::window_host_impl> g_tab_host;
+extern ui_extension::window_host_factory<PlaylistTabs::window_host_impl> g_tab_host;
 
 #endif

--- a/foo_ui_columns/playlist_tabs_drop_target.cpp
+++ b/foo_ui_columns/playlist_tabs_drop_target.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "playlist_tabs.h"
 
-HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::QueryInterface(
+HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::QueryInterface(
     REFIID riid, LPVOID FAR* ppvObject)
 {
     if (ppvObject == nullptr)
@@ -19,11 +19,11 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::QueryInterfa
     }
     return E_NOINTERFACE;
 }
-ULONG STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::AddRef()
+ULONG STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::AddRef()
 {
     return InterlockedIncrement(&drop_ref_count);
 }
-ULONG STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::Release()
+ULONG STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Release()
 {
     LONG rv = InterlockedDecrement(&drop_ref_count);
     if (!rv) {
@@ -35,7 +35,7 @@ ULONG STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::Release()
     return rv;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragEnter(
+HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::DragEnter(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -57,7 +57,7 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragEnter(
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragOver(
+HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::DragOver(
     DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -127,7 +127,7 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragOver(
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragLeave()
+HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::DragLeave()
 {
     if (m_DropTargetHelper.is_valid())
         m_DropTargetHelper->DragLeave();
@@ -140,7 +140,7 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragLeave()
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::Drop(
+HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Drop(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -326,7 +326,7 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::Drop(
 
     return S_OK;
 }
-PlaylistTabs::playlists_tabs_drop_target::playlists_tabs_drop_target(PlaylistTabs* p_wnd)
+PlaylistTabs::PlaylistTabsDropTarget::PlaylistTabsDropTarget(PlaylistTabs* p_wnd)
     : p_list(p_wnd)
 {
     m_DropTargetHelper.instantiate(CLSID_DragDropHelper, nullptr, CLSCTX_INPROC);

--- a/foo_ui_columns/playlist_tabs_drop_target.cpp
+++ b/foo_ui_columns/playlist_tabs_drop_target.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "playlist_tabs.h"
 
-HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::QueryInterface(
+HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::QueryInterface(
     REFIID riid, LPVOID FAR* ppvObject)
 {
     if (ppvObject == nullptr)
@@ -19,11 +19,11 @@ HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::
     }
     return E_NOINTERFACE;
 }
-ULONG STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::AddRef()
+ULONG STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::AddRef()
 {
     return InterlockedIncrement(&drop_ref_count);
 }
-ULONG STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::Release()
+ULONG STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::Release()
 {
     LONG rv = InterlockedDecrement(&drop_ref_count);
     if (!rv) {
@@ -35,7 +35,7 @@ ULONG STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::Re
     return rv;
 }
 
-HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::DragEnter(
+HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragEnter(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -57,7 +57,7 @@ HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::DragOver(
+HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragOver(
     DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -127,7 +127,7 @@ HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::DragLeave()
+HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::DragLeave()
 {
     if (m_DropTargetHelper.is_valid())
         m_DropTargetHelper->DragLeave();
@@ -140,7 +140,7 @@ HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::
     return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::Drop(
+HRESULT STDMETHODCALLTYPE PlaylistTabs::playlists_tabs_drop_target::Drop(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
@@ -326,7 +326,7 @@ HRESULT STDMETHODCALLTYPE playlists_tabs_extension::playlists_tabs_drop_target::
 
     return S_OK;
 }
-playlists_tabs_extension::playlists_tabs_drop_target::playlists_tabs_drop_target(playlists_tabs_extension* p_wnd)
+PlaylistTabs::playlists_tabs_drop_target::playlists_tabs_drop_target(PlaylistTabs* p_wnd)
     : p_list(p_wnd)
 {
     m_DropTargetHelper.instantiate(CLSID_DragDropHelper, nullptr, CLSCTX_INPROC);

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -31,7 +31,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CREATE: {
         initialised = true;
         list_wnd.add_item(this);
-        pfc::com_ptr_t<playlists_tabs_drop_target> m_drop_target = new playlists_tabs_drop_target(this);
+        pfc::com_ptr_t<PlaylistTabsDropTarget> m_drop_target = new PlaylistTabsDropTarget(this);
         RegisterDragDrop(wnd, m_drop_target.get_ptr());
 
         create_tabs();
@@ -41,7 +41,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         g_tab_host.instance_create(p_temp);
 
         // Well simple reinterpret_cast without this mess should work fine but this is "correct"
-        m_host = static_cast<window_host_impl*>(p_temp.get_ptr());
+        m_host = static_cast<WindowHost*>(p_temp.get_ptr());
         if (m_host.is_valid()) {
             m_host->set_this(this);
             create_child();

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -21,7 +21,7 @@ enum {
     ID_RECYCLER_BASE
 };
 
-LRESULT playlists_tabs_extension::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_NCCREATE: {

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -107,8 +107,8 @@ BOOL setup_dialog_t::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             g_set_global_colour_mode(m_previous_colour_mode);
             pvt::cfg_show_artwork = m_previous_show_artwork;
             pvt::cfg_grouping = m_previous_show_grouping;
-            pvt::ng_playlist_view_t::g_on_show_artwork_change();
-            pvt::ng_playlist_view_t::g_on_groups_change();
+            pvt::PlaylistView::g_on_show_artwork_change();
+            pvt::PlaylistView::g_on_groups_change();
         case IDOK:
             DestroyWindow(wnd);
             return 0;
@@ -130,8 +130,8 @@ BOOL setup_dialog_t::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             if (selection == 0)
                 pvt::cfg_grouping = false;
 
-            pvt::ng_playlist_view_t::g_on_show_artwork_change();
-            pvt::ng_playlist_view_t::g_on_groups_change();
+            pvt::PlaylistView::g_on_show_artwork_change();
+            pvt::PlaylistView::g_on_groups_change();
 
         } break;
         }

--- a/foo_ui_columns/tab_display2.cpp
+++ b/foo_ui_columns/tab_display2.cpp
@@ -79,7 +79,7 @@ public:
                     int new_height = GetDlgItemInt(wnd, IDC_HEIGHT, &result, TRUE);
                     if (result)
                         settings::playlist_view_item_padding = new_height;
-                    pvt::ng_playlist_view_t::g_on_vertical_item_padding_change();
+                    pvt::PlaylistView::g_on_vertical_item_padding_change();
                 }
 
             } break;
@@ -93,43 +93,43 @@ public:
             case IDC_TOOLTIPS:
                 cfg_tooltip = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
                 EnableWindow(GetDlgItem(wnd, IDC_TOOLTIPS_CLIPPED), cfg_tooltip);
-                pvt::ng_playlist_view_t::g_on_show_tooltips_change();
+                pvt::PlaylistView::g_on_show_tooltips_change();
                 break;
 
             case IDC_SELECTION_MODEL:
                 cfg_alternative_sel = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                pvt::ng_playlist_view_t::g_on_alternate_selection_change();
+                pvt::PlaylistView::g_on_alternate_selection_change();
                 break;
             case IDC_SORT_ARROWS:
                 cfg_show_sort_arrows = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                pvt::ng_playlist_view_t::g_on_show_sort_indicators_change();
+                pvt::PlaylistView::g_on_show_sort_indicators_change();
                 break;
             case IDC_TOOLTIPS_CLIPPED:
                 cfg_tooltips_clipped = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                pvt::ng_playlist_view_t::g_on_show_tooltips_change();
+                pvt::PlaylistView::g_on_show_tooltips_change();
                 break;
 
             case IDC_ELLIPSIS:
                 cfg_ellipsis = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                pvt::ng_playlist_view_t::s_redraw_all();
+                pvt::PlaylistView::s_redraw_all();
                 break;
 
             case IDC_HEADER: {
                 cfg_header = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                pvt::ng_playlist_view_t::g_on_show_header_change();
+                pvt::PlaylistView::g_on_show_header_change();
             } break;
             case IDC_NOHSCROLL: {
                 cfg_nohscroll = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                pvt::ng_playlist_view_t::g_on_autosize_change();
+                pvt::PlaylistView::g_on_autosize_change();
             } break;
 
             case IDC_HHTRACK: {
                 cfg_header_hottrack = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                pvt::ng_playlist_view_t::g_on_sorting_enabled_change();
+                pvt::PlaylistView::g_on_sorting_enabled_change();
             } break;
             case (CBN_SELCHANGE << 16) | IDC_PLEDGE: {
                 cfg_frame = SendMessage((HWND)lp, CB_GETCURSEL, 0, 0);
-                pvt::ng_playlist_view_t::g_on_edge_style_change();
+                pvt::PlaylistView::g_on_edge_style_change();
             } break;
             case IDC_INLINE_MODE: {
                 main_window::config_set_inline_metafield_edit_mode(SendMessage((HWND)lp, BM_GETCHECK, 0, 0) != 0);

--- a/foo_ui_columns/tab_global.cpp
+++ b/foo_ui_columns/tab_global.cpp
@@ -74,7 +74,7 @@ public:
         case WM_DESTROY: {
             g_editor_font_notify.release();
             save_string(wnd);
-            pvt::ng_playlist_view_t::g_update_all_items();
+            pvt::PlaylistView::g_update_all_items();
         } break;
 
         case WM_COMMAND:
@@ -133,7 +133,7 @@ public:
                     cfg_colour = g_default_colour;
                     if (g_cur_tab2 == 1)
                         uSendDlgItemMessageText(wnd, IDC_STRING, WM_SETTEXT, 0, cfg_colour);
-                    pvt::ng_playlist_view_t::g_update_all_items();
+                    pvt::PlaylistView::g_update_all_items();
                 }
             }
 
@@ -143,7 +143,7 @@ public:
                 break;
             case IDC_APPLY:
                 save_string(wnd);
-                pvt::ng_playlist_view_t::g_update_all_items();
+                pvt::PlaylistView::g_update_all_items();
                 break;
             case IDC_PICK_COLOUR:
                 colour_code_gen(wnd, IDC_COLOUR, false, false);

--- a/foo_ui_columns/tab_playlist_swticher.cpp
+++ b/foo_ui_columns/tab_playlist_swticher.cpp
@@ -33,7 +33,7 @@ public:
                     int new_height = GetDlgItemInt(wnd, IDC_PLHEIGHT, &result, TRUE);
                     if (result)
                         settings::playlist_switcher_item_padding = new_height;
-                    playlist_switcher_t::g_on_vertical_item_padding_change();
+                    PlaylistSwitcher::g_on_vertical_item_padding_change();
                 }
             break;
             case IDC_MCLICK:
@@ -42,15 +42,15 @@ public:
             case (EN_CHANGE << 16) | IDC_PLAYLIST_TF:
                 cfg_playlist_switcher_tagz = string_utf8_from_window((HWND)lp);
                 if (cfg_playlist_switcher_use_tagz)
-                    playlist_switcher_t::g_refresh_all_items();
+                    PlaylistSwitcher::g_refresh_all_items();
                 break;
             case IDC_USE_PLAYLIST_TF:
                 cfg_playlist_switcher_use_tagz = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                playlist_switcher_t::g_refresh_all_items();
+                PlaylistSwitcher::g_refresh_all_items();
                 break;
             case (CBN_SELCHANGE << 16) | IDC_PLISTEDGE:
                 cfg_plistframe = SendMessage((HWND)lp, CB_GETCURSEL, 0, 0);
-                playlist_switcher_t::g_on_edgestyle_change();
+                PlaylistSwitcher::g_on_edgestyle_change();
                 break;
             }
         }

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -28,11 +28,11 @@ public:
             switch (wp) {
             case IDC_SHOWARTWORK:
                 pvt::cfg_show_artwork = SendMessage((HWND)lp, BM_GETCHECK, 0, 0) != BST_UNCHECKED;
-                pvt::ng_playlist_view_t::g_on_show_artwork_change();
+                pvt::PlaylistView::g_on_show_artwork_change();
                 break;
             case IDC_ARTWORKREFLECTION:
                 pvt::cfg_artwork_reflection = SendMessage((HWND)lp, BM_GETCHECK, 0, 0) != BST_UNCHECKED;
-                pvt::ng_playlist_view_t::g_on_artwork_width_change();
+                pvt::PlaylistView::g_on_artwork_width_change();
                 break;
             case IDC_LOWPRIORITY:
                 pvt::cfg_artwork_lowpriority = SendMessage((HWND)lp, BM_GETCHECK, 0, 0) != BST_UNCHECKED;
@@ -40,7 +40,7 @@ public:
             case (EN_CHANGE << 16) | IDC_ARTWORKWIDTH:
                 if (m_initialised) {
                     pvt::cfg_artwork_width = mmh::strtoul_n(string_utf8_from_window((HWND)lp).get_ptr(), pfc_infinite);
-                    pvt::ng_playlist_view_t::g_on_artwork_width_change();
+                    pvt::PlaylistView::g_on_artwork_width_change();
                 }
                 break;
             }


### PR DESCRIPTION
There is a [documented naming convention to use UpperCamelCase for class names](https://github.com/reupen/columns_ui/blob/master/CONTRIBUTING.md). 

However, many existing class names are non-compliant. This renames several existing class names to make them compliant.