### PR TITLE
Use UpperCamelCase for class names (part 6)

### DIFF
--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -28,7 +28,7 @@ static const GUID g_guid_cfg_disc_scripts
 static const GUID g_guid_cfg_artist_scripts
     = {0xc1e7da7e, 0x1d3a, 0x4f30, {0x83, 0x84, 0xe, 0x47, 0xc4, 0x9b, 0x6d, 0xd9}};
 
-enum track_mode_t {
+enum TrackingMode {
     track_auto_playlist_playing,
     track_playlist,
     track_playing,

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -2,7 +2,7 @@
 
 namespace artwork_panel {
 
-enum fb2k_artwork_mode_t {
+enum Fb2KArtworkMode {
     fb2k_artwork_disabled,
     fb2k_artwork_embedded,
     fb2k_artwork_embedded_and_external,

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -547,7 +547,7 @@ void ButtonsToolbar::set_config(stream_reader* p_reader, t_size p_size, abort_ca
         throw pfc::exception_bug_check(
             "uie::window::set_config() cannot be called once the window has been initialised.");
 
-    t_config_version p_version;
+    ConfigVersion p_version;
     unsigned count = m_buttons.get_count();
     p_reader->read_lendian_t(p_version, p_abort);
     if (p_version <= VERSION_CURRENT) {

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -7,7 +7,7 @@ class ButtonsToolbar : public ui_extension::container_ui_extension {
     int width{0};
     int height{0};
 
-    enum t_config_version { VERSION_1, VERSION_2, VERSION_CURRENT = VERSION_2 };
+    enum ConfigVersion { VERSION_1, VERSION_2, VERSION_CURRENT = VERSION_2 };
 
     /** For config dialog */
     enum { MSG_BUTTON_CHANGE = WM_USER + 2, MSG_COMMAND_CHANGE = WM_USER + 3 };
@@ -56,9 +56,9 @@ public:
 
             void get_path(pfc::string8& p_out) const;
             void write(stream_writer* out, abort_callback& p_abort) const;
-            void read(t_config_version p_version, stream_reader* reader, abort_callback& p_abort);
+            void read(ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort);
             void write_to_file(stream_writer& p_file, bool b_paths, abort_callback& p_abort);
-            void read_from_file(t_config_version p_version, const char* p_base, const char* p_name,
+            void read_from_file(ConfigVersion p_version, const char* p_base, const char* p_name,
                 stream_reader* p_file, unsigned p_size, abort_callback& p_abort);
         };
 
@@ -94,7 +94,7 @@ public:
 
         void write(stream_writer* out, abort_callback& p_abort) const;
 
-        void read(t_config_version p_version, stream_reader* reader, abort_callback& p_abort);
+        void read(ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort);
         void get_display_text(pfc::string_base& p_out); // display
         void get_short_name(pfc::string_base& p_out); // tooltip
 
@@ -102,7 +102,7 @@ public:
         void get_name_name(pfc::string_base& p_out); // config
         void get_name(pfc::string_base& p_out); // config
         void write_to_file(stream_writer& p_file, bool b_paths, abort_callback& p_abort);
-        void read_from_file(t_config_version p_version, const char* p_base, const char* p_name, stream_reader* p_file,
+        void read_from_file(ConfigVersion p_version, const char* p_base, const char* p_name, stream_reader* p_file,
             unsigned p_size, abort_callback& p_abort);
     };
 
@@ -343,7 +343,7 @@ template <>
 class traits_t<ButtonsToolbar::Appearance> : public traits_rawobject {
 };
 template <>
-class traits_t<ButtonsToolbar::t_config_version> : public traits_rawobject {
+class traits_t<ButtonsToolbar::ConfigVersion> : public traits_rawobject {
 };
 template <>
 class traits_t<ButtonsToolbar::Show> : public traits_rawobject {

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -68,7 +68,7 @@ void ButtonsToolbar::Button::write(stream_writer* out, abort_callback& p_abort) 
 }
 
 void ButtonsToolbar::Button::read(
-    ButtonsToolbar::t_config_version p_version, stream_reader* reader, abort_callback& p_abort)
+    ButtonsToolbar::ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort)
 {
     *this = Button{};
 
@@ -172,7 +172,7 @@ void ButtonsToolbar::Button::get_name(pfc::string_base& p_out) // config
     }
 }
 
-void ButtonsToolbar::Button::read_from_file(t_config_version p_version, const char* p_base, const char* p_name,
+void ButtonsToolbar::Button::read_from_file(ConfigVersion p_version, const char* p_base, const char* p_name,
     stream_reader* p_file, unsigned p_size, abort_callback& p_abort)
 {
     // t_filesize p_start = p_file->get_position(p_abort);

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -69,7 +69,7 @@ void ButtonsToolbar::ConfigParam::import_from_stream(stream_reader* p_file, bool
         p_file->read_lendian_t(temp, p_abort);
         if (temp != g_guid_fcb)
             throw exception_io_data();
-        t_config_version vers;
+        ConfigVersion vers;
         p_file->read_lendian_t(vers, p_abort);
         if (vers > VERSION_CURRENT)
             throw "Fcb version is newer than component";

--- a/foo_ui_columns/buttons_custom_image.cpp
+++ b/foo_ui_columns/buttons_custom_image.cpp
@@ -31,7 +31,7 @@ void ButtonsToolbar::Button::CustomImage::write(stream_writer* out, abort_callba
         out->write_lendian_t(m_mask_colour, p_abort);
 }
 void ButtonsToolbar::Button::CustomImage::read(
-    t_config_version p_version, stream_reader* reader, abort_callback& p_abort)
+    ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort)
 {
     pfc::string8 temp;
     reader->read_string(temp, p_abort);
@@ -44,7 +44,7 @@ void ButtonsToolbar::Button::CustomImage::read(
         reader->read_lendian_t(m_mask_colour, p_abort);
 }
 
-void ButtonsToolbar::Button::CustomImage::read_from_file(t_config_version p_version, const char* p_base,
+void ButtonsToolbar::Button::CustomImage::read_from_file(ConfigVersion p_version, const char* p_base,
     const char* p_name, stream_reader* p_file, unsigned p_size, abort_callback& p_abort)
 {
     // t_filesize p_start = p_file->get_position(p_abort);

--- a/foo_ui_columns/colours_manager_data.h
+++ b/foo_ui_columns/colours_manager_data.h
@@ -8,7 +8,7 @@ public:
     void set_data_raw(stream_reader* p_stream, t_size p_sizehint, abort_callback& p_abort) override;
     class entry_t : public pfc::refcounted_object_root {
     public:
-        enum t_export_identifiers {
+        enum ExportItemID {
             identifier_guid,
             identifier_mode,
             identifier_background,

--- a/foo_ui_columns/columns_v2.h
+++ b/foo_ui_columns/columns_v2.h
@@ -14,8 +14,8 @@ public:
     bool use_custom_sort{false};
     pfc::string8 sort_spec;
     uih::IntegerAndDpi<int32_t> width{100};
-    alignment align{ALIGN_LEFT};
-    playlist_filter_type filter_type{FILTER_NONE};
+    Alignment align{ALIGN_LEFT};
+    PlaylistFilterType filter_type{FILTER_NONE};
     pfc::string8 filter;
     t_uint32 parts{1};
     bool show{true};
@@ -24,8 +24,8 @@ public:
     PlaylistViewColumnBase() = default;
 
     PlaylistViewColumnBase(const char* pname, const char* pspec, bool b_use_custom_colour, const char* p_colour_spec,
-        bool b_use_custom_sort, const char* p_sort_spec, int p_width, alignment p_align,
-        playlist_filter_type p_filter_type, const char* p_filter_string, unsigned p_parts, bool b_show,
+        bool b_use_custom_sort, const char* p_sort_spec, int p_width, Alignment p_align,
+        PlaylistFilterType p_filter_type, const char* p_filter_string, unsigned p_parts, bool b_show,
         const char* p_edit_field)
         : name(pname)
         , spec(pspec)
@@ -65,8 +65,8 @@ public:
     PlaylistViewColumn() = default;
 
     PlaylistViewColumn(const char* pname, const char* pspec, bool b_use_custom_colour, const char* p_colour_spec,
-        bool b_use_custom_sort, const char* p_sort_spec, unsigned p_width, alignment p_align,
-        playlist_filter_type p_filter_type, const char* p_filter_string, unsigned p_parts, bool b_show,
+        bool b_use_custom_sort, const char* p_sort_spec, unsigned p_width, Alignment p_align,
+        PlaylistFilterType p_filter_type, const char* p_filter_string, unsigned p_parts, bool b_show,
         const char* p_edit_field)
         : PlaylistViewColumnBase(pname, pspec, b_use_custom_colour, p_colour_spec, b_use_custom_sort, p_sort_spec, p_width,
               p_align, p_filter_type, p_filter_string, p_parts, b_show, p_edit_field)

--- a/foo_ui_columns/common.cpp
+++ b/foo_ui_columns/common.cpp
@@ -13,14 +13,14 @@ const char* strchr_n(const char* src, char c, unsigned len)
     return nullptr;
 }
 
-void colour::set(COLORREF new_colour)
+void Colour::set(COLORREF new_colour)
 {
     B = LOBYTE(HIWORD(new_colour));
     G = HIBYTE(LOWORD(new_colour));
     R = LOBYTE(LOWORD(new_colour));
 }
 
-string_pn::string_pn(metadb_handle_list_cref handles, const char* format, const char* def)
+StringFormatCommonTrackTitle::StringFormatCommonTrackTitle(metadb_handle_list_cref handles, const char* format, const char* def)
 {
     pfc::string8_fast_aggressive a, b;
     a.prealloc(512);

--- a/foo_ui_columns/common.h
+++ b/foo_ui_columns/common.h
@@ -33,13 +33,7 @@ class traits_t<Alignment> : public traits_rawobject {
 
 const char* strchr_n(const char* src, char c, unsigned len = -1);
 
-struct colour_bytes {
-    BYTE B;
-    BYTE G;
-    BYTE R;
-};
-
-struct colour {
+struct Colour {
     BYTE B{0};
     BYTE G{0};
     BYTE R{0};
@@ -48,14 +42,14 @@ struct colour {
     operator COLORREF() const { return RGB(R, G, B); }
 };
 
-inline bool operator==(const colour& c1, const colour& c2)
+inline bool operator==(const Colour& c1, const Colour& c2)
 {
     return (c1.B == c2.B && c1.G == c2.G && c1.R == c2.R);
 }
 
-class string_pn : public pfc::string8 {
+class StringFormatCommonTrackTitle : public pfc::string8 {
 public:
-    string_pn(metadb_handle_list_cref handles, const char* format, const char* def = "Untitled");
+    StringFormatCommonTrackTitle(metadb_handle_list_cref handles, const char* format, const char* def = "Untitled");
 };
 
 void g_save_playlist(HWND wnd, const pfc::list_base_const_t<metadb_handle_ptr>& p_items, const char* name);

--- a/foo_ui_columns/common.h
+++ b/foo_ui_columns/common.h
@@ -10,13 +10,13 @@
  * Some common functions and enumerations
  */
 
-enum playlist_filter_type {
+enum PlaylistFilterType {
     FILTER_NONE = 0,
     FILTER_SHOW,
     FILTER_HIDE,
 };
 
-enum alignment {
+enum Alignment {
     ALIGN_LEFT,
     ALIGN_CENTRE,
     ALIGN_RIGHT,
@@ -24,10 +24,10 @@ enum alignment {
 
 namespace pfc {
 template <>
-class traits_t<playlist_filter_type> : public traits_rawobject {
+class traits_t<PlaylistFilterType> : public traits_rawobject {
 };
 template <>
-class traits_t<alignment> : public traits_rawobject {
+class traits_t<Alignment> : public traits_rawobject {
 };
 } // namespace pfc
 

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -294,7 +294,7 @@ class fcl_colours_t : public cui::fcl::dataset {
         static const GUID guid = {0x165946e7, 0x6165, 0x4680, {0xa0, 0x8e, 0x84, 0xb5, 0x76, 0x84, 0x58, 0xe8}};
         return guid;
     }
-    enum identifiers_t {
+    enum Identifier {
         identifier_global_entry,
         identifier_client_entries,
         identifier_client_entry = 0,
@@ -399,7 +399,7 @@ class fcl_fonts_t : public cui::fcl::dataset {
         static const GUID guid = {0xa806a9cd, 0x4117, 0x43da, {0x80, 0x5e, 0xfe, 0x4e, 0xb3, 0x48, 0xc9, 0xc}};
         return guid;
     }
-    enum identifiers_t {
+    enum Identifier {
         identifier_global_items,
         identifier_global_labels,
         identifier_client_entries,

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -130,12 +130,12 @@ public:
             switch (wp) {
             case (CBN_SELCHANGE << 16) | IDC_ALIGNMENT: {
                 if (!initialising && m_column.is_valid()) {
-                    m_column->align = ((alignment)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0));
+                    m_column->align = ((Alignment)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0));
                 }
             } break;
             case (CBN_SELCHANGE << 16) | IDC_PLAYLIST_FILTER_TYPE: {
                 if (!initialising && m_column.is_valid()) {
-                    m_column->filter_type = ((playlist_filter_type)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0));
+                    m_column->filter_type = ((PlaylistFilterType)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0));
                     EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), m_column->filter_type != FILTER_NONE);
                 }
             } break;

--- a/foo_ui_columns/config_defaults.cpp
+++ b/foo_ui_columns/config_defaults.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "main_window.h"
 
-COLORREF get_default_colour(colours::t_colours index, bool themed)
+COLORREF get_default_colour(colours::ColourID index, bool themed)
 {
     switch (index) {
     case colours::COLOUR_TEXT:

--- a/foo_ui_columns/config_items.h
+++ b/foo_ui_columns/config_items.h
@@ -5,7 +5,7 @@ extern fbh::ConfigString config_status_bar_script;
 extern fbh::ConfigString config_notification_icon_script;
 extern fbh::ConfigString config_main_window_title_script;
 
-enum metafield_edit_mode_t { mode_disabled, mode_columns };
+enum MetafieldEditingMode { mode_disabled, mode_columns };
 
 void config_set_inline_metafield_edit_mode(t_uint32 value);
 t_uint32 config_get_inline_metafield_edit_mode();

--- a/foo_ui_columns/config_vars.h
+++ b/foo_ui_columns/config_vars.h
@@ -23,20 +23,20 @@ public:
     ConfigWindowPlacement(const GUID& p_guid);
 };
 
-class ConfigMenuItem : public cfg_struct_t<menu_item_identifier> {
+class ConfigMenuItem : public cfg_struct_t<MenuItemIdentifier> {
 public:
-    using cfg_struct_t<menu_item_identifier>::operator=;
-    using cfg_struct_t<menu_item_identifier>::operator menu_item_identifier;
+    using cfg_struct_t<MenuItemIdentifier>::operator=;
+    using cfg_struct_t<MenuItemIdentifier>::operator MenuItemIdentifier;
     void reset()
     {
-        menu_item_identifier temp;
+        MenuItemIdentifier temp;
         *this = temp;
     }
-    explicit ConfigMenuItem(const GUID& p_guid, const menu_item_identifier& p_val)
-        : cfg_struct_t<menu_item_identifier>(p_guid, p_val){};
+    explicit ConfigMenuItem(const GUID& p_guid, const MenuItemIdentifier& p_val)
+        : cfg_struct_t<MenuItemIdentifier>(p_guid, p_val){};
     explicit ConfigMenuItem(const GUID& p_guid, const GUID& p_val, const GUID& psub = pfc::guid_null)
-        : cfg_struct_t<menu_item_identifier>(p_guid, menu_item_identifier{p_val, psub}){};
-    explicit ConfigMenuItem(const GUID& p_guid) : cfg_struct_t<menu_item_identifier>(p_guid, menu_item_identifier{}){};
+        : cfg_struct_t<MenuItemIdentifier>(p_guid, MenuItemIdentifier{p_val, psub}){};
+    explicit ConfigMenuItem(const GUID& p_guid) : cfg_struct_t<MenuItemIdentifier>(p_guid, MenuItemIdentifier{}){};
 };
 
 namespace settings {

--- a/foo_ui_columns/fcl_colours.cpp
+++ b/foo_ui_columns/fcl_colours.cpp
@@ -5,7 +5,7 @@
 #include "tab_colours.h"
 
 class ColoursDataSet : public cui::fcl::dataset {
-    enum t_colour_pview_identifiers {
+    enum ItemID {
         colours_pview_mode,
         colours_pview_background,
         colours_pview_selection_background,
@@ -143,7 +143,7 @@ class ColoursDataSet : public cui::fcl::dataset {
 cui::fcl::dataset_factory<ColoursDataSet> g_export_colours_t;
 
 class PlaylistSwitcherAppearanceDataSet : public cui::fcl::dataset {
-    enum t_colour_switcher_identifiers {
+    enum ItemID {
         colours_switcher_mode, // not used
         colours_switcher_background,
         colours_switcher_selection_background,
@@ -230,7 +230,7 @@ class PlaylistSwitcherAppearanceDataSet : public cui::fcl::dataset {
 cui::fcl::dataset_factory<PlaylistSwitcherAppearanceDataSet> g_export_colours_switcher_t;
 
 class FontsDataSet : public cui::fcl::dataset {
-    enum t_colour_pview_identifiers {
+    enum ItemID {
         font_status,
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Misc fonts"; }

--- a/foo_ui_columns/fcl_layout.cpp
+++ b/foo_ui_columns/fcl_layout.cpp
@@ -96,7 +96,7 @@ class ToolbarLayoutDataSet : public cui::fcl::dataset_v2 {
 cui::fcl::dataset_factory<ToolbarLayoutDataSet> g_export_toolbars_t;
 
 class MiscLayoutDataSet : public cui::fcl::dataset {
-    enum t_colour_pview_identifiers {
+    enum ItemID {
         identifier_status,
         identifier_status_pane,
         identifier_allow_locked_panel_resizing

--- a/foo_ui_columns/fcl_titles.cpp
+++ b/foo_ui_columns/fcl_titles.cpp
@@ -9,10 +9,10 @@ cui::fcl::group_impl_factory fclgroupcommon(
     cui::fcl::groups::titles_common, "Common Scripts", "Common Scripts", cui::fcl::groups::title_scripts);
 
 class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
-    enum t_identifiers {
+    enum ItemID {
         identifier_column,
     };
-    enum t_columns {
+    enum ColumnItemID {
         identifier_name,
         identifier_display,
         identifier_sort,
@@ -160,7 +160,7 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
 cui::fcl::dataset_factory<PlaylistViewColumnsDataSet> g_export_columns_t;
 
 class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
-    enum t_identifiers {
+    enum ItemID {
         identifier_groups,
         identifier_show_groups,
         /*identifier_show_artwork, //Need somewhere to stick these
@@ -168,9 +168,9 @@ class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
         identifier_artwork_reflection,*/
     };
 
-    enum t_group_identifiers { identifier_group };
+    enum GroupItemID { identifier_group };
 
-    enum t_columns {
+    enum GroupSubItemID {
         identifier_script,
         identifier_playlist_filter_mode,
         identifier_playlist_filter_string,
@@ -304,7 +304,7 @@ class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
 cui::fcl::dataset_factory<PlaylistViewGroupsDataSet> g_export_groups_t;
 
 class PlaylistViewMiscDataSet : public cui::fcl::dataset {
-    enum t_identifiers {
+    enum ItemID {
         identifier_global_script,
         identifier_style_script,
         identifier_show_header,
@@ -380,7 +380,7 @@ class PlaylistViewMiscDataSet : public cui::fcl::dataset {
 cui::fcl::dataset_factory<PlaylistViewMiscDataSet> g_export_pview_t;
 
 class TitlesDataSet : public cui::fcl::dataset {
-    enum t_identifiers {
+    enum ItemID {
         identifier_main_window_title,
         identifier_status_bar,
         identifier_notification_icon_tooltip,

--- a/foo_ui_columns/fcl_titles.cpp
+++ b/foo_ui_columns/fcl_titles.cpp
@@ -126,12 +126,12 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
                 case identifier_alignment: {
                     t_uint32 temp;
                     reader2.read_item(temp);
-                    item->align = ((alignment)temp);
+                    item->align = ((Alignment)temp);
                 } break;
                 case identifier_filter_type: {
                     t_uint32 temp;
                     reader2.read_item(temp);
-                    item->filter_type = ((playlist_filter_type)temp);
+                    item->filter_type = ((PlaylistFilterType)temp);
                 } break;
                 case identifier_use_sort:
                     reader2.read_item(item->use_custom_sort);
@@ -272,7 +272,7 @@ class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
                         case identifier_playlist_filter_mode: {
                             t_uint32 temp;
                             reader2.read_item(temp);
-                            item.filter_type = (playlist_filter_type&)temp;
+                            item.filter_type = (PlaylistFilterType&)temp;
                         } break;
                         case identifier_playlist_filter_string:
                             reader2.read_item(item.filter_playlists, group_element_size);

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -512,14 +512,14 @@ void FilterPanel::get_selection_handles(
     }
 }
 
-void FilterPanel::do_selection_action(action_t action)
+void FilterPanel::do_selection_action(Action action)
 {
     pfc::bit_array_bittable mask(m_nodes.get_count());
     get_selection_state(mask);
     do_items_action(mask, action);
 }
 
-void FilterPanel::do_items_action(const pfc::bit_array& p_nodes, action_t action)
+void FilterPanel::do_items_action(const pfc::bit_array& p_nodes, Action action)
 {
     metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
     handles.prealloc(m_nodes.get_count());
@@ -596,14 +596,14 @@ void FilterPanel::do_items_action(const pfc::bit_array& p_nodes, action_t action
 
 void FilterPanel::execute_default_action(t_size index, t_size column, bool b_keyboard, bool b_ctrl)
 {
-    auto action = static_cast<action_t>(cfg_doubleclickaction.get_value());
+    auto action = static_cast<Action>(cfg_doubleclickaction.get_value());
     do_selection_action(action);
 }
 
 bool FilterPanel::notify_on_middleclick(bool on_item, t_size index)
 {
     if (cfg_middleclickaction && on_item && index < m_nodes.get_count()) {
-        auto action = static_cast<action_t>(cfg_middleclickaction.get_value() - 1);
+        auto action = static_cast<Action>(cfg_middleclickaction.get_value() - 1);
         do_items_action(pfc::bit_array_one(index), action);
         return true;
     }

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -85,7 +85,7 @@ public:
 
     enum { config_version_current = 1 };
 
-    enum action_t {
+    enum Action {
         action_send_to_autosend,
         action_send_to_autosend_play,
         action_send_to_new,
@@ -161,8 +161,8 @@ private:
     void get_selection_handles(
         metadb_handle_list_t<pfc::alloc_fast_aggressive>& p_out, bool fallback = true, bool b_sort = false);
     bool get_nothing_or_all_node_selected() { return get_selection_count(1) == 0 || get_item_selected(0); }
-    void do_selection_action(action_t action = action_send_to_autosend);
-    void do_items_action(const pfc::bit_array& p_nodes, action_t action = action_send_to_autosend);
+    void do_selection_action(Action action = action_send_to_autosend);
+    void do_items_action(const pfc::bit_array& p_nodes, Action action = action_send_to_autosend);
     void send_results_to_playlist(bool b_play = false);
 
     void update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>& p_data);

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -76,7 +76,7 @@ public:
 };
 
 class FilterPanel
-    : public t_list_view_panel<AppearanceClient, uie::window>
+    : public ListViewPanelBase<AppearanceClient, uie::window>
     , fbh::LibraryCallback {
     friend class FilterSearchToolbar;
 

--- a/foo_ui_columns/filter_menu.cpp
+++ b/foo_ui_columns/filter_menu.cpp
@@ -143,7 +143,7 @@ bool FilterPanel::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
     if (cmd >= ID_BASE)
         manager->execute_by_id(cmd - ID_BASE);
     else if (cmd > 0)
-        do_selection_action((action_t)(cmd - 1));
+        do_selection_action((Action)(cmd - 1));
 
     return true;
 }

--- a/foo_ui_columns/fonts_manager_data.h
+++ b/foo_ui_columns/fonts_manager_data.h
@@ -10,7 +10,7 @@ public:
 
     class entry_t : public pfc::refcounted_object_root {
     public:
-        enum identifier_t {
+        enum ItemID {
             identifier_guid,
             identifier_mode,
             identifier_font,

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -180,7 +180,7 @@ class ItemDetails
     class_data& get_class_data() const override;
 
 public:
-    enum track_mode_t {
+    enum TrackingMode {
         track_auto_playlist_playing,
         track_playlist,
         track_playing,

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -118,7 +118,7 @@ private:
 };
 
 class ItemProperties
-    : public t_list_view_panel<ItemPropertiesColoursClient, uie::window>
+    : public ListViewPanelBase<ItemPropertiesColoursClient, uie::window>
     , public ui_selection_callback
     , public play_callback
     , public metadb_io_callback_dynamic {

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -1,7 +1,7 @@
 #pragma once
 
 template <typename t_appearance_client, typename t_window = uie::window>
-class t_list_view_panel
+class ListViewPanelBase
     : public uih::ListView
     , public t_window {
 public:

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -17,7 +17,7 @@
 RebarWindow* g_rebar_window = nullptr;
 LayoutWindow g_layout_window;
 cui::MainWindow cui::main_window;
-status_pane g_status_pane;
+StatusPane g_status_pane;
 
 HIMAGELIST g_imagelist = nullptr;
 

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -55,7 +55,7 @@ void on_show_status_change();
 void on_show_status_pane_change();
 void on_show_toolbars_change();
 
-extern class status_pane g_status_pane;
+extern class StatusPane g_status_pane;
 extern class RebarWindow* g_rebar_window;
 
 namespace taskbar_buttons {

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -11,7 +11,7 @@
  */
 
 namespace colours {
-enum t_colours {
+enum ColourID {
     COLOUR_TEXT,
     COLOUR_SELECTED_TEXT,
     COLOUR_BACK,
@@ -22,7 +22,7 @@ enum t_colours {
 };
 };
 
-COLORREF get_default_colour(colours::t_colours index, bool themed = false);
+COLORREF get_default_colour(colours::ColourID index, bool themed = false);
 
 /** Main window UI control IDs */
 #define ID_REBAR 2100

--- a/foo_ui_columns/menu_helpers.cpp
+++ b/foo_ui_columns/menu_helpers.cpp
@@ -1,12 +1,12 @@
 #include "stdafx.h"
 #include "menu_helpers.h"
 
-bool operator==(const menu_item_identifier& p1, const menu_item_identifier& p2)
+bool operator==(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2)
 {
     return p1.m_command == p2.m_command && p1.m_subcommand == p2.m_subcommand;
 }
 
-bool operator!=(const menu_item_identifier& p1, const menu_item_identifier& p2)
+bool operator!=(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2)
 {
     return !(p1 == p2);
 }

--- a/foo_ui_columns/menu_helpers.h
+++ b/foo_ui_columns/menu_helpers.h
@@ -20,16 +20,16 @@ bool mainmenunode_subguid_to_path(
 void mainpath_from_guid(const GUID& p_guid, const GUID& p_subguid, pfc::string_base& p_out, bool b_short = false);
 }; // namespace menu_helpers
 
-struct menu_item_identifier {
+struct MenuItemIdentifier {
     GUID m_command{};
     GUID m_subcommand{};
 };
 
-bool operator==(const menu_item_identifier& p1, const menu_item_identifier& p2);
-bool operator!=(const menu_item_identifier& p1, const menu_item_identifier& p2);
+bool operator==(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2);
+bool operator!=(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2);
 
 class menu_item_cache {
-    class menu_item_info : public menu_item_identifier {
+    class menu_item_info : public MenuItemIdentifier {
     public:
         pfc::string8 m_name;
         pfc::string8 m_desc;

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -928,7 +928,7 @@ const style_data_t& PlaylistView::get_style_data(t_size index)
 }
 bool PlaylistView::notify_on_middleclick(bool on_item, t_size index)
 {
-    return cui::playlist_item_helpers::mclick_action::run(cfg_playlist_middle_action, on_item, index);
+    return cui::playlist_item_helpers::MiddleClickActionManager::run(cfg_playlist_middle_action, on_item, index);
 }
 bool PlaylistView::notify_on_doubleleftclick_nowhere()
 {

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -313,7 +313,7 @@ public:
 };
 
 class PlaylistView
-    : public t_list_view_panel<ColoursClient, uie::playlist_window>
+    : public ListViewPanelBase<ColoursClient, uie::playlist_window>
     , playlist_callback_single
     , BasePlaylistCallback {
     friend class NgTfThread;

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -42,14 +42,14 @@ static BOOL CALLBACK EditViewProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         case (CBN_SELCHANGE << 16) | IDC_PLAYLIST_FILTER_TYPE: {
             if (true) {
                 EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING),
-                    ((playlist_filter_type)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0)) != FILTER_NONE);
+                    ((PlaylistFilterType)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0)) != FILTER_NONE);
             }
         } break;
         case IDOK: {
             auto* ptr = reinterpret_cast<edit_view_param*>(GetWindowLongPtr(wnd, DWLP_USER));
             uGetDlgItemText(wnd, IDC_VALUE, ptr->value.string);
             ptr->value.filter_type
-                = ((playlist_filter_type)SendDlgItemMessage(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_GETCURSEL, 0, 0));
+                = ((PlaylistFilterType)SendDlgItemMessage(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_GETCURSEL, 0, 0));
             ptr->value.filter_playlists = (string_utf8_from_window(wnd, IDC_PLAYLIST_FILTER_STRING));
             EndDialog(wnd, 1);
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_groups.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist_groups.h
@@ -4,7 +4,7 @@ namespace pvt {
 
 class Group {
 public:
-    Group(const char* p_string, playlist_filter_type p_filter_type = FILTER_NONE, const char* p_filter = "")
+    Group(const char* p_string, PlaylistFilterType p_filter_type = FILTER_NONE, const char* p_filter = "")
         : string(p_string), filter_type(p_filter_type), filter_playlists(p_filter){};
     Group() = default;
     void write(stream_writer* p_stream, abort_callback& p_abort)
@@ -22,7 +22,7 @@ public:
         }
     }
     pfc::string8 string;
-    playlist_filter_type filter_type{FILTER_NONE};
+    PlaylistFilterType filter_type{FILTER_NONE};
     pfc::string8 filter_playlists;
 
 private:

--- a/foo_ui_columns/ng_playlist/ng_playlist_style.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist_style.h
@@ -3,16 +3,16 @@
 namespace pvt {
 class CellStyleData {
 public:
-    colour text_colour;
-    colour selected_text_colour;
-    colour background_colour;
-    colour selected_background_colour;
-    colour selected_text_colour_non_focus;
-    colour selected_background_colour_non_focus;
-    colour frame_left;
-    colour frame_top;
-    colour frame_right;
-    colour frame_bottom;
+    Colour text_colour;
+    Colour selected_text_colour;
+    Colour background_colour;
+    Colour selected_background_colour;
+    Colour selected_text_colour_non_focus;
+    Colour selected_background_colour_non_focus;
+    Colour frame_left;
+    Colour frame_top;
+    Colour frame_right;
+    Colour frame_bottom;
     bool use_frame_left : 1;
     bool use_frame_top : 1;
     bool use_frame_right : 1;

--- a/foo_ui_columns/playlist_item_helpers.cpp
+++ b/foo_ui_columns/playlist_item_helpers.cpp
@@ -24,18 +24,18 @@ void action_add_to_queue(bool on_item, unsigned idx)
 
 void action_none(bool on_on_item, unsigned idx) {}
 
-pma mclick_action::g_pma_actions[] = {
+MiddleLickAction MiddleClickActionManager::g_pma_actions[] = {
     {"(None)", 0, action_none},
     {"Remove track from playlist", 1, action_remove_track},
     {"Add to playback queue", 2, action_add_to_queue},
 };
 
-unsigned mclick_action::get_count()
+unsigned MiddleClickActionManager::get_count()
 {
     return tabsize(g_pma_actions);
 }
 
-unsigned mclick_action::id_to_idx(unsigned id)
+unsigned MiddleClickActionManager::id_to_idx(unsigned id)
 {
     unsigned count = tabsize(g_pma_actions);
     for (unsigned n = 0; n < count; n++) {

--- a/foo_ui_columns/playlist_item_helpers.h
+++ b/foo_ui_columns/playlist_item_helpers.h
@@ -2,17 +2,17 @@
 
 namespace cui::playlist_item_helpers {
 
-using pma_action = void (*)(bool, unsigned int);
+using MiddleClickFunction = void (*)(bool, unsigned int);
 
-struct pma {
+struct MiddleLickAction {
     const char* name;
     unsigned id;
-    pma_action p_run;
+    MiddleClickFunction p_run;
 };
 
-class mclick_action {
+class MiddleClickActionManager {
 public:
-    static pma g_pma_actions[];
+    static MiddleLickAction g_pma_actions[];
     static unsigned id_to_idx(unsigned id);
 
     static bool run(unsigned id, bool on_item, unsigned idx)

--- a/foo_ui_columns/playlist_manager_utils.cpp
+++ b/foo_ui_columns/playlist_manager_utils.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "playlist_manager_utils.h"
 
-playlist_format_name_t::titleformat_hook_playlist_t::titleformat_hook_playlist_t(
+StringPlaylistFormatName::PlaylistSwitcherTitleformatHook::PlaylistSwitcherTitleformatHook(
     unsigned p_index, const char* p_name, t_size p_playing)
     : m_name(p_name)
     , m_playing(p_playing == p_index)
@@ -18,18 +18,18 @@ playlist_format_name_t::titleformat_hook_playlist_t::titleformat_hook_playlist_t
     m_active = m_api->get_active_playlist() == p_index;
 };
 
-playlist_format_name_t::playlist_format_name_t(unsigned p_index, const char* src, t_size p_playing)
+StringPlaylistFormatName::StringPlaylistFormatName(unsigned p_index, const char* src, t_size p_playing)
 {
     if (cfg_playlist_switcher_use_tagz) {
         service_ptr_t<titleformat_object> to_temp;
         static_api_ptr_t<titleformat_compiler>()->compile_safe(to_temp, cfg_playlist_switcher_tagz);
-        titleformat_hook_playlist_t tf_hook(p_index, src, p_playing);
+        PlaylistSwitcherTitleformatHook tf_hook(p_index, src, p_playing);
         to_temp->run(&tf_hook, *this, nullptr);
     } else
         set_string(src);
 }
 
-bool playlist_format_name_t::titleformat_hook_playlist_t::process_field(
+bool StringPlaylistFormatName::PlaylistSwitcherTitleformatHook::process_field(
     titleformat_text_out* p_out, const char* p_name, unsigned p_name_length, bool& p_found_flag)
 {
     p_found_flag = false;
@@ -104,7 +104,7 @@ bool playlist_format_name_t::titleformat_hook_playlist_t::process_field(
 
 namespace playlist_manager_utils {
 
-class rename_param {
+class RenameParam {
 public:
     modal_dialog_scope m_scope;
     pfc::string8* m_text{};
@@ -116,7 +116,7 @@ static BOOL CALLBACK RenameProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_INITDIALOG:
         SetWindowLongPtr(wnd, DWLP_USER, lp);
         {
-            auto* ptr = (rename_param*)lp;
+            auto* ptr = (RenameParam*)lp;
             ptr->m_scope.initialize(FindOwningPopup(wnd));
             pfc::string_formatter formatter;
             formatter << R"(Rename playlist: ")" << *ptr->m_text << R"(")";
@@ -127,7 +127,7 @@ static BOOL CALLBACK RenameProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_COMMAND:
         switch (wp) {
         case IDOK: {
-            auto* ptr = (rename_param*)GetWindowLong(wnd, DWLP_USER);
+            auto* ptr = (RenameParam*)GetWindowLong(wnd, DWLP_USER);
             uGetDlgItemText(wnd, IDC_EDIT, *ptr->m_text);
             EndDialog(wnd, 1);
         } break;
@@ -145,7 +145,7 @@ static BOOL CALLBACK RenameProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
 static bool rename_dialog(pfc::string8* text, HWND parent)
 {
-    rename_param param;
+    RenameParam param;
     param.m_text = text;
     return !!uDialogBox(IDD_RENAME_PLAYLIST, parent, RenameProc, (LPARAM)(&param));
 }

--- a/foo_ui_columns/playlist_manager_utils.h
+++ b/foo_ui_columns/playlist_manager_utils.h
@@ -1,7 +1,7 @@
 #pragma once
 
-class playlist_format_name_t : private pfc::string8 {
-    class titleformat_hook_playlist_t : public titleformat_hook {
+class StringPlaylistFormatName : private pfc::string8 {
+    class PlaylistSwitcherTitleformatHook : public titleformat_hook {
         const char* m_name;
         bool m_locked;
         bool m_playing;
@@ -41,11 +41,11 @@ class playlist_format_name_t : private pfc::string8 {
             p_found_flag = false;
             return false;
         }
-        titleformat_hook_playlist_t(unsigned p_index, const char* p_name, t_size p_playing);
+        PlaylistSwitcherTitleformatHook(unsigned p_index, const char* p_name, t_size p_playing);
     };
 
 public:
-    playlist_format_name_t(unsigned p_index, const char* src, t_size p_playing);
+    StringPlaylistFormatName(unsigned p_index, const char* src, t_size p_playing);
     operator const char*() { return get_ptr(); }
 };
 

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -410,7 +410,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
                                 if (m_new_playlist) {
                                     if (!m_playlist_name.length()) {
                                         if (cfg_pgen_tf)
-                                            m_playlist_name = string_pn(p_items, cfg_pgenstring);
+                                            m_playlist_name = StringFormatCommonTrackTitle(p_items, cfg_pgenstring);
                                         else
                                             m_playlist_name = "Untitled";
                                     }

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -15,7 +15,7 @@ void PlaylistSwitcher::get_insert_items(t_size base, t_size count, pfc::list_t<u
         p_out[i].m_subitems.set_count(1);
         pfc::string8 temp;
         m_playlist_api->playlist_get_name(i + base, temp);
-        p_out[i].m_subitems[0].set_string(playlist_format_name_t(i + base, temp, get_playing_playlist()));
+        p_out[i].m_subitems[0].set_string(StringPlaylistFormatName(i + base, temp, get_playing_playlist()));
     }
 }
 

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -5,7 +5,7 @@
 #include "list_view_panel.h"
 
 class PlaylistSwitcher
-    : public t_list_view_panel<PlaylistSwitcherColoursClient, uie::window>
+    : public ListViewPanelBase<PlaylistSwitcherColoursClient, uie::window>
     , private playlist_callback
     , private play_callback {
     enum {

--- a/foo_ui_columns/playlist_tabs_drop_target.cpp
+++ b/foo_ui_columns/playlist_tabs_drop_target.cpp
@@ -304,7 +304,7 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Drop(
                     playlist_name.replace_char('_', ' ', 0);
                 if (!named && cfg_pgen_tf)
                     new_idx = playlist_api->create_playlist(
-                        string_pn(data, cfg_pgenstring), pfc_infinite, newPlaylistIndex);
+                        StringFormatCommonTrackTitle(data, cfg_pgenstring), pfc_infinite, newPlaylistIndex);
 
                 else
                     new_idx = playlist_api->create_playlist(playlist_name, pfc_infinite, newPlaylistIndex);

--- a/foo_ui_columns/prefs_utils.cpp
+++ b/foo_ui_columns/prefs_utils.cpp
@@ -82,7 +82,7 @@ bool colour_picker(HWND wnd, COLORREF& out, COLORREF custom)
     return rv;
 }
 
-void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const menu_item_identifier& p_item,
+void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItemIdentifier& p_item,
     menu_item_cache& p_cache, bool insert_none)
 {
     HWND wnd_combo = GetDlgItem(wnd, ID);
@@ -127,7 +127,7 @@ void on_menu_combo_change(
     unsigned cache_idx = SendMessage(wnd_combo, CB_GETITEMDATA, SendMessage(wnd_combo, CB_GETCURSEL, 0, 0), 0);
 
     if (cache_idx == -1) {
-        cfg_menu_store = menu_item_identifier();
+        cfg_menu_store = MenuItemIdentifier();
     } else if (cache_idx < p_cache.get_count()) {
         cfg_menu_store = p_cache.get_item(cache_idx);
     }

--- a/foo_ui_columns/prefs_utils.h
+++ b/foo_ui_columns/prefs_utils.h
@@ -1,7 +1,7 @@
 #ifndef _COLOUMNS_PREFS_H_
 #define _COLOUMNS_PREFS_H_
 
-void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const menu_item_identifier& p_item,
+void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItemIdentifier& p_item,
     menu_item_cache& p_cache, bool insert_none);
 void on_menu_combo_change(
     HWND wnd, LPARAM lp, class ConfigMenuItem& cfg_menu_store, menu_item_cache& p_cache, unsigned ID_DESC);

--- a/foo_ui_columns/splitter.cpp
+++ b/foo_ui_columns/splitter.cpp
@@ -71,7 +71,7 @@ class HorizontalSplitterPanel : public FlatSplitterPanel {
         static const GUID rv = {0x8fa0bc24, 0x882a, 0x4fff, {0x8a, 0x3b, 0x21, 0x5e, 0xa7, 0xfb, 0xd0, 0x7f}};
         return rv;
     }
-    orientation_t get_orientation() const override { return horizontal; }
+    Orientation get_orientation() const override { return horizontal; }
 };
 
 class VerticalSplitterPanel : public FlatSplitterPanel {
@@ -87,7 +87,7 @@ class VerticalSplitterPanel : public FlatSplitterPanel {
         static const GUID rv = {0x77653a44, 0x66d1, 0x49e0, {0x9a, 0x7a, 0x1c, 0x71, 0x89, 0x8c, 0x4, 0x41}};
         return rv;
     }
-    orientation_t get_orientation() const override { return vertical; }
+    Orientation get_orientation() const override { return vertical; }
 };
 
 uie::window_factory<HorizontalSplitterPanel> g_splitter_window_horizontal;

--- a/foo_ui_columns/splitter.cpp
+++ b/foo_ui_columns/splitter.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "splitter.h"
 
-pfc::ptr_list_t<splitter_window_impl> splitter_window_impl::g_instances;
+pfc::ptr_list_t<FlatSplitterPanel> FlatSplitterPanel::g_instances;
 
 void g_get_panel_list(uie::window_info_list_simple& p_out, uie::window_host_ptr& p_host)
 {
@@ -58,7 +58,7 @@ void clip_minmaxinfo(MINMAXINFO& mmi)
     mmi.ptMaxTrackSize.x = min(mmi.ptMaxTrackSize.x, MAXSHORT);
 }
 
-class splitter_window_horizontal : public splitter_window_impl {
+class splitter_window_horizontal : public FlatSplitterPanel {
     class_data& get_class_data() const override
     {
         __implement_get_class_data_ex(_T("{72FACC90-BB7E-4733-8449-D7537232AD26}"), _T(""), false, 0,
@@ -74,7 +74,7 @@ class splitter_window_horizontal : public splitter_window_impl {
     orientation_t get_orientation() const override { return horizontal; }
 };
 
-class splitter_window_vertical : public splitter_window_impl {
+class splitter_window_vertical : public FlatSplitterPanel {
     class_data& get_class_data() const override
     {
         __implement_get_class_data_ex(_T("{77653A44-66D1-49e0-9A7A-1C71898C0441}"), _T(""), false, 0,
@@ -93,7 +93,7 @@ class splitter_window_vertical : public splitter_window_impl {
 uie::window_factory<splitter_window_horizontal> g_splitter_window_horizontal;
 uie::window_factory<splitter_window_vertical> g_splitter_window_vertical;
 
-splitter_window_impl::panel::ptr splitter_window_impl::panel::null_ptr = splitter_window_impl::panel::ptr();
+FlatSplitterPanel::panel::ptr FlatSplitterPanel::panel::null_ptr = FlatSplitterPanel::panel::ptr();
 
 #if 0
 template <orientation_t t_orientation>

--- a/foo_ui_columns/splitter.cpp
+++ b/foo_ui_columns/splitter.cpp
@@ -58,7 +58,7 @@ void clip_minmaxinfo(MINMAXINFO& mmi)
     mmi.ptMaxTrackSize.x = min(mmi.ptMaxTrackSize.x, MAXSHORT);
 }
 
-class splitter_window_horizontal : public FlatSplitterPanel {
+class HorizontalSplitterPanel : public FlatSplitterPanel {
     class_data& get_class_data() const override
     {
         __implement_get_class_data_ex(_T("{72FACC90-BB7E-4733-8449-D7537232AD26}"), _T(""), false, 0,
@@ -74,7 +74,7 @@ class splitter_window_horizontal : public FlatSplitterPanel {
     orientation_t get_orientation() const override { return horizontal; }
 };
 
-class splitter_window_vertical : public FlatSplitterPanel {
+class VerticalSplitterPanel : public FlatSplitterPanel {
     class_data& get_class_data() const override
     {
         __implement_get_class_data_ex(_T("{77653A44-66D1-49e0-9A7A-1C71898C0441}"), _T(""), false, 0,
@@ -90,10 +90,10 @@ class splitter_window_vertical : public FlatSplitterPanel {
     orientation_t get_orientation() const override { return vertical; }
 };
 
-uie::window_factory<splitter_window_horizontal> g_splitter_window_horizontal;
-uie::window_factory<splitter_window_vertical> g_splitter_window_vertical;
+uie::window_factory<HorizontalSplitterPanel> g_splitter_window_horizontal;
+uie::window_factory<VerticalSplitterPanel> g_splitter_window_vertical;
 
-FlatSplitterPanel::panel::ptr FlatSplitterPanel::panel::null_ptr = FlatSplitterPanel::panel::ptr();
+FlatSplitterPanel::Panel::ptr FlatSplitterPanel::Panel::null_ptr = FlatSplitterPanel::Panel::ptr();
 
 #if 0
 template <orientation_t t_orientation>

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -1,7 +1,7 @@
 #ifndef _COLUMNS_SPLITTER_H_
 #define _COLUMNS_SPLITTER_H_
 
-enum orientation_t {
+enum Orientation {
     horizontal,
     vertical,
 };
@@ -9,7 +9,7 @@ enum orientation_t {
 class FlatSplitterPanel
     : public uie::container_ui_extension_t<ui_helpers::container_window, uie::splitter_window_v2> {
 public:
-    virtual orientation_t get_orientation() const = 0;
+    virtual Orientation get_orientation() const = 0;
     static unsigned g_get_caption_size();
     void get_category(pfc::string_base& p_out) const override;
     unsigned get_type() const override;
@@ -51,7 +51,7 @@ public:
         ;
 
         // unsigned get_orientation();
-        orientation_t get_orientation() const;
+        Orientation get_orientation() const;
 
         unsigned is_resize_supported(HWND wnd) const override;
 

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -38,7 +38,7 @@ public:
 
     bool set_config_item(unsigned index, const GUID& p_type, stream_reader* p_source, abort_callback& p_abort) override;
 
-    class splitter_host_impl : public ui_extension::window_host_ex {
+    class FlatSplitterPanelHost : public ui_extension::window_host_ex {
         service_ptr_t<FlatSplitterPanel> m_this;
 
     public:
@@ -77,25 +77,25 @@ public:
     static void g_on_size_change();
 
 private:
-    struct t_size_limit {
+    struct SizeLimit {
         unsigned min_height{0};
         unsigned max_height{0};
         unsigned min_width{0};
         unsigned max_width{0};
-        t_size_limit() = default;
+        SizeLimit() = default;
         ;
     };
-    class panel : public pfc::refcounted_object_root {
+    class Panel : public pfc::refcounted_object_root {
     public:
-        class panel_container
+        class PanelContainer
             : public ui_helpers::container_window
             , private fbh::LowLevelMouseHookManager::HookCallback {
         public:
             enum { MSG_AUTOHIDE_END = WM_USER + 2 };
 
-            panel_container(panel* p_panel);
+            PanelContainer(Panel* p_panel);
             ;
-            ~panel_container();
+            ~PanelContainer();
             void set_window_ptr(FlatSplitterPanel* p_ptr);
             void enter_autohide_hook();
             // private:
@@ -105,7 +105,7 @@ private:
             service_ptr_t<FlatSplitterPanel> m_this;
 
             HTHEME m_theme;
-            panel* m_panel;
+            Panel* m_panel;
 
             bool m_hook_active;
             bool m_timer_active;
@@ -123,13 +123,13 @@ private:
         HWND m_wnd_child{nullptr};
         bool m_show_caption{true};
         pfc::array_t<t_uint8> m_child_data;
-        t_size_limit m_size_limits;
+        SizeLimit m_size_limits;
         uie::window_ptr m_child;
         bool m_show_toggle_area{false};
         bool m_use_custom_title{false};
         pfc::string8 m_custom_title;
 
-        service_ptr_t<class splitter_host_impl> m_interface;
+        service_ptr_t<class FlatSplitterPanelHost> m_interface;
 
         uih::IntegerAndDpi<uint32_t> m_size{150};
 
@@ -150,12 +150,12 @@ private:
         void on_size(unsigned cx, unsigned cy);
 
         void destroy();
-        panel();
+        Panel();
 
-        using ptr = pfc::refcounted_object_ptr_t<panel>;
+        using ptr = pfc::refcounted_object_ptr_t<Panel>;
         static ptr null_ptr;
     };
-    class panel_list : public pfc::list_t<pfc::refcounted_object_ptr_t<panel>> {
+    class PanelList : public pfc::list_t<pfc::refcounted_object_ptr_t<Panel>> {
     public:
         bool find_by_wnd(HWND wnd, unsigned& p_out);
         bool find_by_wnd_child(HWND wnd, unsigned& p_out);
@@ -187,7 +187,7 @@ private:
     void destroy_children();
 
     // unsigned get_orientation();
-    panel_list m_panels;
+    PanelList m_panels;
     HWND m_wnd{nullptr};
 
     int m_last_position{NULL};

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -6,7 +6,7 @@ enum orientation_t {
     vertical,
 };
 
-class splitter_window_impl
+class FlatSplitterPanel
     : public uie::container_ui_extension_t<ui_helpers::container_window, uie::splitter_window_v2> {
 public:
     virtual orientation_t get_orientation() const = 0;
@@ -39,7 +39,7 @@ public:
     bool set_config_item(unsigned index, const GUID& p_type, stream_reader* p_source, abort_callback& p_abort) override;
 
     class splitter_host_impl : public ui_extension::window_host_ex {
-        service_ptr_t<splitter_window_impl> m_this;
+        service_ptr_t<FlatSplitterPanel> m_this;
 
     public:
         const GUID& get_host_guid() const override;
@@ -64,7 +64,7 @@ public:
         bool is_visibility_modifiable(HWND wnd, bool desired_visibility) const override;
         bool set_window_visibility(HWND wnd, bool visibility) override;
 
-        void set_window_ptr(splitter_window_impl* p_ptr);
+        void set_window_ptr(FlatSplitterPanel* p_ptr);
 
         void relinquish_ownership(HWND wnd) override;
     };
@@ -96,13 +96,13 @@ private:
             panel_container(panel* p_panel);
             ;
             ~panel_container();
-            void set_window_ptr(splitter_window_impl* p_ptr);
+            void set_window_ptr(FlatSplitterPanel* p_ptr);
             void enter_autohide_hook();
             // private:
             class_data& get_class_data() const override;
             LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
             void on_hooked_message(WPARAM msg, const MSLLHOOKSTRUCT& mllhs) override;
-            service_ptr_t<splitter_window_impl> m_this;
+            service_ptr_t<FlatSplitterPanel> m_this;
 
             HTHEME m_theme;
             panel* m_panel;
@@ -197,10 +197,10 @@ private:
     static gdi_object_t<HFONT>::ptr_t g_font_menu_horizontal;
     static gdi_object_t<HFONT>::ptr_t g_font_menu_vertical;
     static unsigned g_count;
-    static pfc::ptr_list_t<splitter_window_impl> g_instances;
+    static pfc::ptr_list_t<FlatSplitterPanel> g_instances;
 
 public:
-    splitter_window_impl() = default;
+    FlatSplitterPanel() = default;
 
     //
 };

--- a/foo_ui_columns/splitter_panel.cpp
+++ b/foo_ui_columns/splitter_panel.cpp
@@ -1,9 +1,9 @@
 #include "stdafx.h"
 #include "splitter.h"
 
-splitter_window_impl::panel::panel() : m_container(this) {}
+FlatSplitterPanel::panel::panel() : m_container(this) {}
 
-void splitter_window_impl::panel::destroy()
+void FlatSplitterPanel::panel::destroy()
 {
     if (m_child.is_valid()) {
         //            pal.m_child_data.set_size(0);
@@ -19,7 +19,7 @@ void splitter_window_impl::panel::destroy()
         m_container.destroy();
 }
 
-void splitter_window_impl::panel::on_size(unsigned cx, unsigned cy)
+void FlatSplitterPanel::panel::on_size(unsigned cx, unsigned cy)
 {
     unsigned caption_size = m_show_caption ? g_get_caption_size() : 0;
 
@@ -42,7 +42,7 @@ void splitter_window_impl::panel::on_size(unsigned cx, unsigned cy)
     }
 }
 
-void splitter_window_impl::panel::on_size()
+void FlatSplitterPanel::panel::on_size()
 {
     RECT rc;
     if (GetClientRect(m_wnd, &rc)) {
@@ -50,7 +50,7 @@ void splitter_window_impl::panel::on_size()
     }
 }
 
-void splitter_window_impl::panel::set_hidden(bool val)
+void FlatSplitterPanel::panel::set_hidden(bool val)
 {
     m_hidden = val;
     if (m_container.m_this.is_valid()) {
@@ -59,7 +59,7 @@ void splitter_window_impl::panel::set_hidden(bool val)
     }
 }
 
-void splitter_window_impl::panel::read(stream_reader* t, abort_callback& p_abort)
+void FlatSplitterPanel::panel::read(stream_reader* t, abort_callback& p_abort)
 {
     t->read_lendian_t(m_guid, p_abort);
     t->read_lendian_t(m_caption_orientation, p_abort);
@@ -82,7 +82,7 @@ void splitter_window_impl::panel::read(stream_reader* t, abort_callback& p_abort
     t->read_string(m_custom_title, p_abort);
 }
 
-void splitter_window_impl::panel::import(stream_reader* t, abort_callback& p_abort)
+void FlatSplitterPanel::panel::import(stream_reader* t, abort_callback& p_abort)
 {
     t->read_lendian_t(m_guid, p_abort);
     t->read_lendian_t(m_caption_orientation, p_abort);
@@ -116,19 +116,19 @@ void splitter_window_impl::panel::import(stream_reader* t, abort_callback& p_abo
     //    throw pfc::exception_not_implemented();
 }
 
-void splitter_window_impl::panel::read_extra(stream_reader* reader, abort_callback& p_abort)
+void FlatSplitterPanel::panel::read_extra(stream_reader* reader, abort_callback& p_abort)
 {
     reader->read_lendian_t(m_size.value, p_abort);
     reader->read_lendian_t(m_size.dpi, p_abort);
 }
 
-void splitter_window_impl::panel::write_extra(stream_writer* writer, abort_callback& p_abort)
+void FlatSplitterPanel::panel::write_extra(stream_writer* writer, abort_callback& p_abort)
 {
     writer->write_lendian_t(m_size.value, p_abort);
     writer->write_lendian_t(m_size.dpi, p_abort);
 }
 
-void splitter_window_impl::panel::write(stream_writer* out, abort_callback& p_abort)
+void FlatSplitterPanel::panel::write(stream_writer* out, abort_callback& p_abort)
 {
     if (m_child.is_valid()) {
         m_child->get_config_to_array(m_child_data, p_abort, true);
@@ -147,7 +147,7 @@ void splitter_window_impl::panel::write(stream_writer* out, abort_callback& p_ab
     out->write_string(m_custom_title, p_abort);
 }
 
-void splitter_window_impl::panel::_export(stream_writer* out, abort_callback& p_abort)
+void FlatSplitterPanel::panel::_export(stream_writer* out, abort_callback& p_abort)
 {
     stream_writer_memblock child_exported_data;
     uie::window_ptr ptr = m_child;
@@ -176,7 +176,7 @@ void splitter_window_impl::panel::_export(stream_writer* out, abort_callback& p_
     out->write_string(m_custom_title, p_abort);
 }
 
-void splitter_window_impl::panel::set_from_splitter_item(const uie::splitter_item_t* p_source)
+void FlatSplitterPanel::panel::set_from_splitter_item(const uie::splitter_item_t* p_source)
 {
     if (m_wnd)
         destroy();
@@ -201,7 +201,7 @@ void splitter_window_impl::panel::set_from_splitter_item(const uie::splitter_ite
     p_source->get_panel_config_to_array(m_child_data, true);
 }
 
-uie::splitter_item_full_v2_t* splitter_window_impl::panel::create_splitter_item(bool b_set_ptr /*= true*/)
+uie::splitter_item_full_v2_t* FlatSplitterPanel::panel::create_splitter_item(bool b_set_ptr /*= true*/)
 {
     auto ret = new uie::splitter_item_full_v2_impl_t;
     ret->m_autohide = m_autohide;
@@ -223,7 +223,7 @@ uie::splitter_item_full_v2_t* splitter_window_impl::panel::create_splitter_item(
     return ret;
 }
 
-bool splitter_window_impl::panel_list::find_by_wnd_child(HWND wnd, unsigned& p_out)
+bool FlatSplitterPanel::panel_list::find_by_wnd_child(HWND wnd, unsigned& p_out)
 {
     unsigned count = get_count();
     for (unsigned n = 0; n < count; n++) {
@@ -235,7 +235,7 @@ bool splitter_window_impl::panel_list::find_by_wnd_child(HWND wnd, unsigned& p_o
     return false;
 }
 
-bool splitter_window_impl::panel_list::find_by_wnd(HWND wnd, unsigned& p_out)
+bool FlatSplitterPanel::panel_list::find_by_wnd(HWND wnd, unsigned& p_out)
 {
     unsigned count = get_count();
     for (unsigned n = 0; n < count; n++) {

--- a/foo_ui_columns/splitter_panel.cpp
+++ b/foo_ui_columns/splitter_panel.cpp
@@ -1,9 +1,9 @@
 #include "stdafx.h"
 #include "splitter.h"
 
-FlatSplitterPanel::panel::panel() : m_container(this) {}
+FlatSplitterPanel::Panel::Panel() : m_container(this) {}
 
-void FlatSplitterPanel::panel::destroy()
+void FlatSplitterPanel::Panel::destroy()
 {
     if (m_child.is_valid()) {
         //            pal.m_child_data.set_size(0);
@@ -19,7 +19,7 @@ void FlatSplitterPanel::panel::destroy()
         m_container.destroy();
 }
 
-void FlatSplitterPanel::panel::on_size(unsigned cx, unsigned cy)
+void FlatSplitterPanel::Panel::on_size(unsigned cx, unsigned cy)
 {
     unsigned caption_size = m_show_caption ? g_get_caption_size() : 0;
 
@@ -42,7 +42,7 @@ void FlatSplitterPanel::panel::on_size(unsigned cx, unsigned cy)
     }
 }
 
-void FlatSplitterPanel::panel::on_size()
+void FlatSplitterPanel::Panel::on_size()
 {
     RECT rc;
     if (GetClientRect(m_wnd, &rc)) {
@@ -50,7 +50,7 @@ void FlatSplitterPanel::panel::on_size()
     }
 }
 
-void FlatSplitterPanel::panel::set_hidden(bool val)
+void FlatSplitterPanel::Panel::set_hidden(bool val)
 {
     m_hidden = val;
     if (m_container.m_this.is_valid()) {
@@ -59,7 +59,7 @@ void FlatSplitterPanel::panel::set_hidden(bool val)
     }
 }
 
-void FlatSplitterPanel::panel::read(stream_reader* t, abort_callback& p_abort)
+void FlatSplitterPanel::Panel::read(stream_reader* t, abort_callback& p_abort)
 {
     t->read_lendian_t(m_guid, p_abort);
     t->read_lendian_t(m_caption_orientation, p_abort);
@@ -82,7 +82,7 @@ void FlatSplitterPanel::panel::read(stream_reader* t, abort_callback& p_abort)
     t->read_string(m_custom_title, p_abort);
 }
 
-void FlatSplitterPanel::panel::import(stream_reader* t, abort_callback& p_abort)
+void FlatSplitterPanel::Panel::import(stream_reader* t, abort_callback& p_abort)
 {
     t->read_lendian_t(m_guid, p_abort);
     t->read_lendian_t(m_caption_orientation, p_abort);
@@ -116,19 +116,19 @@ void FlatSplitterPanel::panel::import(stream_reader* t, abort_callback& p_abort)
     //    throw pfc::exception_not_implemented();
 }
 
-void FlatSplitterPanel::panel::read_extra(stream_reader* reader, abort_callback& p_abort)
+void FlatSplitterPanel::Panel::read_extra(stream_reader* reader, abort_callback& p_abort)
 {
     reader->read_lendian_t(m_size.value, p_abort);
     reader->read_lendian_t(m_size.dpi, p_abort);
 }
 
-void FlatSplitterPanel::panel::write_extra(stream_writer* writer, abort_callback& p_abort)
+void FlatSplitterPanel::Panel::write_extra(stream_writer* writer, abort_callback& p_abort)
 {
     writer->write_lendian_t(m_size.value, p_abort);
     writer->write_lendian_t(m_size.dpi, p_abort);
 }
 
-void FlatSplitterPanel::panel::write(stream_writer* out, abort_callback& p_abort)
+void FlatSplitterPanel::Panel::write(stream_writer* out, abort_callback& p_abort)
 {
     if (m_child.is_valid()) {
         m_child->get_config_to_array(m_child_data, p_abort, true);
@@ -147,7 +147,7 @@ void FlatSplitterPanel::panel::write(stream_writer* out, abort_callback& p_abort
     out->write_string(m_custom_title, p_abort);
 }
 
-void FlatSplitterPanel::panel::_export(stream_writer* out, abort_callback& p_abort)
+void FlatSplitterPanel::Panel::_export(stream_writer* out, abort_callback& p_abort)
 {
     stream_writer_memblock child_exported_data;
     uie::window_ptr ptr = m_child;
@@ -176,7 +176,7 @@ void FlatSplitterPanel::panel::_export(stream_writer* out, abort_callback& p_abo
     out->write_string(m_custom_title, p_abort);
 }
 
-void FlatSplitterPanel::panel::set_from_splitter_item(const uie::splitter_item_t* p_source)
+void FlatSplitterPanel::Panel::set_from_splitter_item(const uie::splitter_item_t* p_source)
 {
     if (m_wnd)
         destroy();
@@ -201,7 +201,7 @@ void FlatSplitterPanel::panel::set_from_splitter_item(const uie::splitter_item_t
     p_source->get_panel_config_to_array(m_child_data, true);
 }
 
-uie::splitter_item_full_v2_t* FlatSplitterPanel::panel::create_splitter_item(bool b_set_ptr /*= true*/)
+uie::splitter_item_full_v2_t* FlatSplitterPanel::Panel::create_splitter_item(bool b_set_ptr /*= true*/)
 {
     auto ret = new uie::splitter_item_full_v2_impl_t;
     ret->m_autohide = m_autohide;
@@ -223,7 +223,7 @@ uie::splitter_item_full_v2_t* FlatSplitterPanel::panel::create_splitter_item(boo
     return ret;
 }
 
-bool FlatSplitterPanel::panel_list::find_by_wnd_child(HWND wnd, unsigned& p_out)
+bool FlatSplitterPanel::PanelList::find_by_wnd_child(HWND wnd, unsigned& p_out)
 {
     unsigned count = get_count();
     for (unsigned n = 0; n < count; n++) {
@@ -235,7 +235,7 @@ bool FlatSplitterPanel::panel_list::find_by_wnd_child(HWND wnd, unsigned& p_out)
     return false;
 }
 
-bool FlatSplitterPanel::panel_list::find_by_wnd(HWND wnd, unsigned& p_out)
+bool FlatSplitterPanel::PanelList::find_by_wnd(HWND wnd, unsigned& p_out)
 {
     unsigned count = get_count();
     for (unsigned n = 0; n < count; n++) {

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -4,12 +4,12 @@
 
 #define HOST_AUTOHIDE_TIMER_ID 672
 
-bool FlatSplitterPanel::panel::panel_container::test_autohide_window(HWND wnd)
+bool FlatSplitterPanel::Panel::PanelContainer::test_autohide_window(HWND wnd)
 {
     return IsChild(get_wnd(), wnd) || wnd == get_wnd() || wnd == m_this->get_wnd();
 }
 
-void FlatSplitterPanel::panel::panel_container::on_hooked_message(WPARAM msg, const MSLLHOOKSTRUCT& mllhs)
+void FlatSplitterPanel::Panel::PanelContainer::on_hooked_message(WPARAM msg, const MSLLHOOKSTRUCT& mllhs)
 {
     if (msg == WM_MOUSEMOVE && m_this.is_valid() && MonitorFromPoint(mllhs.pt, MONITOR_DEFAULTTONULL)) {
         unsigned index = m_this->m_panels.find_item(m_panel);
@@ -39,7 +39,7 @@ void FlatSplitterPanel::panel::panel_container::on_hooked_message(WPARAM msg, co
     }
 }
 
-LRESULT FlatSplitterPanel::panel::panel_container::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_NCCREATE:
@@ -266,7 +266,7 @@ LRESULT FlatSplitterPanel::panel::panel_container::on_message(HWND wnd, UINT msg
         if (m_this.is_valid()) {
             unsigned index = 0;
             if (m_this->m_panels.find_by_wnd(wnd, index)) {
-                pfc::refcounted_object_ptr_t<panel> p_panel = m_this->m_panels[index];
+                pfc::refcounted_object_ptr_t<Panel> p_panel = m_this->m_panels[index];
 
                 AppendMenu(
                     menu, (MF_STRING | (p_panel->m_show_caption ? MF_CHECKED : 0)), IDM_CAPTION, _T("Show &caption"));
@@ -336,14 +336,14 @@ LRESULT FlatSplitterPanel::panel::panel_container::on_message(HWND wnd, UINT msg
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-FlatSplitterPanel::panel::panel_container::class_data&
-FlatSplitterPanel::panel::panel_container::get_class_data() const
+FlatSplitterPanel::Panel::PanelContainer::class_data&
+FlatSplitterPanel::Panel::PanelContainer::get_class_data() const
 {
     __implement_get_class_data_ex(_T("foo_ui_columns_splitter_panel_child_container"), _T(""), false, NULL,
         WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, WS_EX_CONTROLPARENT, CS_DBLCLKS);
 }
 
-void FlatSplitterPanel::panel::panel_container::enter_autohide_hook()
+void FlatSplitterPanel::Panel::PanelContainer::enter_autohide_hook()
 {
     if (!m_hook_active) {
         fbh::LowLevelMouseHookManager::s_get_instance().register_hook(this);
@@ -351,14 +351,14 @@ void FlatSplitterPanel::panel::panel_container::enter_autohide_hook()
     }
 }
 
-void FlatSplitterPanel::panel::panel_container::set_window_ptr(FlatSplitterPanel* p_ptr)
+void FlatSplitterPanel::Panel::PanelContainer::set_window_ptr(FlatSplitterPanel* p_ptr)
 {
     m_this = p_ptr;
 }
 
-FlatSplitterPanel::panel::panel_container::~panel_container() = default;
+FlatSplitterPanel::Panel::PanelContainer::~PanelContainer() = default;
 
-FlatSplitterPanel::panel::panel_container::panel_container(panel* p_panel)
+FlatSplitterPanel::Panel::PanelContainer::PanelContainer(Panel* p_panel)
     : m_theme(nullptr), m_panel(p_panel), m_hook_active(false), m_timer_active(false)
 {
 }

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -4,12 +4,12 @@
 
 #define HOST_AUTOHIDE_TIMER_ID 672
 
-bool splitter_window_impl::panel::panel_container::test_autohide_window(HWND wnd)
+bool FlatSplitterPanel::panel::panel_container::test_autohide_window(HWND wnd)
 {
     return IsChild(get_wnd(), wnd) || wnd == get_wnd() || wnd == m_this->get_wnd();
 }
 
-void splitter_window_impl::panel::panel_container::on_hooked_message(WPARAM msg, const MSLLHOOKSTRUCT& mllhs)
+void FlatSplitterPanel::panel::panel_container::on_hooked_message(WPARAM msg, const MSLLHOOKSTRUCT& mllhs)
 {
     if (msg == WM_MOUSEMOVE && m_this.is_valid() && MonitorFromPoint(mllhs.pt, MONITOR_DEFAULTTONULL)) {
         unsigned index = m_this->m_panels.find_item(m_panel);
@@ -39,7 +39,7 @@ void splitter_window_impl::panel::panel_container::on_hooked_message(WPARAM msg,
     }
 }
 
-LRESULT splitter_window_impl::panel::panel_container::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT FlatSplitterPanel::panel::panel_container::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_NCCREATE:
@@ -303,7 +303,7 @@ LRESULT splitter_window_impl::panel::panel_container::on_message(HWND wnd, UINT 
                 DestroyMenu(menu);
 
                 if (cmd == IDM_CLOSE && p_panel->m_child.is_valid()) {
-                    service_ptr_t<splitter_window_impl> p_this = m_this;
+                    service_ptr_t<FlatSplitterPanel> p_this = m_this;
                     p_panel->destroy();
                     p_this->m_panels.remove_by_idx(index);
                     p_this->get_host()->on_size_limit_change(p_this->get_wnd(), uie::size_limit_all);
@@ -336,14 +336,14 @@ LRESULT splitter_window_impl::panel::panel_container::on_message(HWND wnd, UINT 
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-splitter_window_impl::panel::panel_container::class_data&
-splitter_window_impl::panel::panel_container::get_class_data() const
+FlatSplitterPanel::panel::panel_container::class_data&
+FlatSplitterPanel::panel::panel_container::get_class_data() const
 {
     __implement_get_class_data_ex(_T("foo_ui_columns_splitter_panel_child_container"), _T(""), false, NULL,
         WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, WS_EX_CONTROLPARENT, CS_DBLCLKS);
 }
 
-void splitter_window_impl::panel::panel_container::enter_autohide_hook()
+void FlatSplitterPanel::panel::panel_container::enter_autohide_hook()
 {
     if (!m_hook_active) {
         fbh::LowLevelMouseHookManager::s_get_instance().register_hook(this);
@@ -351,14 +351,14 @@ void splitter_window_impl::panel::panel_container::enter_autohide_hook()
     }
 }
 
-void splitter_window_impl::panel::panel_container::set_window_ptr(splitter_window_impl* p_ptr)
+void FlatSplitterPanel::panel::panel_container::set_window_ptr(FlatSplitterPanel* p_ptr)
 {
     m_this = p_ptr;
 }
 
-splitter_window_impl::panel::panel_container::~panel_container() = default;
+FlatSplitterPanel::panel::panel_container::~panel_container() = default;
 
-splitter_window_impl::panel::panel_container::panel_container(panel* p_panel)
+FlatSplitterPanel::panel::panel_container::panel_container(panel* p_panel)
     : m_theme(nullptr), m_panel(p_panel), m_hook_active(false), m_timer_active(false)
 {
 }

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -1,9 +1,9 @@
 #ifndef _SPLITTER_TABS_H_
 #define _SPLITTER_TABS_H_
 
-class splitter_window_tabs_impl
+class TabStackPanel
     : public uie::container_ui_extension_t<ui_helpers::container_window, uie::splitter_window_v2> {
-    using t_self = splitter_window_tabs_impl;
+    using t_self = TabStackPanel;
 
 public:
     class_data& get_class_data() const override;
@@ -64,27 +64,27 @@ public:
 
     void import_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort) override;
 
-    class splitter_host_impl;
+    class TabStackSplitterHost;
 
-    struct t_size_limit {
+    struct SizeLimit {
         unsigned min_height{0};
         unsigned max_height{0};
         unsigned min_width{0};
         unsigned max_width{0};
-        t_size_limit() = default;
+        SizeLimit() = default;
         ;
     };
-    class panel : public pfc::refcounted_object_root {
+    class Panel : public pfc::refcounted_object_root {
     public:
         GUID m_guid{};
         HWND m_wnd{nullptr};
         pfc::array_t<t_uint8> m_child_data;
-        t_size_limit m_size_limits;
+        SizeLimit m_size_limits;
         uie::window_ptr m_child;
         bool m_use_custom_title{false};
         pfc::string8 m_custom_title;
-        service_ptr_t<splitter_window_tabs_impl> m_this;
-        void set_splitter_window_ptr(splitter_window_tabs_impl* ptr) { m_this = ptr; }
+        service_ptr_t<TabStackPanel> m_this;
+        void set_splitter_window_ptr(TabStackPanel* ptr) { m_this = ptr; }
 
         uie::splitter_item_full_v2_t* create_splitter_item();
 
@@ -98,10 +98,10 @@ public:
         void _export(stream_writer* out, abort_callback& p_abort);
         void import(stream_reader* t, abort_callback& p_abort);
 
-        service_ptr_t<class splitter_host_impl> m_interface;
+        service_ptr_t<class TabStackSplitterHost> m_interface;
     };
 
-    class panel_list : public pfc::list_t<pfc::refcounted_object_ptr_t<panel>> {
+    class PanelList : public pfc::list_t<pfc::refcounted_object_ptr_t<Panel>> {
     public:
         // bool move_up(unsigned idx);
         // bool move_down(unsigned idx);
@@ -119,8 +119,8 @@ public:
     void destroy_children();
     void adjust_rect(bool b_larger, RECT* rc);
     void set_styles(bool visible = true);
-    panel_list m_panels;
-    panel_list m_active_panels;
+    PanelList m_panels;
+    PanelList m_active_panels;
     HWND m_wnd_tabs{nullptr};
     t_size m_active_tab{(std::numeric_limits<size_t>::max)()};
     static std::vector<service_ptr_t<t_self>> g_windows;
@@ -136,7 +136,7 @@ public:
     void on_active_tab_changing(t_size index_from);
     void on_active_tab_changed(t_size index_to);
 
-    splitter_window_tabs_impl() = default;
+    TabStackPanel() = default;
 };
 
 #endif

--- a/foo_ui_columns/splitter_window.cpp
+++ b/foo_ui_columns/splitter_window.cpp
@@ -1070,7 +1070,7 @@ unsigned FlatSplitterPanel::FlatSplitterPanelHost::is_resize_supported(HWND wnd)
     return get_orientation() == vertical ? ui_extension::size_height : uie::size_width;
 }
 
-orientation_t FlatSplitterPanel::FlatSplitterPanelHost::get_orientation() const
+Orientation FlatSplitterPanel::FlatSplitterPanelHost::get_orientation() const
 {
     return m_this.is_valid() ? m_this->get_orientation() : vertical;
 }

--- a/foo_ui_columns/splitter_window.cpp
+++ b/foo_ui_columns/splitter_window.cpp
@@ -1,13 +1,13 @@
 #include "stdafx.h"
 #include "splitter.h"
 
-ui_extension::window_host_factory<splitter_window_impl::splitter_host_impl> g_splitter_host_vert;
+ui_extension::window_host_factory<FlatSplitterPanel::splitter_host_impl> g_splitter_host_vert;
 
-unsigned splitter_window_impl::g_count = 0;
-gdi_object_t<HFONT>::ptr_t splitter_window_impl::g_font_menu_horizontal;
-gdi_object_t<HFONT>::ptr_t splitter_window_impl::g_font_menu_vertical;
+unsigned FlatSplitterPanel::g_count = 0;
+gdi_object_t<HFONT>::ptr_t FlatSplitterPanel::g_font_menu_horizontal;
+gdi_object_t<HFONT>::ptr_t FlatSplitterPanel::g_font_menu_vertical;
 
-void splitter_window_impl::insert_panel(unsigned index, const uie::splitter_item_t* p_item)
+void FlatSplitterPanel::insert_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
     if (index <= m_panels.get_count()) {
         pfc::refcounted_object_ptr_t<panel> temp = new panel;
@@ -20,7 +20,7 @@ void splitter_window_impl::insert_panel(unsigned index, const uie::splitter_item
     }
 };
 
-void splitter_window_impl::replace_panel(unsigned index, const uie::splitter_item_t* p_item)
+void FlatSplitterPanel::replace_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
     if (index < m_panels.get_count()) {
         if (get_wnd())
@@ -34,7 +34,7 @@ void splitter_window_impl::replace_panel(unsigned index, const uie::splitter_ite
     }
 };
 
-void splitter_window_impl::destroy_children()
+void FlatSplitterPanel::destroy_children()
 {
     unsigned count = m_panels.get_count();
     for (unsigned n = 0; n < count; n++) {
@@ -56,7 +56,7 @@ void splitter_window_impl::destroy_children()
     // m_wnd = NULL;
 }
 
-void splitter_window_impl::refresh_children()
+void FlatSplitterPanel::refresh_children()
 {
     unsigned n, count = m_panels.get_count(), size_cumulative = 0;
     pfc::array_t<bool> new_items;
@@ -160,7 +160,7 @@ void splitter_window_impl::refresh_children()
     }
 }
 
-void splitter_window_impl::on_size_changed(unsigned width, unsigned height)
+void FlatSplitterPanel::on_size_changed(unsigned width, unsigned height)
 {
     pfc::list_t<unsigned> sizes;
     get_panels_sizes(width, height, sizes);
@@ -190,14 +190,14 @@ void splitter_window_impl::on_size_changed(unsigned width, unsigned height)
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_UPDATENOW);
 }
 
-void splitter_window_impl::on_size_changed()
+void FlatSplitterPanel::on_size_changed()
 {
     RECT rc;
     GetClientRect(m_wnd, &rc);
     on_size_changed(rc.right, rc.bottom);
 }
 
-bool splitter_window_impl::find_by_divider_pt(POINT& pt, unsigned& p_out)
+bool FlatSplitterPanel::find_by_divider_pt(POINT& pt, unsigned& p_out)
 {
     unsigned count = m_panels.get_count();
     for (unsigned n = 0; n < count; n++) {
@@ -225,7 +225,7 @@ bool splitter_window_impl::find_by_divider_pt(POINT& pt, unsigned& p_out)
     return false;
 }
 
-bool splitter_window_impl::test_divider_pt(const POINT& pt, unsigned index)
+bool FlatSplitterPanel::test_divider_pt(const POINT& pt, unsigned index)
 {
     unsigned divider_index;
     POINT pt2 = pt;
@@ -235,7 +235,7 @@ bool splitter_window_impl::test_divider_pt(const POINT& pt, unsigned index)
     return false;
 }
 
-void splitter_window_impl::save_sizes(unsigned width, unsigned height)
+void FlatSplitterPanel::save_sizes(unsigned width, unsigned height)
 {
     pfc::list_t<unsigned> sizes;
     get_panels_sizes(width, height, sizes);
@@ -247,14 +247,14 @@ void splitter_window_impl::save_sizes(unsigned width, unsigned height)
     }
 }
 
-void splitter_window_impl::save_sizes()
+void FlatSplitterPanel::save_sizes()
 {
     RECT rc;
     GetClientRect(m_wnd, &rc);
     save_sizes(rc.right, rc.bottom);
 }
 
-void splitter_window_impl::get_panels_sizes(
+void FlatSplitterPanel::get_panels_sizes(
     unsigned client_width, unsigned client_height, pfc::list_base_t<unsigned>& p_out)
 {
     struct t_size_info {
@@ -382,7 +382,7 @@ void splitter_window_impl::get_panels_sizes(
     }
 }
 
-bool splitter_window_impl::can_resize_divider(t_size index) const
+bool FlatSplitterPanel::can_resize_divider(t_size index) const
 {
     t_size count_left = 0;
     t_size count_right = 0;
@@ -397,7 +397,7 @@ bool splitter_window_impl::can_resize_divider(t_size index) const
     return count_left && count_right;
 }
 
-bool splitter_window_impl::can_resize_panel(t_size index) const
+bool FlatSplitterPanel::can_resize_panel(t_size index) const
 {
     const auto& panel = m_panels[index];
 
@@ -420,7 +420,7 @@ bool splitter_window_impl::can_resize_panel(t_size index) const
     return true;
 }
 
-int splitter_window_impl::override_size(unsigned& panel, int delta)
+int FlatSplitterPanel::override_size(unsigned& panel, int delta)
 {
     // console::formatter() << "Overriding " << panel << " by " << delta;
     struct t_min_max_info {
@@ -637,7 +637,7 @@ int splitter_window_impl::override_size(unsigned& panel, int delta)
     return 0;
 }
 
-void splitter_window_impl::start_autohide_dehide(unsigned p_panel, bool b_next_too)
+void FlatSplitterPanel::start_autohide_dehide(unsigned p_panel, bool b_next_too)
 {
     bool b_have_next = b_next_too && is_index_valid(p_panel + 1);
     auto& panel_before = m_panels[p_panel];
@@ -664,7 +664,7 @@ void splitter_window_impl::start_autohide_dehide(unsigned p_panel, bool b_next_t
     }
 }
 
-void splitter_window_impl::get_supported_panels(
+void FlatSplitterPanel::get_supported_panels(
     const pfc::list_base_const_t<uie::window::ptr>& p_windows, pfc::bit_array_var& p_mask_unsupported)
 {
     service_ptr_t<service_base> temp;
@@ -677,7 +677,7 @@ void splitter_window_impl::get_supported_panels(
         p_mask_unsupported.set(i, !p_windows[i]->is_available(ptr));
 }
 
-bool splitter_window_impl::is_point_ours(
+bool FlatSplitterPanel::is_point_ours(
     HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<uie::window::ptr>& p_hierarchy)
 {
     if (wnd_point == get_wnd() || IsChild(get_wnd(), wnd_point)) {
@@ -710,12 +710,12 @@ bool splitter_window_impl::is_point_ours(
     return false;
 };
 
-unsigned splitter_window_impl::get_panel_divider_size(unsigned index)
+unsigned FlatSplitterPanel::get_panel_divider_size(unsigned index)
 {
     return index + 1 < m_panels.get_count() ? settings::custom_splitter_divider_width : 0;
 }
 
-bool splitter_window_impl::set_config_item(
+bool FlatSplitterPanel::set_config_item(
     unsigned index, const GUID& p_type, stream_reader* p_source, abort_callback& p_abort)
 {
     if (is_index_valid(index)) {
@@ -779,7 +779,7 @@ bool splitter_window_impl::set_config_item(
     return false;
 }
 
-bool splitter_window_impl::get_config_item(
+bool FlatSplitterPanel::get_config_item(
     unsigned index, const GUID& p_type, stream_writer* p_out, abort_callback& p_abort) const
 {
     if (is_index_valid(index)) {
@@ -829,7 +829,7 @@ bool splitter_window_impl::get_config_item(
     return false;
 }
 
-bool splitter_window_impl::get_config_item_supported(unsigned index, const GUID& p_type) const
+bool FlatSplitterPanel::get_config_item_supported(unsigned index, const GUID& p_type) const
 {
     if (is_index_valid(index)) {
         if (p_type == uie::splitter_window::bool_show_caption || p_type == uie::splitter_window::bool_locked
@@ -844,22 +844,22 @@ bool splitter_window_impl::get_config_item_supported(unsigned index, const GUID&
     return false;
 }
 
-bool splitter_window_impl::is_index_valid(unsigned index) const
+bool FlatSplitterPanel::is_index_valid(unsigned index) const
 {
     return index < m_panels.get_count();
 }
 
-void splitter_window_impl::get_config(stream_writer* out, abort_callback& p_abort) const
+void FlatSplitterPanel::get_config(stream_writer* out, abort_callback& p_abort) const
 {
     write_config(out, false, p_abort);
 }
 
-void splitter_window_impl::export_config(stream_writer* p_writer, abort_callback& p_abort) const
+void FlatSplitterPanel::export_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
     write_config(p_writer, true, p_abort);
 }
 
-void splitter_window_impl::write_config(stream_writer* p_writer, bool is_export, abort_callback& p_abort) const
+void FlatSplitterPanel::write_config(stream_writer* p_writer, bool is_export, abort_callback& p_abort) const
 {
     p_writer->write_lendian_t(static_cast<t_uint32>(stream_version_current), p_abort);
     unsigned i, count = m_panels.get_count();
@@ -879,7 +879,7 @@ void splitter_window_impl::write_config(stream_writer* p_writer, bool is_export,
     }
 }
 
-void splitter_window_impl::read_config(stream_reader* config, t_size p_size, bool is_import, abort_callback& p_abort)
+void FlatSplitterPanel::read_config(stream_reader* config, t_size p_size, bool is_import, abort_callback& p_abort)
 {
     if (p_size) {
         t_uint32 version;
@@ -921,17 +921,17 @@ void splitter_window_impl::read_config(stream_reader* config, t_size p_size, boo
     }
 }
 
-void splitter_window_impl::import_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
+void FlatSplitterPanel::import_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
 {
     read_config(p_reader, p_size, true, p_abort);
 }
 
-void splitter_window_impl::set_config(stream_reader* config, t_size p_size, abort_callback& p_abort)
+void FlatSplitterPanel::set_config(stream_reader* config, t_size p_size, abort_callback& p_abort)
 {
     read_config(config, p_size, false, p_abort);
 }
 
-uie::splitter_item_t* splitter_window_impl::get_panel(unsigned index) const
+uie::splitter_item_t* FlatSplitterPanel::get_panel(unsigned index) const
 {
     if (index < m_panels.get_count()) {
         return m_panels[index]->create_splitter_item();
@@ -939,12 +939,12 @@ uie::splitter_item_t* splitter_window_impl::get_panel(unsigned index) const
     return nullptr;
 }
 
-unsigned splitter_window_impl::get_panel_count() const
+unsigned FlatSplitterPanel::get_panel_count() const
 {
     return m_panels.get_count();
 }
 
-void splitter_window_impl::remove_panel(unsigned index)
+void FlatSplitterPanel::remove_panel(unsigned index)
 {
     if (index < m_panels.get_count()) {
         m_panels[index]->destroy();
@@ -955,28 +955,28 @@ void splitter_window_impl::remove_panel(unsigned index)
     }
 }
 
-unsigned splitter_window_impl::get_type() const
+unsigned FlatSplitterPanel::get_type() const
 {
     return ui_extension::type_layout | uie::type_splitter;
 }
 
-void splitter_window_impl::get_category(pfc::string_base& p_out) const
+void FlatSplitterPanel::get_category(pfc::string_base& p_out) const
 {
     p_out = "Splitters";
 }
 
-unsigned splitter_window_impl::g_get_caption_size()
+unsigned FlatSplitterPanel::g_get_caption_size()
 {
     unsigned rv = uGetFontHeight(g_font_menu_horizontal);
     rv += 9;
     return rv;
 }
 
-void splitter_window_impl::splitter_host_impl::relinquish_ownership(HWND wnd)
+void FlatSplitterPanel::splitter_host_impl::relinquish_ownership(HWND wnd)
 {
     unsigned index;
     if (m_this->m_panels.find_by_wnd_child(wnd, index)) {
-        pfc::refcounted_object_ptr_t<splitter_window_impl::panel> p_ext = m_this->m_panels[index];
+        pfc::refcounted_object_ptr_t<FlatSplitterPanel::panel> p_ext = m_this->m_panels[index];
 
         {
             if (GetAncestor(wnd, GA_PARENT) == p_ext->m_wnd) {
@@ -993,12 +993,12 @@ void splitter_window_impl::splitter_host_impl::relinquish_ownership(HWND wnd)
     }
 }
 
-void splitter_window_impl::splitter_host_impl::set_window_ptr(splitter_window_impl* p_ptr)
+void FlatSplitterPanel::splitter_host_impl::set_window_ptr(FlatSplitterPanel* p_ptr)
 {
     m_this = p_ptr;
 }
 
-bool splitter_window_impl::splitter_host_impl::set_window_visibility(HWND wnd, bool visibility)
+bool FlatSplitterPanel::splitter_host_impl::set_window_visibility(HWND wnd, bool visibility)
 {
     bool rv = false;
     if (!m_this->get_host()->is_visible(m_this->get_wnd()))
@@ -1014,7 +1014,7 @@ bool splitter_window_impl::splitter_host_impl::set_window_visibility(HWND wnd, b
     return rv;
 }
 
-bool splitter_window_impl::splitter_host_impl::is_visibility_modifiable(HWND wnd, bool desired_visibility) const
+bool FlatSplitterPanel::splitter_host_impl::is_visibility_modifiable(HWND wnd, bool desired_visibility) const
 {
     bool rv = false;
 
@@ -1027,7 +1027,7 @@ bool splitter_window_impl::splitter_host_impl::is_visibility_modifiable(HWND wnd
     return rv;
 }
 
-bool splitter_window_impl::splitter_host_impl::is_visible(HWND wnd) const
+bool FlatSplitterPanel::splitter_host_impl::is_visible(HWND wnd) const
 {
     bool rv = false;
 
@@ -1042,13 +1042,13 @@ bool splitter_window_impl::splitter_host_impl::is_visible(HWND wnd) const
     return rv;
 }
 
-bool splitter_window_impl::splitter_host_impl::override_status_text_create(
+bool FlatSplitterPanel::splitter_host_impl::override_status_text_create(
     service_ptr_t<ui_status_text_override>& p_out)
 {
     return m_this->get_host()->override_status_text_create(p_out);
 }
 
-bool splitter_window_impl::splitter_host_impl::request_resize(HWND wnd, unsigned flags, unsigned width, unsigned height)
+bool FlatSplitterPanel::splitter_host_impl::request_resize(HWND wnd, unsigned flags, unsigned width, unsigned height)
 {
     bool rv = false;
     if (!(flags & (get_orientation() == horizontal ? ui_extension::size_height : uie::size_width))) {
@@ -1065,21 +1065,21 @@ bool splitter_window_impl::splitter_host_impl::request_resize(HWND wnd, unsigned
     return rv;
 }
 
-unsigned splitter_window_impl::splitter_host_impl::is_resize_supported(HWND wnd) const
+unsigned FlatSplitterPanel::splitter_host_impl::is_resize_supported(HWND wnd) const
 {
     return get_orientation() == vertical ? ui_extension::size_height : uie::size_width;
 }
 
-orientation_t splitter_window_impl::splitter_host_impl::get_orientation() const
+orientation_t FlatSplitterPanel::splitter_host_impl::get_orientation() const
 {
     return m_this.is_valid() ? m_this->get_orientation() : vertical;
 }
 
-void splitter_window_impl::splitter_host_impl::on_size_limit_change(HWND wnd, unsigned flags)
+void FlatSplitterPanel::splitter_host_impl::on_size_limit_change(HWND wnd, unsigned flags)
 {
     unsigned index;
     if (m_this->m_panels.find_by_wnd_child(wnd, index)) {
-        pfc::refcounted_object_ptr_t<splitter_window_impl::panel> p_ext = m_this->m_panels[index];
+        pfc::refcounted_object_ptr_t<FlatSplitterPanel::panel> p_ext = m_this->m_panels[index];
         MINMAXINFO mmi;
         memset(&mmi, 0, sizeof(MINMAXINFO));
         mmi.ptMaxTrackSize.x = MAXLONG;
@@ -1099,7 +1099,7 @@ void splitter_window_impl::splitter_host_impl::on_size_limit_change(HWND wnd, un
     }
 }
 
-void splitter_window_impl::splitter_host_impl::get_children(pfc::list_base_t<uie::window::ptr>& p_out)
+void FlatSplitterPanel::splitter_host_impl::get_children(pfc::list_base_t<uie::window::ptr>& p_out)
 {
     if (m_this.is_valid()) {
         t_size count = m_this->m_panels.get_count();
@@ -1110,19 +1110,19 @@ void splitter_window_impl::splitter_host_impl::get_children(pfc::list_base_t<uie
     }
 }
 
-bool splitter_window_impl::splitter_host_impl::get_keyboard_shortcuts_enabled() const
+bool FlatSplitterPanel::splitter_host_impl::get_keyboard_shortcuts_enabled() const
 {
     return m_this->get_host()->get_keyboard_shortcuts_enabled();
 }
 
-const GUID& splitter_window_impl::splitter_host_impl::get_host_guid() const
+const GUID& FlatSplitterPanel::splitter_host_impl::get_host_guid() const
 {
     // {FC0ED6EF-DCA2-4679-B7FE-48162DE321FC}
     static const GUID rv = {0xfc0ed6ef, 0xdca2, 0x4679, {0xb7, 0xfe, 0x48, 0x16, 0x2d, 0xe3, 0x21, 0xfc}};
     return rv;
 }
 
-void splitter_window_impl::g_on_size_change()
+void FlatSplitterPanel::g_on_size_change()
 {
     for (t_size index = 0; index < g_instances.get_count(); index++) {
         g_instances[index]->on_size_changed();

--- a/foo_ui_columns/splitter_window_wndproc.cpp
+++ b/foo_ui_columns/splitter_window_wndproc.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "splitter.h"
 
-LRESULT splitter_window_impl::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_NCCREATE:

--- a/foo_ui_columns/status_bar.h
+++ b/foo_ui_columns/status_bar.h
@@ -23,7 +23,7 @@ extern HTHEME thm_status;
 
 extern volume_popup_t volume_popup_window;
 
-enum t_parts : uint32_t {
+enum StatusBarPart : uint32_t {
     t_parts_none = 0,
     t_parts_all = 0xffffffff,
     t_part_main = 1 << 0,

--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -4,11 +4,11 @@
 #include "status_pane.h"
 
 // {522E01C6-EA7C-49f2-AE5E-702B8C6B4B24}
-const GUID status_pane::g_guid_font = {0x522e01c6, 0xea7c, 0x49f2, {0xae, 0x5e, 0x70, 0x2b, 0x8c, 0x6b, 0x4b, 0x24}};
+const GUID StatusPane::g_guid_font = {0x522e01c6, 0xea7c, 0x49f2, {0xae, 0x5e, 0x70, 0x2b, 0x8c, 0x6b, 0x4b, 0x24}};
 
-class font_client_status_pane : public cui::fonts::client {
+class StatusPaneFontClient : public cui::fonts::client {
 public:
-    const GUID& get_client_guid() const override { return status_pane::g_guid_font; }
+    const GUID& get_client_guid() const override { return StatusPane::g_guid_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Status pane"; }
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_labels; }
@@ -16,15 +16,15 @@ public:
     void on_font_changed() const override { g_status_pane.on_font_changed(); }
 };
 
-font_client_status_pane::factory<font_client_status_pane> g_font_client_status_pane;
+StatusPaneFontClient::factory<StatusPaneFontClient> g_font_client_status_pane;
 
-void status_pane::on_font_changed()
+void StatusPane::on_font_changed()
 {
     m_font = cui::fonts::helper(g_guid_font).get_font();
     cui::main_window.resize_child_windows();
 }
 
-void status_pane::render_background(HDC dc, const RECT& rc)
+void StatusPane::render_background(HDC dc, const RECT& rc)
 {
     COLORREF cr = GetSysColor(COLOR_BTNFACE);
     COLORREF cr2 = GetSysColor(COLOR_3DDKSHADOW);
@@ -44,7 +44,7 @@ void status_pane::render_background(HDC dc, const RECT& rc)
     }
 }
 
-void status_pane::update_playback_status_text()
+void StatusPane::update_playback_status_text()
 {
     static_api_ptr_t<playback_control> api;
     if (api->is_playing()) {
@@ -54,7 +54,7 @@ void status_pane::update_playback_status_text()
     }
 }
 
-void status_pane::get_length_data(bool& p_selection, t_size& p_count, pfc::string_base& p_out)
+void StatusPane::get_length_data(bool& p_selection, t_size& p_count, pfc::string_base& p_out)
 {
     metadb_handle_list_t<pfc::alloc_fast_aggressive> sels;
     double length = 0;

--- a/foo_ui_columns/status_pane.h
+++ b/foo_ui_columns/status_pane.h
@@ -3,19 +3,19 @@
 
 void g_split_string_by_crlf(const char* text, pfc::string_list_impl& p_out);
 
-class status_pane
+class StatusPane
     : public ui_helpers::container_window
     , private playlist_callback_single
     , play_callback {
-    class volume_panel_attributes {
+    class StatusPaneVolumeBarAttributes {
     public:
         static const TCHAR* get_class_name() { return _T("volume_toolbar_pain"); }
         static bool get_show_caption() { return false; }
         static COLORREF get_background_colour() { return -1; /*RGB(230,230,255);*/ }
     };
-    volume_control_t<false, false, volume_panel_attributes> m_volume_control;
+    volume_control_t<false, false, StatusPaneVolumeBarAttributes> m_volume_control;
 
-    class titleformat_hook_impl : public titleformat_hook {
+    class StatusPaneTitleformatHook : public titleformat_hook {
     public:
         bool process_field(
             titleformat_text_out* p_out, const char* p_name, unsigned p_name_length, bool& p_found_flag) override
@@ -36,7 +36,7 @@ class status_pane
             return false;
         }
 
-        titleformat_hook_impl() = default;
+        StatusPaneTitleformatHook() = default;
 
     private:
     };
@@ -160,7 +160,7 @@ class status_pane
             service_ptr_t<titleformat_object> to_status;
             static_api_ptr_t<titleformat_compiler>()->compile_safe(
                 to_status, main_window::config_status_bar_script.get());
-            titleformat_hook_impl tf_hook;
+            StatusPaneTitleformatHook tf_hook;
             play_api->playback_format_title_ex(
                 track, &tf_hook, playing1, to_status, nullptr, play_control::display_level_all);
 
@@ -172,7 +172,7 @@ class status_pane
     void get_length_data(bool& p_selection, t_size& p_count, pfc::string_base& p_out);
 
 public:
-    status_pane() = default;
+    StatusPane() = default;
     t_size get_ideal_height()
     {
         return uGetFontHeight(m_font) * 2 + uih::scale_dpi_value(2) + uih::scale_dpi_value(4)

--- a/foo_ui_columns/status_pane.h
+++ b/foo_ui_columns/status_pane.h
@@ -13,7 +13,7 @@ class StatusPane
         static bool get_show_caption() { return false; }
         static COLORREF get_background_colour() { return -1; /*RGB(230,230,255);*/ }
     };
-    volume_control_t<false, false, StatusPaneVolumeBarAttributes> m_volume_control;
+    VolumeBar<false, false, StatusPaneVolumeBarAttributes> m_volume_control;
 
     class StatusPaneTitleformatHook : public titleformat_hook {
     public:

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -2,7 +2,7 @@
 
 #include "status_pane.h"
 
-LRESULT status_pane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE: {

--- a/foo_ui_columns/tab_display2.cpp
+++ b/foo_ui_columns/tab_display2.cpp
@@ -48,16 +48,16 @@ public:
 
             populate_menu_combo(wnd, IDC_PLAYLIST_DOUBLE, IDC_MENU_DESC, cfg_playlist_double, *m_menu_cache, true);
 
-            unsigned count = cui::playlist_item_helpers::mclick_action::get_count();
+            unsigned count = cui::playlist_item_helpers::MiddleClickActionManager::get_count();
             for (unsigned n = 0; n < count; n++) {
                 uSendDlgItemMessageText(wnd, IDC_PLAYLIST_MIDDLE, CB_ADDSTRING, 0,
-                    cui::playlist_item_helpers::mclick_action::g_pma_actions[n].name);
+                    cui::playlist_item_helpers::MiddleClickActionManager::g_pma_actions[n].name);
                 SendDlgItemMessage(wnd, IDC_PLAYLIST_MIDDLE, CB_SETITEMDATA, n,
-                    cui::playlist_item_helpers::mclick_action::g_pma_actions[n].id);
+                    cui::playlist_item_helpers::MiddleClickActionManager::g_pma_actions[n].id);
             }
 
             SendDlgItemMessage(wnd, IDC_PLAYLIST_MIDDLE, CB_SETCURSEL,
-                cui::playlist_item_helpers::mclick_action::id_to_idx(cfg_playlist_middle_action), 0);
+                cui::playlist_item_helpers::MiddleClickActionManager::id_to_idx(cfg_playlist_middle_action), 0);
 
             refresh_me(wnd);
             m_initialised = true;

--- a/foo_ui_columns/tab_layout_misc.cpp
+++ b/foo_ui_columns/tab_layout_misc.cpp
@@ -71,7 +71,7 @@ BOOL LayoutMiscTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 const int new_width = GetDlgItemInt(wnd, LOWORD(wp), &result, FALSE);
                 if (result)
                     settings::custom_splitter_divider_width = new_width;
-                splitter_window_impl::g_on_size_change();
+                FlatSplitterPanel::g_on_size_change();
             }
             break;
         case IDC_USE_CUSTOM_SHOW_DELAY:

--- a/foo_ui_columns/volume.cpp
+++ b/foo_ui_columns/volume.cpp
@@ -1,15 +1,15 @@
 #include "stdafx.h"
 #include "volume.h"
 
-class volume_panel_class_name {
+class VolumeBarToolbarAttributes {
 public:
     static const TCHAR* get_class_name() { return _T("volume_toolbar"); }
     static bool get_show_caption() { return false; }
     static COLORREF get_background_colour() { return -1; }
 };
 
-class volume_control_panel
-    : public volume_control_t<false, false, volume_panel_class_name, uie::container_ui_extension_t<>> {
+class VolumeBarToolbar
+    : public VolumeBar<false, false, VolumeBarToolbarAttributes, uie::container_ui_extension_t<>> {
     const GUID& get_extension_guid() const override
     {
         // {B3259290-CB68-4d37-B0F1-8094862A9524}
@@ -23,4 +23,4 @@ class volume_control_panel
     unsigned get_type() const override { return uie::type_toolbar; }
 };
 
-uie::window_factory<volume_control_panel> g_volume_panel;
+uie::window_factory<VolumeBarToolbar> g_volume_panel;

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -13,10 +13,10 @@
 #include "main_window.h"
 
 template <bool b_vertical, bool b_popup, typename t_attributes, class t_base = ui_helpers::container_window>
-class volume_control_t
+class VolumeBar
     : public t_base
     , private play_callback {
-    class track_bar_volume : public uih::Trackbar {
+    class VolumeTrackBar : public uih::Trackbar {
         void get_channel_rect(RECT* rc) const override
         {
             if (b_popup)
@@ -119,13 +119,13 @@ class volume_control_t
                 }
             }
         }
-        volume_control_t<b_vertical, b_popup, t_attributes, t_base>* m_this;
+        VolumeBar<b_vertical, b_popup, t_attributes, t_base>* m_this;
 
     public:
-        track_bar_volume(volume_control_t<b_vertical, b_popup, t_attributes, t_base>* p_this) : m_this(p_this){};
+        VolumeTrackBar(VolumeBar<b_vertical, b_popup, t_attributes, t_base>* p_this) : m_this(p_this){};
     } m_child;
 
-    class track_bar_host_impl : public uih::TrackbarCallback {
+    class VolumeTrackBarCallback : public uih::TrackbarCallback {
         void on_position_change(unsigned pos, bool b_tracking) override
         {
             const auto volume = position_to_volume(pos);
@@ -147,10 +147,10 @@ class volume_control_t
             }
             return false;
         }
-        volume_control_t<b_vertical, b_popup, t_attributes, t_base>* m_this;
+        VolumeBar<b_vertical, b_popup, t_attributes, t_base>* m_this;
 
     public:
-        track_bar_host_impl(volume_control_t<b_vertical, b_popup, t_attributes, t_base>* p_this) : m_this(p_this){};
+        VolumeTrackBarCallback(VolumeBar<b_vertical, b_popup, t_attributes, t_base>* p_this) : m_this(p_this){};
     } m_track_bar_host;
 
 public:
@@ -302,12 +302,12 @@ public:
         return DefWindowProc(wnd, msg, wp, lp);
     }
 
-    volume_control_t() : m_child(this), m_track_bar_host(this) {}
-    volume_control_t(const volume_control_t&) = delete;
-    volume_control_t& operator=(const volume_control_t&) = delete;
-    volume_control_t(volume_control_t&&) = delete;
-    volume_control_t& operator=(volume_control_t&&) = delete;
-    ~volume_control_t() = default;
+    VolumeBar() : m_child(this), m_track_bar_host(this) {}
+    VolumeBar(const VolumeBar&) = delete;
+    VolumeBar& operator=(const VolumeBar&) = delete;
+    VolumeBar(VolumeBar&&) = delete;
+    VolumeBar& operator=(VolumeBar&&) = delete;
+    ~VolumeBar() = default;
 
     ui_helpers::container_window::class_data& get_class_data() const override
     {
@@ -370,13 +370,13 @@ private:
     bool m_using_gdiplus{false};
 };
 
-class volume_popup_class_name {
+class PopupVolumeBarAttributes {
 public:
     static const TCHAR* get_class_name() { return _T("volume_popup"); }
     static bool get_show_caption() { return true; }
     static COLORREF get_background_colour() { return -1; }
 };
 
-using volume_popup_t = volume_control_t<true, true, volume_popup_class_name>;
+using volume_popup_t = VolumeBar<true, true, PopupVolumeBarAttributes>;
 
 #endif


### PR DESCRIPTION
There is a [documented naming convention to use UpperCamelCase for class names and other custom types](https://github.com/reupen/columns_ui/blob/master/CONTRIBUTING.md). 

However, many existing class names are non-compliant. This renames several existing class names to make them compliant.