### PR TITLE
Remove forced window updating in list views

### DIFF
--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -183,7 +183,7 @@ void ButtonsToolbar::ConfigParam::refresh_buttons_list_items(t_size index, t_siz
         m_buttons[n].get_name_type(name);
         items[n - index].m_subitems[1] = name;
     }
-    m_button_list.replace_items(index, items, b_update_display);
+    m_button_list.replace_items(index, items);
 }
 
 BOOL CALLBACK ButtonsToolbar::ConfigParam::g_ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -345,7 +345,7 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
                     _T("This will reset all your buttons to the default buttons. Continue?"), _T("Reset buttons"),
                     MB_YESNO)
                 == IDYES) {
-                m_button_list.remove_items(pfc::bit_array_true(), false);
+                m_button_list.remove_items(pfc::bit_array_true());
                 ButtonsToolbar::reset_buttons(m_buttons);
                 populate_buttons_list();
             }
@@ -426,7 +426,7 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
                 pfc::string8 path;
                 if (uGetOpenFileName(wnd, "fcb Files (*.fcb)|*.fcb|All Files (*.*)|*.*", 0, "fcb", "Open file", nullptr,
                         path, FALSE)) {
-                    m_button_list.remove_items(pfc::bit_array_true(), false);
+                    m_button_list.remove_items(pfc::bit_array_true());
 
                     HWND wnd_show = GetDlgItem(wnd, IDC_SHOW);
                     HWND wnd_text = GetDlgItem(wnd, IDC_TEXT_LOCATION);

--- a/foo_ui_columns/filter_items.cpp
+++ b/foo_ui_columns/filter_items.cpp
@@ -259,7 +259,7 @@ void FilterPanel::update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
 
             m_nodes.insert_item(node, index_item);
             InsertItem item;
-            insert_items(index_item, 1, &item, false);
+            insert_items(index_item, 1, &item);
         }
     }
 
@@ -272,7 +272,7 @@ void FilterPanel::update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
         mask_nodes[node_index] = m_nodes[node_index].m_handles.get_count() == 0;
     }
     m_nodes.remove_mask(mask_nodes.get_ptr());
-    remove_items(pfc::bit_array_table(mask_nodes.get_ptr(), mask_nodes.get_size()), true);
+    remove_items(pfc::bit_array_table(mask_nodes.get_ptr(), mask_nodes.get_size()));
     update_first_node_text(true);
 
     if (next_window) {

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -473,13 +473,13 @@ void ItemProperties::refresh_contents()
     if (new_count && old_count) {
         pfc::list_t<uih::ListView::InsertItem> items_replace;
         items_replace.add_items_fromptr(items.get_ptr(), min(new_count, old_count));
-        uih::ListView::replace_items(0, items_replace, false);
+        uih::ListView::replace_items(0, items_replace);
     }
 
     if (new_count > old_count) {
-        uih::ListView::insert_items(old_count, items.get_count() - old_count, items.get_ptr() + old_count, false);
+        uih::ListView::insert_items(old_count, items.get_count() - old_count, items.get_ptr() + old_count);
     } else if (new_count < old_count) {
-        uih::ListView::remove_items(pfc::bit_array_range(new_count, old_count - new_count), false);
+        uih::ListView::remove_items(pfc::bit_array_range(new_count, old_count - new_count));
     }
 
     if (b_redraw)
@@ -811,7 +811,7 @@ bool ItemProperties::show_config_popup(HWND wnd_parent)
                 m_show_group_titles = dialog.m_show_groups;
                 cfg_selection_poperties_show_group_titles = m_show_group_titles;
 
-                remove_items(pfc::bit_array_true(), false);
+                remove_items(pfc::bit_array_true());
                 set_group_count(m_show_group_titles ? 1 : 0);
             }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -245,7 +245,7 @@ void PlaylistView::on_groups_change()
     }
 }
 
-void PlaylistView::update_all_items(bool b_update_display)
+void PlaylistView::update_all_items()
 {
     static_api_ptr_t<titleformat_compiler> p_compiler;
     service_ptr_t<titleformat_object> p_script, p_script_group;
@@ -257,14 +257,13 @@ void PlaylistView::update_all_items(bool b_update_display)
         p_compiler->compile_safe(m_script_global, cfg_globalstring);
     p_compiler->compile_safe(m_script_global_style, cfg_colour);
 
-    refresh_all_items_text(b_update_display);
+    refresh_all_items_text();
 }
