### PR TITLE
Update build status badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 http://yuo.be/columns_ui
 
-[![Build status](https://ci.appveyor.com/api/projects/status/h1iqjogb73f3yqp1/branch/master?svg=true)](https://ci.appveyor.com/project/reupen/columns-ui/branch/master)
+[![Build Status](https://reupen.visualstudio.com/Columns%20UI/_apis/build/status/reupen.columns_ui?branchName=master)](https://reupen.visualstudio.com/Columns%20UI/_build/latest?definitionId=3&branchName=master)
 
 Columns UI is released under the Lesser GNU Public Licence (see COPYING and COPYING.LESSER).
 


### PR DESCRIPTION
I shamelessly stole(!) your azure pipelines config for my own project earlier and I couldn't help notice you're using an out of date appveyor badge in your readme. This replaces it with a "current" azure one.