### PR TITLE
Update range-v3

### DIFF
--- a/foo_ui_columns/fcl.cpp
+++ b/foo_ui_columns/fcl.cpp
@@ -352,7 +352,7 @@ void g_import_layout(HWND wnd, const char* path, bool quiet)
             std::vector<RawDataSet> datasets;
             datasets.resize(count);
 
-            for (auto i : ranges::view::iota(size_t{0}, count)) {
+            for (auto i : ranges::views::iota(size_t{0}, count)) {
                 // GUID guiditem;
                 pfc::string8 name;
                 p_file->read_lendian_t(datasets[i].guid, p_abort);
@@ -387,7 +387,7 @@ void g_import_layout(HWND wnd, const char* path, bool quiet)
 
             uih::DisableRedrawScope p_NoRedraw(cui::main_window.get_wnd());
 
-            for (auto export_item_index : ranges::view::iota(size_t{0}, export_items.get_count())) {
+            for (auto export_item_index : ranges::views::iota(size_t{0}, export_items.get_count())) {
                 auto ptr = export_items[export_item_index];
                 auto data_set_iter
                     = ranges::find_if(datasets, [&ptr](auto&& data_set) { return data_set.guid == ptr->get_guid(); });

--- a/foo_ui_columns/filter_fcl.cpp
+++ b/foo_ui_columns/filter_fcl.cpp
@@ -167,7 +167,7 @@ class FavouritesDataSet : public cui::fcl::dataset {
         const auto count = gsl::narrow<uint32_t>(filter_panel::cfg_favourites.get_count());
         p_writer->write_lendian_t(count, p_abort);
 
-        for (auto i : ranges::view::iota(0u, count)) {
+        for (auto i : ranges::views::iota(0u, count)) {
             auto& favourite = filter_panel::cfg_favourites[i];
             auto data = write_favourite(favourite, p_abort);
 
@@ -183,7 +183,7 @@ class FavouritesDataSet : public cui::fcl::dataset {
         p_reader->read_lendian_t(count, p_abort);
         pfc::array_staticsize_t<pfc::string8> imported_favourites{count};
 
-        for (auto i : ranges::view::iota(0u, count)) {
+        for (auto i : ranges::views::iota(0u, count)) {
             uint32_t favourite_data_size{};
             p_reader->read_lendian_t(favourite_data_size, p_abort);
             pfc::array_staticsize_t<uint8_t> favourite_data(favourite_data_size);
@@ -245,7 +245,7 @@ class FieldsDataSet : public cui::fcl::dataset {
         const auto count = gsl::narrow<uint32_t>(filter_panel::cfg_field_list.get_count());
         p_writer->write_lendian_t(count, p_abort);
 
-        for (auto i : ranges::view::iota(0u, count)) {
+        for (auto i : ranges::views::iota(0u, count)) {
             auto& field = filter_panel::cfg_field_list[i];
             auto data = write_field(field, p_abort);
 
@@ -262,7 +262,7 @@ class FieldsDataSet : public cui::fcl::dataset {
         p_reader->read_lendian_t(count, p_abort);
         pfc::array_staticsize_t<filter_panel::Field> imported_fields{count};
 
-        for (auto i : ranges::view::iota(0u, count)) {
+        for (auto i : ranges::views::iota(0u, count)) {
             uint32_t field_size{};
             p_reader->read_lendian_t(field_size, p_abort);
             pfc::array_staticsize_t<uint8_t> field_data(field_size);

--- a/foo_ui_columns/fonts_manager_data.cpp
+++ b/foo_ui_columns/fonts_manager_data.cpp
@@ -97,7 +97,7 @@ void FontsManagerData::get_data_raw(stream_writer* p_stream, abort_callback& p_a
     size_t counter = 0;
     mask.set_count(count);
 
-    for (auto&& i : ranges::view::iota(size_t{0}, count))
+    for (auto&& i : ranges::views::iota(size_t{0}, count))
         if ((mask[i] = clients.have_item(m_entries[i]->guid)))
             counter++;
 
@@ -106,14 +106,14 @@ void FontsManagerData::get_data_raw(stream_writer* p_stream, abort_callback& p_a
     m_common_labels_entry->write(p_stream, p_abort);
     p_stream->write_lendian_t(counter, p_abort);
 
-    for (auto&& i : ranges::view::iota(size_t{0}, count))
+    for (auto&& i : ranges::views::iota(size_t{0}, count))
         if (mask[i])
             m_entries[i]->write(p_stream, p_abort);
 
     m_common_items_entry->write_extra_data(p_stream, p_abort);
     m_common_labels_entry->write_extra_data(p_stream, p_abort);
 
-    for (auto&& i : ranges::view::iota(size_t{0}, count))
+    for (auto&& i : ranges::views::iota(size_t{0}, count))
         if (mask[i])
             m_entries[i]->write_extra_data(p_stream, p_abort);
 }

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -106,7 +106,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
-      <AdditionalOptions>/Zc:threadSafeInit- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:threadSafeInit- -experimental:preprocessor /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -153,7 +153,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
-      <AdditionalOptions>/Zc:threadSafeInit- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:threadSafeInit- -experimental:preprocessor /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -195,7 +195,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalOptions>/Zc:threadSafeInit- /Zm125 /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:threadSafeInit- -experimental:preprocessor /Zm125 /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -241,7 +241,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalOptions>/Zc:threadSafeInit- /Zm125 /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:threadSafeInit- -experimental:preprocessor /Zm125 /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_WIN32_WINNT=0x600;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -267,7 +267,7 @@ public:
 
         const t_size value_count = info->meta_enum_value_count(field_index);
 
-        for (auto value_index : ranges::view::iota(size_t{0}, value_count)) {
+        for (auto value_index : ranges::views::iota(size_t{0}, value_count)) {
             const auto value = info->meta_enum_value(field_index, value_index);
             add_value(value);
         }
@@ -358,7 +358,7 @@ public:
         std::vector<std::tuple<std::string, concurrency::concurrent_vector<TrackProperty>>> all_sections;
         std::vector<std::tuple<std::string, concurrency::concurrent_vector<TrackProperty>>> unknown_sections;
 
-        for (auto&& [index, values] : ranges::view::enumerate(m_known_sections)) {
+        for (auto&& [index, values] : ranges::views::enumerate(m_known_sections)) {
             if (values.empty())
                 continue;
 

--- a/foo_ui_columns/item_properties_config.cpp
+++ b/foo_ui_columns/item_properties_config.cpp
@@ -19,7 +19,7 @@ BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
         GetClientRect(wnd_lv, &rc);
         uih::list_view_insert_column_text(wnd_lv, 0, L"", RECT_CX(rc));
 
-        for (auto&& [index, section] : ranges::view::enumerate(g_info_sections)) {
+        for (auto&& [index, section] : ranges::views::enumerate(g_info_sections)) {
             uih::list_view_insert_item_text(wnd_lv, index, 0, section.name);
             ListView_SetCheckState(wnd_lv, index, (m_info_sections_mask & (1 << section.id)) ? TRUE : FALSE);
         }

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -336,7 +336,7 @@ HWND RebarWindow::init()
     auto& band_states = g_cfg_rebar.get_rebar_info();
     m_bands.reserve(band_states.size());
 
-    /// Using ranges::view::transform here seems to make VS 2019 freeze
+    /// Using ranges::views::transform here seems to make VS 2019 freeze
     for (auto&& band_state : band_states) {
         m_bands.emplace_back(RebarBand{band_state});
     }
@@ -595,7 +595,7 @@ void RebarWindow::delete_band(HWND wnd, bool destroy)
 
 std::vector<RebarBandState> RebarWindow::get_band_states() const
 {
-    /// Using ranges::view::transform here seems to make VS 2019 freeze
+    /// Using ranges::views::transform here seems to make VS 2019 freeze
     std::vector<RebarBandState> band_states;
     band_states.reserve(m_bands.size());
     for (auto&& band : m_bands)

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -35,7 +35,7 @@ void LayoutTabNode::build()
         m_name = "<unknown>";
 
     if (m_window.is_valid() && m_window->service_query_t(m_splitter)) {
-        for (auto i : ranges::view::iota(size_t{0}, m_splitter->get_panel_count())) {
+        for (auto i : ranges::views::iota(size_t{0}, m_splitter->get_panel_count())) {
             auto& child = m_children.emplace_back(std::make_shared<LayoutTabNode>());
             m_splitter->get_panel(i, *child->m_item);
 
@@ -888,7 +888,7 @@ void LayoutTab::on_tree_selection_change(HTREEITEM tree_item)
         = {{uie::splitter_window::uint32_orientation, IDC_CAPTIONSTYLE},
             {uie::splitter_window::string_custom_title, IDC_CUSTOM_TITLE}};
 
-    const auto all_item_and_control_ids = ranges::view::concat(bool_item_and_control_ids, other_item_and_control_ids);
+    const auto all_item_and_control_ids = ranges::views::concat(bool_item_and_control_ids, other_item_and_control_ids);
 
     std::unordered_map<GUID, bool, GUIDHasher> supported_map;
     std::unordered_map<GUID, bool, GUIDHasher> enable_map;

--- a/ports/range-v3/CONTROL
+++ b/ports/range-v3/CONTROL
@@ -1,4 +1,4 @@
 Source: range-v3
-Version: 0.5.0
+Version: 0.9.1
 Homepage: https://github.com/ericniebler/range-v3
 Description: Range library for C++11/14/17.

--- a/ports/range-v3/portfile.cmake
+++ b/ports/range-v3/portfile.cmake
@@ -3,8 +3,8 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO ericniebler/range-v3
-    REF 0.5.0
-    SHA512 076be03b0f4113acb5fb4db83ed5e755bed60ff8df9a7b982b144949cce40f0bb0579ecca38c1f33643b63037b8d311afa6d613b50811e1191b63e2c42a0d4bf
+    REF 8a732ee6736af8af024b5b2032580b85a9be8239
+    SHA512 a052d29fd0164d8a0ad2c70da0fe4e771c98bac3fb5ccdde4819f1b9b865504f9e649736a2adf996e62b08f2499feeaedf19dc47a0ff846d3482b79ef2946ead
     HEAD_REF master
 )
 


### PR DESCRIPTION
This updates range-v3 to the latest version available via vcpkg.

The `/experimental:preprocessor` compiler option is now used as it is required by the new version of range-v3. (`-experimental:preprocessor` was actually used for compatibility with Clang.)