### PR TITLE
Split statements declaring multiple variables

### DIFF
--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -444,7 +444,8 @@ void ArtworkPanel::refresh_cached_bitmap()
     RECT rc;
     GetClientRect(get_wnd(), &rc);
     if (RECT_CX(rc) && RECT_CY(rc) && m_image.is_valid()) {
-        HDC dc = nullptr, dcc = nullptr;
+        HDC dc = nullptr;
+        HDC dcc = nullptr;
         dc = GetDC(get_wnd());
         dcc = CreateCompatibleDC(dc);
 
@@ -464,7 +465,8 @@ void ArtworkPanel::refresh_cached_bitmap()
 
         double ar_source = (double)m_image->GetWidth() / (double)m_image->GetHeight();
         double ar_dest = (double)RECT_CX(rc) / (double)RECT_CY(rc);
-        unsigned cx = RECT_CX(rc), cy = RECT_CY(rc);
+        unsigned cx = RECT_CX(rc);
+        unsigned cy = RECT_CY(rc);
 
         graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHighQuality);
         graphics.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);

--- a/foo_ui_columns/artwork_helpers.cpp
+++ b/foo_ui_columns/artwork_helpers.cpp
@@ -266,7 +266,8 @@ unsigned artwork_panel::ArtworkReader::read_artwork(abort_callback& p_abort)
     pfc::map_t<GUID, album_art_data_ptr> content_previous = m_content;
     m_content.remove_all();
 
-    bool b_opened = false, b_extracter_attempted = false;
+    bool b_opened = false;
+    bool b_extracter_attempted = false;
     album_art_extractor_instance_ptr p_extractor;
     album_art_extractor_instance_v2::ptr artwork_api_v2;
     static_api_ptr_t<album_art_manager_v2> p_album_art_manager_v2;

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -133,7 +133,8 @@ void ButtonsToolbar::create_toolbar()
 
         bool b_need_hot = false;
 
