### PR TITLE
Replace uses of gdi_object_t<>::ptr_t with WIL equivalents 

### DIFF
--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -186,7 +186,7 @@ private:
     std::shared_ptr<ArtworkReaderManager> m_artwork_loader;
     // now_playing_album_art_manager m_nowplaying_artwork_loader;
     std::unique_ptr<Gdiplus::Bitmap> m_image;
-    gdi_object_t<HBITMAP>::ptr_t m_bitmap;
+    wil::unique_hbitmap m_bitmap;
     t_size m_position{0};
     t_size m_track_mode;
     bool m_preserve_aspect_ratio, m_lock_type{false};

--- a/foo_ui_columns/artwork_helpers.cpp
+++ b/foo_ui_columns/artwork_helpers.cpp
@@ -73,7 +73,7 @@ void artwork_panel::ArtworkReaderManager::deinitialise()
         m_current_reader->wait_for_and_release_thread();
         m_current_reader.reset();
     }
-    m_emptycover.release();
+    m_emptycover.reset();
 }
 
 void artwork_panel::ArtworkReaderManager::initialise() {}
@@ -119,14 +119,14 @@ void artwork_panel::ArtworkReaderManager::Reset()
 {
     abort_current_task();
     m_current_reader.reset();
-    m_emptycover.release();
+    m_emptycover.reset();
 }
 
 void artwork_panel::ArtworkReaderManager::ResetRepository()
 {
     abort_current_task();
     m_repositories.remove_all();
-    m_emptycover.release();
+    m_emptycover.reset();
 }
 
 void artwork_panel::ArtworkReaderManager::SetScript(const GUID& p_what, const pfc::list_t<pfc::string8>& script)

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -243,7 +243,7 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
 {
     switch (msg) {
     case WM_CREATE:
-        m_font = uCreateIconFont();
+        m_font.reset(uCreateIconFont());
         create_edit();
         g_active_instances.add_item(this);
         break;
@@ -251,7 +251,7 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
         g_active_instances.remove_item(this);
         if (!core_api::is_shutting_down())
             commit_search_results("");
-        m_font.release();
+        m_font.reset();
         m_active_handles.remove_all();
         m_active_search_string.reset();
         if (m_imagelist) {

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -76,7 +76,7 @@ private:
     bool m_show_clear_button{cfg_showsearchclearbutton};
     pfc::string8 m_active_search_string;
     metadb_handle_list m_active_handles;
-    gdi_object_t<HFONT>::ptr_t m_font;
+    wil::unique_hfont m_font;
     HIMAGELIST m_imagelist{};
     int m_combo_cx{};
     int m_combo_cy{};

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -757,9 +757,9 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         static_api_ptr_t<metadb_io_v3>()->register_callback(this);
 
         m_font_change_info.m_default_font = std::make_shared<Font>();
-        m_font_change_info.m_default_font->m_font
-            = static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client);
-        m_font_change_info.m_default_font->m_height = uGetFontHeight(m_font_change_info.m_default_font->m_font);
+        m_font_change_info.m_default_font->m_font.reset(
+            static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client));
+        m_font_change_info.m_default_font->m_height = uGetFontHeight(m_font_change_info.m_default_font->m_font.get());
 
         if (g_windows.empty())
             g_message_window.create(nullptr);
@@ -938,8 +938,8 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         const int client_height = RECT_CY(rc_client);
 
-        FillRect(dc_mem, &rc,
-            gdi_object_t<HBRUSH>::ptr_t(CreateSolidBrush(p_helper.get_colour(cui::colours::colour_background))));
+        auto background_colour = p_helper.get_colour(cui::colours::colour_background);
+        FillRect(dc_mem, &rc, wil::unique_hbrush(CreateSolidBrush(background_colour)).get());
 
         int line_height = uGetTextHeight(dc_mem) + uih::scale_dpi_value(2);
 
@@ -995,8 +995,8 @@ void ItemDetails::g_on_colours_change()
 
 void ItemDetails::on_font_change()
 {
-    m_font_change_info.m_default_font->m_font
-        = static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client);
+    m_font_change_info.m_default_font->m_font.reset(
+        static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client));
     refresh_contents(false);
     /*
     invalidate_all(false);

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -85,7 +85,7 @@ public:
 
     FontData m_data;
 
-    gdi_object_t<HFONT>::ptr_t m_font;
+    wil::unique_hfont m_font;
     t_size m_height{};
     // font_t (const font_t & p_font) : m_font(p_font.m_font), m_height(p_font.m_height), m_data(p_font.m_data) {};
 };

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -97,8 +97,8 @@ void g_get_text_font_info(const font_change_data_list_t& p_data, FontChangeNotif
                         maskKeepFonts[index] = true;
                 } else {
                     Font::ptr_t font = std::make_shared<Font>();
-                    font->m_font = CreateFontIndirect(&lf);
-                    font->m_height = uGetFontHeight(font->m_font);
+                    font->m_font.reset(CreateFontIndirect(&lf));
+                    font->m_height = uGetFontHeight(font->m_font.get());
                     font->m_data = p_data[i].m_font_data;
                     index = p_info.m_fonts.add_item(font);
                     // maskKeepFonts.add_item(true);

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -194,8 +194,8 @@ private:
     unsigned m_panel_dragging{NULL};
     bool m_panel_dragging_valid{false};
 
-    static gdi_object_t<HFONT>::ptr_t g_font_menu_horizontal;
-    static gdi_object_t<HFONT>::ptr_t g_font_menu_vertical;
+    static wil::unique_hfont g_font_menu_horizontal;
+    static wil::unique_hfont g_font_menu_vertical;
     static unsigned g_count;
     static pfc::ptr_list_t<FlatSplitterPanel> g_instances;
 

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -130,7 +130,8 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
                     uGetWindowText(wnd, text);
 
                     HFONT old = SelectFont(dc,
-                        m_panel->m_caption_orientation == horizontal ? g_font_menu_horizontal : g_font_menu_vertical);
+                        m_panel->m_caption_orientation == horizontal ? g_font_menu_horizontal.get()
+                                                                     : g_font_menu_vertical.get());
                     // rc_caption.left += 11;
                     uDrawPanelTitle(dc, &rc_caption, text, text.length(),
                         m_this->m_panels[index]->m_caption_orientation == vertical, false);

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -810,7 +810,7 @@ void TabStackPanel::remove_panel(unsigned index)
 
 void TabStackPanel::create_tabs()
 {
-    g_font = static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_splitter_tabs);
+    g_font.reset(static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_splitter_tabs));
     RECT rc;
     GetClientRect(get_wnd(), &rc);
     DWORD flags = WS_CHILD | WS_TABSTOP | TCS_HOTTRACK | TCS_TABS | TCS_MULTILINE
@@ -826,7 +826,7 @@ void TabStackPanel::destroy_tabs()
 {
     DestroyWindow(m_wnd_tabs);
     m_wnd_tabs = nullptr;
-    g_font.release();
+    g_font.reset();
 }
 uie::window_factory<TabStackPanel> g_splitter_window_tabs;
 std::vector<service_ptr_t<TabStackPanel::t_self>> TabStackPanel::g_windows;
@@ -841,11 +841,11 @@ void TabStackPanel::g_on_font_change()
 void TabStackPanel::on_font_change()
 {
     if (m_wnd_tabs) {
-        if (g_font.is_valid()) {
+        if (g_font) {
             SendMessage(m_wnd_tabs, WM_SETFONT, (WPARAM)0, MAKELPARAM(0, 0));
         }
 
-        g_font = static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_splitter_tabs);
+        g_font.reset(static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_splitter_tabs));
 
         if (m_wnd_tabs) {
             SendMessage(m_wnd_tabs, WM_SETFONT, (WPARAM)g_font.get(), MAKELPARAM(1, 0));

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -130,7 +130,7 @@ public:
     void update_size_limits();
     void on_font_change();
     static void g_on_font_change();
-    gdi_object_t<HFONT>::ptr_t g_font;
+    wil::unique_hfont g_font;
     void on_size_changed(unsigned width, unsigned height);
     void on_size_changed();
     void on_active_tab_changing(t_size index_from);

--- a/foo_ui_columns/splitter_window.cpp
+++ b/foo_ui_columns/splitter_window.cpp
@@ -4,8 +4,8 @@
 ui_extension::window_host_factory<FlatSplitterPanel::FlatSplitterPanelHost> g_splitter_host_vert;
 
 unsigned FlatSplitterPanel::g_count = 0;
-gdi_object_t<HFONT>::ptr_t FlatSplitterPanel::g_font_menu_horizontal;
-gdi_object_t<HFONT>::ptr_t FlatSplitterPanel::g_font_menu_vertical;
+wil::unique_hfont FlatSplitterPanel::g_font_menu_horizontal;
+wil::unique_hfont FlatSplitterPanel::g_font_menu_vertical;
 
 void FlatSplitterPanel::insert_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
@@ -975,7 +975,7 @@ void FlatSplitterPanel::get_category(pfc::string_base& p_out) const
 
 unsigned FlatSplitterPanel::g_get_caption_size()
 {
-    unsigned rv = uGetFontHeight(g_font_menu_horizontal);
+    unsigned rv = uGetFontHeight(g_font_menu_horizontal.get());
     rv += 9;
     return rv;
 }

--- a/foo_ui_columns/splitter_window_wndproc.cpp
+++ b/foo_ui_columns/splitter_window_wndproc.cpp
@@ -10,16 +10,16 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     case WM_CREATE:
         if (!g_count++) {
-            g_font_menu_horizontal = uCreateMenuFont();
-            g_font_menu_vertical = uCreateMenuFont(true);
+            g_font_menu_horizontal.reset(uCreateMenuFont());
+            g_font_menu_vertical.reset(uCreateMenuFont(true));
         }
         refresh_children();
         break;
     case WM_DESTROY:
         destroy_children();
         if (!--g_count) {
-            g_font_menu_horizontal.release();
-            g_font_menu_vertical.release();
+            g_font_menu_horizontal.reset();
+            g_font_menu_vertical.reset();
         }
         break;
     case WM_NCDESTROY:
@@ -297,7 +297,7 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         PAINTSTRUCT ps;
         BeginPaint(wnd, &ps);
         COLORREF cr = GetSysColor(COLOR_3DFACE);
-        gdi_object_t<HBRUSH>::ptr_t br_line = CreateSolidBrush(/*RGB(226, 226, 226)*/cr);
+        wil::unique_hbrush br_line(CreateSolidBrush(/*RGB(226, 226, 226)*/cr));
 
         t_size n, count = m_panels.get_count();
         for (n = 0; n + 1<count; n++)
