### PR TITLE
Replace uses of uDialogBox with DialogBoxParam

### DIFF
--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -681,12 +681,15 @@ bool ButtonsToolbar::show_config_popup(HWND wnd_parent)
     param.m_image = nullptr;
     param.m_text_below = m_text_below;
     param.m_appearance = m_appearance;
-    bool rv = !!uDialogBox(
-        IDD_BUTTONS_OPTIONS, wnd_parent, ConfigParam::g_ConfigPopupProc, reinterpret_cast<LPARAM>(&param));
-    if (rv) {
+
+    const auto dialog_result = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_BUTTONS_OPTIONS),
+        wnd_parent, ConfigParam::g_ConfigPopupProc, reinterpret_cast<LPARAM>(&param));
+
+    if (dialog_result > 0) {
         configure(param.m_buttons, param.m_text_below, param.m_appearance);
+        return true;
     }
-    return rv;
+    return false;
 }
 
 // {D8E65660-64ED-42e7-850B-31D828C25294}

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -302,7 +302,11 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
             CommandPickerData p_temp;
             CommandPickerParam p_data{};
             p_temp.set_data(p_data);
-            if (uDialogBox(IDD_BUTTON_COMMAND_PICKER, wnd, ConfigCommandProc, reinterpret_cast<LPARAM>(&p_temp))) {
+
+            const auto dialog_result = DialogBoxParam(mmh::get_current_instance(),
+                MAKEINTRESOURCE(IDD_BUTTON_COMMAND_PICKER), wnd, ConfigCommandProc, reinterpret_cast<LPARAM>(&p_temp));
+
+            if (dialog_result > 0) {
                 t_size index = m_buttons.add_item(Button{});
 
                 p_temp.get_data(p_data);
@@ -446,7 +450,12 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
                 CommandPickerParam p_data{
                     m_selection->m_guid, m_selection->m_subcommand, m_selection->m_type, m_selection->m_filter};
                 p_temp.set_data(p_data);
-                if (uDialogBox(IDD_BUTTON_COMMAND_PICKER, wnd, ConfigCommandProc, reinterpret_cast<LPARAM>(&p_temp))) {
+
+                const auto dialog_result
+                    = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_BUTTON_COMMAND_PICKER), wnd,
+                        ConfigCommandProc, reinterpret_cast<LPARAM>(&p_temp));
+
+                if (dialog_result > 0) {
                     p_temp.get_data(p_data);
                     m_selection->m_type = (Type)p_data.m_group;
                     m_selection->m_guid = p_data.m_guid;

--- a/foo_ui_columns/fcl.cpp
+++ b/foo_ui_columns/fcl.cpp
@@ -375,7 +375,10 @@ void g_import_layout(HWND wnd, const char* path, bool quiet)
 
             FCLDialog pFCLDialog(true, datasetsguids);
             if (!quiet) {
-                if (!uDialogBox(IDD_FCL_IMPORT, wnd, FCLDialog::g_FCLDialogProc, (LPARAM)&pFCLDialog))
+                const auto dialog_result = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_FCL_IMPORT),
+                    wnd, FCLDialog::g_FCLDialogProc, reinterpret_cast<LPARAM>(&pFCLDialog));
+
+                if (dialog_result <= 0)
                     throw exception_aborted();
             }
 
