### PR TITLE
Improve naming of menu item-based buttons in buttons toolbar

### DIFF
--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -222,9 +222,8 @@ void ButtonsToolbar::create_toolbar()
 
                 if (/*m_text_below || (tbb[n].fsStyle & BTNS_SHOWTEXT) */ m_buttons[n].m_show == SHOW_TEXT
                     || m_buttons[n].m_show == SHOW_IMAGE_TEXT) {
-                    pfc::string8 temp;
-                    m_buttons[n].get_display_text(temp);
-                    pfc::stringcvt::string_os_from_utf8 str_conv(temp);
+                    const auto display_text = m_buttons[n].get_display_text();
+                    pfc::stringcvt::string_os_from_utf8 str_conv(display_text.c_str());
                     pfc::array_t<TCHAR, pfc::alloc_fast_aggressive> name;
                     name.prealloc(str_conv.length() + 4);
                     name.append_fromptr(str_conv.get_ptr(), str_conv.length());
@@ -389,9 +388,9 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             auto lpnmtbgit = (LPNMTBGETINFOTIP)lp;
             if (!m_buttons[lpnmtbgit->iItem].m_interface.is_valid()
                 || (m_buttons[lpnmtbgit->iItem].m_interface->get_button_state() & uie::BUTTON_STATE_SHOW_TOOLTIP)) {
-                pfc::string8 temp;
-                m_buttons[lpnmtbgit->iItem].get_short_name(temp);
-                StringCchCopy(lpnmtbgit->pszText, lpnmtbgit->cchTextMax, pfc::stringcvt::string_wide_from_utf8(temp));
+                const auto text = m_buttons[lpnmtbgit->iItem].get_name(true);
+                StringCchCopy(
+                    lpnmtbgit->pszText, lpnmtbgit->cchTextMax, pfc::stringcvt::string_wide_from_utf8(text.c_str()));
             }
         } break;
         case TBN_DROPDOWN: {

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -95,12 +95,11 @@ public:
         void write(stream_writer* out, abort_callback& p_abort) const;
 
         void read(ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort);
-        void get_display_text(pfc::string_base& p_out); // display
-        void get_short_name(pfc::string_base& p_out); // tooltip
+        std::string get_display_text() const;
 
-        void get_name_type(pfc::string_base& p_out); // config
-        void get_name_name(pfc::string_base& p_out); // config
-        void get_name(pfc::string_base& p_out); // config
+        std::string get_type_desc() const;
+        std::string get_name(bool short_form = false) const;
+        std::string get_name_with_type() const;
         void write_to_file(stream_writer& p_file, bool b_paths, abort_callback& p_abort);
         void read_from_file(ConfigVersion p_version, const char* p_base, const char* p_name, stream_reader* p_file,
             unsigned p_size, abort_callback& p_abort);

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -109,7 +109,7 @@ void ButtonsToolbar::Button::get_short_name(pfc::string_base& p_out) // tooltip
     else if (m_type == TYPE_SEPARATOR)
         p_out = "Separator";
     else if (m_type == TYPE_MENU_ITEM_MAIN)
-        menu_helpers::mainpath_from_guid(m_guid, m_subcommand, p_out, true);
+        p_out = menu_helpers::mainpath_from_guid(m_guid, m_subcommand, true).c_str();
     else
         menu_helpers::contextpath_from_guid(m_guid, m_subcommand, p_out, true);
 }
