### PR TITLE
Use standard library smart pointer types in various places

### DIFF
--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -183,7 +183,7 @@ private:
     bool m_gdiplus_initialised{false};
 
     // pfc::rcptr_t<CCustomAlbumArtLoader> m_artwork_loader;
-    pfc::refcounted_object_ptr_t<ArtworkReaderManager> m_artwork_loader;
+    std::shared_ptr<ArtworkReaderManager> m_artwork_loader;
     // now_playing_album_art_manager m_nowplaying_artwork_loader;
     std::unique_ptr<Gdiplus::Bitmap> m_image;
     gdi_object_t<HBITMAP>::ptr_t m_bitmap;

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -24,7 +24,7 @@ public:
         const pfc::map_t<GUID, album_art_data_ptr>& p_content_previous,
         const pfc::map_t<GUID, pfc::list_t<pfc::string8>>& p_repositories, bool b_read_emptycover,
         t_size b_native_artwork_reader_mode, const metadb_handle_ptr& p_handle, const completion_notify_ptr& p_notify,
-        class ArtworkReaderManager* const p_manager);
+        std::shared_ptr<class ArtworkReaderManager> p_manager);
     void run_notification_thisthread(DWORD state);
 
 protected:
@@ -45,10 +45,10 @@ private:
     album_art_data_ptr m_emptycover;
     t_size m_native_artwork_reader_mode{fb2k_artwork_embedded_and_external};
     abort_callback_impl m_abort;
-    pfc::refcounted_object_ptr_t<class ArtworkReaderManager> m_manager;
+    std::shared_ptr<class ArtworkReaderManager> m_manager;
 };
 
-class ArtworkReaderManager : public pfc::refcounted_object_root {
+class ArtworkReaderManager : public std::enable_shared_from_this<ArtworkReaderManager> {
 public:
     void AddType(const GUID& p_what);
     void abort_current_task();
@@ -92,12 +92,12 @@ public:
     void callback_run() override;
 
     static void g_run(
-        ArtworkReaderManager* p_manager, bool p_aborted, DWORD ret, const ArtworkReader* p_reader);
+        std::shared_ptr<ArtworkReaderManager> p_manager, bool p_aborted, DWORD ret, const ArtworkReader* p_reader);
 
     bool m_aborted;
     DWORD m_ret;
     const ArtworkReader* m_reader;
-    pfc::refcounted_object_ptr_t<ArtworkReaderManager> m_manager;
+    std::shared_ptr<ArtworkReaderManager> m_manager;
 };
 
 bool g_get_album_art_extractor_interface(service_ptr_t<album_art_extractor>& out, const char* path);

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -77,8 +77,8 @@ public:
 
 private:
     bool find_aborting_reader(const ArtworkReader* ptr, t_size& index);
-    pfc::list_t<pfc::rcptr_t<ArtworkReader>> m_aborting_readers;
-    pfc::rcptr_t<ArtworkReader> m_current_reader;
+    pfc::list_t<std::shared_ptr<ArtworkReader>> m_aborting_readers;
+    std::shared_ptr<ArtworkReader> m_current_reader;
     // album_art_manager_instance_ptr m_api;
 
     pfc::chain_list_v2_t<GUID> m_requestIds;

--- a/foo_ui_columns/colours_manager_data.cpp
+++ b/foo_ui_columns/colours_manager_data.cpp
@@ -28,7 +28,7 @@ void ColoursManagerData::register_common_callback(cui::colours::common_callback*
 
 ColoursManagerData::ColoursManagerData() : cfg_var(g_cfg_guid)
 {
-    m_global_entry = new Entry(true);
+    m_global_entry = std::make_shared<Entry>(true);
 }
 
 void ColoursManagerData::find_by_guid(const GUID& p_guid, entry_ptr_t& p_out)
@@ -44,7 +44,7 @@ void ColoursManagerData::find_by_guid(const GUID& p_guid, entry_ptr_t& p_out)
             return;
         }
     }
-    p_out = new Entry;
+    p_out = std::make_shared<Entry>();
     p_out->guid = p_guid;
     m_entries.add_item(p_out);
 }
