### PR TITLE
Correct handling of null file_info with track_property_provider_v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0-beta.1
 
-* The time it takes Item properties to update was reduced for very large selections. [[#199](https://github.com/reupen/columns_ui/pull/199)]
+* The time it takes Item properties to update was reduced for very large selections. [[#199](https://github.com/reupen/columns_ui/pull/199), [#209](https://github.com/reupen/columns_ui/pull/209)]
 
 * Flickering in the playlist view was reduced when all items are replaced (e.g. when using Filters) [[#198](https://github.com/reupen/columns_ui/pull/198)]
 

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -385,16 +385,13 @@ void ItemProperties::refresh_contents()
     info_refs.resize(count);
 
     for (i = 0; i < count; i++)
-        m_handles[i]->get_info_ref(info_refs[i]);
+        info_refs[i] = m_handles[i]->get_info_ref();
 
     concurrency::parallel_for(size_t{0}, field_count, [&metadata_aggregators, &info_refs, this](auto&& field_index) {
         auto& metadata_aggregator = metadata_aggregators[field_index];
 
         for (size_t i = 0; i < m_handles.get_count(); i++) {
             auto&& info_ref = info_refs[i];
-
-            if (!info_ref.is_valid())
-                continue;
 
             if (!metadata_aggregator.process_file_info(m_fields[field_index].m_name, &info_ref->info()))
                 break;


### PR DESCRIPTION
This was a result of the changes in #199. `track_property_provider_v3` expects provided `metadb_info_container` objects to be non-null and there is a subtle difference in behaviour between the `metadb_handle::get_info_ref()` overloads.

Now, invalid `metadb_info_container::ptr` objects are avoided completely.