### PR TITLE
Fix loss of a panel's custom title when copying and pasting the panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Various bugs relating to the display of ellipses in truncated text containing colour codes were fixed. [[#249](https://github.com/reupen/columns_ui/pull/249), [ui_helpers#42](https://github.com/reupen/ui_helpers/pull/42), [ui_helpers#43](https://github.com/reupen/ui_helpers/pull/43)]
 
+* A bug was fixed where, when a panel with a custom title was copied and pasted, the custom title would not be set on the pasted panel. [[#253](https://github.com/reupen/columns_ui/pull/253)]
+
 * All built-in panels now have a default edge style of 'none'.
 
 * The playlist switcher configuration now includes a playing indicator in playlist titles. [[#248](https://github.com/reupen/columns_ui/pull/248)]

--- a/foo_ui_columns/splitter_utils.cpp
+++ b/foo_ui_columns/splitter_utils.cpp
@@ -107,6 +107,7 @@ std::unique_ptr<uie::splitter_item_full_v3_impl_t> deserialise_splitter_item(gsl
 
     pfc::string8 title;
     reader.read_string(title, aborter);
+    item->set_title(title, title.get_length());
 
     uint32_t panel_data_size{};
     reader.read_lendian_t(panel_data_size, aborter);


### PR DESCRIPTION
This fixes a bug where, if a panel with a custom title was copied and pasted, the pasted panel would not have the custom title that the original panel had.