### PR TITLE
Use UpperCamelCase for class names (part 7)

### DIFF
--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -529,7 +529,7 @@ std::vector<ArtworkPanel*> ArtworkPanel::g_windows;
 
 uie::window_factory<ArtworkPanel> g_artwork_panel;
 
-class appearance_client_artwork_impl : public cui::colours::client {
+class ArtworkColoursClient : public cui::colours::client {
 public:
     static const GUID g_guid;
 
@@ -545,7 +545,7 @@ public:
 };
 
 namespace {
-cui::colours::client::factory<appearance_client_artwork_impl> g_appearance_client_impl;
+cui::colours::client::factory<ArtworkColoursClient> g_appearance_client_impl;
 };
 
 ArtworkPanel::CompletionNotifyForwarder::CompletionNotifyForwarder(ArtworkPanel* p_this) : m_this(p_this) {}

--- a/foo_ui_columns/buttons_stock.cpp
+++ b/foo_ui_columns/buttons_stock.cpp
@@ -43,7 +43,7 @@
     };                                                                                                                \
     pfc::ptr_list_t<MenuCommandButton> MenuCommandButton::m_buttons;                                                  \
     uie::button_factory<MenuCommandButton> g_menu_command_button;                                                     \
-    class config_object_notify_impl : public config_object_notify {                                                   \
+    class MenuCommandConfigObjectNotify : public config_object_notify {                                               \
     public:                                                                                                           \
         virtual t_size get_watched_object_count() { return 1; }                                                       \
         virtual GUID get_watched_object(t_size p_index) { return _guid_config; }                                      \
@@ -57,7 +57,7 @@
             };                                                                                                        \
         }                                                                                                             \
     };                                                                                                                \
-    service_factory_t<config_object_notify_impl> g_config_object_notify_impl;                                         \
+    service_factory_t<MenuCommandConfigObjectNotify> g_menu_command_config_object_notify;                             \
     }
 
 __DEFINE_MENU_BUTTON(

--- a/foo_ui_columns/colours_manager_data.cpp
+++ b/foo_ui_columns/colours_manager_data.cpp
@@ -28,7 +28,7 @@ void ColoursManagerData::register_common_callback(cui::colours::common_callback*
 
 ColoursManagerData::ColoursManagerData() : cfg_var(g_cfg_guid)
 {
-    m_global_entry = new entry_t(true);
+    m_global_entry = new Entry(true);
 }
 
 void ColoursManagerData::find_by_guid(const GUID& p_guid, entry_ptr_t& p_out)
@@ -44,7 +44,7 @@ void ColoursManagerData::find_by_guid(const GUID& p_guid, entry_ptr_t& p_out)
             return;
         }
     }
-    p_out = new entry_t;
+    p_out = new Entry;
     p_out->guid = p_guid;
     m_entries.add_item(p_out);
 }