@@ -139,9 +139,7 @@ void ButtonsToolbar::Button::get_name_name(pfc::string_base& p_out) // config
     } else if (m_type == TYPE_SEPARATOR)
         p_out = "-";
     else if (m_type == TYPE_MENU_ITEM_MAIN) {
-        pfc::string8 temp;
-        menu_helpers::mainpath_from_guid(m_guid, m_subcommand, temp);
-        p_out += temp;
+        p_out += menu_helpers::mainpath_from_guid(m_guid, m_subcommand).c_str();
     } else {
         pfc::string8 temp;
         menu_helpers::contextpath_from_guid(m_guid, m_subcommand, temp);
@@ -160,10 +158,8 @@ void ButtonsToolbar::Button::get_name(pfc::string_base& p_out) // config
     } else if (m_type == TYPE_SEPARATOR)
         p_out = "[Separator]";
     else if (m_type == TYPE_MENU_ITEM_MAIN) {
-        pfc::string8 temp;
         p_out = "[Main menu item] ";
-        menu_helpers::mainpath_from_guid(m_guid, m_subcommand, temp);
-        p_out += temp;
+        p_out += menu_helpers::mainpath_from_guid(m_guid, m_subcommand).c_str();
     } else {
         pfc::string8 temp;
         menu_helpers::contextpath_from_guid(m_guid, m_subcommand, temp);

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -111,7 +111,7 @@ void ButtonsToolbar::Button::get_short_name(pfc::string_base& p_out) // tooltip
     else if (m_type == TYPE_MENU_ITEM_MAIN)
         p_out = menu_helpers::mainpath_from_guid(m_guid, m_subcommand, true).c_str();
     else
-        menu_helpers::contextpath_from_guid(m_guid, m_subcommand, p_out, true);
+        p_out = menu_helpers::contextpath_from_guid(m_guid, m_subcommand, true).c_str();
 }
 
 void ButtonsToolbar::Button::get_name_type(pfc::string_base& p_out) // config
@@ -141,9 +141,7 @@ void ButtonsToolbar::Button::get_name_name(pfc::string_base& p_out) // config
     else if (m_type == TYPE_MENU_ITEM_MAIN) {
         p_out += menu_helpers::mainpath_from_guid(m_guid, m_subcommand).c_str();
     } else {
-        pfc::string8 temp;
-        menu_helpers::contextpath_from_guid(m_guid, m_subcommand, temp);
-        p_out += temp;
+        p_out = menu_helpers::contextpath_from_guid(m_guid, m_subcommand).c_str();
     }
 }
 void ButtonsToolbar::Button::get_name(pfc::string_base& p_out) // config
@@ -161,10 +159,8 @@ void ButtonsToolbar::Button::get_name(pfc::string_base& p_out) // config
         p_out = "[Main menu item] ";
         p_out += menu_helpers::mainpath_from_guid(m_guid, m_subcommand).c_str();
     } else {
-        pfc::string8 temp;
-        menu_helpers::contextpath_from_guid(m_guid, m_subcommand, temp);
         p_out = "[Context menu item] ";
-        p_out += temp;
+        p_out += menu_helpers::contextpath_from_guid(m_guid, m_subcommand).c_str();
     }
 }
 

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -93,75 +93,53 @@ void ButtonsToolbar::Button::read(
         m_text = temp;
     }
 }
-void ButtonsToolbar::Button::get_display_text(pfc::string_base& p_out) // display
+
+std::string ButtonsToolbar::Button::get_display_text() const
 {
-    p_out.reset();
     if (m_use_custom_text)
-        p_out = m_text;
-    else
-        get_short_name(p_out);
-}
-void ButtonsToolbar::Button::get_short_name(pfc::string_base& p_out) // tooltip
-{
-    p_out.reset();
-    if (m_type == TYPE_BUTTON)
-        uie::custom_button::g_button_get_name(m_guid, p_out);
-    else if (m_type == TYPE_SEPARATOR)
-        p_out = "Separator";
-    else if (m_type == TYPE_MENU_ITEM_MAIN)
-        p_out = menu_helpers::mainpath_from_guid(m_guid, m_subcommand, true).c_str();
-    else
-        p_out = menu_helpers::contextpath_from_guid(m_guid, m_subcommand, true).c_str();
+        return m_text.c_str();
+
+    return get_name(true);
 }
 
