### PR TITLE
Fix inability to scroll drop-down list toolbars with many items

### DIFF
--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -138,8 +138,9 @@ LRESULT DropDownListToolbar<ToolbarArgs>::on_message(HWND wnd, UINT msg, WPARAM 
         if (!s_icon_font)
             s_icon_font = uCreateIconFont();
 
-        m_wnd_combo = CreateWindowEx(0, WC_COMBOBOX, nullptr, CBS_DROPDOWNLIST | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 0,
-            0, uih::scale_dpi_value(initial_width), uih::scale_dpi_value(initial_height), wnd,
+        m_wnd_combo = CreateWindowEx(0, WC_COMBOBOX, nullptr,
+            CBS_DROPDOWNLIST | WS_CHILD | WS_TABSTOP | WS_VISIBLE | WS_VSCROLL, 0, 0,
+            uih::scale_dpi_value(initial_width), uih::scale_dpi_value(initial_height), wnd,
             reinterpret_cast<HMENU>(ID_COMBOBOX), core_api::get_my_instance(), nullptr);
 
         m_initialised = true;


### PR DESCRIPTION
Resolves #281

This fixes the inability to vertically scroll the output device, DSP preset and other build-in drop-down list toolbars when they contain a large number of items.