@@ -322,7 +322,7 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     //FillRect(ps.hdc, &rc_area, GetSysColorBrush(COLOR_WINDOW));
                     //rc_area.right--;
                 }
-                FillRect(ps.hdc, &rc_area, br_line);
+                FillRect(ps.hdc, &rc_area, br_line.get());
             }
         }
 

--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -20,7 +20,7 @@ StatusPaneFontClient::factory<StatusPaneFontClient> g_font_client_status_pane;
 
 void StatusPane::on_font_changed()
 {
-    m_font = cui::fonts::helper(g_guid_font).get_font();
+    m_font.reset(cui::fonts::helper(g_guid_font).get_font());
     cui::main_window.resize_child_windows();
 }
 
@@ -29,7 +29,7 @@ void StatusPane::render_background(HDC dc, const RECT& rc)
     COLORREF cr = GetSysColor(COLOR_BTNFACE);
     COLORREF cr2 = GetSysColor(COLOR_3DDKSHADOW);
 
-    FillRect(dc, &rc, gdi_object_t<HBRUSH>::ptr_t(CreateSolidBrush(cr)));
+    FillRect(dc, &rc, wil::unique_hbrush(CreateSolidBrush(cr)).get());
 
     if (m_theme) {
         COLORREF cr_back = cr2;

--- a/foo_ui_columns/status_pane.h
+++ b/foo_ui_columns/status_pane.h
@@ -175,7 +175,7 @@ public:
     StatusPane() = default;
     t_size get_ideal_height()
     {
-        return uGetFontHeight(m_font) * 2 + uih::scale_dpi_value(2) + uih::scale_dpi_value(4)
+        return uGetFontHeight(m_font.get()) * 2 + uih::scale_dpi_value(2) + uih::scale_dpi_value(4)
             + uih::scale_dpi_value(3) * 2;
     }
     void enter_menu_mode(const char* p_text)
@@ -204,6 +204,6 @@ private:
     pfc::string8_fast_aggressive playing1;
     pfc::string8 m_menu_text;
     bool m_menu_active{false};
-    gdi_object_t<HFONT>::ptr_t m_font;
+    wil::unique_hfont m_font;
     HTHEME m_theme{nullptr};
 };

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -8,7 +8,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CREATE: {
         ShowWindow(m_volume_control.create(wnd), SW_SHOWNORMAL);
 
-        m_font = cui::fonts::helper(g_guid_font).get_font();
+        m_font.reset(cui::fonts::helper(g_guid_font).get_font());
         m_theme = IsThemeActive() && IsAppThemed() ? OpenThemeData(wnd, L"Window") : nullptr;
 
         update_playlist_data();
@@ -23,7 +23,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         m_volume_control.destroy();
 
-        m_font.release();
+        m_font.reset();
         if (m_theme) {
             CloseThemeData(m_theme);
             m_theme = nullptr;
@@ -63,7 +63,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         uih::PaintScope ps(wnd);
         uih::MemoryDC dc(ps);
 
-        const auto font_height = uGetFontHeight(m_font);
+        const auto font_height = uGetFontHeight(m_font.get());
         const auto line_height = font_height + uih::scale_dpi_value(3);
 
         RECT rc_client{};
@@ -85,7 +85,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         rc_line_2.top = rc_line_1.bottom;
         rc_line_2.bottom = rc_line_2.top + line_height;
 
-        HFONT fnt_old = SelectFont(dc, m_font);
+        HFONT fnt_old = SelectFont(dc, m_font.get());
 
         const char* placeholder = "999999999 items selected";
         const auto default_text_colour = GetSysColor(COLOR_BTNTEXT);


### PR DESCRIPTION
This replaces uses of `gdi_object_t<>::ptr_t` from ui_helpers with equivalents from WIL such as `wil::unique_hbrush` and `wil::shared_hbitmap`.