-void ButtonsToolbar::Button::get_name_type(pfc::string_base& p_out) // config
+std::string ButtonsToolbar::Button::get_type_desc() const
 {
-    p_out.reset();
-    if (m_type == TYPE_BUTTON) {
-        p_out = "Button";
-    } else if (m_type == TYPE_SEPARATOR)
-        p_out = "Separator";
-    else if (m_type == TYPE_MENU_ITEM_MAIN) {
-        p_out = "Main menu item";
-    } else {
-        p_out = "Context menu item";
+    switch (m_type) {
+    case TYPE_BUTTON:
+        return "Button";
+    case TYPE_SEPARATOR:
+        return "Separator";
+    case TYPE_MENU_ITEM_CONTEXT:
+        return "Context menu item";
+    case TYPE_MENU_ITEM_MAIN:
+        return "Main menu item";
+    default:
+        return "Unknown";
     }
 }
 
-void ButtonsToolbar::Button::get_name_name(pfc::string_base& p_out) // config
+std::string ButtonsToolbar::Button::get_name(bool short_form) const
 {
-    p_out.reset();
-    if (m_type == TYPE_BUTTON) {
+    switch (m_type) {
+    case TYPE_BUTTON: {
         pfc::string8 temp;
-        if (uie::custom_button::g_button_get_name(m_guid, temp)) {
-            p_out += temp;
-        }
-    } else if (m_type == TYPE_SEPARATOR)
-        p_out = "-";
-    else if (m_type == TYPE_MENU_ITEM_MAIN) {
-        p_out += menu_helpers::mainpath_from_guid(m_guid, m_subcommand).c_str();
-    } else {
-        p_out = menu_helpers::contextpath_from_guid(m_guid, m_subcommand).c_str();
+        uie::custom_button::g_button_get_name(m_guid, temp);
+        return temp.c_str();
+    }
+    case TYPE_SEPARATOR:
+        return "-";
+    case TYPE_MENU_ITEM_CONTEXT:
+        return menu_helpers::contextpath_from_guid(m_guid, m_subcommand, short_form);
+    case TYPE_MENU_ITEM_MAIN:
+        return menu_helpers::mainpath_from_guid(m_guid, m_subcommand, short_form);
+    default:
+        return "Unknown";
     }
 }
-void ButtonsToolbar::Button::get_name(pfc::string_base& p_out) // config
+
+std::string ButtonsToolbar::Button::get_name_with_type() const
 {
-    p_out.reset();
-    if (m_type == TYPE_BUTTON) {
-        p_out = "[Button] ";
-        pfc::string8 temp;
-        if (uie::custom_button::g_button_get_name(m_guid, temp)) {
-            p_out += temp;
-        }
-    } else if (m_type == TYPE_SEPARATOR)
-        p_out = "[Separator]";
-    else if (m_type == TYPE_MENU_ITEM_MAIN) {
-        p_out = "[Main menu item] ";
-        p_out += menu_helpers::mainpath_from_guid(m_guid, m_subcommand).c_str();
-    } else {
-        p_out = "[Context menu item] ";
-        p_out += menu_helpers::contextpath_from_guid(m_guid, m_subcommand).c_str();
-    }
+    return "["s + get_type_desc() + "] "s + get_name();
 }
 
 void ButtonsToolbar::Button::read_from_file(ConfigVersion p_version, const char* p_base, const char* p_name,

--- a/foo_ui_columns/buttons_command_picker.cpp
+++ b/foo_ui_columns/buttons_command_picker.cpp
@@ -140,7 +140,7 @@ void CommandPickerData::populate_commands()
                         GUID parent = ptr->get_parent();
                         while (parent != pfc::guid_null) {
                             pfc::string8 parentname;
-                            if (menu_helpers::maingroupname_from_guid(GUID(parent), parentname, parent))
+                            if (menu_helpers::maingroupname_from_guid(parent, parentname, parent))
                                 name_parts.emplace_front(parentname);
                         }
                     }

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -132,11 +132,8 @@ void ButtonsToolbar::ConfigParam::on_selection_change(t_size index)
 {
     m_selection = index != pfc_infinite && index < m_buttons.get_count() ? &m_buttons[index] : nullptr;
     m_image = m_selection ? (m_active ? &m_selection->m_custom_hot_image : &m_selection->m_custom_image) : nullptr;
-    pfc::string8 temp;
-    if (m_selection) {
-        m_selection->get_name(temp);
-    }
-    uSendDlgItemMessageText(m_wnd, IDC_COMMAND_DESC, WM_SETTEXT, 0, temp);
+    std::string command_desc = m_selection ? m_selection->get_name_with_type() : ""s;
+    uSendDlgItemMessageText(m_wnd, IDC_COMMAND_DESC, WM_SETTEXT, 0, command_desc.c_str());
     SendDlgItemMessage(m_wnd, IDC_SHOW, CB_SETCURSEL, m_selection ? m_selection->m_show : -1, 0);
 
     bool b_enable = index != pfc_infinite && m_selection && m_selection->m_type != TYPE_SEPARATOR;
@@ -154,14 +151,11 @@ void ButtonsToolbar::ConfigParam::populate_buttons_list()
 {
     unsigned count = m_buttons.get_count();
 
-    pfc::string8_fast_aggressive name;
     pfc::array_staticsize_t<uih::ListView::InsertItem> items(count);
     for (unsigned n = 0; n < count; n++) {
         items[n].m_subitems.set_size(2);
-        m_buttons[n].get_name_name(name);
-        items[n].m_subitems[0] = name;
-        m_buttons[n].get_name_type(name);
-        items[n].m_subitems[1] = name;
+        items[n].m_subitems[0] = m_buttons[n].get_name().c_str();
+        items[n].m_subitems[1] = m_buttons[n].get_type_desc().c_str();
     }
     m_button_list.insert_items(0, count, items.get_ptr());
 }
@@ -173,15 +167,12 @@ void ButtonsToolbar::ConfigParam::refresh_buttons_list_items(t_size index, t_siz
     if (index + count > real_count)
         count = real_count - index;
 
-    pfc::string8_fast_aggressive name;
     pfc::list_t<uih::ListView::InsertItem> items;
     items.set_count(count);
     for (unsigned n = index; n < index + count; n++) {
         items[n - index].m_subitems.set_size(2);
-        m_buttons[n].get_name_name(name);
-        items[n - index].m_subitems[0] = name;
-        m_buttons[n].get_name_type(name);
-        items[n - index].m_subitems[1] = name;
+        items[n - index].m_subitems[0] = m_buttons[n].get_name().c_str();
+        items[n - index].m_subitems[1] = m_buttons[n].get_type_desc().c_str();
     }
     m_button_list.replace_items(index, items);
 }
@@ -326,10 +317,8 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
 
                 uih::ListView::InsertItem item;
                 item.m_subitems.set_size(2);
-                m_buttons[index].get_name_name(name);
-                item.m_subitems[0] = name;
-                m_buttons[index].get_name_type(name);
-                item.m_subitems[1] = name;
+                item.m_subitems[0] = m_buttons[index].get_name().c_str();
+                item.m_subitems[1] = m_buttons[index].get_type_desc().c_str();
                 t_size index_list = m_button_list.get_item_count();
                 m_button_list.insert_items(index_list, 1, &item);
                 m_button_list.set_item_selected_single(index_list);
@@ -469,11 +458,9 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
                     if (idx != pfc_infinite) {
                         refresh_buttons_list_items(idx, 1);
 
-                        pfc::string8 name;
+                        const auto name = m_buttons[idx].get_name_with_type();
 
-                        m_buttons[idx].get_name(name);
-
-                        uSendDlgItemMessageText(wnd, IDC_COMMAND_DESC, WM_SETTEXT, 0, name);
+                        uSendDlgItemMessageText(wnd, IDC_COMMAND_DESC, WM_SETTEXT, 0, name.c_str());
                     }
                     bool b_enable = m_selection->m_type != TYPE_SEPARATOR;
                     EnableWindow(GetDlgItem(wnd, IDC_SHOW), m_selection->m_type != TYPE_SEPARATOR);

--- a/foo_ui_columns/menu_helpers.cpp
+++ b/foo_ui_columns/menu_helpers.cpp
@@ -165,28 +165,20 @@ auto get_context_menu_item_name_parts(GUID p_guid, GUID p_subcommand)
             menu_item_index, metadb_handle_list(), contextmenu_item::caller_keyboard_shortcut_list);
 
         if (!__contextpath_from_guid_recur(p_node.get_ptr(), p_subcommand, item_parts, true))
-            item_parts.emplace_back("Unknown command");
+            item_parts.emplace_back("Unknown");
     }
 
     return item_parts;
 }
 