-        unsigned n, count = tbb.get_size();
+        unsigned n;
+        unsigned count = tbb.get_size();
         for (n = 0; n < count; n++) {
             if (m_buttons[n].m_use_custom_hot) {
                 b_need_hot = true;
@@ -371,7 +372,8 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
     else if (msg == WM_USER + 2) {
         if (wnd_toolbar && wp < m_buttons.get_count() && m_buttons[wp].m_interface.is_valid()) {
-            unsigned state = m_buttons[wp].m_interface->get_button_state(), tbstate = 0;
+            unsigned state = m_buttons[wp].m_interface->get_button_state();
+            unsigned tbstate = 0;
             if (state & uie::BUTTON_STATE_PRESSED) {
                 PostMessage(wnd_toolbar, TB_PRESSBUTTON, wp, MAKELONG(TRUE, 0));
             }

--- a/foo_ui_columns/buttons_custom_image.cpp
+++ b/foo_ui_columns/buttons_custom_image.cpp
@@ -272,7 +272,8 @@ void ButtonsToolbar::Button::CustomImage::write_to_file(
         p_file.write_lendian_t(m_path.length(), p_abort);
         p_file.write(m_path.get_ptr(), m_path.length(), p_abort);
     } else {
-        pfc::string8 realPath, canPath;
+        pfc::string8 realPath;
+        pfc::string8 canPath;
         try {
             p_file.write_lendian_t(I_BUTTON_CUSTOM_IMAGE_DATA, p_abort);
 

--- a/foo_ui_columns/colours_manager_data.cpp
+++ b/foo_ui_columns/colours_manager_data.cpp
@@ -77,7 +77,9 @@ void ColoursManagerData::get_data_raw(stream_writer* p_stream, abort_callback& p
     }
 
     pfc::array_t<bool> mask;
-    t_size i, count = m_entries.get_count(), counter = 0;
+    t_size i;
+    t_size count = m_entries.get_count();
+    t_size counter = 0;
     mask.set_count(count);
     for (i = 0; i < count; i++)
         if (mask[i] = clients.have_item(m_entries[i]->guid))

--- a/foo_ui_columns/common.cpp
+++ b/foo_ui_columns/common.cpp
@@ -22,7 +22,8 @@ void Colour::set(COLORREF new_colour)
 
 StringFormatCommonTrackTitle::StringFormatCommonTrackTitle(metadb_handle_list_cref handles, const char* format, const char* def)
 {
-    pfc::string8_fast_aggressive a, b;
+    pfc::string8_fast_aggressive a;
+    pfc::string8_fast_aggressive b;
     a.prealloc(512);
     b.prealloc(512);
     unsigned count = handles.get_count();
@@ -79,7 +80,8 @@ void g_save_playlist(HWND wnd, const pfc::list_base_const_t<metadb_handle_ptr>& 
     pfc::string_formatter ext;
     service_enum_t<playlist_loader> e;
     service_ptr_t<playlist_loader> ptr;
-    unsigned def_index = 0, n = 0;
+    unsigned def_index = 0;
+    unsigned n = 0;
 
     while (e.next(ptr)) {
         if (ptr->can_write()) {

--- a/foo_ui_columns/config_artwork.cpp
+++ b/foo_ui_columns/config_artwork.cpp
@@ -30,7 +30,8 @@ public:
 
     static t_size get_combined_index(t_size index, t_size subindex)
     {
-        t_size i = 0, ret = 0;
+        t_size i = 0;
+        t_size ret = 0;
         while (i < tabsize(g_artwork_sources) && i < index) {
             ret += g_artwork_sources[i].m_scripts->get_count();
             i++;
@@ -102,7 +103,8 @@ public:
         {
             t_size indices_count = indices.get_count();
             if (indices_count == 1) {
-                t_size index, subindex;
+                t_size index;
+                t_size subindex;
                 if (get_separated_index(indices[0], index, subindex)) {
                     m_edit_index = index;
                     m_edit_subindex = subindex;
@@ -225,7 +227,8 @@ public:
 
                 enum { IDM_FRONT = 1 };
 
-                t_size index, indexcount = tabsize(g_artwork_sources);
+                t_size index;
+                t_size indexcount = tabsize(g_artwork_sources);
                 for (index = 0; index < indexcount; index++) {
                     AppendMenuW(menu, (MF_STRING), index + 1,
                         pfc::stringcvt::string_wide_from_utf8(g_artwork_sources[index].m_name));
@@ -255,13 +258,15 @@ public:
                     pfc::bit_array_bittable mask(m_source_list.get_item_count());
                     m_source_list.get_selection_state(mask);
                     // bool b_found = false;
-                    t_size combined_index = 0, count = m_source_list.get_item_count();
+                    t_size combined_index = 0;
+                    t_size count = m_source_list.get_item_count();
                     while (combined_index < count) {
                         if (mask[combined_index])
                             break;
                         combined_index++;
                     }
-                    t_size index, subindex;
+                    t_size index;
+                    t_size subindex;
                     if (combined_index < count && get_separated_index(combined_index, index, subindex)) {
                         g_artwork_sources[index].m_scripts->remove_by_idx(subindex);
                         m_source_list.remove_item(combined_index);
@@ -285,7 +290,10 @@ public:
                             combined_index++;
                     }
 
-                    t_size index, subindex, combined_index_start, count;
+                    t_size index;
+                    t_size subindex;
+                    t_size combined_index_start;
+                    t_size count;
 
                     get_group_from_combined_index(combined_index, index, subindex, combined_index_start, count);
 
@@ -314,7 +322,10 @@ public:
                             combined_index++;
                     }
 
-                    t_size index, subindex, combined_index_start, count;
+                    t_size index;
+                    t_size subindex;
+                    t_size combined_index_start;
+                    t_size count;
 
                     get_group_from_combined_index(combined_index, index, subindex, combined_index_start, count);
 

--- a/foo_ui_columns/config_columns.cpp
+++ b/foo_ui_columns/config_columns.cpp
@@ -21,7 +21,8 @@ struct ColumnTimes {
 
 void double_to_string(double blah, pfc::string_base& p_out, int points = 10, bool ms = true)
 {
-    int decimal, sign;
+    int decimal;
+    int sign;
     pfc::array_t<char> buffer;
     buffer.set_size(_CVTBUFSIZE);
     buffer.fill_null();
@@ -67,7 +68,10 @@ void speedtest(ColumnListCRef columns, bool b_global)
 
     GlobalVariableList p_vars;
 
-    double time_compile_global = 0, time_compile_global_colour = 0, time_global = 0, time_colour = 0;
+    double time_compile_global = 0;
+    double time_compile_global_colour = 0;
+    double time_global = 0;
+    double time_colour = 0;
 
     service_ptr_t<titleformat_object> to_global;
     service_ptr_t<titleformat_object> to_global_colour;

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -135,7 +135,8 @@ public:
             } break;
             case IDC_UP: {
                 if (m_field_list.get_selection_count(2) == 1) {
-                    t_size index = 0, count = m_field_list.get_item_count();
+                    t_size index = 0;
+                    t_size count = m_field_list.get_item_count();
                     while (!m_field_list.get_item_selected(index) && index < count)
                         index++;
                     if (index && filter_panel::cfg_field_list.get_count()) {
@@ -151,7 +152,8 @@ public:
             } break;
             case IDC_DOWN: {
                 if (m_field_list.get_selection_count(2) == 1) {
-                    t_size index = 0, count = m_field_list.get_item_count();
+                    t_size index = 0;
+                    t_size count = m_field_list.get_item_count();
                     while (!m_field_list.get_item_selected(index) && index < count)
                         index++;
                     if (index + 1 < count && index + 1 < filter_panel::cfg_field_list.get_count()) {
@@ -185,7 +187,8 @@ public:
                     pfc::bit_array_bittable mask(m_field_list.get_item_count());
                     m_field_list.get_selection_state(mask);
                     // bool b_found = false;
-                    t_size index = 0, count = m_field_list.get_item_count();
+                    t_size index = 0;
+                    t_size count = m_field_list.get_item_count();
                     while (index < count) {
                         if (mask[index])
                             break;

--- a/foo_ui_columns/fcl_layout.cpp
+++ b/foo_ui_columns/fcl_layout.cpp
@@ -29,7 +29,8 @@ class LayoutDataSet : public cui::fcl::dataset_v2 {
         p_reader->read_lendian_t(version, p_abort);
         if (version > 0)
             throw pfc::exception("Need new columns ui");
-        t_uint32 pcount, active;
+        t_uint32 pcount;
+        t_uint32 active;
         p_reader->read_lendian_t(active, p_abort);
         p_reader->read_lendian_t(pcount, p_abort);
 

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -277,7 +277,8 @@ void FilterPanel::refresh(bool b_allow_autosend)
 
 t_size FilterPanel::get_field_index()
 {
-    t_size count = g_field_data.get_count(), ret = pfc_infinite;
+    t_size count = g_field_data.get_count();
+    t_size ret = pfc_infinite;
     for (t_size i = 0; i < count; i++)
         if (!stricmp_utf8(g_field_data[i].m_name, m_field_data.m_name)) {
             ret = i;
@@ -523,7 +524,8 @@ void FilterPanel::do_items_action(const pfc::bit_array& p_nodes, Action action)
 {
     metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
     handles.prealloc(m_nodes.get_count());
-    t_size i, count = m_nodes.get_count();
+    t_size i;
+    t_size count = m_nodes.get_count();
     for (i = 0; i < count; i++)
         if (p_nodes[i])
             handles.add_items(m_nodes[i].m_handles);

--- a/foo_ui_columns/filter_config_var.cpp
+++ b/foo_ui_columns/filter_config_var.cpp
@@ -45,7 +45,8 @@ void ConfigFields::set_data_raw(stream_reader* p_stream, t_size p_sizehint, abor
     t_uint32 version;
     p_stream->read_lendian_t(version, p_abort);
     if (version <= stream_version_current) {
-        t_uint32 count, i;
+        t_uint32 count;
+        t_uint32 i;
         p_stream->read_lendian_t(count, p_abort);
         set_count(count);
         for (i = 0; i < count; i++) {
@@ -78,7 +79,8 @@ void ConfigFields::set_data_raw(stream_reader* p_stream, t_size p_sizehint, abor
 void ConfigFields::get_data_raw(stream_writer* p_stream, abort_callback& p_abort)
 {
     p_stream->write_lendian_t((t_uint32)stream_version_current, p_abort);
-    t_uint32 i, count = gsl::narrow<uint32_t>(get_count());
+    t_uint32 i;
+    t_uint32 count = gsl::narrow<uint32_t>(get_count());
     p_stream->write_lendian_t(count, p_abort);
     for (i = 0; i < count; i++) {
         const auto& field = (*this)[i];
@@ -145,7 +147,8 @@ void ConfigFields::fix_name(pfc::string8& p_name)
 
 void ConfigFavourites::get_data_raw(stream_writer* p_stream, abort_callback& p_abort)
 {
-    t_uint32 m = gsl::narrow<t_uint32>(get_count()), v = 0;
+    t_uint32 m = gsl::narrow<t_uint32>(get_count());
+    t_uint32 v = 0;
     p_stream->write_lendian_t(v, p_abort);
     p_stream->write_lendian_t(m, p_abort);
     for (t_uint32 n = 0; n < m; n++)
@@ -154,7 +157,8 @@ void ConfigFavourites::get_data_raw(stream_writer* p_stream, abort_callback& p_a
 
 void ConfigFavourites::set_data_raw(stream_reader* p_stream, t_size p_sizehint, abort_callback& p_abort)
 {
-    t_uint32 count, version;
+    t_uint32 count;
+    t_uint32 version;
     p_stream->read_lendian_t(version, p_abort);
     if (version <= 0) {
         p_stream->read_lendian_t(count, p_abort);

--- a/foo_ui_columns/filter_items.cpp
+++ b/foo_ui_columns/filter_items.cpp
@@ -333,7 +333,8 @@ size_t FilterPanel::make_data_entries(const metadb_handle_list_t<pfc::alloc_fast
         infos.set_count(track_count);
         HandleInfo* p_infos = infos.get_ptr();
 
-        t_size counter = 0, field_count = m_field_data.m_fields.get_count();
+        t_size counter = 0;
+        t_size field_count = m_field_data.m_fields.get_count();
 
         for (size_t i{0}; i < track_count; i++) {
             if (tracks_ptr[i]->get_info_ref(p_infos[i].m_info)) {

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -409,7 +409,8 @@ void FilterSearchToolbar::create_edit()
         0, 0, 0, 0, get_wnd(), (HMENU)id_toolbar, core_api::get_my_instance(), nullptr);
     // SetWindowTheme(m_wnd_toolbar, L"SearchButton", NULL);
 
-    const unsigned cx = GetSystemMetrics(SM_CXSMICON), cy = GetSystemMetrics(SM_CYSMICON);
+    const unsigned cx = GetSystemMetrics(SM_CXSMICON);
+    const unsigned cy = GetSystemMetrics(SM_CYSMICON);
 
     m_imagelist = ImageList_Create(cx, cy, ILC_COLOR32, 0, 3);
 

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -429,7 +429,8 @@ void ItemDetails::refresh_contents(bool reset_scroll_position)
         static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client, lf);
 
         TitleformatHookChangeFont tf_hook(lf);
-        pfc::string8_fast_aggressive temp, temp2;
+        pfc::string8_fast_aggressive temp;
+        pfc::string8_fast_aggressive temp2;
         temp.prealloc(2048);
         temp2.prealloc(2048);
         if (m_nowplaying_active) {
@@ -708,7 +709,8 @@ void ItemDetails::on_size(t_size cx, t_size cy)
 
 void ItemDetails::scroll(INT SB, int position, bool b_absolute)
 {
-    SCROLLINFO si, si2;
+    SCROLLINFO si;
+    SCROLLINFO si2;
     memset(&si, 0, sizeof(SCROLLINFO));
     si.cbSize = sizeof(si);
     si.fMask = SIF_POS | SIF_TRACKPOS | SIF_PAGE | SIF_RANGE;
@@ -857,7 +859,8 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_HSCROLL:
     case WM_VSCROLL: {
         UINT SB = msg == WM_VSCROLL ? SB_VERT : SB_HORZ;
-        SCROLLINFO si, si2;
+        SCROLLINFO si;
+        SCROLLINFO si2;
         memset(&si, 0, sizeof(SCROLLINFO));
         si.cbSize = sizeof(si);
         si.fMask = SIF_POS | SIF_TRACKPOS | SIF_PAGE | SIF_RANGE;

--- a/foo_ui_columns/item_details_font.cpp
+++ b/foo_ui_columns/item_details_font.cpp
@@ -45,8 +45,12 @@ bool TitleformatHookChangeFont::process_function(titleformat_text_out* p_out, co
         case 2:
         case 3: {
             bool b_have_flags = p_params->get_param_count() == 3;
-            const char *face, *pointsize, *flags;
-            t_size face_length, pointsize_length, flags_length;
+            const char* face;
+            const char* pointsize;
+            const char* flags;
+            t_size face_length;
+            t_size pointsize_length;
+            t_size flags_length;
             p_params->get_param(0, face, face_length);
             p_params->get_param(1, pointsize, pointsize_length);
             if (b_have_flags)

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -210,7 +210,8 @@ t_size get_text_ptr_length_colour(const char * ptr, t_size ptr_length)
 
 t_size g_get_text_ptr_characters_colour(const char* ptr, t_size ptr_length)
 {
-    t_size i = 0, charCount = 0;
+    t_size i = 0;
+    t_size charCount = 0;
 
     while (ptr[i] && i < ptr_length) {
         while (ptr[i] && i < ptr_length && ptr[i] != '\x3') {
@@ -235,7 +236,8 @@ t_size g_get_text_ptr_characters_colour(const char* ptr, t_size ptr_length)
 
 t_size g_increase_text_ptr_colour(const char* ptr, t_size ptr_length, t_size count)
 {
-    t_size i = 0, charCount = 0;
+    t_size i = 0;
+    t_size charCount = 0;
 
     while (ptr[i] && i < ptr_length && charCount < count) {
         while (ptr[i] && i < ptr_length && charCount < count && ptr[i] != '\x3') {
@@ -271,7 +273,10 @@ t_size utf8_char_prev_len(const char * str, t_size ptr)
 bool text_ptr_find_break(
     const char* ptr, t_size length, t_size desiredPositionChar, t_size& positionChar, t_size& positionByte)
 {
-    t_size i = 0, charPos = 0, prevSpaceByte = pfc_infinite, prevSpaceChar = pfc_infinite;
+    t_size i = 0;
+    t_size charPos = 0;
+    t_size prevSpaceByte = pfc_infinite;
+    t_size prevSpaceChar = pfc_infinite;
 
     while (i < length /* && ptr[i] != ' '*/) {
         if (i < length && ptr[i] == ' ') {
@@ -327,7 +332,8 @@ void g_get_multiline_text_dimensions(HDC dc, pfc::string8_fast_aggressive& text_
     displayLines.prealloc(rawLines.get_count() * 2);
     sz.cx = 0;
     sz.cy = 0;
-    t_size i, count = rawLines.get_count();
+    t_size i;
+    t_size count = rawLines.get_count();
     displayLines.set_count(count);
     for (i = 0; i < count; i++) {
         displayLines[i].m_raw_bytes = rawLines[i].m_raw_bytes;
@@ -367,8 +373,11 @@ void g_get_multiline_text_dimensions(HDC dc, pfc::string8_fast_aggressive& text_
             t_size ptrStart = ptr;
 
             bool bWrapped = false;
-            t_size textWrappedPtr = 0, ptrLengthNoColours = 0, ptrLength = 0; // no colour codes
-            t_size ptrTextWidth = 0, ptrCharacterExtent = 0;
+            t_size textWrappedPtr = 0;
+            t_size ptrLengthNoColours = 0;
+            t_size ptrLength = 0; // no colour codes
+            t_size ptrTextWidth = 0;
+            t_size ptrCharacterExtent = 0;
 
             t_size lineTotalChars = g_get_text_ptr_characters_colour(&text[ptr], ptrRemaining);
             pfc::array_t<INT, pfc::alloc_fast_aggressive> character_extents;
@@ -477,7 +486,8 @@ void g_get_multiline_text_dimensions(HDC dc, pfc::string8_fast_aggressive& text_
             }
 
             bool b_skipped = false;
-            t_size wrapChar = 0, wrapByte = 0;
+            t_size wrapChar = 0;
+            t_size wrapByte = 0;
             if (bWrapped) {
                 if (text_ptr_find_break(&text[ptrStart], ptrLength + (ptr - ptrStart),
                         (textWrappedPtr ? textWrappedPtr - 1 : 0)
@@ -696,7 +706,9 @@ void g_text_out_multiline_font(HDC dc, const RECT& rc_topleft, t_size line_heigh
     t_size fontChangesCount = p_font_data.m_font_changes.get_count();
     t_size fontPtr = 0;
 
-    t_size i, count = newLineDataWrapped.get_count(), start = 0; //(rc.top<0?(0-rc.top)/line_height : 0);
+    t_size i;
+    t_size count = newLineDataWrapped.get_count();
+    t_size start = 0; //(rc.top<0?(0-rc.top)/line_height : 0);
 
     RECT rc_line = rc;
     const t_size ySkip = rc.top < 0 ? 0 - rc.top : 0; // Hackish - meh
@@ -774,7 +786,8 @@ void g_text_out_multiline_font(HDC dc, const RECT& rc_topleft, t_size line_heigh
         rc_line.left = rc.left + min(RECT_CX(rc), half_padding_size);
         rc_line.right = rc.right - min(RECT_CX(rc), half_padding_size);
 
-        t_size widthLine = RECT_CX(rc_line), widthLineText = newLineDataWrapped[i].m_width;
+        t_size widthLine = RECT_CX(rc_line);
+        t_size widthLineText = newLineDataWrapped[i].m_width;
 
         if (widthLineText < widthLine) {
             if (align == uih::ALIGN_CENTRE)

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -426,7 +426,8 @@ void ItemProperties::refresh_contents()
     metadata_aggregators.resize(field_count);
 
     pfc::list_t<uih::ListView::InsertItem> items;
-    t_size i, count = m_handles.get_count();
+    t_size i;
+    t_size count = m_handles.get_count();
 
     std::vector<metadb_info_container::ptr> info_refs;
     info_refs.resize(count);
@@ -492,7 +493,8 @@ void ItemProperties::refresh_contents()
         }
     }
 
-    t_size old_count = get_item_count(), new_count = items.get_count();
+    t_size old_count = get_item_count();
+    t_size new_count = items.get_count();
 
     if (new_count && old_count) {
         pfc::list_t<uih::ListView::InsertItem> items_replace;
@@ -676,7 +678,8 @@ void ItemProperties::notify_save_inline_edit(const char* value)
     static_api_ptr_t<metadb_io_v2> tagger_api;
     if (strcmp(value, "<mixed values>") != 0) {
         pfc::list_t<pfc::string8> values;
-        const char *ptr = value, *start = ptr;
+        const char* ptr = value;
+        const char* start = ptr;
         while (*ptr) {
             start = ptr;
             while (*ptr != ';' && *ptr)
@@ -746,7 +749,8 @@ bool ItemProperties::notify_create_inline_edit(const pfc::list_base_const_t<t_si
         m_edit_field = m_fields[m_edit_index].m_name;
         m_edit_handles = m_handles;
 
-        pfc::string8_fast_aggressive text, temp;
+        pfc::string8_fast_aggressive text;
+        pfc::string8_fast_aggressive temp;
         {
             metadb_info_container::ptr p_info;
             if (m_edit_handles[0]->get_info_ref(p_info))

--- a/foo_ui_columns/item_properties_config.cpp
+++ b/foo_ui_columns/item_properties_config.cpp
@@ -89,7 +89,8 @@ BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
             break;
         case IDC_UP: {
             if (m_field_list.get_selection_count(2) == 1) {
-                t_size index = 0, count = m_field_list.get_item_count();
+                t_size index = 0;
+                t_size count = m_field_list.get_item_count();
                 while (!m_field_list.get_item_selected(index) && index < count)
                     index++;
                 if (index && m_fields.get_count()) {
@@ -104,7 +105,8 @@ BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
         } break;
         case IDC_DOWN: {
             if (m_field_list.get_selection_count(2) == 1) {
-                t_size index = 0, count = m_field_list.get_item_count();
+                t_size index = 0;
+                t_size count = m_field_list.get_item_count();
                 while (!m_field_list.get_item_selected(index) && index < count)
                     index++;
                 if (index + 1 < count && index + 1 < m_fields.get_count()) {
@@ -136,7 +138,8 @@ BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
                 pfc::bit_array_bittable mask(m_field_list.get_item_count());
                 m_field_list.get_selection_state(mask);
                 // bool b_found = false;
-                t_size index = 0, count = m_field_list.get_item_count();
+                t_size index = 0;
+                t_size count = m_field_list.get_item_count();
                 while (index < count) {
                     if (mask[index])
                         break;

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -569,7 +569,8 @@ void LayoutWindow::run_live_edit_base(const LiveEditData& p_data)
         throw pfc::exception_bug_check();
 
     uie::window::ptr p_window = p_data.m_hierarchy[hierarchy_count - 1];
-    uie::splitter_window_ptr p_container, p_splitter;
+    uie::splitter_window_ptr p_container;
+    uie::splitter_window_ptr p_splitter;
     uie::splitter_window_v2_ptr p_container_v2;
 
     if (p_window.is_valid())

--- a/foo_ui_columns/menu_items.cpp
+++ b/foo_ui_columns/menu_items.cpp
@@ -152,7 +152,8 @@ class MainMenuLayoutPresets : public mainmenu_commands {
     t_uint32 get_command_count() override { return cfg_layout.get_presets().get_count(); }
     GUID get_command(t_uint32 p_index) override
     {
-        pfc::string8 name, buff;
+        pfc::string8 name;
+        pfc::string8 buff;
         get_name(p_index, name);
         buff << "[View/Layout] " << name;
         return static_api_ptr_t<hasher_md5>()->process_single_guid(buff.get_ptr(), buff.get_length());

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -89,7 +89,8 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (SUCCEEDED(p_ITaskbarList.instantiate(CLSID_TaskbarList))) {
             m_taskbar_list = p_ITaskbarList;
             if (m_taskbar_list.is_valid() && SUCCEEDED(m_taskbar_list->HrInit())) {
-                const unsigned cx = GetSystemMetrics(SM_CXSMICON), cy = GetSystemMetrics(SM_CYSMICON);
+                const unsigned cx = GetSystemMetrics(SM_CXSMICON);
+                const unsigned cy = GetSystemMetrics(SM_CYSMICON);
 
                 g_imagelist_taskbar = ImageList_Create(cx, cy, ILC_COLOR32, 0, 6);
 
@@ -624,7 +625,10 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                                 systray_contextmenus::ID_NOW_PLAYING_BASE,
                                 systray_contextmenus::ID_BASE_FILE_PREFS - 1);
 
-                            pfc::string8_fast_aggressive title, name, title2, title3;
+                            pfc::string8_fast_aggressive title;
+                            pfc::string8_fast_aggressive name;
+                            pfc::string8_fast_aggressive title2;
+                            pfc::string8_fast_aggressive title3;
                             static_api_ptr_t<play_control> play_api;
                             metadb_handle_ptr track;
                             if (play_api->get_now_playing(track)) {
@@ -775,7 +779,8 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     parts[u_parts - 1] = rc.right - GetSystemMetrics(SM_CXVSCROLL);
                 }
 
-                unsigned part = -1, n = 0;
+                unsigned part = -1;
+                unsigned n = 0;
                 for (n = 0; n < u_parts; n++) {
                     if ((unsigned)lpnmm->pt.x < parts[n]) {
                         part = n;

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -103,13 +103,16 @@ void PlaylistView::populate_list()
 void PlaylistView::refresh_groups(bool b_update_columns)
 {
     static_api_ptr_t<titleformat_compiler> p_compiler;
-    service_ptr_t<titleformat_object> p_script, p_script_group;
+    service_ptr_t<titleformat_object> p_script;
+    service_ptr_t<titleformat_object> p_script_group;
     m_scripts.remove_all();
 
-    pfc::string8 filter, playlist_name;
+    pfc::string8 filter;
+    pfc::string8 playlist_name;
     m_playlist_api->activeplaylist_get_name(playlist_name);
 
-    t_size count = cfg_grouping ? g_groups.get_groups().get_count() : 0, used_count = 0;
+    t_size count = cfg_grouping ? g_groups.get_groups().get_count() : 0;
+    t_size used_count = 0;
     for (t_size i = 0; i < count; i++) {
         bool b_valid = false;
         switch (g_groups.get_groups()[i].filter_type) {
@@ -136,7 +139,8 @@ void PlaylistView::refresh_groups(bool b_update_columns)
 
 t_size PlaylistView::column_index_display_to_actual(t_size display_index)
 {
-    t_size count = m_column_mask.get_count(), counter = 0;
+    t_size count = m_column_mask.get_count();
+    t_size counter = 0;
     for (t_size i = 0; i < count; i++) {
         if (m_column_mask[i])
             if (counter++ == display_index)
@@ -147,7 +151,8 @@ t_size PlaylistView::column_index_display_to_actual(t_size display_index)
 
 t_size PlaylistView::column_index_actual_to_display(t_size actual_index)
 {
-    t_size count = m_column_mask.get_count(), counter = 0;
+    t_size count = m_column_mask.get_count();
+    t_size counter = 0;
     for (t_size i = 0; i < count; i++) {
         if (m_column_mask[i]) {
             counter++;
@@ -177,7 +182,8 @@ void PlaylistView::g_on_column_widths_change(const PlaylistView* p_skip)
 void PlaylistView::refresh_columns()
 {
     static_api_ptr_t<titleformat_compiler> p_compiler;
-    service_ptr_t<titleformat_object> p_script, p_script_group;
+    service_ptr_t<titleformat_object> p_script;
+    service_ptr_t<titleformat_object> p_script_group;
     m_script_global.release();
     m_script_global_style.release();
 
@@ -185,7 +191,8 @@ void PlaylistView::refresh_columns()
     m_edit_fields.remove_all();
     pfc::list_t<Column> columns;
 
-    pfc::string8 filter, playlist_name;
+    pfc::string8 filter;
+    pfc::string8 playlist_name;
     m_playlist_api->activeplaylist_get_name(playlist_name);
 
     if (cfg_global)
@@ -248,7 +255,8 @@ void PlaylistView::on_groups_change()
 void PlaylistView::update_all_items()
 {
     static_api_ptr_t<titleformat_compiler> p_compiler;
-    service_ptr_t<titleformat_object> p_script, p_script_group;
+    service_ptr_t<titleformat_object> p_script;
+    service_ptr_t<titleformat_object> p_script_group;
 
     m_script_global.release();
     m_script_global_style.release();
@@ -414,7 +422,8 @@ void PlaylistView::notify_sort_column(t_size index, bool b_descending, bool b_se
     if (active_playlist != -1
         && (!m_playlist_api->playlist_lock_is_present(active_playlist)
                || !(m_playlist_api->playlist_lock_get_filter_mask(active_playlist) & playlist_lock::filter_reorder))) {
-        unsigned n, count = m_playlist_api->activeplaylist_get_item_count();
+        unsigned n;
+        unsigned count = m_playlist_api->activeplaylist_get_item_count();
 
         pfc::list_t<pfc::array_t<WCHAR>, pfc::alloc_fast_aggressive> data;
         pfc::list_t<t_size, pfc::alloc_fast_aggressive> source_indices;
@@ -642,7 +651,8 @@ bool PlaylistView::notify_on_contextmenu_header(const POINT& pt, const HDHITTEST
         static_api_ptr_t<playlist_manager> playlist_api;
         playlist_api->activeplaylist_get_name(playlist_name);
 
-        pfc::string8_fast_aggressive filter, name;
+        pfc::string8_fast_aggressive filter;
+        pfc::string8_fast_aggressive name;
 
         int e = g_columns.get_count();
         for (int s = 0; s < e; s++) {
@@ -831,10 +841,12 @@ void PlaylistView::notify_update_item_data(t_size index)
     string_array& p_out = get_item_subitems(index);
     PlaylistViewItem* p_item = get_item(index);
 
-    t_size group_index = 0, group_count = 0;
+    t_size group_index = 0;
+    t_size group_count = 0;
     // uih::ListView::get_item_group(index, get_group_count()-1, group_index, group_count);
 
-    pfc::string8_fast_aggressive temp, str_dummy;
+    pfc::string8_fast_aggressive temp;
+    pfc::string8_fast_aggressive str_dummy;
     temp.prealloc(32);
     GlobalVariableList globals;
     bool b_global = m_script_global.is_valid();
@@ -855,7 +867,9 @@ void PlaylistView::notify_update_item_data(t_size index)
     CellStyleData style_data_item = CellStyleData::g_create_default();
 
     bool colour_global_av = false;
-    t_size i, count = m_column_data.get_count(), count_display_groups = get_item_display_group_count(index);
+    t_size i;
+    t_size count = m_column_data.get_count();
+    t_size count_display_groups = get_item_display_group_count(index);
     p_out.set_count(count);
     get_item(index)->m_style_data.set_count(count);
 
@@ -977,7 +991,8 @@ void PlaylistView::reset_items()
 t_size PlaylistView::get_highlight_item()
 {
     if (static_api_ptr_t<play_control>()->is_playing()) {
-        t_size playing_index, playing_playlist;
+        t_size playing_index;
+        t_size playing_playlist;
         m_playlist_api->get_playing_item_location(&playing_playlist, &playing_index);
         if (playing_playlist == m_playlist_api->get_active_playlist())
             return playing_index;

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -214,7 +214,8 @@ public:
 
     void flush_pending()
     {
-        t_size count = m_current_readers.get_count(), count_pending = m_pending_readers.get_count();
+        t_size count = m_current_readers.get_count();
+        t_size count_pending = m_pending_readers.get_count();
         if (count < max_readers) {
             if (count_pending) {
                 pfc::rcptr_t<ArtworkReader> p_reader = m_pending_readers[count_pending - 1];
@@ -439,7 +440,8 @@ private:
         const PlaylistViewGroup::ptr& p_group, const pfc::rcptr_t<ArtworkReader>& p_reader)
     {
         if (!p_reader->is_aborting()) {
-            t_size count = get_item_count(), group_count = m_scripts.get_count();
+            t_size count = get_item_count();
+            t_size group_count = m_scripts.get_count();
 
             if (group_count) {
                 for (t_size i = 0; i < count; i++) {

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -131,7 +131,8 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
     TRACK_CALL_TEXT("artwork_reader_ng_t::read_artwork");
     m_bitmaps.remove_all();
 
-    bool b_loaded = false, b_extracter_attempted = false;
+    bool b_loaded = false;
+    bool b_extracter_attempted = false;
     album_art_extractor_instance_ptr p_extractor;
     static_api_ptr_t<album_art_manager_v2> p_album_art_manager_v2;
 
@@ -289,15 +290,18 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
 
 HBITMAP g_create_hbitmap_from_image(Gdiplus::Bitmap& bm, t_size& cx, t_size& cy, COLORREF cr_back, bool b_reflection)
 {
-    HDC dc = nullptr, dcc = nullptr;
+    HDC dc = nullptr;
+    HDC dcc = nullptr;
     dc = GetDC(nullptr);
     dcc = CreateCompatibleDC(dc);
     // cy = bm.GetHeight();
     if (b_reflection)
         cy = cx; //(cy*11 -7) / 14;
-    t_size ocx = cx, ocy = cy;
+    t_size ocx = cx;
+    t_size ocy = cy;
 
-    t_size cx_source = bm.GetWidth(), cy_source = bm.GetHeight();
+    t_size cx_source = bm.GetWidth();
+    t_size cy_source = bm.GetHeight();
 
     double ar_source = (double)cx_source / (double)cy_source;
     double ar_dest = (double)ocx / (double)ocy;
@@ -437,7 +441,8 @@ HBITMAP PlaylistView::request_group_artwork(t_size index_item, t_size item_group
                 ret = *group->m_artwork_bitmap;
             }
         } else {
-            t_size cx = get_group_info_area_width(), cy = get_group_info_area_height();
+            t_size cx = get_group_info_area_width();
+            t_size cy = get_group_info_area_height();
             /*t_size padding=get_default_indentation_step();
             if (cx>padding)
                 cx-=padding;

--- a/foo_ui_columns/ng_playlist/ng_playlist_groups.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist_groups.h
@@ -55,7 +55,8 @@ private:
 
     void set_data_raw(stream_reader* p_stream, t_size p_sizehint, abort_callback& p_abort) override
     {
-        t_size count, version;
+        t_size count;
+        t_size version;
         p_stream->read_lendian_t(version, p_abort);
         if (version <= stream_version_current) {
             m_groups.remove_all();

--- a/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
@@ -330,8 +330,10 @@ bool StyleTitleformatHook::process_function(titleformat_text_out* p_out, const c
         }
     } else if (!stricmp_utf8_ex(p_name, p_name_length, "offset_colour", pfc_infinite)) {
         if (p_params->get_param_count() == 3) {
-            const char *p_val, *p_val2;
-            unsigned p_val_length, p_val2_length;
+            const char* p_val;
+            const char* p_val2;
+            unsigned p_val_length;
+            unsigned p_val2_length;
             p_params->get_param(0, p_val, p_val_length);
             int colour = mmh::strtoul_n(p_val, p_val_length, 0x10);
             p_params->get_param(1, p_val2, p_val2_length);

--- a/foo_ui_columns/notification_area.cpp
+++ b/foo_ui_columns/notification_area.cpp
@@ -13,7 +13,8 @@ void update_systray(bool balloon, int btitle, bool force_balloon)
         metadb_handle_ptr track;
         static_api_ptr_t<play_control> play_api;
         play_api->get_now_playing(track);
-        pfc::string8 sys, title;
+        pfc::string8 sys;
+        pfc::string8 title;
 
         if (track.is_valid()) {
             service_ptr_t<titleformat_object> to_systray;

--- a/foo_ui_columns/playlist_manager_utils.cpp
+++ b/foo_ui_columns/playlist_manager_utils.cpp
@@ -160,7 +160,8 @@ bool cut(const pfc::bit_array& mask)
 bool cut(const pfc::list_base_const_t<t_size>& indices)
 {
     static_api_ptr_t<playlist_manager> m_playlist_api;
-    t_size count = indices.get_count(), playlist_count = m_playlist_api->get_playlist_count();
+    t_size count = indices.get_count();
+    t_size playlist_count = m_playlist_api->get_playlist_count();
     pfc::bit_array_bittable mask(playlist_count);
     for (t_size i = 0; i < count; i++) {
         if (indices[i] < playlist_count)
@@ -183,7 +184,8 @@ bool copy(const pfc::bit_array& mask)
 bool copy(const pfc::list_base_const_t<t_size>& indices)
 {
     static_api_ptr_t<playlist_manager> m_playlist_api;
-    t_size count = indices.get_count(), playlist_count = m_playlist_api->get_playlist_count();
+    t_size count = indices.get_count();
+    t_size playlist_count = m_playlist_api->get_playlist_count();
     pfc::bit_array_bittable mask(playlist_count);
     for (t_size i = 0; i < count; i++) {
         if (indices[i] < playlist_count)

--- a/foo_ui_columns/playlist_switcher_shortcut_menu.cpp
+++ b/foo_ui_columns/playlist_switcher_shortcut_menu.cpp
@@ -11,7 +11,8 @@ bool PlaylistSwitcher::notify_on_contextmenu(const POINT& pt, bool from_keyboard
     playlist_position_reference_tracker indexTracked(false);
     indexTracked.m_playlist = index;
 
-    t_size num = m_playlist_api->get_playlist_count(), active = m_playlist_api->get_active_playlist();
+    t_size num = m_playlist_api->get_playlist_count();
+    t_size active = m_playlist_api->get_active_playlist();
     bool b_index_valid = index < num;
 
     if (b_index_valid)

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -214,7 +214,8 @@ public:
             if (numSelected == 1) {
                 pfc::bit_array_bittable mask(get_item_count());
                 get_selection_state(mask);
-                t_size index = 0, count = get_item_count();
+                t_size index = 0;
+                t_size count = get_item_count();
                 while (index < count) {
                     if (mask[index])
                         break;

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -360,7 +360,9 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             memset(str_class, 0, sizeof(str_class));
             if (wnd_child && RealGetWindowClass(wnd_child, str_class, tabsize(str_class) - 1)
                 && !wcscmp(str_class, UPDOWN_CLASS) && IsWindowVisible(wnd_child)) {
-                INT min = NULL, max = NULL, index = NULL;
+                INT min = NULL;
+                INT max = NULL;
+                INT index = NULL;
                 BOOL err = FALSE;
                 SendMessage(wnd_child, UDM_GETRANGE32, (WPARAM)&min, (LPARAM)&max);
                 index = SendMessage(wnd_child, UDM_GETPOS32, (WPARAM)NULL, (LPARAM)&err);
@@ -749,7 +751,8 @@ void PlaylistTabs::on_playlists_reorder(const unsigned* p_order, unsigned p_coun
 
         for (unsigned n = 0; n < p_count; n++) {
             if (n != (unsigned)p_order[n]) {
-                pfc::string8 temp, temp2;
+                pfc::string8 temp;
+                pfc::string8 temp2;
                 playlist_api->playlist_get_name(n, temp);
 
                 uTabCtrl_InsertItemText(wnd_tabs, n, temp, false);

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -234,7 +234,8 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
                 static_api_ptr_t<playlist_manager_v3> playlist_api;
 
-                unsigned num = playlist_api->get_playlist_count(), active = playlist_api->get_active_playlist();
+                unsigned num = playlist_api->get_playlist_count();
+                unsigned active = playlist_api->get_active_playlist();
                 bool b_index_valid = idx < num;
 
                 metadb_handle_list_t<pfc::alloc_fast_aggressive> data;

--- a/foo_ui_columns/seekbar.cpp
+++ b/foo_ui_columns/seekbar.cpp
@@ -20,7 +20,8 @@ void SeekBarToolbar::SeekBarTrackbarCallback::get_tooltip_text(unsigned pos, uih
 
 void SeekBarToolbar::update_seekbars(bool positions_only)
 {
-    unsigned n, count = windows.get_count();
+    unsigned n;
+    unsigned count = windows.get_count();
     if (positions_only) {
         for (n = 0; n < count; n++)
             if (windows[n]->get_wnd())
@@ -54,7 +55,8 @@ void SeekBarToolbar::update_seek_pos()
     static_api_ptr_t<play_control> play_api;
 
     if (play_api->is_playing() && play_api->playback_get_length() /* && play_api->playback_can_seek()*/) {
-        double position = 0, length = 0;
+        double position = 0;
+        double length = 0;
         position = play_api->playback_get_position();
         length = play_api->playback_get_length();
 
@@ -88,7 +90,8 @@ void SeekBarToolbar::update_seek()
     static_api_ptr_t<play_control> play_api;
 
     if (play_api->is_playing() && play_api->playback_get_length() /* && play_api->playback_can_seek()*/) {
-        double position = 0, length = 0;
+        double position = 0;
+        double length = 0;
         position = play_api->playback_get_position();
         length = play_api->playback_get_length();
 

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -27,7 +27,8 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         uih::list_view_set_explorer_theme(wnd_lv);
 
-        RECT rc_work, rc_dialog;
+        RECT rc_work;
+        RECT rc_dialog;
         SystemParametersInfo(SPI_GETWORKAREA, NULL, &rc_work, NULL);
         GetWindowRect(wnd, &rc_dialog);
 

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -14,7 +14,8 @@ void FlatSplitterPanel::Panel::PanelContainer::on_hooked_message(WPARAM msg, con
     if (msg == WM_MOUSEMOVE && m_this.is_valid() && MonitorFromPoint(mllhs.pt, MONITOR_DEFAULTTONULL)) {
         unsigned index = m_this->m_panels.find_item(m_panel);
         if (index != pfc_infinite) {
-            HWND wnd_capture = GetCapture(), wnd_pt = WindowFromPoint(mllhs.pt);
+            HWND wnd_capture = GetCapture();
+            HWND wnd_pt = WindowFromPoint(mllhs.pt);
             POINT pt = mllhs.pt;
             ScreenToClient(m_this->get_wnd(), &pt);
             // if (!hwnd)
@@ -102,7 +103,8 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
         if (m_this.is_valid()) {
             unsigned index = 0;
             if (m_this->m_panels.find_by_wnd(wnd, index) && m_this->m_panels[index]->m_show_caption) {
-                RECT rc_client, rc_dummy;
+                RECT rc_client;
+                RECT rc_dummy;
                 GetClientRect(wnd, &rc_client);
 
                 unsigned caption_size = g_get_caption_size();
@@ -148,7 +150,8 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
     }
     case WM_ERASEBKGND: {
         RECT rc_caption = {0, 0, 0, 0};
-        RECT rc_fill, rc_client;
+        RECT rc_fill;
+        RECT rc_client;
         GetClientRect(wnd, &rc_client);
         if (m_this.is_valid()) {
             unsigned index = 0;

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -82,7 +82,8 @@ public:
     }
     bool set_window_visibility(HWND wnd, bool visibility) override
     {
-        bool rv = false, b_usvisible = true;
+        bool rv = false;
+        bool b_usvisible = true;
         if (!m_this->get_host()->is_visible(m_this->get_wnd()))
             b_usvisible = m_this->get_host()->set_window_visibility(m_this->get_wnd(), visibility);
         if (b_usvisible && visibility) {
@@ -560,7 +561,8 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (pt.x == -1 && pt.y == -1)
             GetMessagePos(&pt);
 
-        POINT pt_client = pt, pt_client_tabs = pt;
+        POINT pt_client = pt;
+        POINT pt_client_tabs = pt;
 
         ScreenToClient(wnd, &pt_client);
 
@@ -623,7 +625,8 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 on_active_tab_changed(TabCtrl_GetCurSel(m_wnd_tabs));
                 if (m_active_tab != pfc_infinite && m_active_tab < m_active_panels.get_count()
                     && GetFocus() != m_wnd_tabs) {
-                    HWND wnd_root = GetAncestor(m_wnd_tabs, GA_ROOT), wnd_focus = nullptr;
+                    HWND wnd_root = GetAncestor(m_wnd_tabs, GA_ROOT);
+                    HWND wnd_focus = nullptr;
                     if (wnd_root) {
                         wnd_focus = m_active_panels[m_active_tab]->m_wnd;
                         if (!(GetWindowLongPtr(wnd_focus, GWL_STYLE) & WS_TABSTOP))
@@ -931,7 +934,9 @@ LRESULT WINAPI TabStackPanel::on_hooked_message(HWND wnd, UINT msg, WPARAM wp, L
             memset(str_class, 0, sizeof(str_class));
             if (wnd_child && RealGetWindowClass(wnd_child, str_class, tabsize(str_class) - 1)
                 && !wcscmp(str_class, UPDOWN_CLASS) && IsWindowVisible(wnd_child)) {
-                INT min = NULL, max = NULL, index = NULL;
+                INT min = NULL;
+                INT max = NULL;
+                INT index = NULL;
                 BOOL err = FALSE;
                 SendMessage(wnd_child, UDM_GETRANGE32, (WPARAM)&min, (LPARAM)&max);
                 index = SendMessage(wnd_child, UDM_GETPOS32, (WPARAM)NULL, (LPARAM)&err);

--- a/foo_ui_columns/splitter_window.cpp
+++ b/foo_ui_columns/splitter_window.cpp
@@ -58,7 +58,9 @@ void FlatSplitterPanel::destroy_children()
 
 void FlatSplitterPanel::refresh_children()
 {
-    unsigned n, count = m_panels.get_count(), size_cumulative = 0;
+    unsigned n;
+    unsigned count = m_panels.get_count();
+    unsigned size_cumulative = 0;
     pfc::array_t<bool> new_items;
     new_items.set_count(count);
     new_items.fill_null();
@@ -263,7 +265,9 @@ void FlatSplitterPanel::get_panels_sizes(
         unsigned parts;
     };
 
-    unsigned n, count = m_panels.get_count(), height_allocated = 0;
+    unsigned n;
+    unsigned count = m_panels.get_count();
+    unsigned height_allocated = 0;
 
     if (count) {
         pfc::array_t<t_size_info> size_info;
@@ -480,7 +484,8 @@ int FlatSplitterPanel::override_size(unsigned& panel, int delta)
             bool is_down = delta > 0; // new_height > m_panels[panel].height;
 
             if (is_up /*&& !m_panels[panel].locked*/) {
-                unsigned diff_abs = 0, diff_avail = abs(delta);
+                unsigned diff_abs = 0;
+                unsigned diff_avail = abs(delta);
 
                 unsigned n = panel + 1;
                 while (n < count && diff_abs < diff_avail) {
@@ -555,7 +560,8 @@ int FlatSplitterPanel::override_size(unsigned& panel, int delta)
                 return (abs(delta) - obtained);
             }
             if (is_down /*&& !m_panels[panel].locked*/) {
-                unsigned diff_abs = 0, diff_avail = abs(delta);
+                unsigned diff_abs = 0;
+                unsigned diff_avail = abs(delta);
 
                 n = panel + 1;
                 while (n > 0 && diff_abs < diff_avail) {
@@ -644,7 +650,8 @@ void FlatSplitterPanel::start_autohide_dehide(unsigned p_panel, bool b_next_too)
     auto& panel_after = b_have_next ? m_panels[p_panel + 1] : Panel::null_ptr;
     if ((panel_before->m_autohide && !panel_before->m_container.m_hook_active)
         || (b_have_next && panel_after->m_autohide && !panel_after->m_container.m_hook_active)) {
-        bool a1 = false, a2 = false;
+        bool a1 = false;
+        bool a2 = false;
         if (panel_before->m_autohide && !panel_before->m_container.m_hook_active) {
             panel_before->m_hidden = false;
             a1 = true;
@@ -862,7 +869,8 @@ void FlatSplitterPanel::export_config(stream_writer* p_writer, abort_callback& p
 void FlatSplitterPanel::write_config(stream_writer* p_writer, bool is_export, abort_callback& p_abort) const
 {
     p_writer->write_lendian_t(static_cast<t_uint32>(stream_version_current), p_abort);
-    unsigned i, count = m_panels.get_count();
+    unsigned i;
+    unsigned count = m_panels.get_count();
     p_writer->write_lendian_t(count, p_abort);
     for (i = 0; i < count; i++) {
         if (is_export)

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -223,7 +223,9 @@ void set_part_sizes(unsigned p_parts)
 
         m_parts.add_item(-1); // dummy
 
-        pfc::string8 text_lock, text_volume, text_length;
+        pfc::string8 text_lock;
+        pfc::string8 text_volume;
+        pfc::string8 text_length;
         static_api_ptr_t<playlist_manager> playlist_api;
         unsigned active = playlist_api->get_active_playlist();
 
@@ -261,7 +263,8 @@ void set_part_sizes(unsigned p_parts)
 
         m_parts[0] = rc2.right - rc2.left;
 
-        unsigned n, count = m_parts.get_count();
+        unsigned n;
+        unsigned count = m_parts.get_count();
         for (n = 1; n < count; n++)
             m_parts[0] -= m_parts[n];
 

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -11,7 +11,8 @@ bool LayoutTabNode::have_item(const GUID& p_guid)
 {
     if (m_item->get_ptr()->get_panel_guid() == p_guid)
         return true;
-    unsigned n, count;
+    unsigned n;
+    unsigned count;
     for (n = 0, count = m_children.get_count(); n < count; n++) {
         if (m_children[n]->have_item(p_guid))
             return true;
@@ -202,7 +203,8 @@ bool LayoutTab::_fix_single_instance_recur(uie::splitter_window_ptr& p_window)
         return false;
 
     bool modified = false;
-    t_size i, count = p_window->get_panel_count();
+    t_size i;
+    t_size count = p_window->get_panel_count();
     pfc::array_staticsize_t<bool> mask(count);
 
     for (i = 0; i < count; i++) {
@@ -875,7 +877,8 @@ BOOL LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 if (p_splitter.is_valid() && p_node->m_children.get_count() < p_splitter->get_maximum_panel_count()) {
                     HMENU menu_change_base = CreatePopupMenu();
                     HMENU popup = nullptr;
-                    unsigned count = panels.get_count(), last = 0;
+                    unsigned count = panels.get_count();
+                    unsigned last = 0;
                     for (unsigned n = 0; n < count; n++) {
                         if (!panels[n].prefer_multiple_instances || !m_node_root->have_item(panels[n].guid)) {
                             if (!popup || uStringCompare(panels[last].category, panels[n].category)) {

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -420,7 +420,8 @@ void CALLBACK SpectrumAnalyserVisualisation::g_timer_proc(HWND wnd, UINT msg, UI
 void g_scale_value(
     t_size source_count, t_size index, t_size dest_count, t_size& source_start, t_size& source_end, bool b_log)
 {
-    double start, end;
+    double start;
+    double end;
     if (b_log) {
         static constexpr auto power = 500;
         static const double exp0 = pow(power, 0);
@@ -477,7 +478,8 @@ void SpectrumAnalyserVisualisation::refresh(const audio_chunk* p_chunk)
                     t_size channel_count = p_chunk->get_channels();
                     for (t_size i = 0; i < totalbars; i++) {
                         double val = 0;
-                        t_size starti, endi;
+                        t_size starti;
+                        t_size endi;
                         g_scale_value(sample_count, i, totalbars, starti, endi, m_scale == scale_logarithmic);
                         for (t_size j = starti; j <= endi; j++) {
                             if (j < sample_count) {
@@ -511,7 +513,8 @@ void SpectrumAnalyserVisualisation::refresh(const audio_chunk* p_chunk)
                 t_size channel_count = p_chunk->get_channels();
                 for (t_size i = 0; i < (t_size)rc_client->right; i++) {
                     double val = 0;
-                    t_size starti, endi;
+                    t_size starti;
+                    t_size endi;
                     g_scale_value(sample_count, i, rc_client->right, starti, endi, m_scale == scale_logarithmic);
                     for (t_size j = starti; j <= endi; j++) {
                         if (j < sample_count) {


### PR DESCRIPTION
This applies the clang-tidy fix for the `readability-isolate-declaration` rule to split statements that declare multiple variables into multiple statements that each declare only one variable.