### PR TITLE
Preserve tree view node state in layout preferences when moving items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * A bug was fixed where, when a panel with a custom title was copied and pasted, the custom title would not be set on the pasted panel. [[#253](https://github.com/reupen/columns_ui/pull/253)]
 
+* The expansion state of items in the layout tree on the Layout preferences page is now fully preserved when moving items up and down. [[#255](https://github.com/reupen/columns_ui/pull/255)]
+
 * All built-in panels now have a default edge style of 'none'.
 
 * The playlist switcher configuration now includes a playing indicator in playlist titles. [[#248](https://github.com/reupen/columns_ui/pull/248)]

--- a/foo_ui_columns/tab_layout.h
+++ b/foo_ui_columns/tab_layout.h
@@ -16,6 +16,8 @@ public:
     service_ptr_t<uie::splitter_window> m_splitter;
     pfc::list_t<ptr> m_children;
     pfc::rcptr_t<uie::splitter_item_ptr> m_item;
+    bool m_expanded{true};
+
     LayoutTabNode() : m_item(pfc::rcnew_t<uie::splitter_item_ptr>()) {}
 };
 
@@ -27,7 +29,7 @@ public:
 
 private:
     static HTREEITEM insert_item_in_tree_view(
-        HWND wnd_tree, const char* sz_text, HTREEITEM ti_parent = TVI_ROOT, HTREEITEM ti_after = TVI_LAST);
+        HWND wnd_tree, const char* sz_text, HTREEITEM ti_parent, HTREEITEM ti_after, bool is_expanded);
     static void get_panel_list(uie::window_info_list_simple& p_out);
     static HTREEITEM tree_view_get_child_by_index(HWND wnd_tv, HTREEITEM ti, unsigned index);
     static unsigned tree_view_get_child_index(HWND wnd_tv, HTREEITEM ti);


### PR DESCRIPTION
This fixes a bug where the expansion state of some nodes in the tree view in Layout preferences was lost when moving a node up or down.