### PR TITLE
Fix various inline editing bugs in the playlist view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+* A crash was fixed when using in-line field editing in the playlist view and setting a field to an empty string. [[#266](https://github.com/reupen/columns_ui/pull/266)]
+
 ## 1.3.0-beta.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development version
 
+### Features
+
+* When using in-line field editing in the playlist view, empty field values are no longer written to the file when saving changes. (If no field values are entered, the field is now removed from the file.) [[#266](https://github.com/reupen/columns_ui/pull/266)]
+
 ### Bug fixes
 
 * A crash was fixed when using in-line field editing in the playlist view and setting a field to an empty string. [[#266](https://github.com/reupen/columns_ui/pull/266)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@
 
 * When using in-line field editing in the playlist view, empty field values are no longer written to the file when saving changes. (If no field values are entered, the field is now removed from the file.) [[#266](https://github.com/reupen/columns_ui/pull/266)]
 
+* In-line field editing in the playlist view is no longer sometimes blocked if a file with no loaded metadata is encountered. [[#266](https://github.com/reupen/columns_ui/pull/266)]
+
 ### Bug fixes
 
 * A crash was fixed when using in-line field editing in the playlist view and setting a field to an empty string. [[#266](https://github.com/reupen/columns_ui/pull/266)]
+
+* A crash was fixed when saving changes after using in-line field editing in the playlist view on more than two tracks with initially differing field values. [[#266](https://github.com/reupen/columns_ui/pull/266)]
 
 ## 1.3.0-beta.1
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
@@ -75,24 +75,22 @@ bool PlaylistView::notify_create_inline_edit(const pfc::list_base_const_t<t_size
 
     m_edit_field = m_edit_fields[column];
 
-    bool matching = true;
-
     for (t_size i = 0; i < indices_count; i++) {
         if (!m_playlist_api->activeplaylist_get_item_handle(m_edit_handles[i], indices[i]))
             return false;
+    }
 
-        metadb_info_container::ptr info_container;
-        if (!m_edit_handles[i]->get_info_ref(info_container))
-            return false;
+    bool matching = true;
+
+    for (t_size i = 0; i < indices_count; i++) {
+        metadb_info_container::ptr info_container = m_edit_handles[i]->get_info_ref();
 
         auto& info = info_container->info();
-
         auto item_values = get_info_field_values(info, m_edit_field.get_ptr());
 
         if (i == 0) {
             values = item_values;
         } else if (item_values != values) {
-            p_text = "<multiple values>";
             matching = false;
             break;
         }
@@ -100,6 +98,8 @@ bool PlaylistView::notify_create_inline_edit(const pfc::list_base_const_t<t_size
 
     if (matching) {
         p_text = mmh::join<decltype(values)&, std::string_view, std::string>(values, "; "sv).c_str();
+    } else {
+        p_text = "<multiple values>";
     }
 
     try {

--- a/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
@@ -122,9 +122,14 @@ void PlaylistView::notify_save_inline_edit(const char* value)
     for (;;) {
         const size_t index = value_view.find(";"sv, offset);
         const auto substr = value_view.substr(offset, index - offset);
-        values.emplace_back(trim_string(substr));
+        const auto trimmed_substr = trim_string(substr);
+
+        if (trimmed_substr.length() > 0)
+            values.emplace_back(trimmed_substr);
+
         if (index == std::string_view::npos)
             break;
+
         offset = index + 1;
     }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
@@ -10,7 +10,7 @@ std::string_view trim_string(std::string_view value)
     const auto start = value.find_first_not_of(' ');
     const auto end = value.find_last_not_of(' ');
 
-    if (start > end)
+    if (start > end || start == std::string_view::npos)
         return ""sv;
 
     return value.substr(start, end - start + 1);


### PR DESCRIPTION
This fixes various problems with inline metadata editing in the playlist view:

- a crash when setting a field to an empty string
- a crash when saving changes after editing multiple files that had initially differing values
- the unwanted saving of empty values to files (rather than omitting them or removing the field completely)

The behaviour is also changed slightly when encountering files with no loaded metadata – it will always let you attempt to update the file (though this will may well fail).