### PR TITLE
Rename common submodule to foobar2000

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "common"]
+[submodule "foobar2000"]
 	path = foobar2000
-	url = https://github.com/reupen/foobar2000-sdk.git
+	url = https://github.com/reupen/foobar2000-sdk-modified.git
 [submodule "ui_helpers"]
 	path = ui_helpers
 	url = https://github.com/reupen/ui_helpers.git
@@ -9,7 +9,7 @@
 	url = https://github.com/reupen/mmh.git
 [submodule "pfc"]
 	path = pfc
-	url = https://github.com/reupen/pfc.git
+	url = https://github.com/reupen/pfc-modified.git
 [submodule "columns_ui-sdk"]
 	path = columns_ui-sdk
 	url = https://github.com/reupen/columns_ui-sdk.git


### PR DESCRIPTION
This renames the `common` submodule to `foobar2000`.

The local path remains unchanged.

The repository URLs for the `foobar2000` and `pfc` submodules were also updated.

It should be possible to update local environments by running `git submodule sync` with these changes in place locally.