### PR TITLE
Fix state bugs in layout tree in layout preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * A bug was fixed where, when a panel with a custom title was copied and pasted, the custom title would not be set on the pasted panel. [[#253](https://github.com/reupen/columns_ui/pull/253)]
 
+* Various Bugs leading to misbehaviour and possible crashes when making changes to the layout tree on the Layout preferences page were fixed. [[#256](https://github.com/reupen/columns_ui/pull/256)]
+
 * The expansion state of items in the layout tree on the Layout preferences page is now fully preserved when moving items up and down. [[#255](https://github.com/reupen/columns_ui/pull/255)]
 
 * All built-in panels now have a default edge style of 'none'.

--- a/foo_ui_columns/tab_layout.h
+++ b/foo_ui_columns/tab_layout.h
@@ -35,13 +35,16 @@ private:
     static unsigned tree_view_get_child_index(HWND wnd_tv, HTREEITEM ti);
     [[nodiscard]] static std::unordered_map<HTREEITEM, LayoutTabNode::ptr> __populate_tree(
         HWND wnd_tree, LayoutTabNode::ptr p_node, HTREEITEM ti_parent, HTREEITEM ti_after = TVI_LAST);
+    [[nodiscard]] static std::unordered_map<HTREEITEM, LayoutTabNode::ptr> __repopulate_node(
+        HWND wnd_tree, LayoutTabNode::ptr node, HTREEITEM ti_parent, HTREEITEM ti_after = TVI_LAST);
     static void print_index_out_of_range();
 
     void populate_tree(HWND wnd, const uie::splitter_item_t* item, LayoutTabNode::ptr p_node,
         HTREEITEM ti_parent = TVI_ROOT, HTREEITEM ti_after = TVI_LAST);
     void populate_tree(
         HWND wnd, LayoutTabNode::ptr p_node, HTREEITEM ti_parent = TVI_ROOT, HTREEITEM ti_after = TVI_LAST);
-    void remove_tree_item(HWND wnd_tv, HTREEITEM ti);
+    void repopulate_node(
+        HWND wnd, LayoutTabNode::ptr node, HTREEITEM ti_parent = TVI_ROOT, HTREEITEM ti_after = TVI_LAST);
     void remove_node(HWND wnd, HTREEITEM ti);
     void insert_item(HWND wnd, HTREEITEM ti_parent, const GUID& p_guid, HTREEITEM ti_after = TVI_LAST);
     void copy_item(HWND wnd, HTREEITEM ti);


### PR DESCRIPTION
This fixes a few bugs in the state management of the layout tree in layout preferences that were leading to misbehaviour and potential crashes.

This happened in particular when reordering panels or removing panels and inserting new ones (after which, the tree items could end up pointing at the wrong nodes).