### PR TITLE
Update Item properties default settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * The playlist switcher configuration now includes a playing indicator in playlist titles. [[#248](https://github.com/reupen/columns_ui/pull/248)]
 
+* The default information sections displayed by the Item properties panel were changed. [[#251]](https://github.com/reupen/columns_ui/pull/251)
+
 * The Windows notification icon is now disabled by default. [[#245](https://github.com/reupen/columns_ui/pull/245)]
 
 * The component is now compiled using foobar2000 SDK 2019-09-18. [[#243](https://github.com/reupen/columns_ui/pull/243)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * The default information sections displayed by the Item properties panel were changed. [[#251]](https://github.com/reupen/columns_ui/pull/251)
 
+* The default metadata field titles in the Item properties panel now use sentence case. [[#251]](https://github.com/reupen/columns_ui/pull/251)
+
 * The Windows notification icon is now disabled by default. [[#245](https://github.com/reupen/columns_ui/pull/245)]
 
 * The component is now compiled using foobar2000 SDK 2019-09-18. [[#243](https://github.com/reupen/columns_ui/pull/243)]

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -699,11 +699,11 @@ ItemProperties::ItemProperties()
     m_fields.add_item(Field("Genre", "GENRE"));
     m_fields.add_item(Field("Composer", "COMPOSER"));
     m_fields.add_item(Field("Performer", "PERFORMER"));
-    m_fields.add_item(Field("Album Artist", "ALBUM ARTIST"));
-    m_fields.add_item(Field("Track Number", "TRACKNUMBER"));
-    m_fields.add_item(Field("Total Tracks", "TOTALTRACKS"));
-    m_fields.add_item(Field("Disc Number", "DISCNUMBER"));
-    m_fields.add_item(Field("Total Discs", "TOTALDISCS"));
+    m_fields.add_item(Field("Album artist", "ALBUM ARTIST"));
+    m_fields.add_item(Field("Track number", "TRACKNUMBER"));
+    m_fields.add_item(Field("Total tracks", "TOTALTRACKS"));
+    m_fields.add_item(Field("Disc number", "DISCNUMBER"));
+    m_fields.add_item(Field("Total discs", "TOTALDISCS"));
     m_fields.add_item(Field("Comment", "COMMENT"));
 }
 

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -39,7 +39,7 @@ static const GUID g_guid_selection_poperties_show_group_titles
 
 cfg_uint cfg_selection_properties_tracking_mode(g_guid_selection_properties_tracking_mode, 0);
 cfg_uint cfg_selection_properties_edge_style(g_guid_selection_poperties_edge_style, 0);
-cfg_uint cfg_selection_properties_info_sections(g_guid_selection_poperties_info_sections, 1 + 2 + 4 + 8 + 16);
+cfg_uint cfg_selection_properties_info_sections(g_guid_selection_poperties_info_sections, 1 + 2 + 4);
 cfg_bool cfg_selection_poperties_show_column_titles(g_guid_selection_poperties_show_column_titles, true);
 cfg_bool cfg_selection_poperties_show_group_titles(g_guid_selection_poperties_show_group_titles, true);
 


### PR DESCRIPTION
This updates the default Item properties settings so that:

- the playback statistics and any unknown information sections are hidden by default
- metadata field titles use sentence case, in line with the standard information fields
