### PR TITLE
Fix potential crash on foobar2000 exit involving the toolbars

### DIFF
--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -50,7 +50,7 @@ class ConfigRebar : public cfg_var {
 private:
     enum class StreamVersion : uint32_t { Version0 = 0, Version1 = 1, VersionCurrent = Version1 };
 
-    std::vector<RebarBandInfo> m_entries;
+    std::vector<RebarBandState> m_entries;
 
     void get_data_raw(stream_writer* out, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort) override;
@@ -63,7 +63,7 @@ public:
 
     explicit ConfigRebar(const GUID& p_guid) : cfg_var(p_guid) { reset(); };
 
-    const std::vector<RebarBandInfo>& get_rebar_info() { return m_entries; }
+    const std::vector<RebarBandState>& get_rebar_info() { return m_entries; }
 
     template <typename Container>
     void set_rebar_info(Container&& in)
@@ -92,7 +92,9 @@ public:
     HWND init();
 
     void refresh_band_configs();
-    const std::vector<RebarBandInfo>& get_bands() const { return m_bands; }
+    const std::vector<RebarBand>& get_bands() const { return m_bands; }
+
+    [[nodiscard]] std::vector<RebarBandState> get_band_states() const;
 
     void add_band(
         const GUID& guid, unsigned width = 100, const ui_extension::window_ptr& p_ext = ui_extension::window_ptr_null);
@@ -135,7 +137,7 @@ private:
      */
     void fix_z_order();
 
-    std::vector<RebarBandInfo> m_bands;
+    std::vector<RebarBand> m_bands;
 
     friend class RebarWindowHost;
 };

--- a/foo_ui_columns/rebar_band.cpp
+++ b/foo_ui_columns/rebar_band.cpp
@@ -2,19 +2,19 @@
 
 #include "rebar_band.h"
 