@@ -59,7 +59,7 @@ void ColoursManagerData::set_data_raw(stream_reader* p_stream, t_size p_sizehint
         p_stream->read_lendian_t(count, p_abort);
         m_entries.remove_all();
         for (t_size i = 0; i < count; i++) {
-            entry_ptr_t ptr = new Entry;
+            entry_ptr_t ptr = std::make_shared<Entry>();
             ptr->read(version, p_stream, p_abort);
             m_entries.add_item(ptr);
         }

--- a/foo_ui_columns/colours_manager_data.h
+++ b/foo_ui_columns/colours_manager_data.h
@@ -6,7 +6,7 @@ public:
     enum { cfg_version = 0 };
     void get_data_raw(stream_writer* p_stream, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* p_stream, t_size p_sizehint, abort_callback& p_abort) override;
-    class Entry : public pfc::refcounted_object_root {
+    class Entry {
     public:
         enum ExportItemID {
             identifier_guid,
@@ -44,7 +44,7 @@ public:
         void reset_colors();
         Entry(bool b_global = false);
     };
-    using entry_ptr_t = pfc::refcounted_object_ptr_t<Entry>;
+    using entry_ptr_t = std::shared_ptr<Entry>;
     pfc::list_t<entry_ptr_t> m_entries;
     entry_ptr_t m_global_entry;
 

--- a/foo_ui_columns/columns_v2.cpp
+++ b/foo_ui_columns/columns_v2.cpp
@@ -130,7 +130,7 @@ void ConfigColumns::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, a
     t_uint32 num;
     p_reader->read_lendian_t(num, p_abort);
     for (t_size i = 0; i < num; i++) {
-        PlaylistViewColumn::ptr item = new PlaylistViewColumn;
+        PlaylistViewColumn::ptr item = std::make_shared<PlaylistViewColumn>();
         item->read(p_reader, p_abort);
         items.add_item(item);
     }
@@ -159,17 +159,18 @@ void ConfigColumns::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, a
 void ConfigColumns::reset()
 {
     remove_all();
-    add_item(new PlaylistViewColumn(
+    add_item(std::make_shared<PlaylistViewColumn>(
         "Artist", "[%artist%]", false, "", false, "", 180, ALIGN_LEFT, FILTER_NONE, "", 180, true, "ARTIST"));
-    add_item(new PlaylistViewColumn(
+    add_item(std::make_shared<PlaylistViewColumn>(
         "#", "[%tracknumber%]", false, "", false, "", 18, ALIGN_RIGHT, FILTER_NONE, "", 18, true, "TRACKNUMBER"));
-    add_item(
-        new PlaylistViewColumn("Title", "[%title%]", false, "", false, "", 300, ALIGN_LEFT, FILTER_NONE, "", 300, true, "TITLE"));
-    add_item(
-        new PlaylistViewColumn("Album", "[%album%]", false, "", false, "", 200, ALIGN_LEFT, FILTER_NONE, "", 200, true, "ALBUM"));
-    add_item(new PlaylistViewColumn("Date", "[%date%]", false, "", false, "", 60, ALIGN_LEFT, FILTER_NONE, "", 60, true, "DATE"));
-    add_item(new PlaylistViewColumn("Length", "[%_time_elapsed% / ]%_length%", false, "", true, "$num(%_length_seconds%,6)", 60,
-        ALIGN_RIGHT, FILTER_NONE, "", 60, true, ""));
+    add_item(std::make_shared<PlaylistViewColumn>(
+        "Title", "[%title%]", false, "", false, "", 300, ALIGN_LEFT, FILTER_NONE, "", 300, true, "TITLE"));
+    add_item(std::make_shared<PlaylistViewColumn>(
+        "Album", "[%album%]", false, "", false, "", 200, ALIGN_LEFT, FILTER_NONE, "", 200, true, "ALBUM"));
+    add_item(std::make_shared<PlaylistViewColumn>(
+        "Date", "[%date%]", false, "", false, "", 60, ALIGN_LEFT, FILTER_NONE, "", 60, true, "DATE"));
+    add_item(std::make_shared<PlaylistViewColumn>("Length", "[%_time_elapsed% / ]%_length%", false, "", true,
+        "$num(%_length_seconds%,6)", 60, ALIGN_RIGHT, FILTER_NONE, "", 60, true, ""));
 }
 
 ConfigColumns::ConfigColumns(const GUID& p_guid, ColumnStreamVersion streamVersion) : cfg_var(p_guid)

--- a/foo_ui_columns/columns_v2.h
+++ b/foo_ui_columns/columns_v2.h
@@ -1,12 +1,8 @@
 #ifndef _COLUMNS_2_H_
 #define _COLUMNS_2_H_
 
-class PlaylistViewColumnBase : public pfc::refcounted_object_root {
-    using self_t = PlaylistViewColumnBase;
-
+class PlaylistViewColumnBase {
 public:
-    using ptr = pfc::refcounted_object_ptr_t<self_t>;
-
     pfc::string8 name;
     pfc::string8 spec;
     bool use_custom_colour{false};
@@ -53,7 +49,7 @@ class PlaylistViewColumn : public PlaylistViewColumnBase {
     using self_t = PlaylistViewColumn;
 
 public:
-    using ptr = pfc::refcounted_object_ptr_t<self_t>;
+    using ptr = std::shared_ptr<self_t>;
 
     ptr source_item;
 
@@ -101,7 +97,7 @@ public:
         t_size count = entries.get_count();
         set_count(count);
         for (t_size i = 0; i < count; i++) {
-            PlaylistViewColumn::ptr item = new PlaylistViewColumn(*entries[i].get_ptr());
+            PlaylistViewColumn::ptr item = std::make_shared<PlaylistViewColumn>(*entries[i].get());
             if (keep_reference_to_source_items)
                 item->source_item = entries[i];
             (*this)[i] = item;

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -362,7 +362,7 @@ class ColoursDataSet : public cui::fcl::dataset {
                         data2.set_size(element_size2);
                         reader2.read(data2.get_ptr(), data2.get_size());
                         stream_reader_memblock_ref colour_reader(data2);
-                        g_colours_manager_data.m_entries[i] = new ColoursManagerData::Entry;
+                        g_colours_manager_data.m_entries[i] = std::make_shared<ColoursManagerData::Entry>();
                         g_colours_manager_data.m_entries[i]->import(&colour_reader, data2.get_size(), type, p_abort);
                     } else
                         reader2.skip(element_size2);

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -476,7 +476,7 @@ class FontsDataSet : public cui::fcl::dataset {
                         data2.set_size(element_size2);
                         reader2.read(data2.get_ptr(), data2.get_size());
                         stream_reader_memblock_ref element_reader(data2);
-                        g_fonts_manager_data.m_entries[i] = new FontsManagerData::Entry;
+                        g_fonts_manager_data.m_entries[i] = std::make_shared<FontsManagerData::Entry>();
                         g_fonts_manager_data.m_entries[i]->import(&element_reader, data2.get_size(), type, p_abort);
                     } else
                         reader2.skip(element_size2);
@@ -529,10 +529,10 @@ LRESULT AppearanceMessageWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARA
         }
     } break;
     case WM_SETTINGCHANGE:
-        if ((wp == SPI_GETICONTITLELOGFONT && g_fonts_manager_data.m_common_items_entry.is_valid()
+        if ((wp == SPI_GETICONTITLELOGFONT && g_fonts_manager_data.m_common_items_entry
                 && g_fonts_manager_data.m_common_items_entry->font_mode == cui::fonts::font_mode_system)
-            || (wp == SPI_GETNONCLIENTMETRICS && g_fonts_manager_data.m_common_labels_entry.is_valid()
-                   && g_fonts_manager_data.m_common_labels_entry->font_mode == cui::fonts::font_mode_system)) {
+            || (wp == SPI_GETNONCLIENTMETRICS && g_fonts_manager_data.m_common_labels_entry
+                && g_fonts_manager_data.m_common_labels_entry->font_mode == cui::fonts::font_mode_system)) {
             FontsClientList m_fonts_client_list;
             FontsClientList::g_get_list(m_fonts_client_list);
             t_size count = m_fonts_client_list.get_count();

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -58,8 +58,8 @@ public:
         EnableWindow(GetDlgItem(wnd, IDC_PARTS), show);
         EnableWindow(GetDlgItem(wnd, IDC_SHOW_COLUMN), show);
         EnableWindow(GetDlgItem(wnd, IDC_ALIGNMENT), show);
-        EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING),
-            show && m_column.is_valid() && m_column->filter_type != FILTER_NONE);
+        EnableWindow(
+            GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), show && m_column && m_column->filter_type != FILTER_NONE);
         EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_TYPE), show);
         EnableWindow(GetDlgItem(wnd, IDC_EDITFIELD), show);
     }
@@ -68,7 +68,7 @@ public:
     {
         initialising = true;
 
-        if (m_column.is_valid()) {
+        if (m_column) {
             uSendDlgItemMessageText(wnd, IDC_NAME, WM_SETTEXT, 0, m_column->name);
             uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_STRING, WM_SETTEXT, 0, m_column->filter);
             uSendDlgItemMessageText(wnd, IDC_EDITFIELD, WM_SETTEXT, 0, m_column->edit_field);
@@ -83,12 +83,12 @@ public:
 
         initialising = false;
 
-        set_detail_enabled(wnd, m_column.is_valid());
+        set_detail_enabled(wnd, static_cast<bool>(m_column));
     }
 
     void set_column(const PlaylistViewColumn::ptr& column) override
     {
-        if (m_column.get_ptr() != column.get_ptr()) {
+        if (m_column != column) {
             m_column = column;
             refresh_me(m_wnd);
         }
@@ -133,23 +133,23 @@ public:
         case WM_COMMAND:
             switch (wp) {
             case (CBN_SELCHANGE << 16) | IDC_ALIGNMENT: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->align = ((Alignment)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0));
                 }
             } break;
             case (CBN_SELCHANGE << 16) | IDC_PLAYLIST_FILTER_TYPE: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->filter_type = ((PlaylistFilterType)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0));
                     EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), m_column->filter_type != FILTER_NONE);
                 }
             } break;
             case IDC_SHOW_COLUMN: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->show = ((SendMessage((HWND)lp, BM_GETCHECK, 0, 0) != 0));
                 }
             } break;
             case (EN_CHANGE << 16) | IDC_SORT: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->sort_spec = (string_utf8_from_window((HWND)lp));
                 }
             } break;
