### PR TITLE
Include version in component archives for releases

### DIFF
--- a/scripts/post-build.ps1
+++ b/scripts/post-build.ps1
@@ -1,14 +1,25 @@
 Param(
-    [Parameter(Mandatory=$true)][String]$ComponentPath,
-    [Parameter(Mandatory=$true)][String]$OutputDir
+    [Parameter(Mandatory=$true)][string]$ComponentPath,
+    [Parameter(Mandatory=$true)][string]$OutputDir
 )
 
-$input_base_name = [io.path]::GetFileNameWithoutExtension($ComponentPath)
-$output_path = "$OutputDir$input_base_name.fb2k-component"
-$intermediate_file_path = "$output_path.zip"
+Import-Module "$PSScriptRoot\versioning"
+
+$version = Get-Version
+
+$inputBaseName = [io.path]::GetFileNameWithoutExtension($ComponentPath)
+
+$verionPart = ''
+
+if ($version -and $version.IsRelease()) {
+    $verionPart = "-$version"
+}
+
+$outputPath = "$OutputDir$inputBaseName$verionPart.fb2k-component"
+$intermediateFilePath = "$outputPath.zip"
 
 # Note that Compress-Archive won't accept a file extension other than .zip. Hence, we add .zip to the file name
 # and then remove it using Move-Item.
 # (Also note that both Compress-Archive and Move-Item should overwite the destination file if it exists.)
-Compress-Archive -Path $ComponentPath -CompressionLevel Optimal -DestinationPath $intermediate_file_path -Force
-Move-Item $intermediate_file_path $output_path -Force
+Compress-Archive -Path $ComponentPath -CompressionLevel Optimal -DestinationPath $intermediateFilePath -Force
+Move-Item $intermediateFilePath $outputPath -Force

--- a/scripts/pre-build.ps1
+++ b/scripts/pre-build.ps1
@@ -1,6 +1,6 @@
 Param(
-    [Parameter(Mandatory=$true)][String]$TemplatePath,
-    [Parameter(Mandatory=$true)][String]$OutputPath
+    [Parameter(Mandatory=$true)][string]$TemplatePath,
+    [Parameter(Mandatory=$true)][string]$OutputPath
 )
 
 Import-Module "$PSScriptRoot\versioning"


### PR DESCRIPTION
This alters the post-build script so that, when a tagged release is being built, the version number is included in the file name of the produced component archive.

For example, if the tag `v1.2.0` is being built, the file name of the archive will be `foo_ui_columns-1.2.0.fb2k-component`.

(For other builds, the file name remains `foo_ui_columns.fb2k-component`.)