-void contextpath_from_guid(GUID p_guid, GUID p_subcommand, pfc::string_base& p_out, bool b_short)
+std::string contextpath_from_guid(GUID p_guid, GUID p_subcommand, bool b_short)
 {
     auto name_parts = get_context_menu_item_name_parts(p_guid, p_subcommand);
 
-    if (b_short) {
-        p_out = (*--name_parts.end()).data();
-        return;
-    }
+    if (b_short)
+        return *--name_parts.end();
 
-    p_out.reset();
-
-    for (auto&& part : name_parts) {
-        if (!p_out.is_empty())
-            p_out << "/";
-        p_out << part.data();
-    }
+    return mmh::join(name_parts, "/");
 }
 
 bool maingroupname_from_guid(GUID p_guid, pfc::string_base& p_out, GUID& parentout)

--- a/foo_ui_columns/menu_helpers.h
+++ b/foo_ui_columns/menu_helpers.h
@@ -16,7 +16,7 @@ namespace menu_helpers {
 pfc::string8 get_context_menu_node_name(contextmenu_item_node* p_node);
 void get_context_menu_item_parent_names(const contextmenu_item::ptr& menu_item, std::list<std::string>& names);
 
-void contextpath_from_guid(GUID p_guid, GUID p_subcommand, pfc::string_base& p_out, bool b_short = false);
+std::string contextpath_from_guid(GUID p_guid, GUID p_subcommand, bool b_short = false);
 bool maingroupname_from_guid(GUID p_guid, pfc::string_base& p_out, GUID& parentout);
 bool mainmenunode_subguid_to_path(
     const mainmenu_node::ptr& ptr_node, const GUID& p_subguid, pfc::string8& p_out, bool b_is_root = false);

--- a/foo_ui_columns/menu_helpers.h
+++ b/foo_ui_columns/menu_helpers.h
@@ -17,10 +17,10 @@ pfc::string8 get_context_menu_node_name(contextmenu_item_node* p_node);
 void get_context_menu_item_parent_names(const contextmenu_item::ptr& menu_item, std::list<std::string>& names);
 
 void contextpath_from_guid(GUID p_guid, GUID p_subcommand, pfc::string_base& p_out, bool b_short = false);
-bool maingroupname_from_guid(const GUID& p_guid, pfc::string_base& p_out, GUID& parentout);
+bool maingroupname_from_guid(GUID p_guid, pfc::string_base& p_out, GUID& parentout);
 bool mainmenunode_subguid_to_path(
     const mainmenu_node::ptr& ptr_node, const GUID& p_subguid, pfc::string8& p_out, bool b_is_root = false);
-void mainpath_from_guid(const GUID& p_guid, const GUID& p_subguid, pfc::string_base& p_out, bool b_short = false);
+std::string mainpath_from_guid(GUID p_guid, GUID p_subguid, bool b_short = false);
 }; // namespace menu_helpers
 
 struct MenuItemIdentifier {

--- a/foo_ui_columns/menu_helpers.h
+++ b/foo_ui_columns/menu_helpers.h
@@ -16,7 +16,7 @@ namespace menu_helpers {
 pfc::string8 get_context_menu_node_name(contextmenu_item_node* p_node);
 void get_context_menu_item_parent_names(const contextmenu_item::ptr& menu_item, std::list<std::string>& names);
 
-std::string contextpath_from_guid(GUID p_guid, GUID p_subcommand, bool b_short = false);
+std::string contextpath_from_guid(GUID p_guid, GUID p_subcommand, bool short_form = false);
 bool maingroupname_from_guid(GUID p_guid, pfc::string_base& p_out, GUID& parentout);
 bool mainmenunode_subguid_to_path(
     const mainmenu_node::ptr& ptr_node, const GUID& p_subguid, pfc::string8& p_out, bool b_is_root = false);


### PR DESCRIPTION
This:

- improves how buttons linked to unknown (e.g. removed) are displayed
- includes the parent node in names of dynamic context menu items in tooltips or button text
- tidies up some of the logic relating to button names