@@ -157,27 +157,27 @@ public:
                 colour_code_gen(wnd, IDC_COLOUR, true, false);
                 break;
             case (EN_CHANGE << 16) | IDC_WIDTH: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->width = (GetDlgItemInt(wnd, IDC_WIDTH, nullptr, false));
                 }
             } break;
             case (EN_CHANGE << 16) | IDC_PARTS: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->parts = (GetDlgItemInt(wnd, IDC_PARTS, nullptr, false));
                 }
             } break;
             case (EN_CHANGE << 16) | IDC_PLAYLIST_FILTER_STRING: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->filter = (string_utf8_from_window((HWND)lp));
                 }
             } break;
             case (EN_CHANGE << 16) | IDC_EDITFIELD: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->edit_field = (string_utf8_from_window((HWND)lp));
                 }
             } break;
             case (EN_CHANGE << 16) | IDC_NAME: {
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->name = string_utf8_from_window((HWND)lp);
                     SendMessage(GetAncestor(wnd, GA_PARENT), MSG_COLUMN_NAME_CHANGED, NULL, NULL);
                 }
@@ -241,7 +241,7 @@ public:
 
     void set_column(const PlaylistViewColumn::ptr& column) override
     {
-        if (m_column.get_ptr() != column.get_ptr()) {
+        if (m_column != column) {
             m_column = column;
             update_controls();
         }
@@ -265,12 +265,12 @@ private:
     {
         pfc::vartoggle_t<bool> initialising_toggle(initialising, true);
 
-        if (m_column.is_valid()) {
+        if (m_column) {
             uSetWindowText(edit_control(), m_column->spec);
         } else {
             uSendMessageText(edit_control(), WM_SETTEXT, 0, "");
         }
-        EnableWindow(edit_control(), m_column.is_valid());
+        EnableWindow(edit_control(), m_column ? TRUE : FALSE);
     }
 
     BOOL CALLBACK on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -297,7 +297,7 @@ private:
                 colour_code_gen(wnd, IDC_COLOUR, true, false);
                 break;
             case EN_CHANGE << 16 | IDC_DISPLAY_SCRIPT:
-                if (!initialising && m_column.is_valid())
+                if (!initialising && m_column)
                     m_column->spec = string_utf8_from_window(reinterpret_cast<HWND>(lp));
                 break;
             }
@@ -327,7 +327,7 @@ public:
 
     void set_column(const PlaylistViewColumn::ptr& column) override
     {
-        if (m_column.get_ptr() != column.get_ptr()) {
+        if (m_column != column) {
             m_column = column;
             update_controls();
         }
@@ -351,15 +351,15 @@ private:
     {
         pfc::vartoggle_t<bool> initialising_toggle(initialising, true);
 
-        if (m_column.is_valid()) {
+        if (m_column) {
             uSetWindowText(edit_control(), m_column->colour_spec);
             Button_SetCheck(custom_colour_control(), m_column->use_custom_colour ? BST_CHECKED : BST_UNCHECKED);
         } else {
             uSendMessageText(edit_control(), WM_SETTEXT, 0, "");
             Button_SetCheck(custom_colour_control(), BST_UNCHECKED);
         }
-        EnableWindow(edit_control(), m_column.is_valid());
-        EnableWindow(custom_colour_control(), m_column.is_valid());
+        EnableWindow(edit_control(), m_column ? TRUE : FALSE);
+        EnableWindow(custom_colour_control(), m_column ? TRUE : FALSE);
     }
 
     BOOL CALLBACK on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -386,12 +386,12 @@ private:
                 colour_code_gen(wnd, IDC_COLOUR, true, false);
                 break;
             case IDC_CUSTOM_COLOUR:
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->use_custom_colour = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
                 }
                 break;
             case EN_CHANGE << 16 | IDC_STYLE_SCRIPT:
-                if (!initialising && m_column.is_valid())
+                if (!initialising && m_column)
                     m_column->colour_spec = string_utf8_from_window(reinterpret_cast<HWND>(lp));
                 break;
             }
@@ -422,7 +422,7 @@ public:
 
     void set_column(const PlaylistViewColumn::ptr& column) override
     {
-        if (m_column.get_ptr() != column.get_ptr()) {
+        if (m_column != column) {
             m_column = column;
             update_controls();
         }
@@ -446,15 +446,15 @@ private:
     {
         pfc::vartoggle_t<bool> initialising_toggle(initialising, true);
 
-        if (m_column.is_valid()) {
+        if (m_column) {
             uSetWindowText(edit_control(), m_column->sort_spec);
             Button_SetCheck(custom_sorting_control(), m_column->use_custom_sort ? BST_CHECKED : BST_UNCHECKED);
         } else {
             uSendMessageText(edit_control(), WM_SETTEXT, 0, "");
             Button_SetCheck(custom_sorting_control(), BST_UNCHECKED);
         }
-        EnableWindow(edit_control(), m_column.is_valid());
-        EnableWindow(custom_sorting_control(), m_column.is_valid());
+        EnableWindow(edit_control(), m_column ? TRUE : FALSE);
+        EnableWindow(custom_sorting_control(), m_column ? TRUE : FALSE);
     }
 
     BOOL CALLBACK on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -478,12 +478,12 @@ private:
                 show_title_formatting_help_menu(wnd, IDC_SORTING_SCRIPT);
                 break;
             case IDC_CUSTOM_SORT:
-                if (!initialising && m_column.is_valid()) {
+                if (!initialising && m_column) {
                     m_column->use_custom_sort = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
                 }
                 break;
             case EN_CHANGE << 16 | IDC_SORTING_SCRIPT:
-                if (!initialising && m_column.is_valid())
+                if (!initialising && m_column)
                     m_column->sort_spec = string_utf8_from_window(reinterpret_cast<HWND>(lp));
                 break;
             }
@@ -637,7 +637,7 @@ BOOL TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     int& idx = item;
                     auto wnd_lv = HWND(wp);
                     if (cmd == ID_NEW) {
-                        PlaylistViewColumn::ptr temp = new PlaylistViewColumn;
+                        PlaylistViewColumn::ptr temp = std::make_shared<PlaylistViewColumn>();
                         temp->name = "New Column";
                         t_size insert = m_columns.insert_item(
                             temp, idx >= 0 && (t_size)idx < m_columns.get_count() ? idx : m_columns.get_count());
@@ -779,7 +779,7 @@ BOOL TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             int idx = ListView_GetNextItem(wnd_lv, -1, LVNI_SELECTED);
             // if (true)
             {
-                PlaylistViewColumn::ptr temp = new PlaylistViewColumn;
+                PlaylistViewColumn::ptr temp = std::make_shared<PlaylistViewColumn>();
                 temp->name = "New Column";
                 t_size insert = m_columns.insert_item(
                     temp, idx >= 0 && (t_size)idx < m_columns.get_count() ? idx : m_columns.get_count());

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -512,7 +512,7 @@ void TabColumns::make_child()
         ShowWindow(m_wnd_child, SW_HIDE);
         DestroyWindow(m_wnd_child);
         m_wnd_child = nullptr;
-        m_child.release();
+        m_child.reset();
     }
 
     HWND wnd_tab = GetDlgItem(m_wnd, IDC_TAB1);
@@ -536,13 +536,13 @@ void TabColumns::make_child()
             column = m_columns[item];
 
         if (cfg_child_column == 0)
-            m_child = new EditColumnWindowOptions(column);
+            m_child = std::make_unique<EditColumnWindowOptions>(column);
         else if (cfg_child_column == 1)
-            m_child = new DisplayScriptTab(column);
+            m_child = std::make_unique<DisplayScriptTab>(column);
         else if (cfg_child_column == 2)
-            m_child = new StyleScriptTab(column);
+            m_child = std::make_unique<StyleScriptTab>(column);
         else if (cfg_child_column == 3)
-            m_child = new SortingScriptTab(column);
+            m_child = std::make_unique<SortingScriptTab>(column);
         m_wnd_child = m_child->create(m_wnd);
     }
 
@@ -693,7 +693,7 @@ BOOL TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (m_wnd_child) {
             DestroyWindow(m_wnd_child);
             m_wnd_child = nullptr;
-            m_child.release();
+            m_child.reset();
         }
     } break;
     case MSG_SELECTION_CHANGED: {
@@ -716,7 +716,7 @@ BOOL TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             switch (lpnm->code) {
             case LVN_ITEMCHANGED: {
                 auto lpnmlv = (LPNMLISTVIEW)lp;
-                if (m_child.is_valid()) {
+                if (m_child) {
                     if (lpnmlv->iItem != -1 && lpnmlv->iItem >= 0 && (t_size)lpnmlv->iItem < m_columns.get_count()) {
                         if ((lpnmlv->uNewState & LVIS_SELECTED) != (lpnmlv->uOldState & LVIS_SELECTED))
                             PostMessage(wnd, MSG_SELECTION_CHANGED, NULL, NULL);

--- a/foo_ui_columns/config_columns_v2.h
+++ b/foo_ui_columns/config_columns_v2.h
@@ -1,9 +1,9 @@
 #pragma once
 
-class ColumnTab : public pfc::refcounted_object_root {
+class ColumnTab {
 public:
-    using self_t = ColumnTab;
-    using ptr = pfc::refcounted_object_ptr_t<self_t>;
+    virtual ~ColumnTab() = default;
+
     virtual HWND create(HWND wnd) = 0;
     // virtual void destroy(HWND wnd)=0;
     // virtual const char * get_name()=0;
@@ -16,7 +16,7 @@ private:
     HWND m_wnd_child{nullptr};
     HWND m_wnd{nullptr};
     HWND m_wnd_lv{nullptr};
-    ColumnTab::ptr m_child;
+    std::unique_ptr<ColumnTab> m_child;
     // edit_column_window_options m_tab_options;
     // edit_column_window_scripts m_tab_scripts;
 public:

--- a/foo_ui_columns/fcl_titles.cpp
+++ b/foo_ui_columns/fcl_titles.cpp
@@ -80,7 +80,7 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
             reader.read_item(column_id);
             reader.read_item(column_size);
 
-            PlaylistViewColumn::ptr item = new PlaylistViewColumn;
+            PlaylistViewColumn::ptr item = std::make_shared<PlaylistViewColumn>();
 
             fbh::fcl::Reader reader2(reader, column_size, p_abort);
 

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -730,7 +730,7 @@ int Node::g_compare_ptr_with_node(const Node& i1, const Node& i2)
 
 void FilterPanel::refresh_stream()
 {
-    m_stream.release();
+    m_stream.reset();
     if (cfg_orderedbysplitters) {
         t_size stream_index = pfc_infinite;
         uie::window_host_ex::ptr hostex;
@@ -746,14 +746,14 @@ void FilterPanel::refresh_stream()
         if (stream_index != pfc_infinite)
             g_streams[stream_index]->m_windows.add_item(this);
         else {
-            FilterStream::ptr streamnew = new FilterStream;
+            FilterStream::ptr streamnew = std::make_shared<FilterStream>();
             streamnew->m_windows.add_item(this);
             stream_index = g_streams.add_item(streamnew);
         }
         m_stream = g_streams[stream_index];
     } else {
         if (!g_streams.get_count()) {
-            m_stream = new FilterStream;
+            m_stream = std::make_shared<FilterStream>();
             g_streams.add_item(m_stream);
         } else
             m_stream = g_streams[0];
@@ -860,7 +860,7 @@ void FilterPanel::notify_on_destroy()
     m_stream->m_windows.remove_item(this);
     if (m_stream->m_windows.get_count() == 0)
         g_streams.remove_item(m_stream);
-    m_stream.release();
+    m_stream.reset();
 
     g_windows.erase(std::remove(g_windows.begin(), g_windows.end(), this), g_windows.end());
     if (g_windows.empty())

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -62,10 +62,10 @@ public:
     }
 };
 
-class FilterStream : public pfc::refcounted_object_root {
+class FilterStream {
 public:
     using self_t = FilterStream;
-    using ptr = pfc::refcounted_object_ptr_t<self_t>;
+    using ptr = std::shared_ptr<self_t>;
     /** Unordered */
     pfc::ptr_list_t<class FilterPanel> m_windows;
 

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -64,7 +64,7 @@ void g_get_search_bar_sibling_streams(FilterSearchToolbar const* p_serach_bar, p
 
             if (p_window->get_extension_guid() == cui::panels::guid_filter) {
                 auto* p_filter = static_cast<FilterPanel*>(p_window.get_ptr());
-                if (!p_out.have_item(p_filter->m_stream.get_ptr()))
+                if (!p_out.have_item(p_filter->m_stream))
                     p_out.add_item(p_filter->m_stream);
             } else if (p_window->service_query_t(p_splitter)) {
                 t_size splitter_child_count = p_splitter->get_panel_count();
@@ -143,11 +143,11 @@ bool FilterSearchToolbar::g_activate()
 }
 
 bool FilterSearchToolbar::g_filter_search_bar_has_stream(
-    FilterSearchToolbar const* p_seach_bar, const FilterStream* p_stream)
+    FilterSearchToolbar const* p_seach_bar, const FilterStream::ptr& p_stream)
 {
     pfc::list_t<FilterStream::ptr> p_streams;
     g_get_search_bar_sibling_streams(p_seach_bar, p_streams);
-    return p_streams.have_item(const_cast<FilterStream*>(p_stream)); // meh
+    return p_streams.have_item(p_stream);
 }
 
 void FilterSearchToolbar::s_on_favourites_change()

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -8,14 +8,14 @@ namespace filter_panel {
 class FilterSearchToolbar : public uie::container_uie_window_v2 {
 public:
     static bool g_activate();
-    static bool g_filter_search_bar_has_stream(FilterSearchToolbar const* p_seach_bar, const FilterStream* p_stream);
+    static bool g_filter_search_bar_has_stream(
+        FilterSearchToolbar const* p_seach_bar, const FilterStream::ptr& p_stream);
     static void s_on_favourites_change();
 
-    template <class TStream>
-    static void g_initialise_filter_stream(const TStream& p_stream)
+    static void g_initialise_filter_stream(const FilterStream::ptr& p_stream)
     {
         for (t_size i = 0, count = g_active_instances.get_count(); i < count; i++) {
-            if (!cfg_orderedbysplitters || g_filter_search_bar_has_stream(g_active_instances[i], p_stream.get_ptr())) {
+            if (!cfg_orderedbysplitters || g_filter_search_bar_has_stream(g_active_instances[i], p_stream)) {
                 if (!g_active_instances[i]->m_active_search_string.is_empty()) {
                     p_stream->m_source_overriden = true;
                     p_stream->m_source_handles = g_active_instances[i]->m_active_handles;

--- a/foo_ui_columns/fonts_manager_data.cpp
+++ b/foo_ui_columns/fonts_manager_data.cpp
@@ -5,11 +5,11 @@
 
 FontsManagerData::FontsManagerData() : cfg_var(g_cfg_guid)
 {
-    m_common_items_entry = new Entry;
+    m_common_items_entry = std::make_shared<Entry>();
     uGetIconFont(&m_common_items_entry->font_description.log_font);
     m_common_items_entry->font_description.estimate_point_size();
 
-    m_common_labels_entry = new Entry;
+    m_common_labels_entry = std::make_shared<FontsManagerData::Entry>();
     uGetMenuFont(&m_common_labels_entry->font_description.log_font);
     m_common_labels_entry->font_description.estimate_point_size();
 }
@@ -41,7 +41,7 @@ void FontsManagerData::find_by_guid(const GUID& p_guid, entry_ptr_t& p_out)
         }
     }
     {
-        p_out = new Entry;
+        p_out = std::make_shared<FontsManagerData::Entry>();
         p_out->guid = p_guid;
         cui::fonts::client::ptr ptr;
         if (cui::fonts::client::create_by_guid(p_guid, ptr)) {
@@ -65,7 +65,7 @@ void FontsManagerData::set_data_raw(stream_reader* p_stream, t_size p_sizehint, 
         p_stream->read_lendian_t(count, p_abort);
         m_entries.remove_all();
         for (t_size i = 0; i < count; i++) {
-            entry_ptr_t ptr = new Entry;
+            entry_ptr_t ptr = std::make_shared<Entry>();
             ptr->read(version, p_stream, p_abort);
             m_entries.add_item(ptr);
         }

--- a/foo_ui_columns/fonts_manager_data.h
+++ b/foo_ui_columns/fonts_manager_data.h
@@ -8,7 +8,7 @@ public:
     void get_data_raw(stream_writer* p_stream, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* p_stream, t_size p_sizehint, abort_callback& p_abort) override;
 
-    class Entry : public pfc::refcounted_object_root {
+    class Entry {
     public:
         enum ItemID {
             identifier_guid,
@@ -32,7 +32,7 @@ public:
 
         Entry();
     };
-    using entry_ptr_t = pfc::refcounted_object_ptr_t<Entry>;
+    using entry_ptr_t = std::shared_ptr<Entry>;
     pfc::list_t<entry_ptr_t> m_entries;
     entry_ptr_t m_common_items_entry;
     entry_ptr_t m_common_labels_entry;

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -756,7 +756,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         static_api_ptr_t<playlist_manager_v3>()->register_callback(this, playlist_callback_flags);
         static_api_ptr_t<metadb_io_v3>()->register_callback(this);
 
-        m_font_change_info.m_default_font = new Font;
+        m_font_change_info.m_default_font = std::make_shared<Font>();
         m_font_change_info.m_default_font->m_font
             = static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client);
         m_font_change_info.m_default_font->m_height = uGetFontHeight(m_font_change_info.m_default_font->m_font);
@@ -783,7 +783,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (g_windows.empty())
             g_message_window.destroy();
 
-        m_font_change_info.m_default_font.release();
+        m_font_change_info.m_default_font.reset();
 
         static_api_ptr_t<play_callback_manager>()->unregister_callback(this);
         static_api_ptr_t<metadb_io_v3>()->unregister_callback(this);

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -79,9 +79,9 @@ using display_line_info_list_t = pfc::list_t<DisplayLineInfo, pfc::alloc_fast_ag
 void g_parse_font_format_string(const char* str, t_size len, FontData& p_out);
 void g_get_text_font_data(const char* p_text, pfc::string8_fast_aggressive& p_new_text, font_change_data_list_t& p_out);
 
-class Font : public pfc::refcounted_object_root {
+class Font {
 public:
-    using ptr_t = pfc::refcounted_object_ptr_t<Font>;
+    using ptr_t = std::shared_ptr<Font>;
 
     FontData m_data;
 

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -96,7 +96,7 @@ void g_get_text_font_info(const font_change_data_list_t& p_data, FontChangeNotif
                     if (index < maskKeepFonts.get_count())
                         maskKeepFonts[index] = true;
                 } else {
-                    Font::ptr_t font = new Font;
+                    Font::ptr_t font = std::make_shared<Font>();
                     font->m_font = CreateFontIndirect(&lf);
                     font->m_height = uGetFontHeight(font->m_font);
                     font->m_data = p_data[i].m_font_data;

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -321,7 +321,7 @@ void PlaylistView::g_flush_artwork(bool b_redraw, const PlaylistView* p_skip)
 void PlaylistView::g_on_artwork_repositories_change()
 {
     for (auto& window : g_windows) {
-        if (window->m_artwork_manager.is_valid()) {
+        if (window->m_artwork_manager) {
             window->m_artwork_manager->set_script(album_art_ids::cover_front, artwork_panel::cfg_front_scripts);
         }
     }
@@ -541,7 +541,7 @@ void PlaylistView::notify_on_initialisation()
 
     Gdiplus::GdiplusStartupInput gdiplusStartupInput;
     m_gdiplus_initialised = (Gdiplus::Ok == Gdiplus::GdiplusStartup(&m_gdiplus_token, &gdiplusStartupInput, nullptr));
-    m_artwork_manager = new ArtworkReaderManager;
+    m_artwork_manager = std::make_shared<ArtworkReaderManager>();
     m_artwork_manager->initialise();
     m_artwork_manager->add_type(album_art_ids::cover_front);
     m_artwork_manager->set_script(album_art_ids::cover_front, artwork_panel::cfg_front_scripts);
@@ -592,7 +592,7 @@ void PlaylistView::notify_on_destroy()
     m_column_mask.set_size(0);
 
     m_artwork_manager->deinitialise();
-    m_artwork_manager.release();
+    m_artwork_manager.reset();
 
     m_selection_holder.release();
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -204,7 +204,7 @@ void PlaylistView::refresh_columns()
     t_size count = g_columns.get_count();
     m_column_mask.set_size(count);
     for (t_size i = 0; i < count; i++) {
-        PlaylistViewColumn* source = g_columns[i].get_ptr();
+        PlaylistViewColumn* source = g_columns[i].get();
         bool b_valid = false;
         if (source->show) {
             switch (source->filter_type) {

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -111,10 +111,11 @@ public:
     titleformat_object::ptr m_sort_script;
 };
 
-class BaseArtworkCompletionNotify : public pfc::refcounted_object_root {
+class BaseArtworkCompletionNotify {
 public:
-    using ptr_t = pfc::refcounted_object_ptr_t<BaseArtworkCompletionNotify>;
+    using ptr_t = std::shared_ptr<BaseArtworkCompletionNotify>;
 
+    virtual ~BaseArtworkCompletionNotify() = default;
     virtual void on_completion(const std::shared_ptr<class ArtworkReader>& p_reader) = 0;
 
 private:
@@ -133,12 +134,12 @@ public:
     void initialise(const pfc::chain_list_v2_t<GUID>& p_requestIds,
         const pfc::map_t<GUID, pfc::list_t<pfc::string8>>& p_repositories, t_size native_artwork_reader_mode,
         const metadb_handle_ptr& p_handle, t_size cx, t_size cy, COLORREF cr_back, bool b_reflection,
-        const BaseArtworkCompletionNotify::ptr_t& p_notify, std::shared_ptr<class ArtworkReaderManager> p_manager)
+        BaseArtworkCompletionNotify::ptr_t p_notify, std::shared_ptr<class ArtworkReaderManager> p_manager)
     {
         m_requestIds = p_requestIds;
         m_repositories = p_repositories;
         m_handle = p_handle;
-        m_notify = p_notify;
+        m_notify = std::move(p_notify);
         m_cx = cx;
         m_cy = cy;
         m_reflection = b_reflection;
@@ -148,7 +149,7 @@ public:
     }
     void send_completion_notification(const std::shared_ptr<ArtworkReader>& p_this)
     {
-        if (m_notify.is_valid()) {
+        if (m_notify) {
             m_notify->on_completion(p_this);
         }
     }
@@ -475,7 +476,7 @@ private:
 
     class ArtworkCompletionNotify : public BaseArtworkCompletionNotify {
     public:
-        using ptr_t = pfc::refcounted_object_ptr_t<ArtworkCompletionNotify>;
+        using ptr_t = std::shared_ptr<ArtworkCompletionNotify>;
 
         void on_completion(const std::shared_ptr<ArtworkReader>& p_reader) override
         {
@@ -484,8 +485,6 @@ private:
 
         PlaylistViewGroup::ptr m_group;
         service_ptr_t<PlaylistView> m_window;
-
-    private:
     };
 
     HBITMAP request_group_artwork(t_size index_item);

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -44,7 +44,7 @@ void ArtworkReaderManager::request(const metadb_handle_ptr& p_handle, std::share
 {
     auto p_new_reader = std::make_shared<ArtworkReader>();
     p_new_reader->initialise(m_requestIds, m_repositories, artwork_panel::cfg_fb2k_artwork_mode, p_handle, cx, cy,
-        cr_back, b_reflection, p_notify, shared_from_this());
+        cr_back, b_reflection, std::move(p_notify), shared_from_this());
     m_pending_readers.add_item(p_new_reader);
     p_out = p_new_reader;
     flush_pending();
@@ -455,7 +455,7 @@ HBITMAP PlaylistView::request_group_artwork(t_size index_item)
                 cy-= (1*padding);
             else cy =0;*/
 
-            ArtworkCompletionNotify::ptr_t ptr = new ArtworkCompletionNotify;
+            ArtworkCompletionNotify::ptr_t ptr = std::make_shared<ArtworkCompletionNotify>();
             ptr->m_group = group;
             ptr->m_window = this;
             metadb_handle_ptr handle;
@@ -463,7 +463,7 @@ HBITMAP PlaylistView::request_group_artwork(t_size index_item)
             std::shared_ptr<ArtworkReader> p_reader;
             m_artwork_manager->request(handle, p_reader, cx, cy,
                 cui::colours::helper(ColoursClient::g_guid).get_colour(cui::colours::colour_background),
-                cfg_artwork_reflection, ptr.get_ptr());
+                cfg_artwork_reflection, std::move(ptr));
             group->m_artwork_load_attempted = true;
         }
     }

--- a/foo_ui_columns/playlist_switcher_inline_edit.cpp
+++ b/foo_ui_columns/playlist_switcher_inline_edit.cpp
@@ -11,7 +11,7 @@ bool PlaylistSwitcher::notify_create_inline_edit(const pfc::list_base_const_t<t_
 {
     t_size indices_count = indices.get_count();
     if (indices_count == 1 && indices[0] < m_playlist_api->get_playlist_count()) {
-        m_edit_playlist = pfc::rcnew_t<playlist_position_reference_tracker>(false);
+        m_edit_playlist = std::make_shared<playlist_position_reference_tracker>(false);
         m_edit_playlist->m_playlist = indices[0];
         m_playlist_api->playlist_get_name(indices[0], p_text);
         return true;
@@ -20,12 +20,12 @@ bool PlaylistSwitcher::notify_create_inline_edit(const pfc::list_base_const_t<t_
 };
 void PlaylistSwitcher::notify_save_inline_edit(const char* value)
 {
-    if (m_edit_playlist.is_valid() && m_edit_playlist->m_playlist != pfc_infinite) {
+    if (m_edit_playlist && m_edit_playlist->m_playlist != pfc_infinite) {
         pfc::string8 current;
         m_playlist_api->playlist_get_name(m_edit_playlist->m_playlist, current);
         if (strcmp(current, value) != 0) {
             m_playlist_api->playlist_rename(m_edit_playlist->m_playlist, value, pfc_infinite);
         }
     }
-    m_edit_playlist.release();
+    m_edit_playlist.reset();
 }

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -80,15 +80,15 @@ public:
         if (m_switch_timer_active) {
             KillTimer(get_wnd(), TIMER_SWITCH);
             m_switch_timer_active = false;
-            m_switch_playlist.release();
+            m_switch_playlist.reset();
         }
     }
     void set_switch_timer(t_size index)
     {
-        if (!m_switch_timer_active || !m_switch_playlist.is_valid() || m_switch_playlist->m_playlist != index) {
+        if (!m_switch_timer_active || !m_switch_playlist || m_switch_playlist->m_playlist != index) {
             if (index != m_playlist_api->get_active_playlist()) {
                 destroy_switch_timer();
-                m_switch_playlist = pfc::rcnew_t<playlist_position_reference_tracker>(false);
+                m_switch_playlist = std::make_shared<playlist_position_reference_tracker>(false);
                 m_switch_playlist->m_playlist = index;
                 SetTimer(get_wnd(), TIMER_SWITCH, cfg_autoswitch_delay, nullptr);
                 m_switch_timer_active = true;
@@ -99,7 +99,7 @@ public:
     bool notify_on_timer(UINT_PTR timerid) override
     {
         if (timerid == TIMER_SWITCH) {
-            t_size index = m_switch_playlist.is_valid() ? m_switch_playlist->m_playlist : pfc_infinite;
+            t_size index = m_switch_playlist ? m_switch_playlist->m_playlist : pfc_infinite;
             destroy_switch_timer();
             if (index != pfc_infinite)
                 m_playlist_api->set_active_playlist(index);
@@ -316,12 +316,12 @@ private:
     ui_selection_holder::ptr m_selection_holder;
 
     bool m_switch_timer_active{false};
-    pfc::rcptr_t<playlist_position_reference_tracker> m_switch_playlist;
+    std::shared_ptr<playlist_position_reference_tracker> m_switch_playlist;
 
     bool m_dragging{false};
     wil::com_ptr_t<IDataObject> m_DataObject;
 
-    pfc::rcptr_t<playlist_position_reference_tracker> m_edit_playlist;
+    std::shared_ptr<playlist_position_reference_tracker> m_edit_playlist;
     t_size m_playing_playlist;
     service_ptr_t<playlist_manager_v3> m_playlist_api;
     service_ptr_t<playback_control> m_playback_api;

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -17,7 +17,7 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_INITDIALOG: {
-        m_this = this;
+        m_this = shared_from_this();
 
         modeless_dialog_manager::g_add(wnd);
 
@@ -166,7 +166,7 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     case WM_NCDESTROY:
         SetWindowLongPtr(wnd, DWLP_USER, NULL);
-        m_this.release();
+        m_this.reset();
         return FALSE;
     }
 
@@ -175,7 +175,7 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
 void QuickSetupDialog::g_run()
 {
-    QuickSetupDialog::ptr_t dialog = new QuickSetupDialog;
+    QuickSetupDialog::ptr_t dialog = std::make_shared<QuickSetupDialog>();
     CreateDialogParam(mmh::get_current_instance(), MAKEINTRESOURCE(IDD_QUICK_SETUP), cui::main_window.get_wnd(),
-        g_SetupDialogProc, reinterpret_cast<LPARAM>(dialog.get_ptr()));
+        g_SetupDialogProc, reinterpret_cast<LPARAM>(dialog.get()));
 }

--- a/foo_ui_columns/setup_dialog.h
+++ b/foo_ui_columns/setup_dialog.h
@@ -11,13 +11,13 @@
 
 #include "layout.h"
 
-class QuickSetupDialog : public pfc::refcounted_object_root {
+class QuickSetupDialog : public std::enable_shared_from_this<QuickSetupDialog> {
     pfc::list_t<ConfigLayout::Preset> m_presets;
     uie::splitter_item_ptr m_previous_layout;
     cui::colours::colour_mode_t m_previous_colour_mode{columns_ui::colours::colour_mode_themed};
     bool m_previous_show_artwork{};
     bool m_previous_show_grouping{};
-    using ptr_t = pfc::refcounted_object_ptr_t<QuickSetupDialog>;
+    using ptr_t = std::shared_ptr<QuickSetupDialog>;
     ptr_t m_this;
     static BOOL CALLBACK g_SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     BOOL SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -85,7 +85,7 @@ private:
         SizeLimit() = default;
         ;
     };
-    class Panel : public pfc::refcounted_object_root {
+    class Panel : public std::enable_shared_from_this<Panel> {
     public:
         class PanelContainer
             : public ui_helpers::container_window
@@ -152,10 +152,10 @@ private:
         void destroy();
         Panel();
 
-        using ptr = pfc::refcounted_object_ptr_t<Panel>;
+        using ptr = std::shared_ptr<Panel>;
         static ptr null_ptr;
     };
-    class PanelList : public pfc::list_t<pfc::refcounted_object_ptr_t<Panel>> {
+    class PanelList : public pfc::list_t<std::shared_ptr<Panel>> {
     public:
         bool find_by_wnd(HWND wnd, unsigned& p_out);
         bool find_by_wnd_child(HWND wnd, unsigned& p_out);

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -12,7 +12,7 @@ bool FlatSplitterPanel::Panel::PanelContainer::test_autohide_window(HWND wnd)
 void FlatSplitterPanel::Panel::PanelContainer::on_hooked_message(WPARAM msg, const MSLLHOOKSTRUCT& mllhs)
 {
     if (msg == WM_MOUSEMOVE && m_this.is_valid() && MonitorFromPoint(mllhs.pt, MONITOR_DEFAULTTONULL)) {
-        unsigned index = m_this->m_panels.find_item(m_panel);
+        unsigned index = m_this->m_panels.find_item(m_panel->shared_from_this());
         if (index != pfc_infinite) {
             HWND wnd_capture = GetCapture();
             HWND wnd_pt = WindowFromPoint(mllhs.pt);
@@ -269,7 +269,7 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
         if (m_this.is_valid()) {
             unsigned index = 0;
             if (m_this->m_panels.find_by_wnd(wnd, index)) {
-                pfc::refcounted_object_ptr_t<Panel> p_panel = m_this->m_panels[index];
+                std::shared_ptr<Panel> p_panel = m_this->m_panels[index];
 
                 AppendMenu(
                     menu, (MF_STRING | (p_panel->m_show_caption ? MF_CHECKED : 0)), IDM_CAPTION, _T("Show &caption"));

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -24,7 +24,7 @@ public:
     {
         unsigned index;
         if (m_this->m_panels.find_by_wnd(wnd, index)) {
-            pfc::refcounted_object_ptr_t<TabStackPanel::Panel> p_ext = m_this->m_panels[index];
+            std::shared_ptr<TabStackPanel::Panel> p_ext = m_this->m_panels[index];
             MINMAXINFO mmi;
             memset(&mmi, 0, sizeof(MINMAXINFO));
             mmi.ptMaxTrackSize.x = MAXLONG;
@@ -110,7 +110,7 @@ public:
     {
         unsigned index;
         if (m_this->m_active_panels.find_by_wnd(wnd, index)) {
-            pfc::refcounted_object_ptr_t<TabStackPanel::Panel> p_ext = m_this->m_active_panels[index];
+            std::shared_ptr<TabStackPanel::Panel> p_ext = m_this->m_active_panels[index];
 
             {
                 /*if (GetAncestor(wnd, GA_PARENT) == m_this->get_wnd())
@@ -361,7 +361,7 @@ void TabStackPanel::set_config(stream_reader* config, t_size p_size, abort_callb
             config->read_lendian_t(count, p_abort);
 
             for (unsigned n = 0; n < count; n++) {
-                pfc::refcounted_object_ptr_t<Panel> temp = new Panel;
+                auto temp = std::make_shared<Panel>();
                 temp->read(config, p_abort);
                 m_panels.add_item(temp);
             }
@@ -402,7 +402,7 @@ void TabStackPanel::import_config(stream_reader* p_reader, t_size p_size, abort_
         p_reader->read_lendian_t(count, p_abort);
 
         for (unsigned n = 0; n < count; n++) {
-            pfc::refcounted_object_ptr_t<Panel> temp = new Panel;
+            auto temp = std::make_shared<Panel>();
             temp->import(p_reader, p_abort);
             m_panels.add_item(temp);
         }
@@ -588,7 +588,7 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         {
             if (b_found && index < m_active_panels.get_count()) {
-                pfc::refcounted_object_ptr_t<Panel> p_panel = m_active_panels[index];
+                std::shared_ptr<Panel> p_panel = m_active_panels[index];
 
                 pfc::refcounted_object_ptr_t<ui_extension::menu_hook_impl> extension_menu_nodes
                     = new ui_extension::menu_hook_impl;
@@ -756,7 +756,7 @@ void TabStackPanel::destroy_children()
 {
     unsigned count = m_panels.get_count();
     for (unsigned n = 0; n < count; n++) {
-        pfc::refcounted_object_ptr_t<Panel> pal = m_panels[n];
+        std::shared_ptr<Panel> pal = m_panels[n];
         pal->destroy();
     }
     m_active_panels.remove_all();
@@ -765,7 +765,7 @@ void TabStackPanel::destroy_children()
 void TabStackPanel::insert_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
     if (index <= m_panels.get_count()) {
-        pfc::refcounted_object_ptr_t<Panel> temp = new Panel;
+        auto temp = std::make_shared<Panel>();
         temp->set_from_splitter_item(p_item);
         m_panels.insert_item(temp, index);
 
@@ -786,7 +786,7 @@ void TabStackPanel::replace_panel(unsigned index, const uie::splitter_item_t* p_
             TabCtrl_DeleteItem(m_wnd_tabs, activeindex);
         }
 
-        pfc::refcounted_object_ptr_t<Panel> temp = new Panel;
+        auto temp = std::make_shared<Panel>();
         temp->set_from_splitter_item(p_item);
         m_panels.replace_item(index, temp);
 

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -74,7 +74,7 @@ public:
         SizeLimit() = default;
         ;
     };
-    class Panel : public pfc::refcounted_object_root {
+    class Panel {
     public:
         GUID m_guid{};
         HWND m_wnd{nullptr};
@@ -101,7 +101,7 @@ public:
         service_ptr_t<class TabStackSplitterHost> m_interface;
     };
 
-    class PanelList : public pfc::list_t<pfc::refcounted_object_ptr_t<Panel>> {
+    class PanelList : public pfc::list_t<std::shared_ptr<Panel>> {
     public:
         // bool move_up(unsigned idx);
         // bool move_down(unsigned idx);

--- a/foo_ui_columns/splitter_window.cpp
+++ b/foo_ui_columns/splitter_window.cpp
@@ -10,7 +10,7 @@ gdi_object_t<HFONT>::ptr_t FlatSplitterPanel::g_font_menu_vertical;
 void FlatSplitterPanel::insert_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
     if (index <= m_panels.get_count()) {
-        pfc::refcounted_object_ptr_t<Panel> temp = new Panel;
+        auto temp = std::make_shared<Panel>();
         temp->set_from_splitter_item(p_item);
         m_panels.insert_item(temp, index);
 
@@ -25,7 +25,7 @@ void FlatSplitterPanel::replace_panel(unsigned index, const uie::splitter_item_t
     if (index < m_panels.get_count()) {
         if (get_wnd())
             m_panels[index]->destroy();
-        pfc::refcounted_object_ptr_t<Panel> temp = new Panel;
+        auto temp = std::make_shared<Panel>();
         temp->set_from_splitter_item(p_item);
         m_panels.replace_item(index, temp);
 
@@ -38,7 +38,7 @@ void FlatSplitterPanel::destroy_children()
 {
     unsigned count = m_panels.get_count();
     for (unsigned n = 0; n < count; n++) {
-        pfc::refcounted_object_ptr_t<Panel> pal = m_panels[n];
+        std::shared_ptr<Panel> pal = m_panels[n];
         if (pal->m_child.is_valid()) {
             //            pal->m_child_data.set_size(0);
             //            stream_writer_memblock_ref blah(pal->m_child_data);
@@ -203,7 +203,7 @@ bool FlatSplitterPanel::find_by_divider_pt(POINT& pt, unsigned& p_out)
 {
     unsigned count = m_panels.get_count();
     for (unsigned n = 0; n < count; n++) {
-        pfc::refcounted_object_ptr_t<Panel> p_item = m_panels.get_item(n);
+        std::shared_ptr<Panel> p_item = m_panels.get_item(n);
 
         if (p_item->m_wnd_child) {
             RECT rc_area;
@@ -900,7 +900,7 @@ void FlatSplitterPanel::read_config(stream_reader* config, t_size p_size, bool i
 
             unsigned i;
             for (i = 0; i < count; i++) {
-                pfc::refcounted_object_ptr_t<Panel> temp = new Panel;
+                auto temp = std::make_shared<Panel>();
                 if (is_import)
                     temp->import(config, p_abort);
                 else
@@ -984,7 +984,7 @@ void FlatSplitterPanel::FlatSplitterPanelHost::relinquish_ownership(HWND wnd)
 {
     unsigned index;
     if (m_this->m_panels.find_by_wnd_child(wnd, index)) {
-        pfc::refcounted_object_ptr_t<FlatSplitterPanel::Panel> p_ext = m_this->m_panels[index];
+        std::shared_ptr<Panel> p_ext = m_this->m_panels[index];
 
         {
             if (GetAncestor(wnd, GA_PARENT) == p_ext->m_wnd) {
@@ -1087,7 +1087,7 @@ void FlatSplitterPanel::FlatSplitterPanelHost::on_size_limit_change(HWND wnd, un
 {
     unsigned index;
     if (m_this->m_panels.find_by_wnd_child(wnd, index)) {
-        pfc::refcounted_object_ptr_t<FlatSplitterPanel::Panel> p_ext = m_this->m_panels[index];
+        std::shared_ptr<Panel> p_ext = m_this->m_panels[index];
         MINMAXINFO mmi;
         memset(&mmi, 0, sizeof(MINMAXINFO));
         mmi.ptMaxTrackSize.x = MAXLONG;

--- a/foo_ui_columns/splitter_window_wndproc.cpp
+++ b/foo_ui_columns/splitter_window_wndproc.cpp
@@ -302,7 +302,7 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         t_size n, count = m_panels.get_count();
         for (n = 0; n + 1<count; n++)
         {
-            pfc::refcounted_object_ptr_t<panel> p_item = m_panels.get_item(n);
+            std::shared_ptr<Panel> p_item = m_panels.get_item(n);
 
             if (p_item->m_wnd_child)
             {
@@ -364,7 +364,7 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 {
                     if (cmd >= ID_ADD_BASE && cmd < panels.get_count() + ID_ADD_BASE)
                     {
-                        pfc::refcounted_object_ptr_t<panel> ptr = new panel;
+                        auto ptr = std::make_shared<Panel>();
                         ptr->m_guid = panels[cmd - ID_ADD_BASE].guid;
                         m_panels.add_item(ptr);
                         refresh_children();

--- a/foo_ui_columns/tab_colours.cpp
+++ b/foo_ui_columns/tab_colours.cpp
@@ -73,7 +73,7 @@ BOOL TabColours::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_DESTROY: {
         m_colours_client_list.remove_all();
         m_element_guid = pfc::guid_null;
-        m_element_ptr.release();
+        m_element_ptr.reset();
         m_element_api.release();
         m_wnd = nullptr;
     } break;

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -56,7 +56,7 @@ BOOL TabFonts::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_DESTROY: {
         m_wnd = nullptr;
         m_fonts_client_list.remove_all();
-        m_element_ptr.release();
+        m_element_ptr.reset();
         m_element_api.release();
     } break;
     case WM_COMMAND:

--- a/foo_ui_columns/tab_layout.h
+++ b/foo_ui_columns/tab_layout.h
@@ -18,9 +18,9 @@ public:
     uie::window_ptr m_window;
     service_ptr_t<uie::splitter_window> m_splitter;
     std::vector<ptr> m_children;
-    pfc::rcptr_t<uie::splitter_item_ptr> m_item;
+    std::shared_ptr<uie::splitter_item_ptr> m_item;
 
-    LayoutTabNode() : m_item(pfc::rcnew_t<uie::splitter_item_ptr>()) {}
+    LayoutTabNode() : m_item(std::make_shared<uie::splitter_item_ptr>()) {}
 };
 
 class LayoutTab : public PreferencesTab {


### PR DESCRIPTION
This replaces various uses of `pfc::rcptr_t` and `pfc::refcounted_object_ptr_t` with `std::shared_ptr` or `std::unique_ptr`.