### PR TITLE
Remove ability to configure playlist view artwork thread priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Development version
+
+### Removals
+
+* The playlist view ‘Low artwork reader thready priority’ setting was removed; a low thread priority is now always used. [[#270](https://github.com/reupen/columns_ui/pull/270)]
+
 ## 1.3.0
 
 * There were no changes from version 1.3.0-rc.1.

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -606,8 +606,6 @@ BEGIN
     CONTROL         "",IDC_ARTWORKWIDTHSPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | UDS_NOTHOUSANDS,113,69,12,10
     LTEXT           "px",-1,103,71,9,8
     CONTROL         "Show reflection",IDC_ARTWORKREFLECTION,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,49,65,10
-    CONTROL         "Low artwork reader thread priority",IDC_LOWPRIORITY,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,91,127,10
     LTEXT           "Artwork",IDC_TITLE1,7,4,313,16
 END
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -42,7 +42,6 @@ PlaylistView::SharedMesageWindow PlaylistView::g_global_mesage_window;
 ConfigGroups g_groups(g_groups_guid);
 
 cfg_bool cfg_artwork_reflection(g_artwork_reflection, true);
-cfg_bool cfg_artwork_lowpriority(g_artwork_lowpriority, true);
 
 fbh::ConfigBool cfg_grouping(g_guid_grouping, true, [](auto&&) { cui::button_items::ShowGroupsButton::s_on_change(); });
 fbh::ConfigBool cfg_show_artwork(

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -9,7 +9,7 @@
 namespace pvt {
 extern const GUID g_guid_items_font, g_guid_header_font, g_guid_group_header_font;
 
-extern cfg_bool cfg_artwork_reflection, cfg_artwork_lowpriority;
+extern cfg_bool cfg_artwork_reflection;
 extern fbh::ConfigUint32DpiAware cfg_artwork_width;
 extern fbh::ConfigBool cfg_grouping;
 extern fbh::ConfigBool cfg_show_artwork;
@@ -221,8 +221,7 @@ public:
             if (count_pending) {
                 pfc::rcptr_t<ArtworkReader> p_reader = m_pending_readers[count_pending - 1];
                 m_pending_readers.remove_by_idx(count_pending - 1);
-                if (pvt::cfg_artwork_lowpriority)
-                    p_reader->set_priority(THREAD_PRIORITY_BELOW_NORMAL);
+                p_reader->set_priority(THREAD_PRIORITY_BELOW_NORMAL);
                 p_reader->create_thread();
                 m_current_readers.add_item(p_reader);
             }

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -158,7 +158,6 @@
 #define IDC_MENU_DBLCLK                 1053
 #define IDC_REMOVE_UNDERSCORES          1053
 #define IDC_APPEARANCE                  1053
-#define IDC_LOWPRIORITY                 1053
 #define IDC_IMAGE_SIZE                  1054
 #define IDC_TEXT                        1055
 #define IDC_USE_CUSTOM_TEXT             1056

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -7,7 +7,6 @@ static class TabPlaylistViewArtwork : public PreferencesTab {
     {
         SendDlgItemMessage(wnd, IDC_SHOWARTWORK, BM_SETCHECK, pvt::cfg_show_artwork, 0);
         SendDlgItemMessage(wnd, IDC_ARTWORKREFLECTION, BM_SETCHECK, pvt::cfg_artwork_reflection, 0);
-        SendDlgItemMessage(wnd, IDC_LOWPRIORITY, BM_SETCHECK, pvt::cfg_artwork_lowpriority, 0);
         SendDlgItemMessage(wnd, IDC_ARTWORKWIDTHSPIN, UDM_SETRANGE32, 0, MAXLONG);
         SendDlgItemMessage(wnd, IDC_ARTWORKWIDTHSPIN, UDM_SETPOS32, NULL, pvt::cfg_artwork_width);
     }
@@ -32,9 +31,6 @@ public:
             case IDC_ARTWORKREFLECTION:
                 pvt::cfg_artwork_reflection = SendMessage((HWND)lp, BM_GETCHECK, 0, 0) != BST_UNCHECKED;
                 pvt::PlaylistView::g_on_artwork_width_change();
-                break;
-            case IDC_LOWPRIORITY:
-                pvt::cfg_artwork_lowpriority = SendMessage((HWND)lp, BM_GETCHECK, 0, 0) != BST_UNCHECKED;
                 break;
             case (EN_CHANGE << 16) | IDC_ARTWORKWIDTH:
                 if (m_initialised) {


### PR DESCRIPTION
This removes the playlist view ‘Low artwork reader thready priority’ setting as there should be no reason to manually configure the artwork reader thread priority.

It now always uses a low priority.