@@ -59,7 +59,7 @@ void ColoursManagerData::set_data_raw(stream_reader* p_stream, t_size p_sizehint
         p_stream->read_lendian_t(count, p_abort);
         m_entries.remove_all();
         for (t_size i = 0; i < count; i++) {
-            entry_ptr_t ptr = new entry_t;
+            entry_ptr_t ptr = new Entry;
             ptr->read(version, p_stream, p_abort);
             m_entries.add_item(ptr);
         }
@@ -91,13 +91,13 @@ void ColoursManagerData::get_data_raw(stream_writer* p_stream, abort_callback& p
             m_entries[i]->write(p_stream, p_abort);
 }
 
-ColoursManagerData::entry_t::entry_t(bool b_global /*= false*/)
+ColoursManagerData::Entry::Entry(bool b_global /*= false*/)
     : colour_mode(b_global ? cui::colours::colour_mode_themed : cui::colours::colour_mode_global)
 {
     reset_colors();
 }
 
-void ColoursManagerData::entry_t::reset_colors()
+void ColoursManagerData::Entry::reset_colors()
 {
     text = cui::colours::g_get_system_color(cui::colours::colour_text);
     selection_text = cui::colours::g_get_system_color(cui::colours::colour_selection_text);
@@ -112,7 +112,7 @@ void ColoursManagerData::entry_t::reset_colors()
     use_custom_active_item_frame = false;
 }
 
-void ColoursManagerData::entry_t::read(t_uint32 version, stream_reader* p_stream, abort_callback& p_abort)
+void ColoursManagerData::Entry::read(t_uint32 version, stream_reader* p_stream, abort_callback& p_abort)
 {
     p_stream->read_lendian_t(guid, p_abort);
     p_stream->read_lendian_t((t_uint32&)colour_mode, p_abort);
@@ -126,7 +126,7 @@ void ColoursManagerData::entry_t::read(t_uint32 version, stream_reader* p_stream
     p_stream->read_lendian_t(use_custom_active_item_frame, p_abort);
 }
 
-void ColoursManagerData::entry_t::import(
+void ColoursManagerData::Entry::import(
     stream_reader* p_reader, t_size stream_size, t_uint32 type, abort_callback& p_abort)
 {
     fbh::fcl::Reader reader(p_reader, stream_size, p_abort);
@@ -175,7 +175,7 @@ void ColoursManagerData::entry_t::import(
     }
 }
 
-void ColoursManagerData::entry_t::_export(stream_writer* p_stream, abort_callback& p_abort)
+void ColoursManagerData::Entry::_export(stream_writer* p_stream, abort_callback& p_abort)
 {
     fbh::fcl::Writer out(p_stream, p_abort);
     out.write_item(identifier_guid, guid);
@@ -193,7 +193,7 @@ void ColoursManagerData::entry_t::_export(stream_writer* p_stream, abort_callbac
         out.write_item(identifier_custom_active_item_frame, active_item_frame);
 }
 
-void ColoursManagerData::entry_t::write(stream_writer* p_stream, abort_callback& p_abort)
+void ColoursManagerData::Entry::write(stream_writer* p_stream, abort_callback& p_abort)
 {
     p_stream->write_lendian_t(guid, p_abort);
     p_stream->write_lendian_t((t_uint32)colour_mode, p_abort);

--- a/foo_ui_columns/colours_manager_data.h
+++ b/foo_ui_columns/colours_manager_data.h
@@ -6,7 +6,7 @@ public:
     enum { cfg_version = 0 };
     void get_data_raw(stream_writer* p_stream, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* p_stream, t_size p_sizehint, abort_callback& p_abort) override;
-    class entry_t : public pfc::refcounted_object_root {
+    class Entry : public pfc::refcounted_object_root {
     public:
         enum ExportItemID {
             identifier_guid,
@@ -42,9 +42,9 @@ public:
         virtual void import(stream_reader* p_reader, t_size stream_size, t_uint32 type, abort_callback& p_abort);
         void read(t_uint32 version, stream_reader* p_stream, abort_callback& p_abort);
         void reset_colors();
-        entry_t(bool b_global = false);
+        Entry(bool b_global = false);
     };
-    using entry_ptr_t = pfc::refcounted_object_ptr_t<entry_t>;
+    using entry_ptr_t = pfc::refcounted_object_ptr_t<Entry>;
     pfc::list_t<entry_ptr_t> m_entries;
     entry_ptr_t m_global_entry;
 

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -389,7 +389,7 @@ namespace {
 service_factory_t<ColoursDataSet> g_fcl_colours_t;
 };
 
-class fcl_fonts_t : public cui::fcl::dataset {
+class FontsDataSet : public cui::fcl::dataset {
     enum { stream_version = 0 };
     void get_name(pfc::string_base& p_out) const override { p_out = "Fonts (unified)"; }
     const GUID& get_group() const override { return cui::fcl::groups::colours_and_fonts; }
@@ -476,7 +476,7 @@ class fcl_fonts_t : public cui::fcl::dataset {
                         data2.set_size(element_size2);
                         reader2.read(data2.get_ptr(), data2.get_size());
                         stream_reader_memblock_ref element_reader(data2);
-                        g_fonts_manager_data.m_entries[i] = new FontsManagerData::entry_t;
+                        g_fonts_manager_data.m_entries[i] = new FontsManagerData::Entry;
                         g_fonts_manager_data.m_entries[i]->import(&element_reader, data2.get_size(), type, p_abort);
                     } else
                         reader2.skip(element_size2);
@@ -497,7 +497,7 @@ class fcl_fonts_t : public cui::fcl::dataset {
 };
 
 namespace {
-service_factory_t<fcl_fonts_t> g_fcl_fonts_t;
+service_factory_t<FontsDataSet> g_fcl_fonts_t;
 };
 
 // {15FD4FF9-0622-4077-BFBB-DF0102B6A068}

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -19,7 +19,7 @@
 
 #if 1
 
-class appearance_message_window_t : public ui_helpers::container_window_autorelease_t {
+class AppearanceMessageWindow : public ui_helpers::container_window_autorelease_t {
 public:
     class_data& get_class_data() const override
     {
@@ -29,13 +29,13 @@ public:
     static bool g_initialised;
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
 };
-bool appearance_message_window_t::g_initialised = false;
+bool AppearanceMessageWindow::g_initialised = false;
 // pfc::rcptr_t<appearance_message_window_t> g_appearance_message_window;
 
-void appearance_message_window_t::g_initialise()
+void AppearanceMessageWindow::g_initialise()
 {
     if (!g_initialised) {
-        auto ptr = new appearance_message_window_t;
+        auto ptr = new AppearanceMessageWindow;
         ptr->create(HWND_MESSAGE);
         g_initialised = true;
     }
@@ -46,16 +46,16 @@ FontsManagerData g_fonts_manager_data;
 TabColours g_tab_appearance;
 TabFonts g_tab_appearance_fonts;
 
-class colours_manager_instance_impl : public cui::colours::manager_instance {
+class ColoursManagerInstance : public cui::colours::manager_instance {
 public:
-    colours_manager_instance_impl(const GUID& p_client_guid)
+    ColoursManagerInstance(const GUID& p_client_guid)
     {
         g_colours_manager_data.find_by_guid(p_client_guid, m_entry);
         g_colours_manager_data.find_by_guid(pfc::guid_null, m_global_entry);
     }
     COLORREF get_colour(const cui::colours::colour_identifier_t& p_identifier) const override
     {
-        appearance_message_window_t::g_initialise();
+        AppearanceMessageWindow::g_initialise();
         ColoursManagerData::entry_ptr_t p_entry
             = m_entry->colour_mode == cui::colours::colour_mode_global ? m_global_entry : m_entry;
         if (p_entry->colour_mode == cui::colours::colour_mode_system
@@ -103,11 +103,11 @@ private:
     ColoursManagerData::entry_ptr_t m_global_entry;
 };
 
-class colours_manager_impl : public cui::colours::manager {
+class ColoursManager : public cui::colours::manager {
 public:
     void create_instance(const GUID& p_client_guid, cui::colours::manager_instance::ptr& p_out) override
     {
-        p_out = new service_impl_t<colours_manager_instance_impl>(p_client_guid);
+        p_out = new service_impl_t<ColoursManagerInstance>(p_client_guid);
     }
     void register_common_callback(cui::colours::common_callback* p_callback) override
     {
@@ -121,11 +121,11 @@ public:
 private:
 };
 
-class fonts_manager_impl : public cui::fonts::manager {
+class FontsManager : public cui::fonts::manager {
 public:
     void get_font(const GUID& p_guid, LOGFONT& p_out) const override
     {
-        appearance_message_window_t::g_initialise();
+        AppearanceMessageWindow::g_initialise();
         FontsManagerData::entry_ptr_t p_entry;
         g_fonts_manager_data.find_by_guid(p_guid, p_entry);
         if (p_entry->font_mode == cui::fonts::font_mode_common_items)
@@ -177,8 +177,8 @@ private:
 };
 
 namespace {
-service_factory_single_t<colours_manager_impl> g_colours_manager;
-service_factory_t<fonts_manager_impl> g_fonts_manager;
+service_factory_single_t<ColoursManager> g_colours_manager;
+service_factory_t<FontsManager> g_fonts_manager;
 }; // namespace
 
 cui::colours::colour_mode_t g_get_global_colour_mode()
@@ -284,7 +284,7 @@ constexpr const GUID g_guid_colour_preferences
 static service_factory_single_t<PreferencesTabsHost> g_config_tabs("Colours and fonts", g_tabs_appearance,
     tabsize(g_tabs_appearance), g_guid_colour_preferences, g_guid_columns_ui_preferences_page, &cfg_child_appearance);
 
-class fcl_colours_t : public cui::fcl::dataset {
+class ColoursDataSet : public cui::fcl::dataset {
     enum { stream_version = 0 };
     void get_name(pfc::string_base& p_out) const override { p_out = "Colours (unified)"; }
     const GUID& get_group() const override { return cui::fcl::groups::colours_and_fonts; }
@@ -362,7 +362,7 @@ class fcl_colours_t : public cui::fcl::dataset {
                         data2.set_size(element_size2);
                         reader2.read(data2.get_ptr(), data2.get_size());
                         stream_reader_memblock_ref colour_reader(data2);
-                        g_colours_manager_data.m_entries[i] = new ColoursManagerData::entry_t;
+                        g_colours_manager_data.m_entries[i] = new ColoursManagerData::Entry;
                         g_colours_manager_data.m_entries[i]->import(&colour_reader, data2.get_size(), type, p_abort);
                     } else
                         reader2.skip(element_size2);
@@ -386,7 +386,7 @@ class fcl_colours_t : public cui::fcl::dataset {
 };
 
 namespace {
-service_factory_t<fcl_colours_t> g_fcl_colours_t;
+service_factory_t<ColoursDataSet> g_fcl_colours_t;
 };
 
 class fcl_fonts_t : public cui::fcl::dataset {
@@ -508,7 +508,7 @@ const GUID ColoursManagerData::g_cfg_guid
 const GUID FontsManagerData::g_cfg_guid
     = {0x6b71f91c, 0x6b7e, 0x4dbe, {0xb2, 0x7b, 0xc4, 0x93, 0xaa, 0x51, 0x3f, 0xd0}};
 
-LRESULT appearance_message_window_t::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT AppearanceMessageWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_SYSCOLORCHANGE: {

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -18,13 +18,13 @@ struct ColumnTimes {
     double time_colour;
 };
 
-class edit_column_window_options : public ColumnTab {
+class EditColumnWindowOptions : public ColumnTab {
 public:
     void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
-    using self_t = edit_column_window_options;
+    using self_t = EditColumnWindowOptions;
     HWND create(HWND wnd) override { return uCreateDialog(IDD_COLUMN_OPTIONS, wnd, g_on_message, (LPARAM)this); }
     // virtual const char * get_name()=0;
-    edit_column_window_options(PlaylistViewColumn::ptr column)
+    EditColumnWindowOptions(PlaylistViewColumn::ptr column)
         : initialising(false), editproc(nullptr), m_wnd(nullptr), m_column(std::move(column)){};
 
     bool initialising;
@@ -529,7 +529,7 @@ void TabColumns::make_child()
             column = m_columns[item];
 
         if (cfg_child_column == 0)
-            m_child = new edit_column_window_options(column);
+            m_child = new EditColumnWindowOptions(column);
         else if (cfg_child_column == 1)
             m_child = new DisplayScriptTab(column);
         else if (cfg_child_column == 2)

--- a/foo_ui_columns/fcl_colours.cpp
+++ b/foo_ui_columns/fcl_colours.cpp
@@ -4,7 +4,7 @@
 #include "config.h"
 #include "tab_colours.h"
 
-class ColoursDataSet : public cui::fcl::dataset {
+class PlaylistViewAppearanceDataSet : public cui::fcl::dataset {
     enum ItemID {
         colours_pview_mode,
         colours_pview_background,
@@ -140,7 +140,7 @@ class ColoursDataSet : public cui::fcl::dataset {
     }
 };
 
-cui::fcl::dataset_factory<ColoursDataSet> g_export_colours_t;
+cui::fcl::dataset_factory<PlaylistViewAppearanceDataSet> g_export_colours_t;
 
 class PlaylistSwitcherAppearanceDataSet : public cui::fcl::dataset {
     enum ItemID {
@@ -229,7 +229,7 @@ class PlaylistSwitcherAppearanceDataSet : public cui::fcl::dataset {
 
 cui::fcl::dataset_factory<PlaylistSwitcherAppearanceDataSet> g_export_colours_switcher_t;
 
-class FontsDataSet : public cui::fcl::dataset {
+class LegacyFontsDataSet : public cui::fcl::dataset {
     enum ItemID {
         font_status,
     };
@@ -280,4 +280,4 @@ class FontsDataSet : public cui::fcl::dataset {
     }
 };
 
-cui::fcl::dataset_factory<FontsDataSet> g_export_misc_fonts_t;
+cui::fcl::dataset_factory<LegacyFontsDataSet> g_export_misc_fonts_t;

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -909,7 +909,7 @@ namespace {
 cui::colours::client::factory<AppearanceClient> g_appearance_client_impl;
 }
 
-class font_client_filter : public cui::fonts::client {
+class FilterItemFontClient : public cui::fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_filter_items_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel: Items"; }
@@ -919,7 +919,7 @@ public:
     void on_font_changed() const override { FilterPanel::g_on_font_items_change(); }
 };
 
-class font_header_client_filter : public cui::fonts::client {
+class FilterHeaderFontClient : public cui::fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_filter_header_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel: Column titles"; }
@@ -929,8 +929,8 @@ public:
     void on_font_changed() const override { FilterPanel::g_on_font_header_change(); }
 };
 
-font_client_filter::factory<font_client_filter> g_font_client_filter;
-font_header_client_filter::factory<font_header_client_filter> g_font_header_client_filter;
+FilterItemFontClient::factory<FilterItemFontClient> g_font_client_filter;
+FilterHeaderFontClient::factory<FilterHeaderFontClient> g_font_header_client_filter;
 
 void AppearanceClient::on_colour_changed(t_size mask) const
 {

--- a/foo_ui_columns/fonts_manager_data.cpp
+++ b/foo_ui_columns/fonts_manager_data.cpp
@@ -5,11 +5,11 @@
 
 FontsManagerData::FontsManagerData() : cfg_var(g_cfg_guid)
 {
-    m_common_items_entry = new entry_t;
+    m_common_items_entry = new Entry;
     uGetIconFont(&m_common_items_entry->font_description.log_font);
     m_common_items_entry->font_description.estimate_point_size();
 
-    m_common_labels_entry = new entry_t;
+    m_common_labels_entry = new Entry;
     uGetMenuFont(&m_common_labels_entry->font_description.log_font);
     m_common_labels_entry->font_description.estimate_point_size();
 }
@@ -41,7 +41,7 @@ void FontsManagerData::find_by_guid(const GUID& p_guid, entry_ptr_t& p_out)
         }
     }
     {
-        p_out = new entry_t;
+        p_out = new Entry;
         p_out->guid = p_guid;
         cui::fonts::client::ptr ptr;
         if (cui::fonts::client::create_by_guid(p_guid, ptr)) {
@@ -65,7 +65,7 @@ void FontsManagerData::set_data_raw(stream_reader* p_stream, t_size p_sizehint, 
         p_stream->read_lendian_t(count, p_abort);
         m_entries.remove_all();
         for (t_size i = 0; i < count; i++) {
-            entry_ptr_t ptr = new entry_t;
+            entry_ptr_t ptr = new Entry;
             ptr->read(version, p_stream, p_abort);
             m_entries.add_item(ptr);
         }
@@ -118,18 +118,18 @@ void FontsManagerData::get_data_raw(stream_writer* p_stream, abort_callback& p_a
             m_entries[i]->write_extra_data(p_stream, p_abort);
 }
 
-FontsManagerData::entry_t::entry_t()
+FontsManagerData::Entry::Entry()
 {
     reset_fonts();
 }
 
-void FontsManagerData::entry_t::reset_fonts()
+void FontsManagerData::Entry::reset_fonts()
 {
     uGetIconFont(&font_description.log_font);
     font_description.estimate_point_size();
 }
 
-void FontsManagerData::entry_t::import(
+void FontsManagerData::Entry::import(
     stream_reader* p_reader, t_size stream_size, t_uint32 type, abort_callback& p_abort)
 {
     fbh::fcl::Reader reader(p_reader, stream_size, p_abort);
@@ -161,7 +161,7 @@ void FontsManagerData::entry_t::import(
     }
 }
 
-void FontsManagerData::entry_t::_export(stream_writer* p_stream, abort_callback& p_abort)
+void FontsManagerData::Entry::_export(stream_writer* p_stream, abort_callback& p_abort)
 {
     fbh::fcl::Writer out(p_stream, p_abort);
     out.write_item(identifier_guid, guid);
@@ -172,7 +172,7 @@ void FontsManagerData::entry_t::_export(stream_writer* p_stream, abort_callback&
     out.write_item(identifier_point_size_tenths, font_description.point_size_tenths);
 }
 
-void FontsManagerData::entry_t::read(t_uint32 version, stream_reader* p_stream, abort_callback& p_abort)
+void FontsManagerData::Entry::read(t_uint32 version, stream_reader* p_stream, abort_callback& p_abort)
 {
     p_stream->read_lendian_t(guid, p_abort);
     p_stream->read_lendian_t((t_uint32&)font_mode, p_abort);
@@ -180,7 +180,7 @@ void FontsManagerData::entry_t::read(t_uint32 version, stream_reader* p_stream, 
     font_description.estimate_point_size();
 }
 
-void FontsManagerData::entry_t::read_extra_data(stream_reader* stream, abort_callback& aborter)
+void FontsManagerData::Entry::read_extra_data(stream_reader* stream, abort_callback& aborter)
 {
     uint32_t size{};
     stream->read_lendian_t(size, aborter);
@@ -189,21 +189,21 @@ void FontsManagerData::entry_t::read_extra_data(stream_reader* stream, abort_cal
     limited_reader.read_lendian_t(font_description.point_size_tenths, aborter);
 }
 
-LOGFONT FontsManagerData::entry_t::get_normalised_font()
+LOGFONT FontsManagerData::Entry::get_normalised_font()
 {
     LOGFONT lf{font_description.log_font};
     lf.lfHeight = -MulDiv(font_description.point_size_tenths, uih::get_system_dpi_cached().cy, 720);
     return lf;
 }
 
-void FontsManagerData::entry_t::write(stream_writer* p_stream, abort_callback& p_abort)
+void FontsManagerData::Entry::write(stream_writer* p_stream, abort_callback& p_abort)
 {
     p_stream->write_lendian_t(guid, p_abort);
     p_stream->write_lendian_t((t_uint32)font_mode, p_abort);
     cui::fonts::write_font(p_stream, font_description.log_font, p_abort);
 }
 
-void FontsManagerData::entry_t::write_extra_data(stream_writer* stream, abort_callback& aborter)
+void FontsManagerData::Entry::write_extra_data(stream_writer* stream, abort_callback& aborter)
 {
     stream_writer_memblock item_stream;
     item_stream.write_lendian_t(font_description.point_size_tenths, aborter);

--- a/foo_ui_columns/fonts_manager_data.h
+++ b/foo_ui_columns/fonts_manager_data.h
@@ -8,7 +8,7 @@ public:
     void get_data_raw(stream_writer* p_stream, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* p_stream, t_size p_sizehint, abort_callback& p_abort) override;
 
-    class entry_t : public pfc::refcounted_object_root {
+    class Entry : public pfc::refcounted_object_root {
     public:
         enum ItemID {
             identifier_guid,
@@ -30,9 +30,9 @@ public:
         virtual void import(stream_reader* p_reader, t_size stream_size, t_uint32 type, abort_callback& p_abort);
         void reset_fonts();
 
-        entry_t();
+        Entry();
     };
-    using entry_ptr_t = pfc::refcounted_object_ptr_t<entry_t>;
+    using entry_ptr_t = pfc::refcounted_object_ptr_t<Entry>;
     pfc::list_t<entry_ptr_t> m_entries;
     entry_ptr_t m_common_items_entry;
     entry_ptr_t m_common_labels_entry;

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -94,14 +94,14 @@ using font_list_t = pfc::list_t<Font::ptr_t>;
 
 class FontChangeNotify {
 public:
-    class font_change_entry_t {
+    class FontChangeEntry {
     public:
         t_size m_text_index{};
         Font::ptr_t m_font;
     };
 
     font_list_t m_fonts;
-    pfc::array_t<font_change_entry_t> m_font_changes;
+    pfc::array_t<FontChangeEntry> m_font_changes;
     Font::ptr_t m_default_font;
 
     bool find_font(const FontData& p_font, t_size& index);

--- a/foo_ui_columns/item_details_font.cpp
+++ b/foo_ui_columns/item_details_font.cpp
@@ -171,7 +171,7 @@ void g_parse_font_format_string(const char* str, t_size len, FontData& p_out)
     }
 }
 
-class font_client_item_details : public cui::fonts::client {
+class ItemDetailsFontClient : public cui::fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_item_details_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Item details"; }
@@ -181,7 +181,7 @@ public:
     void on_font_changed() const override { ItemDetails::g_on_font_change(); }
 };
 
-class colour_client_item_details : public cui::colours::client {
+class ItemDetailsColoursClient : public cui::colours::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_item_details_colour_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Item details"; }
@@ -199,6 +199,6 @@ public:
 };
 
 namespace {
-font_client_item_details::factory<font_client_item_details> g_font_client_item_details;
-colour_client_item_details::factory<colour_client_item_details> g_colour_client_item_details;
+ItemDetailsFontClient::factory<ItemDetailsFontClient> g_font_client_item_details;
+ItemDetailsColoursClient::factory<ItemDetailsColoursClient> g_colour_client_item_details;
 } // namespace

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -940,7 +940,7 @@ void ItemPropertiesTrackPropertyCallback::sort()
     t_size count = m_values.get_size();
     for (t_size i = 0; i < count; i++) {
         mmh::Permutation perm(m_values[i].get_count());
-        mmh::sort_get_permutation(m_values[i].get_ptr(), perm, track_property_t::g_compare, false);
+        mmh::sort_get_permutation(m_values[i].get_ptr(), perm, TrackProperty::g_compare, false);
         m_values[i].reorder(perm.get_ptr());
     }
 }
@@ -955,16 +955,16 @@ void ItemPropertiesTrackPropertyCallback::set_property(
 {
     t_size index = g_get_info_secion_index_by_name(p_group);
     if (index != pfc_infinite)
-        m_values[index].add_item(track_property_t(p_sortpriority, p_name, p_value));
+        m_values[index].add_item(TrackProperty(p_sortpriority, p_name, p_value));
 }
 
-ItemPropertiesTrackPropertyCallback::track_property_t::track_property_t(
+ItemPropertiesTrackPropertyCallback::TrackProperty::TrackProperty(
     double p_sortpriority, const char* p_name, const char* p_value)
     : m_name(p_name), m_value(p_value), m_sortpriority(p_sortpriority)
 {
 }
 
-int ItemPropertiesTrackPropertyCallback::track_property_t::g_compare(self_t const& a, self_t const& b)
+int ItemPropertiesTrackPropertyCallback::TrackProperty::g_compare(self_t const& a, self_t const& b)
 {
     int ret = pfc::compare_t(a.m_sortpriority, b.m_sortpriority);
     if (!ret)

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -41,16 +41,16 @@ extern const InfoSection g_info_sections[5];
 
 class ItemPropertiesTrackPropertyCallback : public track_property_callback_v2 {
 public:
-    class track_property_t {
+    class TrackProperty {
     public:
-        using self_t = track_property_t;
+        using self_t = TrackProperty;
         pfc::string8 m_name, m_value;
         double m_sortpriority{0};
 
         static int g_compare(self_t const& a, self_t const& b);
 
-        track_property_t(double p_sortpriority, const char* p_name, const char* p_value);
-        track_property_t() = default;
+        TrackProperty(double p_sortpriority, const char* p_name, const char* p_value);
+        TrackProperty() = default;
     };
 
     void set_property(const char* p_group, double p_sortpriority, const char* p_name, const char* p_value) override;
@@ -73,7 +73,7 @@ public:
     void sort();
 
     ItemPropertiesTrackPropertyCallback();
-    pfc::array_staticsize_t<pfc::list_t<track_property_t>> m_values;
+    pfc::array_staticsize_t<pfc::list_t<TrackProperty>> m_values;
 };
 
 class ItemPropertiesColoursClient : public cui::colours::client {

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -313,7 +313,7 @@ bool process_keydown(UINT msg, LPARAM lp, WPARAM wp, bool playlist, bool keyb)
     return false;
 }
 
-class playlist_callback_single_columns : public playlist_callback_single_static {
+class MainWindowPlaylistCallback : public playlist_callback_single_static {
 public:
     void on_items_added(
         unsigned start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const pfc::bit_array& p_selection)
@@ -369,7 +369,7 @@ public:
 
     unsigned get_flags() override { return playlist_callback_single::flag_all; }
 };
-static service_factory_single_t<playlist_callback_single_columns> asdf2;
+static service_factory_single_t<MainWindowPlaylistCallback> asdf2;
 
 void g_split_string_by_crlf(const char* text, pfc::string_list_impl& p_out)
 {
@@ -443,7 +443,7 @@ void on_show_toolbars_change()
     }
 }
 
-class control_impl : public columns_ui::control {
+class UIControl : public columns_ui::control {
 public:
     bool get_string(const GUID& p_guid, pfc::string_base& p_out) const override
     {
@@ -455,4 +455,4 @@ public:
     }
 };
 
-service_factory_single_t<control_impl> g_control_impl;
+service_factory_single_t<UIControl> g_control_impl;

--- a/foo_ui_columns/menu_helpers.cpp
+++ b/foo_ui_columns/menu_helpers.cpp
@@ -11,7 +11,7 @@ bool operator!=(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2)
     return !(p1 == p2);
 }
 
-menu_item_cache::menu_item_cache()
+MenuItemCache::MenuItemCache()
 {
     service_enum_t<mainmenu_commands> e;
     service_ptr_t<mainmenu_commands> ptr;
@@ -22,7 +22,7 @@ menu_item_cache::menu_item_cache()
             unsigned p_service_item_count = ptr->get_command_count();
             for (unsigned p_service_item_index = 0; p_service_item_index < p_service_item_count;
                  p_service_item_index++) {
-                menu_item_info info;
+                MenuItemInfo info;
 
                 info.m_command = ptr->get_command(p_service_item_index);
 
@@ -69,7 +69,7 @@ menu_item_cache::menu_item_cache()
                 }
                 else*/
                 {
-                    auto p_info = new menu_item_info(info);
+                    auto p_info = new MenuItemInfo(info);
                     ptr->get_description(p_service_item_index, p_info->m_desc);
                     p_info->m_name = full;
 
@@ -80,7 +80,7 @@ menu_item_cache::menu_item_cache()
     }
 }
 
-const menu_item_cache::menu_item_info& menu_item_cache::get_item(unsigned n) const
+const MenuItemCache::MenuItemInfo& MenuItemCache::get_item(unsigned n) const
 {
     return *m_data[n];
 }

--- a/foo_ui_columns/menu_helpers.h
+++ b/foo_ui_columns/menu_helpers.h
@@ -28,18 +28,18 @@ struct MenuItemIdentifier {
 bool operator==(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2);
 bool operator!=(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2);
 
-class menu_item_cache {
-    class menu_item_info : public MenuItemIdentifier {
+class MenuItemCache {
+    class MenuItemInfo : public MenuItemIdentifier {
     public:
         pfc::string8 m_name;
         pfc::string8 m_desc;
     };
 
 public:
-    menu_item_cache();
-    const menu_item_info& get_item(unsigned n) const;
+    MenuItemCache();
+    const MenuItemInfo& get_item(unsigned n) const;
     unsigned get_count() { return m_data.get_count(); }
 
 private:
-    pfc::ptr_list_t<menu_item_info> m_data;
+    pfc::ptr_list_t<MenuItemInfo> m_data;
 };

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -1134,7 +1134,7 @@ const GUID g_guid_header_font = {0x30fbd64c, 0x2031, 0x4f0b, {0xa9, 0x37, 0xf2, 
 // {FB127FFA-1B35-4572-9C1A-4B96A5C5D537}
 const GUID g_guid_group_header_font = {0xfb127ffa, 0x1b35, 0x4572, {0x9c, 0x1a, 0x4b, 0x96, 0xa5, 0xc5, 0xd5, 0x37}};
 
-class font_client_ngpv : public cui::fonts::client {
+class PlaylistViewItemFontClient : public cui::fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_items_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view: Items"; }
@@ -1144,7 +1144,7 @@ public:
     void on_font_changed() const override { PlaylistView::g_on_font_change(); }
 };
 
-class font_header_client_ngpv : public cui::fonts::client {
+class PlaylistViewHeaderFontClient : public cui::fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_header_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view: Column titles"; }
@@ -1154,7 +1154,7 @@ public:
     void on_font_changed() const override { PlaylistView::g_on_header_font_change(); }
 };
 
-class font_group_header_client_ngpv : public cui::fonts::client {
+class PlaylistViewGroupFontClient : public cui::fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_group_header_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view: Group titles"; }
@@ -1164,9 +1164,9 @@ public:
     void on_font_changed() const override { PlaylistView::g_on_group_header_font_change(); }
 };
 
-font_client_ngpv::factory<font_client_ngpv> g_font_client_ngpv;
-font_header_client_ngpv::factory<font_header_client_ngpv> g_font_header_client_ngpv;
-font_group_header_client_ngpv::factory<font_group_header_client_ngpv> g_font_group_header_client_ngpv;
+PlaylistViewItemFontClient::factory<PlaylistViewItemFontClient> g_font_client_ngpv;
+PlaylistViewHeaderFontClient::factory<PlaylistViewHeaderFontClient> g_font_header_client_ngpv;
+PlaylistViewGroupFontClient::factory<PlaylistViewGroupFontClient> g_font_group_header_client_ngpv;
 
 void ColoursClient::on_colour_changed(t_size mask) const
 {

--- a/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
@@ -281,7 +281,7 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::Drop(
                 if (b_redraw)
                     p_playlist->enable_redrawing();
             } else {
-                class delayed_drop_target_processer_t : public process_locations_notify {
+                class DelayedDropTargetProcesser : public process_locations_notify {
                 public:
                     playlist_position_reference_tracker m_insertIndexTracker;
                     service_ptr_t<PlaylistView> p_playlist;
@@ -307,8 +307,8 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::Drop(
                     void on_aborted() override {}
                 };
 
-                service_ptr_t<delayed_drop_target_processer_t> ptr
-                    = new service_impl_t<delayed_drop_target_processer_t>;
+                service_ptr_t<DelayedDropTargetProcesser> ptr
+                    = new service_impl_t<DelayedDropTargetProcesser>;
                 ptr->p_playlist = p_playlist;
                 ptr->m_insertIndexTracker.m_playlist = playlist_api->get_active_playlist();
                 ptr->m_insertIndexTracker.m_item = idx;

--- a/foo_ui_columns/playlist_switcher.cpp
+++ b/foo_ui_columns/playlist_switcher.cpp
@@ -10,7 +10,7 @@ cfg_struct_t<LOGFONT> cfg_plist_font(
 const GUID g_guid_playlist_switcher_font
     = {0x70a5c273, 0x67ab, 0x4bb6, {0xb6, 0x1c, 0xf7, 0x97, 0x5a, 0x68, 0x71, 0xfd}};
 
-class font_client_switcher : public cui::fonts::client {
+class PlaylistSwitcherFontClient : public cui::fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_playlist_switcher_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist switcher"; }
@@ -20,7 +20,7 @@ public:
     void on_font_changed() const override { PlaylistSwitcher::g_on_font_items_change(); }
 };
 
-font_client_switcher::factory<font_client_switcher> g_font_client_switcher;
+PlaylistSwitcherFontClient::factory<PlaylistSwitcherFontClient> g_font_client_switcher;
 
 // {EB38A997-3B5F-4126-8746-262AA9C1F94B}
 const GUID PlaylistSwitcherColoursClient::g_guid

--- a/foo_ui_columns/prefs_utils.cpp
+++ b/foo_ui_columns/prefs_utils.cpp
@@ -83,7 +83,7 @@ bool colour_picker(HWND wnd, COLORREF& out, COLORREF custom)
 }
 
 void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItemIdentifier& p_item,
-    menu_item_cache& p_cache, bool insert_none)
+    MenuItemCache& p_cache, bool insert_none)
 {
     HWND wnd_combo = GetDlgItem(wnd, ID);
 
@@ -119,7 +119,7 @@ void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItem
 }
 
 void on_menu_combo_change(
-    HWND wnd, LPARAM lp, ConfigMenuItem& cfg_menu_store, menu_item_cache& p_cache, unsigned ID_DESC)
+    HWND wnd, LPARAM lp, ConfigMenuItem& cfg_menu_store, MenuItemCache& p_cache, unsigned ID_DESC)
 {
     auto wnd_combo = (HWND)lp;
 

--- a/foo_ui_columns/prefs_utils.h
+++ b/foo_ui_columns/prefs_utils.h
@@ -2,9 +2,9 @@
 #define _COLOUMNS_PREFS_H_
 
 void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItemIdentifier& p_item,
-    menu_item_cache& p_cache, bool insert_none);
+    MenuItemCache& p_cache, bool insert_none);
 void on_menu_combo_change(
-    HWND wnd, LPARAM lp, class ConfigMenuItem& cfg_menu_store, menu_item_cache& p_cache, unsigned ID_DESC);
+    HWND wnd, LPARAM lp, class ConfigMenuItem& cfg_menu_store, MenuItemCache& p_cache, unsigned ID_DESC);
 
 namespace cui::prefs {
 

--- a/foo_ui_columns/tab_display2.cpp
+++ b/foo_ui_columns/tab_display2.cpp
@@ -37,7 +37,7 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG: {
-            m_menu_cache = new menu_item_cache;
+            m_menu_cache = new MenuItemCache;
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "None");
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "Sunken");
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "Grey");
@@ -152,7 +152,7 @@ public:
 
 private:
     bool m_initialised{};
-    menu_item_cache* m_menu_cache{};
+    MenuItemCache* m_menu_cache{};
     cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
 } g_tab_display2;
 

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -588,7 +588,7 @@ BOOL LayoutTab::RenameProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_INITDIALOG:
         SetWindowLongPtr(wnd, DWLP_USER, lp);
         {
-            auto* ptr = reinterpret_cast<rename_param*>(lp);
+            auto* ptr = reinterpret_cast<RenameData*>(lp);
             ptr->m_scope.initialize(FindOwningPopup(wnd));
             uSetWindowText(wnd, (ptr->m_title));
             uSetDlgItemText(wnd, IDC_EDIT, ptr->m_text);
@@ -597,7 +597,7 @@ BOOL LayoutTab::RenameProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_COMMAND:
         switch (wp) {
         case IDOK: {
-            auto* ptr = reinterpret_cast<rename_param*>(GetWindowLong(wnd, DWLP_USER));
+            auto* ptr = reinterpret_cast<RenameData*>(GetWindowLong(wnd, DWLP_USER));
             uGetDlgItemText(wnd, IDC_EDIT, ptr->m_text);
             EndDialog(wnd, 1);
         } break;
@@ -646,7 +646,7 @@ BOOL LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             switch_to_preset(wnd, SendMessage((HWND)lp, CB_GETCURSEL, 0, 0));
             break;
         case IDC_NEW_PRESET: {
-            rename_param param;
+            RenameData param;
             param.m_title = "New preset: Enter name";
             param.m_text = "New preset";
             if (uDialogBox(IDD_RENAME_PLAYLIST, wnd, RenameProc, reinterpret_cast<LPARAM>(&param))) {
@@ -657,7 +657,7 @@ BOOL LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             }
         } break;
         case IDC_DUPLICATE_PRESET: {
-            rename_param param;
+            RenameData param;
             param.m_title = "Duplicate preset: Enter name";
             cfg_layout.get_preset_name(m_active_preset, param.m_text);
             param.m_text << " (copy)";
@@ -673,7 +673,7 @@ BOOL LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             }
         } break;
         case IDC_RENAME_PRESET: {
-            rename_param param;
+            RenameData param;
             param.m_title = "Rename preset: Enter name";
             cfg_layout.get_preset_name(m_active_preset, param.m_text);
             HWND wnd_combo = GetDlgItem(wnd, IDC_PRESETS);

--- a/foo_ui_columns/tab_layout.h
+++ b/foo_ui_columns/tab_layout.h
@@ -26,7 +26,7 @@ public:
     bool get_help_url(pfc::string_base& p_out) override;
 
 private:
-    class rename_param {
+    class RenameData {
     public:
         pfc::string8 m_text;
         pfc::string8 m_title;

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -61,7 +61,7 @@ public:
 
 private:
     bool m_initialised{};
-    menu_item_cache* m_menu_cache{};
+    MenuItemCache* m_menu_cache{};
     cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
 } g_tab_pview_artwork;
 

--- a/foo_ui_columns/tab_status.cpp
+++ b/foo_ui_columns/tab_status.cpp
@@ -7,7 +7,7 @@
 static class TabStatus : public PreferencesTab {
 public:
     bool m_initialised{};
-    menu_item_cache* m_cache{};
+    MenuItemCache* m_cache{};
 
     static void refresh_me(HWND wnd)
     {
@@ -24,7 +24,7 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG: {
-            m_cache = new menu_item_cache;
+            m_cache = new MenuItemCache;
 
             populate_menu_combo(wnd, IDC_MENU_DBLCLK, IDC_MENU_DESC, cfg_statusdbl, *m_cache, false);
 


### PR DESCRIPTION
There is a [documented naming convention to use UpperCamelCase for class names and other custom types](https://github.com/reupen/columns_ui/blob/master/CONTRIBUTING.md). 

However, many existing class names are non-compliant. This renames several existing class names to make them compliant.