### PR TITLE
Add support for dynamic main menu items to custom double-click actions

### DIFF
--- a/foo_ui_columns/menu_helpers.h
+++ b/foo_ui_columns/menu_helpers.h
@@ -31,18 +31,13 @@ struct MenuItemIdentifier {
 bool operator==(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2);
 bool operator!=(const MenuItemIdentifier& p1, const MenuItemIdentifier& p2);
 
-class MenuItemCache {
-    class MenuItemInfo : public MenuItemIdentifier {
-    public:
-        pfc::string8 m_name;
-        pfc::string8 m_desc;
-    };
-
+class MenuItemInfo : public MenuItemIdentifier {
 public:
-    MenuItemCache();
-    const MenuItemInfo& get_item(unsigned n) const;
-    unsigned get_count() { return m_data.get_count(); }
-
-private:
-    pfc::ptr_list_t<MenuItemInfo> m_data;
+    pfc::string8 m_name;
+    pfc::string8 m_desc;
 };
+namespace cui::helpers {
+
+std::vector<MenuItemInfo> get_main_menu_items();
+
+}

--- a/foo_ui_columns/menu_helpers.h
+++ b/foo_ui_columns/menu_helpers.h
@@ -40,4 +40,11 @@ namespace cui::helpers {
 
 std::vector<MenuItemInfo> get_main_menu_items();
 
+inline bool execute_main_menu_command(MenuItemIdentifier command)
+{
+    if (command.m_subcommand != GUID{})
+        return mainmenu_commands::g_execute_dynamic(command.m_command, command.m_subcommand);
+
+    return mainmenu_commands::g_execute(command.m_command);
+}
 }

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -825,7 +825,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 unsigned long part = lpnmm->dwItemSpec;
 
                 if (part == 0)
-                    mainmenu_commands::g_execute(cfg_statusdbl.get_value().m_command);
+                    cui::helpers::execute_main_menu_command(cfg_statusdbl);
                 // standard_commands::main_highlight_playing();
                 else if (cfg_show_vol && part == status_bar::u_vol_pos) {
                     // static_api_ptr_t<ui_control>()->show_preferences(preferences_page::guid_playback);

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -932,7 +932,7 @@ bool PlaylistView::notify_on_middleclick(bool on_item, t_size index)
 bool PlaylistView::notify_on_doubleleftclick_nowhere()
 {
     if (cfg_playlist_double.get_value().m_command != pfc::guid_null)
-        return mainmenu_commands::g_execute(cfg_playlist_double.get_value().m_command);
+        return cui::helpers::execute_main_menu_command(cfg_playlist_double);
     return false;
 }
 

--- a/foo_ui_columns/prefs_utils.cpp
+++ b/foo_ui_columns/prefs_utils.cpp
@@ -83,11 +83,11 @@ bool colour_picker(HWND wnd, COLORREF& out, COLORREF custom)
 }
 
 void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItemIdentifier& p_item,
-    MenuItemCache& p_cache, bool insert_none)
+    const std::vector<MenuItemInfo>& p_cache, bool insert_none)
 {
     HWND wnd_combo = GetDlgItem(wnd, ID);
 
-    unsigned count = p_cache.get_count();
+    unsigned count = p_cache.size();
     pfc::string8_fast_aggressive temp;
     unsigned idx_none = 0;
     if (insert_none) {
@@ -99,12 +99,12 @@ void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItem
     pfc::string8 desc;
 
     for (unsigned n = 0; n < count; n++) {
-        unsigned idx = uSendMessageText(wnd_combo, CB_ADDSTRING, 0, p_cache.get_item(n).m_name);
+        unsigned idx = uSendMessageText(wnd_combo, CB_ADDSTRING, 0, p_cache[n].m_name);
         SendMessage(wnd_combo, CB_SETITEMDATA, idx, n);
 
-        if (sel == -1 && p_cache.get_item(n) == p_item) {
+        if (sel == -1 && p_cache[n] == p_item) {
             sel = idx;
-            desc = p_cache.get_item(n).m_desc;
+            desc = p_cache[n].m_desc;
         } else if (sel != -1 && idx <= sel)
             sel++;
 
@@ -119,7 +119,7 @@ void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItem
 }
 
 void on_menu_combo_change(
-    HWND wnd, LPARAM lp, ConfigMenuItem& cfg_menu_store, MenuItemCache& p_cache, unsigned ID_DESC)
+    HWND wnd, LPARAM lp, ConfigMenuItem& cfg_menu_store, const std::vector<MenuItemInfo>& p_cache, unsigned ID_DESC)
 {
     auto wnd_combo = (HWND)lp;
 
@@ -128,14 +128,14 @@ void on_menu_combo_change(
 
     if (cache_idx == -1) {
         cfg_menu_store = MenuItemIdentifier();
-    } else if (cache_idx < p_cache.get_count()) {
-        cfg_menu_store = p_cache.get_item(cache_idx);
+    } else if (cache_idx < p_cache.size()) {
+        cfg_menu_store = p_cache[cache_idx];
     }
 
     pfc::string8 desc;
     // if (cfg_menu_store != pfc::guid_null) menu_helpers::get_description(menu_item::TYPE_MAIN, cfg_menu_store, desc);
-    uSendDlgItemMessageText(wnd, ID_DESC, WM_SETTEXT, 0,
-        cache_idx < p_cache.get_count() ? p_cache.get_item(cache_idx).m_desc.get_ptr() : "");
+    uSendDlgItemMessageText(
+        wnd, ID_DESC, WM_SETTEXT, 0, cache_idx < p_cache.size() ? p_cache[cache_idx].m_desc.get_ptr() : "");
 }
 
 namespace cui::prefs {

--- a/foo_ui_columns/prefs_utils.h
+++ b/foo_ui_columns/prefs_utils.h
@@ -2,9 +2,9 @@
 #define _COLOUMNS_PREFS_H_
 
 void populate_menu_combo(HWND wnd, unsigned ID, unsigned ID_DESC, const MenuItemIdentifier& p_item,
-    MenuItemCache& p_cache, bool insert_none);
-void on_menu_combo_change(
-    HWND wnd, LPARAM lp, class ConfigMenuItem& cfg_menu_store, MenuItemCache& p_cache, unsigned ID_DESC);
+    const std::vector<MenuItemInfo>& p_cache, bool insert_none);
+void on_menu_combo_change(HWND wnd, LPARAM lp, class ConfigMenuItem& cfg_menu_store,
+    const std::vector<MenuItemInfo>& p_cache, unsigned ID_DESC);
 
 namespace cui::prefs {
 

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -48,7 +48,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
     } break;
     case WM_LBUTTONDBLCLK:
-        mainmenu_commands::g_execute(cfg_statusdbl.get_value().m_command);
+        cui::helpers::execute_main_menu_command(cfg_statusdbl);
         return 0;
     case WM_PRINTCLIENT: {
         if (lp & PRF_ERASEBKGND) {

--- a/foo_ui_columns/tab_display2.cpp
+++ b/foo_ui_columns/tab_display2.cpp
@@ -37,7 +37,7 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG: {
-            m_menu_cache = new MenuItemCache;
+            m_menu_cache = cui::helpers::get_main_menu_items();
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "None");
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "Sunken");
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "Grey");
@@ -46,7 +46,7 @@ public:
             //        SendDlgItemMessage(wnd,IDC_SPINPL,UDM_SETRANGE32,-100,100);
             //        SendDlgItemMessage(wnd,IDC_SPINSEL,UDM_SETRANGE32,0,3);
 
-            populate_menu_combo(wnd, IDC_PLAYLIST_DOUBLE, IDC_MENU_DESC, cfg_playlist_double, *m_menu_cache, true);
+            populate_menu_combo(wnd, IDC_PLAYLIST_DOUBLE, IDC_MENU_DESC, cfg_playlist_double, m_menu_cache, true);
 
             unsigned count = cui::playlist_item_helpers::MiddleClickActionManager::get_count();
             for (unsigned n = 0; n < count; n++) {
@@ -64,10 +64,10 @@ public:
         }
 
         break;
-        case WM_DESTROY: {
+        case WM_DESTROY:
             m_initialised = false;
-            delete m_menu_cache;
-        } break;
+            m_menu_cache.clear();
+            break;
         case WM_COMMAND:
             switch (wp) {
             case IDC_DROP_AT_END: {
@@ -84,7 +84,7 @@ public:
 
             } break;
             case (CBN_SELCHANGE << 16) | IDC_PLAYLIST_DOUBLE: {
-                on_menu_combo_change(wnd, lp, cfg_playlist_double, *m_menu_cache, IDC_MENU_DESC);
+                on_menu_combo_change(wnd, lp, cfg_playlist_double, m_menu_cache, IDC_MENU_DESC);
             } break;
             case (CBN_SELCHANGE << 16) | IDC_PLAYLIST_MIDDLE: {
                 cfg_playlist_middle_action
@@ -152,7 +152,7 @@ public:
 
 private:
     bool m_initialised{};
-    MenuItemCache* m_menu_cache{};
+    std::vector<MenuItemInfo> m_menu_cache;
     cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
 } g_tab_display2;
 

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -22,7 +22,6 @@ public:
             break;
         case WM_DESTROY:
             m_initialised = false;
-            delete m_menu_cache;
             break;
         case WM_COMMAND:
             switch (wp) {
@@ -61,7 +60,6 @@ public:
 
 private:
     bool m_initialised{};
-    MenuItemCache* m_menu_cache{};
     cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
 } g_tab_pview_artwork;
 

--- a/foo_ui_columns/tab_status.cpp
+++ b/foo_ui_columns/tab_status.cpp
@@ -7,7 +7,7 @@
 static class TabStatus : public PreferencesTab {
 public:
     bool m_initialised{};
-    MenuItemCache* m_cache{};
+    std::vector<MenuItemInfo> m_cache{};
 
     static void refresh_me(HWND wnd)
     {
@@ -24,27 +24,26 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG: {
-            m_cache = new MenuItemCache;
+            m_cache = cui::helpers::get_main_menu_items();
 
-            populate_menu_combo(wnd, IDC_MENU_DBLCLK, IDC_MENU_DESC, cfg_statusdbl, *m_cache, false);
+            populate_menu_combo(wnd, IDC_MENU_DBLCLK, IDC_MENU_DESC, cfg_statusdbl, m_cache, false);
 
             refresh_me(wnd);
             m_initialised = true;
         }
 
         break;
-        case WM_DESTROY: {
-            delete m_cache;
-            m_cache = nullptr;
+        case WM_DESTROY:
             m_initialised = false;
-        } break;
+            m_cache.clear();
+            break;
         case WM_COMMAND:
             switch (wp) {
             case (EN_CHANGE << 16) | IDC_STRING:
                 main_window::config_status_bar_script.set(string_utf8_from_window((HWND)lp));
                 break;
             case (CBN_SELCHANGE << 16) | IDC_MENU_DBLCLK: {
-                on_menu_combo_change(wnd, lp, cfg_statusdbl, *m_cache, IDC_MENU_DESC);
+                on_menu_combo_change(wnd, lp, cfg_statusdbl, m_cache, IDC_MENU_DESC);
             } break;
             case IDC_SHOW_LOCK: {
                 main_window::config_set_status_show_lock(SendMessage((HWND)lp, BM_GETCHECK, 0, 0) != 0);


### PR DESCRIPTION
This adds support for dynamic main menu items to the status bar double-click action and the empty space playlist view double-click action.