### PR TITLE
Partially fix compatibility with latest version of range-v3

### DIFF
--- a/foo_ui_columns/fcl.cpp
+++ b/foo_ui_columns/fcl.cpp
@@ -352,7 +352,7 @@ void g_import_layout(HWND wnd, const char* path, bool quiet)
             std::vector<RawDataSet> datasets;
             datasets.resize(count);
 
-            for (auto i : ranges::view::iota(0, count)) {
+            for (auto i : ranges::view::iota(size_t{0}, count)) {
                 // GUID guiditem;
                 pfc::string8 name;
                 p_file->read_lendian_t(datasets[i].guid, p_abort);
@@ -387,7 +387,7 @@ void g_import_layout(HWND wnd, const char* path, bool quiet)
 
             uih::DisableRedrawScope p_NoRedraw(cui::main_window.get_wnd());
 
-            for (auto export_item_index : ranges::view::iota(0, export_items.get_count())) {
+            for (auto export_item_index : ranges::view::iota(size_t{0}, export_items.get_count())) {
                 auto ptr = export_items[export_item_index];
                 auto data_set_iter
                     = ranges::find_if(datasets, [&ptr](auto&& data_set) { return data_set.guid == ptr->get_guid(); });

--- a/foo_ui_columns/filter_fcl.cpp
+++ b/foo_ui_columns/filter_fcl.cpp
@@ -167,7 +167,7 @@ class FavouritesDataSet : public cui::fcl::dataset {
         const auto count = gsl::narrow<uint32_t>(filter_panel::cfg_favourites.get_count());
         p_writer->write_lendian_t(count, p_abort);
 
-        for (auto i : ranges::view::iota(0, count)) {
+        for (auto i : ranges::view::iota(0u, count)) {
             auto& favourite = filter_panel::cfg_favourites[i];
             auto data = write_favourite(favourite, p_abort);
 
@@ -183,7 +183,7 @@ class FavouritesDataSet : public cui::fcl::dataset {
         p_reader->read_lendian_t(count, p_abort);
         pfc::array_staticsize_t<pfc::string8> imported_favourites{count};
 
-        for (auto i : ranges::view::iota(0, count)) {
+        for (auto i : ranges::view::iota(0u, count)) {
             uint32_t favourite_data_size{};
             p_reader->read_lendian_t(favourite_data_size, p_abort);
             pfc::array_staticsize_t<uint8_t> favourite_data(favourite_data_size);
@@ -245,7 +245,7 @@ class FieldsDataSet : public cui::fcl::dataset {
         const auto count = gsl::narrow<uint32_t>(filter_panel::cfg_field_list.get_count());
         p_writer->write_lendian_t(count, p_abort);
 
-        for (auto i : ranges::view::iota(0, count)) {
+        for (auto i : ranges::view::iota(0u, count)) {
             auto& field = filter_panel::cfg_field_list[i];
             auto data = write_field(field, p_abort);
 
@@ -262,7 +262,7 @@ class FieldsDataSet : public cui::fcl::dataset {
         p_reader->read_lendian_t(count, p_abort);
         pfc::array_staticsize_t<filter_panel::Field> imported_fields{count};
 
-        for (auto i : ranges::view::iota(0, count)) {
+        for (auto i : ranges::view::iota(0u, count)) {
             uint32_t field_size{};
             p_reader->read_lendian_t(field_size, p_abort);
             pfc::array_staticsize_t<uint8_t> field_data(field_size);

--- a/foo_ui_columns/fonts_manager_data.cpp
+++ b/foo_ui_columns/fonts_manager_data.cpp
@@ -97,7 +97,7 @@ void FontsManagerData::get_data_raw(stream_writer* p_stream, abort_callback& p_a
     size_t counter = 0;
     mask.set_count(count);
 
-    for (auto&& i : ranges::view::iota(0, count))
+    for (auto&& i : ranges::view::iota(size_t{0}, count))
         if ((mask[i] = clients.have_item(m_entries[i]->guid)))
             counter++;
 
@@ -106,14 +106,14 @@ void FontsManagerData::get_data_raw(stream_writer* p_stream, abort_callback& p_a
     m_common_labels_entry->write(p_stream, p_abort);
     p_stream->write_lendian_t(counter, p_abort);
 
-    for (auto&& i : ranges::view::iota(0, count))
+    for (auto&& i : ranges::view::iota(size_t{0}, count))
         if (mask[i])
             m_entries[i]->write(p_stream, p_abort);
 
     m_common_items_entry->write_extra_data(p_stream, p_abort);
     m_common_labels_entry->write_extra_data(p_stream, p_abort);
 
-    for (auto&& i : ranges::view::iota(0, count))
+    for (auto&& i : ranges::view::iota(size_t{0}, count))
         if (mask[i])
             m_entries[i]->write_extra_data(p_stream, p_abort);
 }

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -280,7 +280,7 @@ public:
 
         const t_size value_count = info->meta_enum_value_count(field_index);
 
-        for (auto value_index : ranges::view::iota(0, value_count)) {
+        for (auto value_index : ranges::view::iota(size_t{0}, value_count)) {
             const auto value = info->meta_enum_value(field_index, value_index);
             add_value(value);
         }


### PR DESCRIPTION
Currently, compilation with the latest version of range-v3 is not working.

For Visual Studio, range-v3 now requires the `/experimental:preprocessor` compiler argument. However, specifying this causes an internal compiler error when compiling this project. This will be further investigated separately.

There was also a problem with mixed types when using `ranges::view::iota()`, which was breaking the Clang build (and would probably have also broken the Visual Studio build if it weren't for the other problem). This is fixed here.