### PR TITLE
Fix double-clicking on first few visible items in list views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 1.2.0-beta.3
+
+* A problem was fixed where it was not possible to double-click on the first few visible items in the playlist view and in other list views. [[#214](https://github.com/reupen/columns_ui/pull/214), [ui_helpers#31](https://github.com/reupen/ui_helpers/pull/31)]
+
 ## 1.2.0-beta.2
 
 * A problem was fixed where it was not possible to click exactly at the top of each item in the playlist view and in other list views. [[#210](https://github.com/reupen/columns_ui/pull/210), [ui_helpers#28](https://github.com/reupen/ui_helpers/pull/28)]

--- a/foo_ui_columns/version.cpp
+++ b/foo_ui_columns/version.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 
-#define VERSION "1.2.0-beta.2"
+#define VERSION "1.2.0-beta.3"
 
 #ifndef __clang__
 #define DATE ", Date "__DATE__


### PR DESCRIPTION
This updates ui_helpers to pick up a fix for a bug where it was not possible to double-click on near the top of the viewport in list views.