### PR TITLE
Make 'Edit this column' command more robust

### DIFF
--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -867,9 +867,8 @@ void TabColumns::show_column(size_t index)
                 break;
             }
         }
-        standard_commands::main_preferences();
     } else {
         cfg_cur_prefs_col = index;
-        cui::prefs::page_playlist_view.get_static_instance().show_tab("Columns");
     }
+    cui::prefs::page_playlist_view.get_static_instance().show_tab("Columns");
 }

--- a/foo_ui_columns/config_host.cpp
+++ b/foo_ui_columns/config_host.cpp
@@ -105,6 +105,8 @@ void PreferencesTabHelper::on_ncdestroy()
 
 void PreferencesTabsHost::show_tab(const char* tab_name)
 {
+    const auto previous_tab = m_active_tab.get_value();
+
     for (size_t n = 0; n < m_tab_count; n++) {
         if (!strcmp(m_tabs[n]->get_name(), tab_name)) {
             m_active_tab = n;
@@ -112,13 +114,15 @@ void PreferencesTabsHost::show_tab(const char* tab_name)
         }
     }
 
-    if (m_wnd_tabs) {
+    if (m_wnd_tabs && previous_tab != m_active_tab) {
         TabCtrl_SetCurSel(m_wnd_tabs, m_active_tab);
-        make_child();
-        standard_commands::main_preferences();
-    } else {
-        static_api_ptr_t<ui_control>()->show_preferences(get_guid());
+
+        // See WM_WINDOWPOSCHANGED comment below
+        if (IsWindowVisible(m_wnd))
+            make_child();
     }
+
+    static_api_ptr_t<ui_control>()->show_preferences(get_guid());
 }
 
 BOOL PreferencesTabsHost::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)


### PR DESCRIPTION
This fixes a problem where if you were on the playlist view preferences page and had switched away from it to another page, the 'Edit this column' from the playlist view header context menu would not behave correctly.

This is because the code had the expectation that if the preferences dialog had been created, it was visible. However, foobar2000 hides dialogs after switching away from them rather than destroying them. It's noted in a comment elsewhere that this behaviour changed in foobar2000 1.0.