-void PlaylistView::refresh_all_items_text(bool b_update_display)
+void PlaylistView::refresh_all_items_text()
 {
-    update_items(0, get_item_count(), false);
-    invalidate_all(b_update_display);
+    update_items(0, get_item_count());
 }
-void PlaylistView::update_items(t_size index, t_size count, bool b_update_display)
+void PlaylistView::update_items(t_size index, t_size count)
 {
     for (t_size i = 0; i < count; i++) {
         t_size cg = get_item(i + index)->get_group_count();
@@ -272,7 +271,7 @@ void PlaylistView::update_items(t_size index, t_size count, bool b_update_displa
             get_item(i + index)->get_group(j)->m_style_data.release();
         get_item(i + index)->m_style_data.set_count(0);
     }
-    uih::ListView::update_items(index, count, b_update_display);
+    uih::ListView::update_items(index, count);
 }
 void PlaylistView::g_on_autosize_change()
 {
@@ -402,7 +401,7 @@ void PlaylistView::on_columns_change()
 void PlaylistView::s_redraw_all()
 {
     for (auto&& window : g_windows)
-        RedrawWindow(window->get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
+        RedrawWindow(window->get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
 
 int g_compare_wchar(const pfc::array_t<WCHAR>& a, const pfc::array_t<WCHAR>& b)

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -473,9 +473,9 @@ private:
 
     HBITMAP request_group_artwork(t_size index_item, t_size item_group_count);
 
-    void update_all_items(bool b_update_display = true);
-    void refresh_all_items_text(bool b_update_display = true);
-    void update_items(t_size index, t_size count, bool b_update_display = true);
+    void update_all_items();
+    void refresh_all_items_text();
+    void update_items(t_size index, t_size count);
 
     Item* storage_create_item() override { return new PlaylistViewItem; }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -10,10 +10,8 @@ void PlaylistView::on_items_added(/*unsigned p_playlist, */ unsigned start,
         clear_sort_column();
         InsertItemsContainer items;
         get_insert_items(start, p_data.get_count(), items);
-        insert_items(start, items.get_count(), items.get_ptr(), false);
-        refresh_all_items_text(false);
-        invalidate_all();
-        // reset_items();
+        insert_items(start, items.get_count(), items.get_ptr());
+        refresh_all_items_text();
     }
 }
 void PlaylistView::on_items_reordered(/*t_size p_playlist, */ const t_size* p_order, t_size p_count){
@@ -40,16 +38,12 @@ void PlaylistView::on_items_removed(const pfc::bit_array& p_mask, t_size p_old_c
     clear_sort_column();
 
     if (p_new_count == 0) {
-        remove_all_items(false);
-        // Delay repainting as the removal of all items is often followed by the addition of items
-        invalidate_all(false);
+        remove_all_items();
         return;
     }
 
-    remove_items(p_mask, false);
-    refresh_all_items_text(false);
-
-    invalidate_all();
+    remove_items(p_mask);
+    refresh_all_items_text();
 }
 
 void PlaylistView::on_items_selection_change(
@@ -57,7 +51,7 @@ void PlaylistView::on_items_selection_change(
 {
     /*(if (p_playlist == 0)*/
     if (!m_ignore_callback) {
-        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
+        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
     }
 };
 void PlaylistView::on_item_focus_change(/*t_size p_playlist, */ t_size p_from, t_size p_to)

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -21,7 +21,7 @@ void PlaylistSwitcher::get_insert_items(t_size base, t_size count, pfc::list_t<u
 
 void PlaylistSwitcher::refresh_all_items()
 {
-    remove_items(pfc::bit_array_true(), false);
+    remove_items(pfc::bit_array_true());
 
     add_items(0, m_playlist_api->get_playlist_count());
 
@@ -34,7 +34,7 @@ void PlaylistSwitcher::refresh_items(t_size base, t_size count, bool b_update)
 {
     pfc::list_t<uih::ListView::InsertItem> items_insert;
     get_insert_items(base, count, items_insert);
-    replace_items(base, items_insert, b_update);
+    replace_items(base, items_insert);
 }
 
 void PlaylistSwitcher::add_items(t_size base, t_size count)


### PR DESCRIPTION
This updates ui_helpers to remove almost all use of `UpdateWindow()` and `RDW_UPDATENOW` in list views to minimise flickering (and similar effects).

(Instead, Windows will send a WM_PAINT message when the message queue is next empty. This has the effect of batching what previously were multiple painting operations.)