### PR TITLE
Replace some uses of pfc::list_t with standard library equivalents

### DIFF
--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -796,12 +796,12 @@ const char* ArtworkPanel::MenuNodeArtworkType::get_name(t_size source)
 
 ArtworkPanel::MenuNodeSourcePopup::MenuNodeSourcePopup(ArtworkPanel* p_wnd)
 {
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, 3));
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, 0));
-    m_items.add_item(new uie::menu_node_separator_t());
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, 2));
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, 4));
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, 1));
+    m_items.emplace_back(new MenuNodeTrackMode(p_wnd, 3));
+    m_items.emplace_back(new MenuNodeTrackMode(p_wnd, 0));
+    m_items.emplace_back(new uie::menu_node_separator_t());
+    m_items.emplace_back(new MenuNodeTrackMode(p_wnd, 2));
+    m_items.emplace_back(new MenuNodeTrackMode(p_wnd, 4));
+    m_items.emplace_back(new MenuNodeTrackMode(p_wnd, 1));
 }
 
 void ArtworkPanel::MenuNodeSourcePopup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
@@ -811,7 +811,7 @@ void ArtworkPanel::MenuNodeSourcePopup::get_child(unsigned p_index, uie::menu_no
 
 unsigned ArtworkPanel::MenuNodeSourcePopup::get_children_count() const
 {
-    return m_items.get_count();
+    return m_items.size();
 }
 
 bool ArtworkPanel::MenuNodeSourcePopup::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
@@ -823,11 +823,11 @@ bool ArtworkPanel::MenuNodeSourcePopup::get_display_data(pfc::string_base& p_out
 
 ArtworkPanel::MenuNodeTypePopup::MenuNodeTypePopup(ArtworkPanel* p_wnd)
 {
-    m_items.add_item(new MenuNodeArtworkType(p_wnd, 0));
+    m_items.emplace_back(new MenuNodeArtworkType(p_wnd, 0));
     // m_items.add_item(new uie::menu_node_separator_t());
-    m_items.add_item(new MenuNodeArtworkType(p_wnd, 1));
-    m_items.add_item(new MenuNodeArtworkType(p_wnd, 2));
-    m_items.add_item(new MenuNodeArtworkType(p_wnd, 3));
+    m_items.emplace_back(new MenuNodeArtworkType(p_wnd, 1));
+    m_items.emplace_back(new MenuNodeArtworkType(p_wnd, 2));
+    m_items.emplace_back(new MenuNodeArtworkType(p_wnd, 3));
 }
 
 void ArtworkPanel::MenuNodeTypePopup::get_child(unsigned p_index, uie::menu_node_ptr& p_out) const
@@ -837,7 +837,7 @@ void ArtworkPanel::MenuNodeTypePopup::get_child(unsigned p_index, uie::menu_node
 
 unsigned ArtworkPanel::MenuNodeTypePopup::get_children_count() const
 {
-    return m_items.get_count();
+    return m_items.size();
 }
 
 bool ArtworkPanel::MenuNodeTypePopup::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -118,7 +118,7 @@ private:
     };
 
     class MenuNodeSourcePopup : public ui_extension::menu_node_popup_t {
-        pfc::list_t<ui_extension::menu_node_ptr> m_items;
+        std::vector<ui_extension::menu_node_ptr> m_items;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
@@ -129,7 +129,7 @@ private:
     };
 
     class MenuNodeTypePopup : public ui_extension::menu_node_popup_t {
-        pfc::list_t<ui_extension::menu_node_ptr> m_items;
+        std::vector<ui_extension::menu_node_ptr> m_items;
 
     public:
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -76,8 +76,7 @@ public:
     void on_reader_abort(const ArtworkReader* ptr);
 
 private:
-    bool find_aborting_reader(const ArtworkReader* ptr, t_size& index);
-    pfc::list_t<std::shared_ptr<ArtworkReader>> m_aborting_readers;
+    std::vector<std::shared_ptr<ArtworkReader>> m_aborting_readers;
     std::shared_ptr<ArtworkReader> m_current_reader;
     // album_art_manager_instance_ptr m_api;
 

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -189,7 +189,7 @@ public:
         HWND m_wnd{nullptr}, m_child{nullptr};
         unsigned m_active{0};
         Button::CustomImage* m_image{nullptr};
-        pfc::list_t<Button> m_buttons;
+        std::vector<Button> m_buttons;
         bool m_text_below{false};
         Appearance m_appearance{APPEARANCE_NORMAL};
         void export_to_file(const char* p_path, bool b_paths = false);
@@ -236,12 +236,12 @@ public:
 
     unsigned get_type() const override;
 
-    pfc::list_t<Button> m_buttons;
+    std::vector<Button> m_buttons;
 
     bool m_text_below{false};
     Appearance m_appearance{APPEARANCE_NORMAL};
 
-    static void reset_buttons(pfc::list_base_t<Button>& p_buttons);
+    static void reset_buttons(std::vector<Button>& p_buttons);
 
     void get_config(stream_writer* data, abort_callback& p_abort) const override;
     void set_config(stream_reader* p_reader, t_size p_sizehint, abort_callback& p_abort) override;

--- a/foo_ui_columns/buttons_command_picker.cpp
+++ b/foo_ui_columns/buttons_command_picker.cpp
@@ -136,7 +136,6 @@ void CommandPickerData::populate_commands()
                     std::list<std::string> name_parts{name.get_ptr()};
 
                     {
-                        pfc::list_t<pfc::string8> levels;
                         GUID parent = ptr->get_parent();
                         while (parent != pfc::guid_null) {
                             pfc::string8 parentname;

--- a/foo_ui_columns/buttons_config_droptarget.cpp
+++ b/foo_ui_columns/buttons_config_droptarget.cpp
@@ -160,8 +160,8 @@ HRESULT STDMETHODCALLTYPE ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListD
             --new_index;
 
         if (new_index != pfc_infinite && old_index != pfc_infinite && new_index != old_index
-            && old_index < m_button_list_view->m_param.m_buttons.get_count()) {
-            const size_t button_count = m_button_list_view->m_param.m_buttons.get_count();
+            && old_index < m_button_list_view->m_param.m_buttons.size()) {
+            const size_t button_count = m_button_list_view->m_param.m_buttons.size();
 
             const int step = new_index > old_index ? 1 : -1;
             mmh::Permutation perm(button_count);
@@ -169,7 +169,7 @@ HRESULT STDMETHODCALLTYPE ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListD
             for (t_size i = old_index; i != new_index; i += step)
                 perm.swap_items(i, i + step);
 
-            m_button_list_view->m_param.m_buttons.reorder(perm.get_ptr());
+            mmh::destructive_reorder(m_button_list_view->m_param.m_buttons, perm);
 
             // blaarrgg, designed in the dark ages
             m_button_list_view->m_param.m_selection = &m_button_list_view->m_param.m_buttons[new_index];

--- a/foo_ui_columns/commandline.cpp
+++ b/foo_ui_columns/commandline.cpp
@@ -29,27 +29,27 @@ class CommandLineSingleFileHelper {
 public:
     CommandLineSingleFileHelper(const char* error_title, const char* no_files_error, const char* too_many_files_error)
         : m_error_title{error_title}, m_no_files_error{no_files_error}, m_too_many_files_error{too_many_files_error} {};
-    void reset() { m_files.remove_all(); }
-    void add_file(const char* url) { m_files.add_item(url); }
+    void reset() { m_files.clear(); }
+    void add_file(const char* url) { m_files.emplace_back(url); }
     bool validate_files()
     {
         const auto main_window = core_api::get_main_window();
-        if (m_files.get_count() == 0) {
+        if (m_files.empty()) {
             static_api_ptr_t<ui_control>()->activate();
             fbh::show_info_box(main_window, m_error_title, m_no_files_error, OIC_ERROR);
             return false;
         }
-        if (m_files.get_count() > 1) {
+        if (m_files.size() > 1) {
             static_api_ptr_t<ui_control>()->activate();
             fbh::show_info_box(main_window, m_error_title, m_too_many_files_error, OIC_ERROR);
             return false;
         }
         return true;
     }
-    const char* get_file() { return m_files.get_count() ? m_files[0].get_ptr() : nullptr; }
+    const char* get_file() { return m_files.empty() ? nullptr : m_files[0].get_ptr(); }
 
 private:
-    pfc::list_t<pfc::string8> m_files;
+    std::vector<pfc::string8> m_files;
     const char* m_error_title;
     const char* m_no_files_error;
     const char* m_too_many_files_error;

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -336,18 +336,18 @@ void FilterPanel::g_create_field_data(const Field& field, FieldData& p_out)
     if (strchr(field.m_field, '$') || strchr(field.m_field, '%')) {
         p_out.m_use_script = true;
         p_out.m_script = field.m_field;
-        p_out.m_fields.remove_all();
+        p_out.m_fields.clear();
     } else {
         p_out.m_use_script = false;
         p_out.m_script.reset();
-        p_out.m_fields.remove_all();
+        p_out.m_fields.clear();
         const char* ptr = field.m_field;
         while (*ptr) {
             const char* start = ptr;
             while (*ptr && *ptr != ';')
                 ptr++;
             if (ptr > start)
-                p_out.m_fields.add_item(pfc::string8(start, ptr - start));
+                p_out.m_fields.emplace_back(pfc::string8(start, ptr - start));
             while (*ptr == ';')
                 ptr++;
         }

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -43,9 +43,9 @@ public:
     bool m_last_sort_direction{};
     pfc::string8 m_script;
     pfc::string8 m_name;
-    pfc::list_t<pfc::string8> m_fields;
+    std::vector<pfc::string8> m_fields;
 
-    bool is_empty() const { return !m_use_script && !m_fields.get_count(); }
+    bool is_empty() const { return !m_use_script && m_fields.empty(); }
     void reset() { *this = FieldData(); }
 };
 
@@ -208,7 +208,7 @@ private:
     ui_selection_holder::ptr m_selection_holder;
     t_size m_drag_item_count{0};
     pfc::string8 m_edit_previous_value;
-    pfc::list_t<pfc::string8> m_edit_fields;
+    std::vector<pfc::string8> m_edit_fields;
     metadb_handle_list m_edit_handles;
     pfc::list_t<Node> m_nodes;
     bool m_show_search{false};

--- a/foo_ui_columns/filter_inline_edit.cpp
+++ b/foo_ui_columns/filter_inline_edit.cpp
@@ -6,14 +6,14 @@ namespace filter_panel {
 bool FilterPanel::notify_before_create_inline_edit(
     const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse)
 {
-    return !m_field_data.m_use_script && m_field_data.m_fields.get_count() && column == 0 && indices.get_count() == 1
+    return !m_field_data.m_use_script && !m_field_data.m_fields.empty() && column == 0 && indices.get_count() == 1
         && indices[0] != 0;
 };
 bool FilterPanel::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
     pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
 {
     t_size indices_count = indices.get_count();
-    if (!m_field_data.m_use_script && m_field_data.m_fields.get_count() && indices_count == 1
+    if (!m_field_data.m_use_script && !m_field_data.m_fields.empty() && indices_count == 1
         && indices[0] < m_nodes.get_count()) {
         m_edit_handles = m_nodes[indices[0]].m_handles;
 
@@ -43,7 +43,7 @@ void FilterPanel::notify_save_inline_edit(const char* value)
             infos_ptr.add_item(&infos[i]);
             if (!mask[i]) {
                 bool b_remove = true;
-                t_size jcount = m_edit_fields.get_count();
+                t_size jcount = m_edit_fields.size();
                 for (t_size j = 0; j < jcount; j++) {
                     t_size field_index = infos[i].meta_find(m_edit_fields[j]);
                     if (field_index != pfc_infinite) {
@@ -76,7 +76,7 @@ void FilterPanel::notify_save_inline_edit(const char* value)
 };
 void FilterPanel::notify_exit_inline_edit()
 {
-    m_edit_fields.remove_all();
+    m_edit_fields.clear();
     m_edit_handles.remove_all();
     m_edit_previous_value.reset();
 };

--- a/foo_ui_columns/filter_items.cpp
+++ b/foo_ui_columns/filter_items.cpp
@@ -334,7 +334,7 @@ size_t FilterPanel::make_data_entries(const metadb_handle_list_t<pfc::alloc_fast
         HandleInfo* p_infos = infos.get_ptr();
 
         t_size counter = 0;
-        t_size field_count = m_field_data.m_fields.get_count();
+        t_size field_count = m_field_data.m_fields.size();
 
         for (size_t i{0}; i < track_count; i++) {
             if (tracks_ptr[i]->get_info_ref(p_infos[i].m_info)) {

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -20,6 +20,7 @@
 #include <string_view>
 #include <utility>
 #include <unordered_map>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 


### PR DESCRIPTION
This replaces some uses of `pfc::list_t` with standard library alternatives (particularly in cases that it was easy to do so).