### PR TITLE
Always sort Filter node tracks on selection

### DIFF
--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -658,7 +658,7 @@ void FilterPanel::notify_on_selection_change(
         update_subsequent_filters();
         if (m_selection_holder.is_valid()) {
             metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
-            get_selection_handles(handles, false);
+            get_selection_handles(handles, false, true);
             m_selection_holder->set_selection(handles);
         }
     }
@@ -686,7 +686,7 @@ void FilterPanel::notify_on_set_focus(HWND wnd_lost)
 {
     m_selection_holder = static_api_ptr_t<ui_selection_manager>()->acquire();
     metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
-    get_selection_handles(handles, false);
+    get_selection_handles(handles, false, true);
     m_selection_holder->set_selection(handles);
 }
 void FilterPanel::notify_on_kill_focus(HWND wnd_receiving)


### PR DESCRIPTION
This ensures that the tracks of a Filter panel node are sorted when selected (when sorting is enabled in Filter preferences).

This is so tracks appear sorted in selection viewers.