### PR TITLE
Add support for custom property sections to Item properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Development version
 
+* The Item properties panel can now display custom information sections from third-party components. [[#251](https://github.com/reupen/columns_ui/pull/251)]
+
 * A bug was fixed where, when typing the name of an item in a list view to jump to that item, the space key would not jump to matching items. [[#246](https://github.com/reupen/columns_ui/pull/246), [ui_helpers#41](https://github.com/reupen/ui_helpers/pull/41)]
 
 * Various bugs relating to the display of ellipses in truncated text containing colour codes were fixed. [[#249](https://github.com/reupen/columns_ui/pull/249), [ui_helpers#42](https://github.com/reupen/ui_helpers/pull/42), [ui_helpers#43](https://github.com/reupen/ui_helpers/pull/43)]

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -3,10 +3,14 @@
 #include "list_view_panel.h"
 
 struct InfoSection {
-    t_uint32 id;
-    const char* name;
-    InfoSection(t_uint32 p_id, const char* p_name) : id(p_id), name(p_name){};
+    // The ID is used for settings storage (in case we reorder the sections etc.)
+    int id{};
+    const char* name{};
+    bool is_unknown_section_default{};
 };
+
+constexpr std::array<InfoSection, 5> g_info_sections{
+    {{0, "Location"}, {1, "General"}, {2, "ReplayGain"}, {3, "Playback statistics"}, {4, "All other sections", true}}};
 
 class Field {
 public:
@@ -35,8 +39,6 @@ private:
 };
 
 t_size g_get_info_section_id_by_name(const char* p_name);
-
-extern const InfoSection g_info_sections[5];
 
 class ItemPropertiesColoursClient : public cui::colours::client {
 public:

--- a/foo_ui_columns/item_properties_config.cpp
+++ b/foo_ui_columns/item_properties_config.cpp
@@ -19,10 +19,9 @@ BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
         GetClientRect(wnd_lv, &rc);
         uih::list_view_insert_column_text(wnd_lv, 0, L"", RECT_CX(rc));
 
-        t_size count = tabsize(g_info_sections);
-        for (t_size i = 0; i < count; i++) {
-            uih::list_view_insert_item_text(wnd_lv, i, 0, g_info_sections[i].name);
-            ListView_SetCheckState(wnd_lv, i, (m_info_sections_mask & (1 << g_info_sections[i].id)) ? TRUE : FALSE);
+        for (auto&& [index, section] : ranges::view::enumerate(g_info_sections)) {
+            uih::list_view_insert_item_text(wnd_lv, index, 0, section.name);
+            ListView_SetCheckState(wnd_lv, index, (m_info_sections_mask & (1 << section.id)) ? TRUE : FALSE);
         }
 
         HWND wnd_combo = GetDlgItem(wnd, IDC_EDGESTYLE);
@@ -54,7 +53,8 @@ BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
             switch (lpnm->code) {
             case LVN_ITEMCHANGED: {
                 auto lpnmlv = (LPNMLISTVIEW)lp;
-                if (!m_initialising && lpnmlv->iItem < tabsize(g_info_sections) && (lpnmlv->uChanged & LVIF_STATE)) {
+                if (!m_initialising && lpnmlv->iItem < gsl::narrow<int>(g_info_sections.size())
+                    && (lpnmlv->uChanged & LVIF_STATE)) {
                     m_info_sections_mask = m_info_sections_mask & ~(1 << g_info_sections[lpnmlv->iItem].id);
 
                     // if (((((UINT)(lpnmlv->uNewState & LVIS_STATEIMAGEMASK )) >> 12) -1))

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -23,6 +23,7 @@
 #include <variant>
 #include <vector>
 
+#include <concurrent_unordered_map.h>
 #include <concurrent_vector.h>
 #include <io.h>
 #include <ppl.h>


### PR DESCRIPTION
This adds better support for track property groups from third-party track property providers that use custom group names.

Properties from such custom groups are now displayed under the correct heading.

The 'Other' section in Item properties option has been renamed 'All other sections' and now controls the display of these custom groups.

(Note that some older versions of Columns UI did display these properties, but they were lumped together under a single 'Other' heading.)