### PR TITLE
Use wil::com_ptr_t where possible

### DIFF
--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -390,11 +390,11 @@ void ArtworkPanel::show_emptycover()
     if (m_artwork_loader.is_valid() && m_artwork_loader->IsReady()) {
         album_art_data_ptr data;
         if (m_artwork_loader->QueryEmptyCover(data)) {
-            pfc::com_ptr_t<mmh::IStreamMemblock> pStream
+            wil::com_ptr_t<mmh::IStreamMemblock> pStream
                 = new mmh::IStreamMemblock((const t_uint8*)data->get_ptr(), data->get_size());
             {
-                m_image = std::make_unique<Gdiplus::Bitmap>(pStream.get_ptr());
-                pStream.release();
+                m_image = std::make_unique<Gdiplus::Bitmap>(pStream.get());
+                pStream.reset();
                 if (m_image->GetLastStatus() == Gdiplus::Ok) {
                     flush_cached_bitmap();
                     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -156,8 +156,8 @@ public:
                 long drop_ref_count;
                 bool last_rmb;
                 ButtonsList* m_button_list_view;
-                mmh::ComPtr<IDataObject> m_DataObject;
-                mmh::ComPtr<IDropTargetHelper> m_DropTargetHelper;
+                wil::com_ptr_t<IDataObject> m_DataObject;
+                wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
                 // pfc::string
             public:
                 HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID FAR* ppvObject) override;

--- a/foo_ui_columns/buttons_config_listview.cpp
+++ b/foo_ui_columns/buttons_config_listview.cpp
@@ -19,8 +19,8 @@ void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_initialisation()
 }
 void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_create()
 {
-    pfc::com_ptr_t<ButtonsListDropTarget> IDT_blv = new ButtonsListDropTarget(this);
-    RegisterDragDrop(get_wnd(), IDT_blv.get_ptr());
+    wil::com_ptr_t<ButtonsListDropTarget> IDT_blv = new ButtonsListDropTarget(this);
+    RegisterDragDrop(get_wnd(), IDT_blv.get());
 }
 void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_destroy()
 {
@@ -36,13 +36,13 @@ void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_selection_change(
 bool ButtonsToolbar::ConfigParam::ButtonsList::do_drag_drop(WPARAM wp)
 {
     UINT cf = g_clipformat();
-    mmh::ComPtr<IDataObject> pDO = new CDataObject;
+    wil::com_ptr_t<IDataObject> pDO = new CDataObject;
 
     DDData data = {0, get_wnd()};
-    uih::ole::set_blob(pDO, cf, &data, sizeof(data));
+    uih::ole::set_blob(pDO.get(), cf, &data, sizeof(data));
 
     DWORD drop_effect = DROPEFFECT_NONE;
-    uih::ole::do_drag_drop(get_wnd(), wp, pDO, DROPEFFECT_MOVE, NULL, &drop_effect);
+    uih::ole::do_drag_drop(get_wnd(), wp, pDO.get(), DROPEFFECT_MOVE, NULL, &drop_effect);
 
     return true;
 }

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -467,13 +467,12 @@ bool FilterPanel::do_drag_drop(WPARAM wp)
     if (data.get_count() > 0) {
         sort_tracks(data);
         static_api_ptr_t<playlist_incoming_item_filter> incoming_api;
-        IDataObject* pDataObject = incoming_api->create_dataobject(data);
-        if (pDataObject) {
+        auto pDataObject = incoming_api->create_dataobject_ex(data);
+        if (pDataObject.is_valid()) {
             m_drag_item_count = data.get_count();
             DWORD blah = DROPEFFECT_NONE;
             HRESULT hr = uih::ole::do_drag_drop(
-                get_wnd(), wp, pDataObject, DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
-            pDataObject->Release();
+                get_wnd(), wp, pDataObject.get_ptr(), DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
             m_drag_item_count = 0;
         }
     }

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -177,7 +177,7 @@ void cui::MainWindow::set_title(const char* ptr)
 
 void cui::MainWindow::update_taskbar_buttons(bool update)
 {
-    if (m_wnd && m_taskbar_list.is_valid()) {
+    if (m_wnd && m_taskbar_list) {
         static_api_ptr_t<playback_control> play_api;
 
         bool b_is_playing = play_api->is_playing();

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -94,7 +94,7 @@ private:
     void update_taskbar_buttons(bool update);
 
     pfc::string8 m_window_title;
-    mmh::ComPtr<ITaskbarList3> m_taskbar_list;
+    wil::com_ptr_t<ITaskbarList3> m_taskbar_list;
     HWND m_wnd{};
     user_interface::HookProc_t m_hook_proc{};
     bool m_should_handle_multimedia_keys{true};

--- a/foo_ui_columns/mw_drop_target.h
+++ b/foo_ui_columns/mw_drop_target.h
@@ -30,6 +30,6 @@ private:
 
     long drop_ref_count{0};
     POINTL last_over{};
-    mmh::ComPtr<IDropTargetHelper> m_DropTargetHelper;
-    mmh::ComPtr<IDataObject> m_DataObject;
+    wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
+    wil::com_ptr_t<IDataObject> m_DataObject;
 };

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -562,8 +562,8 @@ void PlaylistView::notify_on_create()
 
     m_playlist_api->register_callback(static_cast<playlist_callback_single*>(this), playlist_callback::flag_all);
 
-    pfc::com_ptr_t<PlaylistViewDropTarget> IDT_playlist = new PlaylistViewDropTarget(this);
-    RegisterDragDrop(get_wnd(), IDT_playlist.get_ptr());
+    wil::com_ptr_t<PlaylistViewDropTarget> IDT_playlist = new PlaylistViewDropTarget(this);
+    RegisterDragDrop(get_wnd(), IDT_playlist.get());
 
     if (g_windows.empty())
         g_global_mesage_window.create(nullptr);

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -394,7 +394,7 @@ public:
     unsigned get_type() const override;
 
     bool m_dragging{false};
-    pfc::com_ptr_t<IDataObject> m_DataObject;
+    wil::com_ptr_t<IDataObject> m_DataObject;
     t_size m_dragging_initial_playlist;
 
 protected:
@@ -710,8 +710,8 @@ private:
     bool last_rmb;
     bool m_is_accepted_type;
     service_ptr_t<PlaylistView> p_playlist;
-    pfc::com_ptr_t<IDataObject> m_DataObject;
-    mmh::ComPtr<IDropTargetHelper> m_DropTargetHelper;
+    wil::com_ptr_t<IDataObject> m_DataObject;
+    wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
 };
 
 class PlaylistViewDropSource : public IDropSource {

--- a/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
@@ -6,13 +6,13 @@ namespace playlist_utils {
 bool check_clipboard()
 {
     static_api_ptr_t<ole_interaction> api;
-    pfc::com_ptr_t<IDataObject> pDO;
-    if (FAILED(OleGetClipboard(pDO.receive_ptr())))
+    wil::com_ptr_t<IDataObject> pDO;
+    if (FAILED(OleGetClipboard(&pDO)))
         return false;
 
     bool b_native;
     DWORD dummy = DROPEFFECT_COPY;
-    if (FAILED(api->check_dataobject(pDO, dummy, b_native)))
+    if (FAILED(api->check_dataobject(pDO.get(), dummy, b_native)))
         return false;
 
     return b_native;
@@ -57,20 +57,20 @@ bool paste(HWND wnd, size_t index)
 {
     static_api_ptr_t<playlist_manager> playlist_api;
     static_api_ptr_t<ole_interaction> ole_api;
-    pfc::com_ptr_t<IDataObject> pDO;
+    wil::com_ptr_t<IDataObject> pDO;
 
-    if (FAILED(OleGetClipboard(pDO.receive_ptr())))
+    if (FAILED(OleGetClipboard(&pDO)))
         return false;
 
     dropped_files_data_impl data;
     metadb_handle_list handles;
     bool b_native;
     DWORD dummy = DROPEFFECT_COPY;
-    HRESULT hr = ole_api->check_dataobject(pDO, dummy, b_native);
+    HRESULT hr = ole_api->check_dataobject(pDO.get(), dummy, b_native);
     if (FAILED(hr))
         return false;
 
-    hr = ole_api->parse_dataobject(pDO, data);
+    hr = ole_api->parse_dataobject(pDO.get(), data);
     if (FAILED(hr))
         return false;
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_dropsource.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_dropsource.cpp
@@ -8,21 +8,20 @@ bool PlaylistView::do_drag_drop(WPARAM wp)
     m_playlist_api->activeplaylist_get_selected_items(data);
     if (data.get_count() > 0) {
         static_api_ptr_t<playlist_incoming_item_filter> incoming_api;
-        mmh::ComPtr<IDataObject> pDataObject;
-        pDataObject.attach(incoming_api->create_dataobject(data));
+        auto pDataObject = incoming_api->create_dataobject_ex(data);
         if (pDataObject.is_valid()) {
             // pfc::com_ptr_t<IAsyncOperation> pAsyncOperation;
             // HRESULT hr = pDataObject->QueryInterface(IID_IAsyncOperation, (void**)pAsyncOperation.receive_ptr());
             DWORD blah = DROPEFFECT_NONE;
             {
                 m_dragging = true;
-                m_DataObject = pDataObject;
+                m_DataObject = pDataObject.get_ptr();
                 m_dragging_initial_playlist = m_playlist_api->get_active_playlist();
                 HRESULT hr = uih::ole::do_drag_drop(
-                    get_wnd(), wp, pDataObject, DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
+                    get_wnd(), wp, pDataObject.get_ptr(), DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
 
                 m_dragging = false;
-                m_DataObject.release();
+                m_DataObject.reset();
                 m_dragging_initial_playlist = pfc_infinite;
             }
         }

--- a/foo_ui_columns/playlist_manager_utils.cpp
+++ b/foo_ui_columns/playlist_manager_utils.cpp
@@ -28,13 +28,13 @@ void rename_playlist(size_t index, HWND wnd_parent)
 bool check_clipboard()
 {
     static_api_ptr_t<ole_interaction> api;
-    pfc::com_ptr_t<IDataObject> pDO;
+    wil::com_ptr_t<IDataObject> pDO;
 
-    HRESULT hr = OleGetClipboard(pDO.receive_ptr());
+    HRESULT hr = OleGetClipboard(&pDO);
     if (FAILED(hr))
         return false;
 
-    hr = api->check_dataobject_playlists(pDO);
+    hr = api->check_dataobject_playlists(pDO.get());
     return SUCCEEDED(hr);
 }
 bool cut(const pfc::bit_array& mask)
@@ -96,18 +96,18 @@ bool paste(HWND wnd, t_size index_insert)
 {
     static_api_ptr_t<playlist_manager> m_playlist_api;
     static_api_ptr_t<ole_interaction> api;
-    pfc::com_ptr_t<IDataObject> pDO;
+    wil::com_ptr_t<IDataObject> pDO;
 
-    HRESULT hr = OleGetClipboard(pDO.receive_ptr());
+    HRESULT hr = OleGetClipboard(&pDO);
     if (FAILED(hr))
         return false;
 
     playlist_dataobject_desc_impl data;
-    hr = api->check_dataobject_playlists(pDO);
+    hr = api->check_dataobject_playlists(pDO.get());
     if (FAILED(hr))
         return false;
 
-    hr = api->parse_dataobject_playlists(pDO, data);
+    hr = api->parse_dataobject_playlists(pDO.get(), data);
     if (FAILED(hr))
         return false;
 

--- a/foo_ui_columns/playlist_switcher_drop_source.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_source.cpp
@@ -14,10 +14,10 @@ bool PlaylistSwitcher::do_drag_drop(WPARAM wp)
     if (pDataObject.is_valid()) {
         DWORD blah = DROPEFFECT_NONE;
         m_dragging = true;
-        m_DataObject = pDataObject;
+        m_DataObject = pDataObject.get_ptr();
         HRESULT hr = uih::ole::do_drag_drop(
             get_wnd(), wp, pDataObject.get_ptr(), DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
-        m_DataObject.release();
+        m_DataObject.reset();
         m_dragging = false;
     }
     return true;

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -132,8 +132,8 @@ void PlaylistSwitcher::notify_on_create()
     m_playlist_api->register_callback(this, playlist_callback::flag_all);
     standard_api_create_t<play_callback_manager>()->register_callback(this, play_callback::flag_on_playback_all, false);
 
-    pfc::com_ptr_t<DropTarget> drop_target = new DropTarget(this);
-    RegisterDragDrop(get_wnd(), drop_target.get_ptr());
+    wil::com_ptr_t<DropTarget> drop_target = new DropTarget(this);
+    RegisterDragDrop(get_wnd(), drop_target.get());
 
     g_windows.push_back(this);
 }

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -62,10 +62,10 @@ class PlaylistSwitcher
         bool m_is_playlists;
         bool m_is_accepted_type;
         service_ptr_t<PlaylistSwitcher> m_window;
-        pfc::com_ptr_t<IDataObject> m_DataObject;
+        wil::com_ptr_t<IDataObject> m_DataObject;
         service_ptr_t<ole_interaction_v2> m_ole_api;
         service_ptr_t<playlist_manager_v4> m_playlist_api;
-        mmh::ComPtr<IDropTargetHelper> m_DropTargetHelper;
+        wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
     };
 
 public:
@@ -319,7 +319,7 @@ private:
     pfc::rcptr_t<playlist_position_reference_tracker> m_switch_playlist;
 
     bool m_dragging{false};
-    pfc::com_ptr_t<IDataObject> m_DataObject;
+    wil::com_ptr_t<IDataObject> m_DataObject;
 
     pfc::rcptr_t<playlist_position_reference_tracker> m_edit_playlist;
     t_size m_playing_playlist;

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -93,8 +93,8 @@ public:
         long drop_ref_count{};
         POINTL last_over{};
         service_ptr_t<PlaylistTabs> p_list;
-        pfc::com_ptr_t<IDataObject> m_DataObject;
-        mmh::ComPtr<IDropTargetHelper> m_DropTargetHelper;
+        wil::com_ptr_t<IDataObject> m_DataObject;
+        wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
     };
 
     void FB2KAPI on_items_removing(

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -31,8 +31,8 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CREATE: {
         initialised = true;
         list_wnd.add_item(this);
-        pfc::com_ptr_t<PlaylistTabsDropTarget> m_drop_target = new PlaylistTabsDropTarget(this);
-        RegisterDragDrop(wnd, m_drop_target.get_ptr());
+        wil::com_ptr_t<PlaylistTabsDropTarget> m_drop_target = new PlaylistTabsDropTarget(this);
+        RegisterDragDrop(wnd, m_drop_target.get());
 
         create_tabs();
 

--- a/foo_ui_columns/wic.cpp
+++ b/foo_ui_columns/wic.cpp
@@ -19,7 +19,7 @@ wil::com_ptr_t<IWICBitmapDecoder> create_decoder_from_data(const void* data, siz
 
     wil::com_ptr_t<IWICBitmapDecoder> bitmap_decoder;
     check_hresult(imaging_factory->CreateDecoderFromStream(
-        stream.get(), nullptr, WICDecodeMetadataCacheOnDemand, bitmap_decoder.addressof()));
+        stream.get(), nullptr, WICDecodeMetadataCacheOnDemand, &bitmap_decoder));
 
     return bitmap_decoder;
 }
@@ -32,7 +32,7 @@ wil::com_ptr_t<IWICBitmapDecoder> create_decoder_from_path(std::string_view path
 
     wil::com_ptr_t<IWICBitmapDecoder> bitmap_decoder;
     check_hresult(imaging_factory->CreateDecoderFromFilename(
-        utf16_path.get_ptr(), nullptr, GENERIC_READ, WICDecodeMetadataCacheOnDemand, bitmap_decoder.addressof()));
+        utf16_path.get_ptr(), nullptr, GENERIC_READ, WICDecodeMetadataCacheOnDemand, &bitmap_decoder));
 
     return bitmap_decoder;
 }
@@ -40,11 +40,10 @@ wil::com_ptr_t<IWICBitmapDecoder> create_decoder_from_path(std::string_view path
 wil::com_ptr_t<IWICBitmapSource> get_image_frame(const wil::com_ptr_t<IWICBitmapDecoder>& bitmap_decoder)
 {
     wil::com_ptr_t<IWICBitmapFrameDecode> bitmap_frame_decode;
-    check_hresult(bitmap_decoder->GetFrame(0, bitmap_frame_decode.addressof()));
+    check_hresult(bitmap_decoder->GetFrame(0, &bitmap_frame_decode));
 
     wil::com_ptr_t<IWICBitmapSource> converted_bitmap;
-    check_hresult(
-        WICConvertBitmapSource(GUID_WICPixelFormat32bppBGRA, bitmap_frame_decode.get(), converted_bitmap.addressof()));
+    check_hresult(WICConvertBitmapSource(GUID_WICPixelFormat32bppBGRA, bitmap_frame_decode.get(), &converted_bitmap));
 
     return converted_bitmap;
 }


### PR DESCRIPTION
This replaces uses of `mmh::ComPtr` and `pfc::com_ptr_t` with `wil::com_ptr_t` where it's easy to do so.