@@ -435,9 +438,13 @@ public:
 void g_export_layout(HWND wnd, pfc::string8 path, bool is_quiet)
 {
     FCLDialog pFCLDialog;
-    if (!is_quiet
-        && !uDialogBox(IDD_FCL_EXPORT, wnd, FCLDialog::g_FCLDialogProc, reinterpret_cast<LPARAM>(&pFCLDialog)))
-        return;
+    if (!is_quiet) {
+        const auto dialog_result = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_FCL_EXPORT), wnd,
+            FCLDialog::g_FCLDialogProc, reinterpret_cast<LPARAM>(&pFCLDialog));
+
+        if (dialog_result <= 0)
+            return;
+    }
 
     if (path.is_empty()
         && !uGetOpenFileName(

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -267,6 +267,7 @@
     <ClCompile Include="filter_fcl.cpp" />
     <ClCompile Include="ng_playlist\config_object_callbacks.cpp" />
     <ClCompile Include="notification_area_callbacks.cpp" />
+    <ClCompile Include="rename_dialog.cpp" />
     <ClCompile Include="seekbar_callbacks.cpp" />
     <ClCompile Include="status_bar_callbacks.cpp" />
     <ClCompile Include="status_bar_font_client.cpp" />
@@ -517,6 +518,7 @@
     <ClInclude Include="notification_area.h" />
     <ClInclude Include="playlist_item_helpers.h" />
     <ClInclude Include="rebar_band.h" />
+    <ClInclude Include="rename_dialog.h" />
     <ClInclude Include="splitter_utils.h" />
     <ClInclude Include="tab_layout.h" />
     <ClInclude Include="tab_layout_misc.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -503,6 +503,9 @@
     <ClCompile Include="tab_playlist_tabs.cpp">
       <Filter>Config UI</Filter>
     </ClCompile>
+    <ClCompile Include="rename_dialog.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include=".\resource.h">
@@ -709,6 +712,9 @@
     </ClInclude>
     <ClInclude Include="menu_mnemonics.h">
       <Filter>Menu toolbar</Filter>
+    </ClInclude>
+    <ClInclude Include="rename_dialog.h">
+      <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -187,7 +187,9 @@ void ItemDetailsConfig::run_modeless(HWND wnd, ItemDetails* p_this)
 bool ItemDetailsConfig::run_modal(HWND wnd)
 {
     m_modal = true;
-    return uDialogBox(IDD_ITEM_DETAILS_OPTIONS, wnd, g_DialogProc, (LPARAM)this) != 0;
+    const auto dialog_result = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_ITEM_DETAILS_OPTIONS),
+        wnd, g_DialogProc, reinterpret_cast<LPARAM>(this));
+    return dialog_result > 0;
 }
 
 ItemDetailsConfig::ItemDetailsConfig(const char* p_text, uint32_t edge_style, uint32_t halign, uint32_t valign)

--- a/foo_ui_columns/item_properties_config.cpp
+++ b/foo_ui_columns/item_properties_config.cpp
@@ -163,7 +163,9 @@ BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
 
 bool ItemPropertiesConfig::run_modal(HWND wnd)
 {
-    return uDialogBox(IDD_ITEM_PROPS_OPTIONS, wnd, g_DialogProc, (LPARAM)this) != 0;
+    const auto dialog_result = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_ITEM_PROPS_OPTIONS), wnd,
+        g_DialogProc, reinterpret_cast<LPARAM>(this));
+    return dialog_result > 0;
 }
 
 ItemPropertiesConfig::ItemPropertiesConfig(pfc::list_t<Field> p_fields, t_size edge_style,

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -62,7 +62,9 @@ static BOOL CALLBACK EditViewProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
 static bool run_edit_view(edit_view_param& param, HWND parent)
 {
-    return uDialogBox(IDD_EDIT_GROUP, parent, EditViewProc, reinterpret_cast<LPARAM>(&param)) != 0;
+    const auto dialog_result = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_EDIT_GROUP), parent,
+        EditViewProc, reinterpret_cast<LPARAM>(&param));
+    return dialog_result > 0;
 }
 
 BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)

--- a/foo_ui_columns/rename_dialog.cpp
+++ b/foo_ui_columns/rename_dialog.cpp
@@ -1,0 +1,61 @@
+#include "stdafx.h"
+#include "rename_dialog.h"
+
+namespace cui::helpers {
+
+class RenameDialogBoxState {
+public:
+    pfc::string8 m_text;
+    pfc::string8 m_title;
+    modal_dialog_scope m_scope;
+};
+
+static BOOL CALLBACK show_rename_dialog_box_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    switch (msg) {
+    case WM_INITDIALOG:
+        SetWindowLongPtr(wnd, DWLP_USER, lp);
+        {
+            auto* ptr = reinterpret_cast<RenameDialogBoxState*>(lp);
+            ptr->m_scope.initialize(FindOwningPopup(wnd));
+            uSetWindowText(wnd, ptr->m_title);
+            uSetDlgItemText(wnd, IDC_EDIT, ptr->m_text);
+        }
+        return TRUE;
+    case WM_COMMAND:
+        switch (wp) {
+        case IDOK: {
+            auto* ptr = reinterpret_cast<RenameDialogBoxState*>(GetWindowLong(wnd, DWLP_USER));
+            uGetDlgItemText(wnd, IDC_EDIT, ptr->m_text);
+            EndDialog(wnd, 1);
+            return FALSE;
+        }
+        case IDCANCEL:
+            EndDialog(wnd, 0);
+            return FALSE;
+        default:
+            return FALSE;
+        }
+    case WM_CLOSE:
+        EndDialog(wnd, 0);
+        return FALSE;
+    default:
+        return FALSE;
+    }
+}
+
+std::optional<pfc::string8> show_rename_dialog_box(HWND wnd_parent, const char* title, const char* initial_text)
+{
+    RenameDialogBoxState param;
+    param.m_title = title;
+    param.m_text = initial_text;
+    const auto dialog_result = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_RENAME_PLAYLIST),
+        wnd_parent, show_rename_dialog_box_proc, reinterpret_cast<LPARAM>(&param));
+
+    if (dialog_result > 0)
+        return {param.m_text};
+
+    return {};
+}
+
+} // namespace cui::helpers

