### PR TITLE
Don't ignore Filter panel selection changes when right-clicking

### DIFF
--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -653,14 +653,11 @@ void FilterPanel::send_results_to_playlist(bool b_play)
 void FilterPanel::notify_on_selection_change(
     const pfc::bit_array& p_affected, const pfc::bit_array& p_status, notification_source_t p_notification_source)
 {
-    if (p_notification_source != notification_source_rmb) {
-        // send_results_to_playlist();
-        update_subsequent_filters();
-        if (m_selection_holder.is_valid()) {
-            metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
-            get_selection_handles(handles, false, true);
-            m_selection_holder->set_selection(handles);
-        }
+    update_subsequent_filters();
+    if (m_selection_holder.is_valid()) {
+        metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
+        get_selection_handles(handles, false, true);
+        m_selection_holder->set_selection(handles);
     }
 }
 void FilterPanel::update_first_node_text(bool b_update)


### PR DESCRIPTION
This changes Filter panel behaviour so that when right-clicking on an item, the selection change is processed normally as it would be when left-clicking.

This means that subsequent Filters are updated, auto-send is triggered and selection viewers are updated.

(Previously, the selection change was effectively ignored, which left the panel in an inconsistent state.)