### PR TITLE
Correctly disable panel options in layout tree when selection cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 * The expansion state of items in the layout tree on the Layout preferences page is now fully preserved when moving items up and down. [[#255](https://github.com/reupen/columns_ui/pull/255)]
 
+* Panel options on the Layout preferences page are now always correctly disabled after the tree selection is cleared (such as after selecting a different preset). [[#261](https://github.com/reupen/columns_ui/pull/261)]
+
 * When typing the name of an item in a list view to jump to that item, the space key now correctly jumps to matching items. [[#246](https://github.com/reupen/columns_ui/pull/246), [ui_helpers#41](https://github.com/reupen/ui_helpers/pull/41)]
 
 * Various bugs relating to the display of ellipses in truncated text containing colour codes were fixed. [[#249](https://github.com/reupen/columns_ui/pull/249), [ui_helpers#42](https://github.com/reupen/ui_helpers/pull/42), [ui_helpers#43](https://github.com/reupen/ui_helpers/pull/43)]

--- a/foo_ui_columns/config_host.h
+++ b/foo_ui_columns/config_host.h
@@ -14,6 +14,8 @@ public:
     PreferencesTabHelper(std::initializer_list<unsigned> title_ctrl_ids) : m_title_ctrl_ids(title_ctrl_ids) {}
 
     HWND create(HWND wnd, UINT id, std::function<BOOL(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message_callback);
+    HWND get_wnd() const { return m_wnd; }
+    HWND get_control_wnd(int item_id) const { return GetDlgItem(m_wnd, item_id); }
 
 private:
     static BOOL CALLBACK s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);

--- a/foo_ui_columns/tab_layout.h
+++ b/foo_ui_columns/tab_layout.h
@@ -96,6 +96,7 @@ private:
     void switch_to_preset(HWND wnd, unsigned index);
 
     BOOL on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    void on_tree_selection_change(HTREEITEM tree_item);
 
     HWND m_wnd_tree{};
     bool m_initialising{};


### PR DESCRIPTION
This fixes a bug in layout preferences where, if the selection was cleared (e.g. by selecting a different preset), the panel-specific controls to the right of the tree would stay active when they should be disabled.