--- a/foo_ui_columns/rename_dialog.h
+++ b/foo_ui_columns/rename_dialog.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace cui::helpers {
+
+std::optional<pfc::string8> show_rename_dialog_box(HWND wnd_parent, const char* title, const char* initial_text);
+
+} // namespace cui::helpers

--- a/foo_ui_columns/tab_layout.h
+++ b/foo_ui_columns/tab_layout.h
@@ -26,13 +26,6 @@ public:
     bool get_help_url(pfc::string_base& p_out) override;
 
 private:
-    class RenameData {
-    public:
-        pfc::string8 m_text;
-        pfc::string8 m_title;
-        modal_dialog_scope m_scope;
-    };
-
     static HTREEITEM insert_item_in_tree_view(
         HWND wnd_tree, const char* sz_text, LPARAM data, HTREEITEM ti_parent = TVI_ROOT, HTREEITEM ti_after = TVI_LAST);
     static void get_panel_list(uie::window_info_list_simple& p_out);
@@ -45,8 +38,6 @@ private:
     static void __populate_tree(
         HWND wnd_tree, LayoutTabNode::ptr p_node, HTREEITEM ti_parent, HTREEITEM ti_after = TVI_LAST);
     static void print_index_out_of_range();
-
-    static BOOL CALLBACK RenameProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
     void remove_item(HWND wnd, HTREEITEM ti);
     void insert_item(HWND wnd, HTREEITEM ti_parent, const GUID& p_guid, HTREEITEM ti_after = TVI_LAST);

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -388,8 +388,11 @@ static BOOL CALLBACK SpectrumPopupProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 bool SpectrumAnalyserVisualisation::show_config_popup(HWND wnd_parent)
 {
     SpectrumAnalyserConfigData param(cr_fore, cr_back, mode, m_scale, m_vertical_scale, this);
-    bool rv = !!uDialogBox(IDD_SPECTRUM_ANALYSER_OPTIONS, wnd_parent, SpectrumPopupProc, (LPARAM)(&param));
-    if (rv) {
+    const auto dialog_result
+        = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_SPECTRUM_ANALYSER_OPTIONS), wnd_parent,
+            SpectrumPopupProc, reinterpret_cast<LPARAM>(&param));
+
+    if (dialog_result > 0) {
         cr_fore = param.cr_fore;
         cfg_vis2 = param.cr_fore;
         cr_back = param.cr_back;
@@ -404,8 +407,9 @@ bool SpectrumAnalyserVisualisation::show_config_popup(HWND wnd_parent)
             flush_brushes();
             clear();
         }
+        return true;
     }
-    return rv;
+    return false;
 }
 
 void CALLBACK SpectrumAnalyserVisualisation::g_timer_proc(HWND wnd, UINT msg, UINT_PTR id_event, DWORD time)
@@ -642,8 +646,11 @@ class SpectrumAnalyserVisualisationPanel : public VisualisationPanel {
         SpectrumAnalyserConfigData param(p_temp->cr_fore, p_temp->cr_back, p_temp->mode, p_temp->m_scale, p_temp->m_vertical_scale,
             p_temp.get_ptr(), true, get_frame_style());
 
-        bool rv = !!uDialogBox(IDD_SPECTRUM_ANALYSER_OPTIONS, wnd_parent, SpectrumPopupProc, (LPARAM)(&param));
-        if (rv) {
+        const auto dialog_result
+            = DialogBoxParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_SPECTRUM_ANALYSER_OPTIONS), wnd_parent,
+                SpectrumPopupProc, reinterpret_cast<LPARAM>(&param));
+
+        if (dialog_result > 0) {
             p_temp->cr_fore = param.cr_fore;
             cfg_vis2 = param.cr_fore;
             p_temp->cr_back = param.cr_back;
@@ -666,8 +673,9 @@ class SpectrumAnalyserVisualisationPanel : public VisualisationPanel {
                 } catch (pfc::exception&) {
                 }
             }
+            return true;
         }
-        return rv;
+        return false;
     }
 };
 


### PR DESCRIPTION
This is to reduce our dependence on foobar2000_sdk_helpers.

A shared utility function was also added as a replacement for various naming and renaming dialogs.