### PR TITLE
Use Visual Studio-provided LLVM on Azure Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,12 @@ msbuild /m /p:Platform=Win32 /p:Configuration=Release /t:Rebuild vc16\columns_ui
 
 ### Using the Clang compiler (experimental)
 
-Columns UI can be also compiled using recent versions of Clang. [Download and install LLVM](http://llvm.org/releases/download.html) and the [LLVM Compiler Toolchain Visual Studio extension](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain). In a (x86 or x64) VS 2017 Native Tools command prompt, run:
+Columns UI can be also compiled using the version of Clang distributed with Visual Studio. 
+
+(Note that Clang is not installed by default – in the Visual Studio 2019 installer, you will need to select the Clang compiler and the Clang build tools components.)
+
+With these installed, open a Developer Command Prompt for VS 2019 from the start menu, switch to the Columns UI source directory and run:
 
 ```
-msbuild /m /p:PlatformToolset=llvm;UseLldLink=false;Platform=Win32;Configuration=Release /t:Rebuild vc16\columns_ui-public.sln
+msbuild /m /p:PlatformToolset=ClangCL;UseLldLink=True;VcpkgAutoLink=False;WholeProgramOptimization=False;Platform=Win32;Configuration=Release /t:Rebuild vc16\columns_ui-public.sln
 ```

--- a/azure/job-build.yml
+++ b/azure/job-build.yml
@@ -1,7 +1,6 @@
 parameters:
   name: ''
   displayName: ''
-  installLlvm: ''
   matrix: {}
   msBuildArgs: ''
   platform: ''
@@ -14,7 +13,6 @@ jobs:
   pool:
     vmImage: ${{ parameters.vmImage }}
   variables:
-    installLlvm: ${{ parameters.installLlvm }}
     msBuildArgs: ${{ parameters.msBuildArgs }}
     platform: ${{ parameters.platform }}
     solution: ${{ parameters.solution }}
@@ -25,14 +23,6 @@ jobs:
   steps:
   - checkout: self
     submodules: recursive
-  - powershell: |
-      Set-PSDebug -Trace 1
-      choco install llvm
-      Invoke-WebRequest https://yuo.be/ci/azure-llvm-msbuild-vs2019.zip -OutFile azure-llvm-msbuild-vs2019.zip
-      Expand-Archive azure-llvm-msbuild-vs2019.zip azure-llvm-msbuild-vs2019
-      cmd /c azure-llvm-msbuild-vs2019\install-enterprise.bat
-    condition: variables.installLlvm
-    displayName: Install LLVM
   - powershell: |
       Set-PSDebug -Trace 1
       vcpkg version

--- a/azure/pipeline.yml
+++ b/azure/pipeline.yml
@@ -1,12 +1,11 @@
 variables:
   solution: vc16/columns_ui-public.sln
-  llvmMsBuildArgs: /p:PlatformToolset=llvm;UseLldLink=False;UseLlvmLib=False;SpectreMitigation=
+  llvmMsBuildArgs: /p:PlatformToolset=ClangCL;UseLldLink=True;VcpkgAutoLink=False;WholeProgramOptimization=False;SpectreMitigation=
   vcpkgInstallArgs: 'ms-gsl range-v3 --overlay-ports=$(System.DefaultWorkingDirectory)\ports'
 jobs:
 - template: job-build.yml
   parameters:
     displayName: VS 2019 LLVM
-    installLlvm: 'true'
     matrix:
       Debug:
         configuration: Debug


### PR DESCRIPTION
This changes the Azure Pipelines configuration to use the Clang toolset as provided by Visual Studio (rather than installing it separately).

It also updates the Clang compilation instructions in the README to do the same.