-void RebarBandInfo::export_to_fcl_stream(stream_writer* writer, t_uint32 fcl_type, abort_callback& aborter) const
+void RebarBandState::export_to_fcl_stream(stream_writer* writer, t_uint32 fcl_type, abort_callback& aborter) const
 {
-    uie::window_ptr ptr = m_window;
-    if (!ptr.is_valid()) {
-        if (uie::window::create_by_guid(m_guid, ptr)) {
-            // if (fcl_type==cui::fcl::type_public)
-            try {
-                ptr->set_config_from_ptr(m_config.get_ptr(), m_config.get_size(), aborter);
-            } catch (const exception_io&) {
-            } // FIXME: Why?
-        } else
-            throw cui::fcl::exception_missing_panel();
-    }
+    uie::window_ptr ptr;
+
+    if (uie::window::create_by_guid(m_guid, ptr)) {
+        // if (fcl_type==cui::fcl::type_public)
+        try {
+            ptr->set_config_from_ptr(m_config.get_ptr(), m_config.get_size(), aborter);
+        } catch (const exception_io&) {
+        } // FIXME: Why?
+    } else
+        throw cui::fcl::exception_missing_panel();
+
     stream_writer_memblock w;
     if (fcl_type == cui::fcl::type_public)
         ptr->export_config(&w, aborter);
@@ -28,10 +28,8 @@ void RebarBandInfo::export_to_fcl_stream(stream_writer* writer, t_uint32 fcl_typ
     writer->write(w.m_data.get_ptr(), size, aborter);
 }
 
-void RebarBandInfo::import_from_fcl_stream(stream_reader* reader, t_uint32 fcl_type, abort_callback& aborter)
+void RebarBandState::import_from_fcl_stream(stream_reader* reader, t_uint32 fcl_type, abort_callback& aborter)
 {
-    if (m_window.is_valid())
-        throw pfc::exception_bug_check();
     reader->read_lendian_t(m_guid, aborter);
     uint32_t width_;
     reader->read_lendian_t(width_, aborter);
@@ -59,7 +57,7 @@ void RebarBandInfo::import_from_fcl_stream(stream_reader* reader, t_uint32 fcl_t
     }
 }
 
-void RebarBandInfo::write_to_stream(stream_writer* writer, abort_callback& aborter) const
+void RebarBandState::write_to_stream(stream_writer* writer, abort_callback& aborter) const
 {
     writer->write_lendian_t(m_guid, aborter);
     writer->write_lendian_t(m_width.get_scaled_value(), aborter);
@@ -69,7 +67,7 @@ void RebarBandInfo::write_to_stream(stream_writer* writer, abort_callback& abort
     writer->write(m_config.get_ptr(), size, aborter);
 }
 
-void RebarBandInfo::read_from_stream(stream_reader* reader, abort_callback& aborter)
+void RebarBandState::read_from_stream(stream_reader* reader, abort_callback& aborter)
 {
     reader->read_lendian_t(m_guid, aborter);
     uint32_t width_;
@@ -86,13 +84,13 @@ void RebarBandInfo::read_from_stream(stream_reader* reader, abort_callback& abor
     }
 }
 
-void RebarBandInfo::write_extra(stream_writer* writer, abort_callback& aborter) const
+void RebarBandState::write_extra(stream_writer* writer, abort_callback& aborter) const
 {
     writer->write_lendian_t(m_width.value, aborter);
     writer->write_lendian_t(m_width.dpi, aborter);
 }
 
-void RebarBandInfo::read_extra(stream_reader* reader, abort_callback& aborter)
+void RebarBandState::read_extra(stream_reader* reader, abort_callback& aborter)
 {
     reader->read_lendian_t(m_width.value, aborter);
     reader->read_lendian_t(m_width.dpi, aborter);

--- a/foo_ui_columns/rebar_band.h
+++ b/foo_ui_columns/rebar_band.h
@@ -1,15 +1,13 @@
 #pragma once
 
-class RebarBandInfo {
+class RebarBandState {
 public:
     GUID m_guid{};
     // Although we store the DPI, this does virtually nothing as remaining space is automatically
     // distributed among the remaining bands.
     uih::IntegerAndDpi<uint32_t> m_width{};
     bool m_break_before_band{};
-    HWND m_wnd{};
-    ui_extension::window_ptr m_window;
-    mutable pfc::array_t<t_uint8> m_config;
+    mutable pfc::array_t<t_uint8> m_config{};
 
     void export_to_fcl_stream(stream_writer* writer, t_uint32 fcl_type, abort_callback& aborter) const;
     void import_from_fcl_stream(stream_reader* reader, t_uint32 fcl_type, abort_callback& aborter);
@@ -18,17 +16,24 @@ public:
     void write_extra(stream_writer* writer, abort_callback& aborter) const;
     void read_extra(stream_reader* reader, abort_callback& aborter);
 
-    RebarBandInfo& operator=(RebarBandInfo&&) = default;
-    RebarBandInfo& operator=(const RebarBandInfo& band_info) = default;
-    RebarBandInfo() = default;
-    ~RebarBandInfo() = default;
+    RebarBandState& operator=(RebarBandState&&) = default;
+    RebarBandState& operator=(const RebarBandState& band_state) = default;
+    RebarBandState() = default;
 
-    RebarBandInfo(
-        GUID guid, uih::IntegerAndDpi<uint32_t> width, bool break_before_band = false, uie::window_ptr window = {})
-        : m_guid{guid}, m_width(width), m_break_before_band{break_before_band}, m_window(std::move(window))
-    {
-    }
+    RebarBandState(RebarBandState&&) = default;
+    RebarBandState(const RebarBandState& band_state) = default;
+};
 
-    RebarBandInfo(RebarBandInfo&&) = default;
-    RebarBandInfo(const RebarBandInfo& band_info) = default;
+class RebarBand {
+public:
+    RebarBandState m_state;
+    ui_extension::window_ptr m_window{};
+    HWND m_wnd{};
+
+    RebarBand& operator=(RebarBand&&) = default;
+    RebarBand& operator=(const RebarBand& band) = default;
+    RebarBand() = default;
+
+    RebarBand(RebarBand&&) = default;
+    RebarBand(const RebarBand& band) = default;
 };


### PR DESCRIPTION
This fixes a nasty bug where `uie::windor::ptr` instances were escaping into the global `g_cfg_rebar` object, and hence released while the DLL was being unloaded.

This was probably a regression from previous refactoring of related code.

This reorganises things so that such a scenario is impossible.