### PR TITLE
Optimise replacement of all items in playlist view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.2.0-beta.1 (in development)
+
+* ...
+
 ## 1.1.0
 
 * The component is now compiled using Visual Studio 2019 16.2.

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -262,7 +262,7 @@ void PlaylistView::update_all_items(bool b_update_display)
 void PlaylistView::refresh_all_items_text(bool b_update_display)
 {
     update_items(0, get_item_count(), false);
-    invalidate_all();
+    invalidate_all(b_update_display);
 }
 void PlaylistView::update_items(t_size index, t_size count, bool b_update_display)
 {

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -35,16 +35,23 @@ void PlaylistView::on_items_reordered(/*t_size p_playlist, */ const t_size* p_or
 ; // changes selection too; doesnt actually change set of items that are selected or item having focus, just changes
   // their order
 
-void PlaylistView::on_items_removed(/*t_size p_playlist, */ const pfc::bit_array& p_mask, t_size p_old_count,
-    t_size p_new_count){/*(if (p_playlist == 0)*/
-    {clear_sort_column();
-remove_items(p_mask, false);
-refresh_all_items_text(false);
-invalidate_all();
-// reset_items();
+void PlaylistView::on_items_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count)
+{
+    clear_sort_column();
+
+    if (p_new_count == 0) {
+        remove_all_items(false);
+        // Delay repainting as the removal of all items is often followed by the addition of items
+        invalidate_all(false);
+        return;
+    }
+
+    remove_items(p_mask, false);
+    refresh_all_items_text(false);
+
+    invalidate_all();
 }
-}
-;
+
 void PlaylistView::on_items_selection_change(
     /*t_size p_playlist, */ const pfc::bit_array& p_affected, const pfc::bit_array& p_state)
 {

--- a/foo_ui_columns/version.cpp
+++ b/foo_ui_columns/version.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 
-#define VERSION "1.1.0"
+#define VERSION "1.2.0-dev"
 
 #ifndef __clang__
 #define DATE ", Date "__DATE__


### PR DESCRIPTION
This uses a more optimised path when all items are being removed from the active playlist.

Flickering is also avoided in this case by some changes in ui_helpers and not calling UpdateWindow in this case. 

(We are, perhaps, being too aggressive in calling UpdateWindow in general. However, this targets the main case causing problems.)