### PR TITLE
Pin ms-gsl and range-v3 ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
 .\bootstrap-vcpkg.bat
 .\vcpkg integrate install
-.\vcpkg install ms-gsl range-v3
+.\vcpkg install ms-gsl range-v3 --overlay-ports=..\columns_ui\ports
 ```
+
+(Note: Change the `..\columns_ui\ports` path in the `.\vcpkg install` command as necessary.)
 
 ### Building using the Visual Studio IDE
 Open `vc16/columns_ui-public.sln` in Visual Studio 2019.

--- a/azure/job-build.yml
+++ b/azure/job-build.yml
@@ -6,7 +6,7 @@ parameters:
   msBuildArgs: ''
   platform: ''
   solution: ''
-  vcpkgPackages: ''
+  vcpkgInstallArgs: ''
   vmImage: ''
 jobs:
 - job: ${{ parameters.name }}
@@ -18,7 +18,7 @@ jobs:
     msBuildArgs: ${{ parameters.msBuildArgs }}
     platform: ${{ parameters.platform }}
     solution: ${{ parameters.solution }}
-    vcpkgPackages: ${{ parameters.vcpkgPackages }}
+    vcpkgInstallArgs: ${{ parameters.vcpkgInstallArgs }}
   strategy:
     matrix:
       ${{ insert }}: ${{ parameters.matrix }}
@@ -26,6 +26,7 @@ jobs:
   - checkout: self
     submodules: recursive
   - powershell: |
+      Set-PSDebug -Trace 1
       choco install llvm
       Invoke-WebRequest https://yuo.be/ci/azure-llvm-msbuild-vs2019.zip -OutFile azure-llvm-msbuild-vs2019.zip
       Expand-Archive azure-llvm-msbuild-vs2019.zip azure-llvm-msbuild-vs2019
@@ -33,9 +34,11 @@ jobs:
     condition: variables.installLlvm
     displayName: Install LLVM
   - powershell: |
+      Set-PSDebug -Trace 1
+      vcpkg version
       vcpkg integrate install
-      vcpkg install $(vcpkgPackages)
-    condition: variables.vcpkgPackages
+      vcpkg install $(vcpkgInstallArgs)
+    condition: variables.vcpkgInstallArgs
     displayName: Install dependencies
   - task: VSBuild@1
     displayName: Build

--- a/azure/pipeline.yml
+++ b/azure/pipeline.yml
@@ -1,7 +1,7 @@
 variables:
   solution: vc16/columns_ui-public.sln
   llvmMsBuildArgs: /p:PlatformToolset=llvm;UseLldLink=False;UseLlvmLib=False;SpectreMitigation=
-  vcpkgPackages: 'ms-gsl range-v3'
+  vcpkgInstallArgs: 'ms-gsl range-v3 --overlay-ports=$(System.DefaultWorkingDirectory)\ports'
 jobs:
 - template: job-build.yml
   parameters:
@@ -16,7 +16,7 @@ jobs:
     name: vs2019_llvm
     platform: Win32
     solution: ${{ variables.solution }}
-    vcpkgPackages: ${{ variables.vcpkgPackages }}
+    vcpkgInstallArgs: ${{ variables.vcpkgInstallArgs }}
     vmImage: windows-2019
 - template: job-build.yml
   parameters:
@@ -29,5 +29,5 @@ jobs:
     name: vs2019_v142
     platform: Win32
     solution: ${{ variables.solution }}
-    vcpkgPackages: ${{ variables.vcpkgPackages }}
+    vcpkgInstallArgs: ${{ variables.vcpkgInstallArgs }}
     vmImage: windows-2019

--- a/ports/ms-gsl/CONTROL
+++ b/ports/ms-gsl/CONTROL
@@ -1,0 +1,4 @@
+Source: ms-gsl
+Version: 2019-07-11
+Homepage: https://github.com/Microsoft/GSL
+Description: Microsoft implementation of the Guidelines Support Library

--- a/ports/ms-gsl/portfile.cmake
+++ b/ports/ms-gsl/portfile.cmake
@@ -1,0 +1,15 @@
+#header-only library
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Microsoft/GSL
+    REF 1212beae777dba02c230ece8c0c0ec12790047ea
+    SHA512 754d0adf32cea1da759be9adb8a64c301ae1cb8556853411bcea4c400079e8e310f1fb8d03f1f26f81553eab24b75fea24a67b9b51d8d92bb4f266e155938230
+    HEAD_REF master
+)
+
+file(INSTALL ${SOURCE_PATH}/include/ DESTINATION ${CURRENT_PACKAGES_DIR}/include)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/ms-gsl RENAME copyright)

--- a/ports/range-v3/CONTROL
+++ b/ports/range-v3/CONTROL
@@ -1,0 +1,4 @@
+Source: range-v3
+Version: 0.5.0
+Homepage: https://github.com/ericniebler/range-v3
+Description: Range library for C++11/14/17.

--- a/ports/range-v3/portfile.cmake
+++ b/ports/range-v3/portfile.cmake
@@ -1,0 +1,30 @@
+include(vcpkg_common_functions)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ericniebler/range-v3
+    REF 0.5.0
+    SHA512 076be03b0f4113acb5fb4db83ed5e755bed60ff8df9a7b982b144949cce40f0bb0579ecca38c1f33643b63037b8d311afa6d613b50811e1191b63e2c42a0d4bf
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DRANGE_V3_TESTS=OFF
+        -DRANGE_V3_EXAMPLES=OFF
+        -DRANGE_V3_PERF=OFF
+        -DRANGE_V3_HEADER_CHECKS=OFF
+)
+
+vcpkg_install_cmake()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/range-v3)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug ${CURRENT_PACKAGES_DIR}/lib)
+
+vcpkg_copy_pdbs()
+
+file(COPY ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/range-v3)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/range-v3/LICENSE.txt ${CURRENT_PACKAGES_DIR}/share/range-v3/copyright)


### PR DESCRIPTION
There was some breakage with the latest version of `range-v3`. This freezes the ports to working versions to get things working again and avoid unexpected breakage in future.

Note: The outstanding problem blocking an upgrade of range-v3 is https://developercommunity.visualstudio.com/content/problem/695652/internal-compiler-error-with-experimentalpreproces.html (which is stated to be fixed in Visual Studio 16.4).