### PR TITLE
Remove artwork source settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Removals
 
+* The artwork source settings in Columns UI were removed and now only the settings on the main Display preferences page are used.
+
+  If Columns UI atwork source settings were in use, you will be prompted to transfer your settings on upgrade. [[#286](https://github.com/reupen/columns_ui/pull/286)]
+
 * The playlist view ‘Low artwork reader thready priority’ setting was removed; a low thread priority is now always used. [[#270](https://github.com/reupen/columns_ui/pull/270)]
 
 * The ability to display tooltips for non-truncated text in the playlist view was removed. [[#271](https://github.com/reupen/columns_ui/pull/271)]

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -5,8 +5,6 @@
 #include "wic.h"
 
 namespace artwork_panel {
-// {A24038C7-C055-45ed-B631-CC8FD2A22473}
-const GUID g_guid_fb2k_artwork_mode = {0xa24038c7, 0xc055, 0x45ed, {0xb6, 0x31, 0xcc, 0x8f, 0xd2, 0xa2, 0x24, 0x73}};
 // {005C7B29-3915-4b83-A283-C01A4EDC4F3A}
 const GUID g_guid_track_mode = {0x5c7b29, 0x3915, 0x4b83, {0xa2, 0x83, 0xc0, 0x1a, 0x4e, 0xdc, 0x4f, 0x3a}};
 // {A35E8697-0B8A-4e6f-9DBE-39EC4626524D}
@@ -15,19 +13,6 @@ const GUID g_guid_preserve_aspect_ratio = {0xa35e8697, 0xb8a, 0x4e6f, {0x9d, 0xb
 // {F5C8CE6B-5D68-4ce2-8B9F-874D8EDB03B3}
 const GUID g_guid_edge_style = {0xf5c8ce6b, 0x5d68, 0x4ce2, {0x8b, 0x9f, 0x87, 0x4d, 0x8e, 0xdb, 0x3, 0xb3}};
 
-// {F6E92FCD-7E02-4329-9DA3-D03AEDD66D07}
-static const GUID g_guid_cfg_front_scripts
-    = {0xf6e92fcd, 0x7e02, 0x4329, {0x9d, 0xa3, 0xd0, 0x3a, 0xed, 0xd6, 0x6d, 0x7}};
-// {BD2474FC-2CF9-475f-AC0B-26130541526C}
-static const GUID g_guid_cfg_back_scripts
-    = {0xbd2474fc, 0x2cf9, 0x475f, {0xac, 0xb, 0x26, 0x13, 0x5, 0x41, 0x52, 0x6c}};
-// {70D71DF4-D1FF-4d19-9412-B949690ED43E}
-static const GUID g_guid_cfg_disc_scripts
-    = {0x70d71df4, 0xd1ff, 0x4d19, {0x94, 0x12, 0xb9, 0x49, 0x69, 0xe, 0xd4, 0x3e}};
-
-// {C1E7DA7E-1D3A-4f30-8384-0E47C49B6DD9}
-static const GUID g_guid_cfg_artist_scripts
-    = {0xc1e7da7e, 0x1d3a, 0x4f30, {0x83, 0x84, 0xe, 0x47, 0xc4, 0x9b, 0x6d, 0xd9}};
 
 enum TrackingMode {
     track_auto_playlist_playing,
@@ -57,13 +42,9 @@ bool g_track_mode_includes_selection(t_size mode)
     return mode == track_auto_selection_playing || mode == track_selection;
 }
 
-cfg_uint cfg_fb2k_artwork_mode(g_guid_fb2k_artwork_mode, fb2k_artwork_embedded_and_external);
 cfg_uint cfg_track_mode(g_guid_track_mode, track_auto_playlist_playing);
 cfg_bool cfg_preserve_aspect_ratio(g_guid_preserve_aspect_ratio, true);
 cfg_uint cfg_edge_style(g_guid_edge_style, 0);
-
-cfg_objList<pfc::string8> cfg_front_scripts(g_guid_cfg_front_scripts), cfg_back_scripts(g_guid_cfg_back_scripts),
-    cfg_disc_scripts(g_guid_cfg_disc_scripts), cfg_artist_scripts(g_guid_cfg_artist_scripts);
 
 // {E32DCBA9-A2BF-4901-AB43-228628071410}
 static const GUID g_guid_colour_client = {0xe32dcba9, 0xa2bf, 0x4901, {0xab, 0x43, 0x22, 0x86, 0x28, 0x7, 0x14, 0x10}};
@@ -124,20 +105,7 @@ unsigned ArtworkPanel::get_type() const
 {
     return uie::type_panel;
 }
-void ArtworkPanel::on_repository_change()
-{
-    if (m_artwork_loader) {
-        m_artwork_loader->ResetRepository();
-        if (cfg_front_scripts.get_count())
-            m_artwork_loader->SetScript(g_artwork_types[0], cfg_front_scripts);
-        if (cfg_back_scripts.get_count())
-            m_artwork_loader->SetScript(g_artwork_types[1], cfg_back_scripts);
-        if (cfg_disc_scripts.get_count())
-            m_artwork_loader->SetScript(g_artwork_types[2], cfg_disc_scripts);
-        if (cfg_artist_scripts.get_count())
-            m_artwork_loader->SetScript(g_artwork_types[3], cfg_artist_scripts);
-    }
-}
+
 LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
@@ -150,8 +118,6 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         t_size count = tabsize(g_artwork_types);
         for (t_size i = 0; i < count; i++)
             m_artwork_loader->AddType(g_artwork_types[i]);
-        on_repository_change();
-        m_artwork_loader->initialise();
         static_api_ptr_t<play_callback_manager>()->register_callback(this,
             play_callback::flag_on_playback_new_track | play_callback::flag_on_playback_stop
                 | play_callback::flag_on_playback_edited,
@@ -522,17 +488,6 @@ void ArtworkPanel::g_on_colours_change()
     for (auto& window : g_windows) {
         window->flush_cached_bitmap();
         RedrawWindow(window->get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
-    }
-}
-
-void g_on_repository_change()
-{
-    ArtworkPanel::g_on_repository_change();
-}
-void ArtworkPanel::g_on_repository_change()
-{
-    for (auto& window : g_windows) {
-        window->on_repository_change();
     }
 }
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -4,8 +4,6 @@
 #include "artwork_helpers.h"
 
 namespace artwork_panel {
-extern cfg_uint cfg_fb2k_artwork_mode;
-extern cfg_objList<pfc::string8> cfg_front_scripts, cfg_back_scripts, cfg_disc_scripts, cfg_artist_scripts;
 
 class ArtworkPanel
     : public uie::container_ui_extension_t<> /*, public now_playing_album_art_receiver*/
@@ -82,7 +80,6 @@ public:
 
     static void g_on_colours_change();
     static void g_on_repository_change();
-    void on_repository_change();
 
     void force_reload_artwork();
 

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -2,12 +2,6 @@
 
 namespace artwork_panel {
 
-enum Fb2KArtworkMode {
-    fb2k_artwork_disabled,
-    fb2k_artwork_embedded,
-    fb2k_artwork_embedded_and_external,
-};
-
 class ArtworkReader : public mmh::Thread {
 public:
     bool is_aborting();
@@ -21,9 +15,8 @@ public:
     ArtworkReader() = default;
 
     void initialise(const std::vector<GUID>& p_requestIds,
-        const std::unordered_map<GUID, album_art_data_ptr>& p_content_previous,
-        const std::unordered_map<GUID, pfc::list_t<pfc::string8>>& p_repositories, bool b_read_emptycover,
-        t_size b_native_artwork_reader_mode, const metadb_handle_ptr& p_handle, const completion_notify_ptr& p_notify,
+        const std::unordered_map<GUID, album_art_data_ptr>& p_content_previous, bool b_read_emptycover,
+        const metadb_handle_ptr& p_handle, const completion_notify_ptr& p_notify,
         std::shared_ptr<class ArtworkReaderManager> p_manager);
     void run_notification_thisthread(DWORD state);
 
@@ -37,13 +30,11 @@ private:
 
     std::vector<GUID> m_requestIds;
     std::unordered_map<GUID, album_art_data_ptr> m_content;
-    std::unordered_map<GUID, pfc::list_t<pfc::string8>> m_repositories;
     metadb_handle_ptr m_handle;
     completion_notify_ptr m_notify;
     bool m_succeeded{false};
     bool m_read_emptycover{true};
     album_art_data_ptr m_emptycover;
-    t_size m_native_artwork_reader_mode{fb2k_artwork_embedded_and_external};
     abort_callback_impl m_abort;
     std::shared_ptr<class ArtworkReaderManager> m_manager;
 };
@@ -52,9 +43,6 @@ class ArtworkReaderManager : public std::enable_shared_from_this<ArtworkReaderMa
 public:
     void AddType(const GUID& p_what);
     void abort_current_task();
-    void SetScript(const GUID& p_what, const pfc::list_t<pfc::string8>& script);
-
-    void ResetRepository();
 
     void Reset();
 
@@ -68,8 +56,6 @@ public:
 
     bool QueryEmptyCover(album_art_data_ptr& p_data);
 
-    void initialise();
-
     void deinitialise();
 
     void on_reader_completion(DWORD ret, const ArtworkReader* ptr);
@@ -82,7 +68,6 @@ private:
 
     std::vector<GUID> m_requestIds;
     std::unordered_map<GUID, album_art_data_ptr> m_content;
-    std::unordered_map<GUID, pfc::list_t<pfc::string8>> m_repositories;
     album_art_data_ptr m_emptycover;
 };
 

--- a/foo_ui_columns/config_artwork.cpp
+++ b/foo_ui_columns/config_artwork.cpp
@@ -1,193 +1,36 @@
 #include "stdafx.h"
-#include "ng_playlist/ng_playlist.h"
+#include "legacy_artwork_config.h"
 #include "artwork.h"
 #include "config.h"
 
 namespace artwork_panel {
-extern cfg_uint cfg_fb2k_artwork_mode, cfg_edge_style;
-void g_on_repository_change();
+extern cfg_uint cfg_edge_style;
 } // namespace artwork_panel
 
-class ArtworkSource {
-public:
-    cfg_objList<pfc::string8>* m_scripts;
-    const char* m_name;
+pfc::string8 format_legacy_artwork_sources()
+{
+    pfc::string8 text;
+    for (auto&& [scripts, type] : cui::artwork::legacy::legacy_sources) {
+        if (scripts->get_count() == 0)
+            continue;
 
-    ArtworkSource(cfg_objList<pfc::string8>& p_scripts, const char* p_name)
-        : m_scripts(&p_scripts), m_name(p_name){};
-};
+        text << type << "\r\n---\r\n";
 
-ArtworkSource g_artwork_sources[] = {
-    ArtworkSource(artwork_panel::cfg_front_scripts, "Front cover"),
-    ArtworkSource(artwork_panel::cfg_back_scripts, "Back cover"),
-    ArtworkSource(artwork_panel::cfg_disc_scripts, "Disc cover"),
-    ArtworkSource(artwork_panel::cfg_artist_scripts, "Artist picture"),
-};
+        for (auto&& script : *scripts) {
+            text << script << ".*\r\n";
+        }
+
+        text << "\r\n";
+    }
+    return text;
+}
 
 static class TabArtwork : public PreferencesTab {
 public:
-    TabArtwork() = default;
-
-    static t_size get_combined_index(t_size index, t_size subindex)
-    {
-        t_size i = 0;
-        t_size ret = 0;
-        while (i < tabsize(g_artwork_sources) && i < index) {
-            ret += g_artwork_sources[i].m_scripts->get_count();
-            i++;
-        }
-        ret += subindex;
-        return ret;
-    }
-
-    static bool get_separated_index(t_size combined_index, t_size& index, t_size& subindex)
-    {
-        index = 0;
-        subindex = 0;
-        while (
-            index < tabsize(g_artwork_sources) && g_artwork_sources[index].m_scripts->get_count() <= combined_index) {
-            combined_index -= g_artwork_sources[index].m_scripts->get_count();
-            index++;
-        }
-        subindex = combined_index;
-        return (index < tabsize(g_artwork_sources) && subindex < g_artwork_sources[index].m_scripts->get_count());
-    }
-
-    static void get_group_combined_index(t_size index, t_size& combined_index_start, t_size& count)
-    {
-        combined_index_start = 0;
-        count = 0;
-        t_size i = 0;
-        while (i < tabsize(g_artwork_sources) && i < index) {
-            combined_index_start += g_artwork_sources[i].m_scripts->get_count();
-            i++;
-        }
-        count = g_artwork_sources[index].m_scripts->get_count();
-        // return (index < tabsize(g_artwork_sources) && subindex < g_artwork_sources[index].m_scripts->get_count());
-    }
-
-    static void get_group_from_combined_index(
-        t_size combined_index, t_size& index, t_size& subindex, t_size& combined_index_start, t_size& count)
-    {
-        get_separated_index(combined_index, index, subindex);
-
-        get_group_combined_index(index, combined_index_start, count);
-    }
-
-    class ListViewArtwork : public uih::ListView {
-    public:
-        t_size m_edit_index, m_edit_subindex, m_edit_combined_index;
-        ListViewArtwork()
-            : m_edit_index(pfc_infinite), m_edit_subindex(pfc_infinite), m_edit_combined_index(pfc_infinite){};
-
-        void notify_on_create() override
-        {
-            set_single_selection(true);
-            set_group_count(1);
-            set_autosize(true);
-            set_show_header(false);
-            set_group_level_indentation_enabled(false);
-            pfc::list_t<Column> columns;
-            columns.set_count(1);
-            columns[0].m_title = "Source script";
-            columns[0].m_size = 100;
-            uih::ListView::set_columns(columns);
-        };
-        bool notify_before_create_inline_edit(
-            const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse) override
-        {
-            return column == 0 && indices.get_count() == 1;
-        };
-        bool notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
-            pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override
-        {
-            t_size indices_count = indices.get_count();
-            if (indices_count == 1) {
-                t_size index;
-                t_size subindex;
-                if (get_separated_index(indices[0], index, subindex)) {
-                    m_edit_index = index;
-                    m_edit_subindex = subindex;
-                    m_edit_combined_index = indices[0];
-
-                    p_text = g_artwork_sources[index].m_scripts->get_item(subindex);
-
-                    return true;
-                }
-            }
-            return false;
-        };
-        void notify_save_inline_edit(const char* value) override
-        {
-            if (m_edit_index < tabsize(g_artwork_sources)
-                && m_edit_subindex < g_artwork_sources[m_edit_index].m_scripts->get_count()) {
-                pfc::string8& dest = (*g_artwork_sources[m_edit_index].m_scripts)[m_edit_subindex];
-                if (strcmp(dest, value) != 0) {
-                    dest = value;
-                    pfc::list_t<uih::ListView::InsertItem> items;
-                    items.set_count(1);
-                    {
-                        items[0].m_groups.resize(1);
-                        items[0].m_subitems.resize(1);
-
-                        items[0].m_groups[0] = g_artwork_sources[m_edit_index].m_name;
-                        items[0].m_subitems[0] = dest;
-                    }
-                    replace_items(m_edit_combined_index, items);
-
-                    m_changed = true;
-                }
-            }
-
-            m_edit_subindex = pfc_infinite;
-            m_edit_index = pfc_infinite;
-            m_edit_combined_index = pfc_infinite;
-        }
-        void notify_on_kill_focus(HWND wnd_receiving) override { on_scripts_change(); };
-        void execute_default_action(t_size index, t_size column, bool b_keyboard, bool b_ctrl) override
-        {
-            if (!b_keyboard)
-                activate_inline_editing();
-        };
-        void on_scripts_change()
-        {
-            if (m_changed) {
-                artwork_panel::g_on_repository_change();
-                pvt::PlaylistView::g_on_artwork_repositories_change();
-                m_changed = false;
-            }
-        }
-        bool m_changed{false};
-
-    private:
-    } m_source_list;
-
     void refresh_me(HWND wnd)
     {
         m_initialising = true;
-        m_source_list.remove_items(pfc::bit_array_true());
-
-        t_size indexcount = tabsize(g_artwork_sources);
-        for (t_size index = 0; index < indexcount; index++) {
-            t_size subindexcount = g_artwork_sources[index].m_scripts->get_count();
-            pfc::array_t<uih::ListView::InsertItem> items;
-            items.set_count(subindexcount);
-            for (t_size subindex = 0; subindex < subindexcount; subindex++) {
-                items[subindex].m_groups.resize(1);
-                items[subindex].m_subitems.resize(1);
-                items[subindex].m_groups[0] = g_artwork_sources[index].m_name;
-                items[subindex].m_subitems[0] = (*g_artwork_sources[index].m_scripts)[subindex];
-            }
-            m_source_list.insert_items(m_source_list.get_item_count(), items.get_count(), items.get_ptr());
-        }
-
-        HWND wnd_combo = GetDlgItem(wnd, IDC_FB2KARTWORK);
-        ComboBox_AddString(wnd_combo, L"Disabled");
-        ComboBox_AddString(wnd_combo, L"Embedded artwork");
-        ComboBox_AddString(wnd_combo, L"Embedded and external artwork");
-        ComboBox_SetCurSel(wnd_combo, artwork_panel::cfg_fb2k_artwork_mode);
-
-        wnd_combo = GetDlgItem(wnd, IDC_EDGESTYLE);
+        const HWND wnd_combo = GetDlgItem(wnd, IDC_EDGESTYLE);
         ComboBox_AddString(wnd_combo, L"None");
         ComboBox_AddString(wnd_combo, L"Sunken");
         ComboBox_AddString(wnd_combo, L"Grey");
@@ -195,156 +38,33 @@ public:
         m_initialising = false;
     }
 
-    void on_scripts_change() { m_source_list.on_scripts_change(); }
-
     BOOL on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     {
         switch (msg) {
         case WM_INITDIALOG: {
-            HWND wnd_fields = m_source_list.create(wnd, uih::WindowPosition(7, 49, 313, 92), true);
-            SetWindowPos(wnd_fields, HWND_TOP, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
-
             refresh_me(wnd);
-
-            ShowWindow(wnd_fields, SW_SHOWNORMAL);
-        } break;
-        case WM_DESTROY: {
-            on_scripts_change();
+            if (cui::artwork::legacy::any_legacy_sources()) {
+                ShowWindow(GetDlgItem(wnd, IDC_OPEN_DISPLAY_PREFERENCES), SW_HIDE);
+            } else {
+                ShowWindow(GetDlgItem(wnd, IDC_VIEW_OLD_ARTWORK_SOURCES_TEXT), SW_HIDE);
+                ShowWindow(GetDlgItem(wnd, IDC_VIEW_OLD_ARTWORK_SOURCES), SW_HIDE);
+                ShowWindow(GetDlgItem(wnd, IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES), SW_HIDE);
+            }
         } break;
         case WM_COMMAND:
             switch (wp) {
-            case IDC_FB2KARTWORK | (CBN_SELCHANGE << 16):
-                artwork_panel::cfg_fb2k_artwork_mode = ComboBox_GetCurSel((HWND)lp);
+            case IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES:
+            case IDC_OPEN_DISPLAY_PREFERENCES:
+                ui_control::get()->show_preferences(preferences_page::guid_display);
+                break;
+            case IDC_VIEW_OLD_ARTWORK_SOURCES:
+                popup_message_v2::g_show(
+                    GetAncestor(wnd, GA_ROOT), format_legacy_artwork_sources(), "Previous Columns UI Artwork Sources");
                 break;
             case IDC_EDGESTYLE | (CBN_SELCHANGE << 16):
                 artwork_panel::cfg_edge_style = ComboBox_GetCurSel((HWND)lp);
                 artwork_panel::ArtworkPanel::g_on_edge_style_change();
                 break;
-            case IDC_ADD: {
-                RECT rc;
-                GetWindowRect((HWND)lp, &rc);
-                HMENU menu = CreatePopupMenu();
-
-                enum { IDM_FRONT = 1 };
-
-                t_size index;
-                t_size indexcount = tabsize(g_artwork_sources);
-                for (index = 0; index < indexcount; index++) {
-                    AppendMenuW(menu, (MF_STRING), index + 1,
-                        pfc::stringcvt::string_wide_from_utf8(g_artwork_sources[index].m_name));
-                }
-
-                int cmd = TrackPopupMenu(
-                    menu, TPM_LEFTBUTTON | TPM_NONOTIFY | TPM_RETURNCMD, rc.left, rc.bottom, 0, wnd, nullptr);
-                DestroyMenu(menu);
-                if (cmd > 0 && (t_size)cmd <= indexcount) {
-                    index = cmd - 1;
-                    t_size subindex = g_artwork_sources[index].m_scripts->add_item("<enter script>");
-
-                    t_size combined_index = get_combined_index(index, subindex);
-
-                    uih::ListView::InsertItem item(1, 1);
-                    item.m_groups[0] = g_artwork_sources[index].m_name;
-                    item.m_subitems[0] = "<enter script>";
-                    m_source_list.insert_items(combined_index, 1, &item);
-                    SetFocus(m_source_list.get_wnd());
-                    m_source_list.set_item_selected_single(combined_index);
-                    m_source_list.activate_inline_editing();
-                    m_source_list.m_changed = true;
-                }
-            } break;
-            case IDC_REMOVE: {
-                if (m_source_list.get_selection_count(2) == 1) {
-                    pfc::bit_array_bittable mask(m_source_list.get_item_count());
-                    m_source_list.get_selection_state(mask);
-                    // bool b_found = false;
-                    t_size combined_index = 0;
-                    t_size count = m_source_list.get_item_count();
-                    while (combined_index < count) {
-                        if (mask[combined_index])
-                            break;
-                        combined_index++;
-                    }
-                    t_size index;
-                    t_size subindex;
-                    if (combined_index < count && get_separated_index(combined_index, index, subindex)) {
-                        g_artwork_sources[index].m_scripts->remove_by_idx(subindex);
-                        m_source_list.remove_item(combined_index);
-                        m_source_list.m_changed = true;
-                        t_size new_count = m_source_list.get_item_count();
-                        if (new_count) {
-                            if (combined_index < new_count)
-                                m_source_list.set_item_selected_single(combined_index);
-                            else if (combined_index)
-                                m_source_list.set_item_selected_single(combined_index - 1);
-                        }
-                    }
-                }
-            } break;
-            case IDC_UP: {
-                if (m_source_list.get_selection_count(2) == 1) {
-                    t_size combined_index = 0;
-                    {
-                        t_size count = m_source_list.get_item_count();
-                        while (!m_source_list.get_item_selected(combined_index) && combined_index < count)
-                            combined_index++;
-                    }
-
-                    t_size index;
-                    t_size subindex;
-                    t_size combined_index_start;
-                    t_size count;
-
-                    get_group_from_combined_index(combined_index, index, subindex, combined_index_start, count);
-
-                    if (subindex && count) {
-                        g_artwork_sources[index].m_scripts->swap_items(subindex, subindex - 1);
-
-                        pfc::list_t<uih::ListView::SizedInsertItem<1, 1>> items;
-                        items.set_count(2);
-
-                        items[0].m_groups[0] = g_artwork_sources[index].m_name;
-                        items[1].m_groups[0] = g_artwork_sources[index].m_name;
-                        items[0].m_subitems[0] = (*g_artwork_sources[index].m_scripts)[subindex - 1];
-                        items[1].m_subitems[0] = (*g_artwork_sources[index].m_scripts)[subindex];
-                        m_source_list.replace_items(combined_index - 1, items);
-                        m_source_list.set_item_selected_single(combined_index - 1);
-                        m_source_list.m_changed = true;
-                    }
-                }
-            } break;
-            case IDC_DOWN: {
-                if (m_source_list.get_selection_count(2) == 1) {
-                    t_size combined_index = 0;
-                    {
-                        t_size count = m_source_list.get_item_count();
-                        while (!m_source_list.get_item_selected(combined_index) && combined_index < count)
-                            combined_index++;
-                    }
-
-                    t_size index;
-                    t_size subindex;
-                    t_size combined_index_start;
-                    t_size count;
-
-                    get_group_from_combined_index(combined_index, index, subindex, combined_index_start, count);
-
-                    if (subindex + 1 < count) {
-                        g_artwork_sources[index].m_scripts->swap_items(subindex, subindex + 1);
-                        pfc::list_t<uih::ListView::SizedInsertItem<1, 1>> items;
-                        items.set_count(2);
-
-                        items[0].m_groups[0] = g_artwork_sources[index].m_name;
-                        items[1].m_groups[0] = g_artwork_sources[index].m_name;
-                        items[0].m_subitems[0] = (*g_artwork_sources[index].m_scripts)[subindex];
-                        items[1].m_subitems[0] = (*g_artwork_sources[index].m_scripts)[subindex + 1];
-
-                        m_source_list.replace_items(combined_index, items);
-                        m_source_list.set_item_selected_single(combined_index + 1);
-                        m_source_list.m_changed = true;
-                    }
-                }
-            } break;
             }
         }
         return 0;

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -499,17 +499,15 @@ STYLE DS_SETFONT | DS_FIXEDSYS | DS_CONTROL | WS_CHILD
 EXSTYLE WS_EX_CONTROLPARENT
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    LTEXT           "Artwork sources",IDC_TITLE1,7,4,252,16
-    LTEXT           "You can set up sources for artwork here. Enter title formatting scripts that specify absolute or relative paths to the artwork. Do not specify the file extension.",IDC_STATIC,7,29,312,17
-    PUSHBUTTON      "Move up",IDC_UP,7,147,50,14
-    PUSHBUTTON      "Move down",IDC_DOWN,60,147,50,14
-    PUSHBUTTON      "Add...",IDC_ADD,216,147,50,14
-    PUSHBUTTON      "Remove",IDC_REMOVE,269,147,50,14
-    LTEXT           "Built-in foobar2000 artwork reader mode",IDC_STATIC,7,172,138,8
-    COMBOBOX        IDC_FB2KARTWORK,7,183,312,30,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Artwork view panel",IDC_TITLE2,7,215,252,16
-    LTEXT           "Panel edge style",IDC_STATIC,7,238,55,8
-    COMBOBOX        IDC_EDGESTYLE,7,249,40,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Artwork view panel",IDC_TITLE2,7,4,252,16
+    LTEXT           "Panel edge style",IDC_STATIC,7,30,55,8
+    COMBOBOX        IDC_EDGESTYLE,7,41,40,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Artwork sources",IDC_TITLE1,7,77,252,16
+    LTEXT           "Artwork sources are now configured on the Display preferences page. Columns UI no longer has separate artwork source settings.",IDC_STATIC,7,102,312,23
+    PUSHBUTTON      "Go to Display preferences",IDC_OPEN_DISPLAY_PREFERENCES,7,133,148,14
+    LTEXT           "You previously had artwork sources configured in Columns UI. If artwork is no longer displaying correctly, manually copy your previous configuration to Display preferences.",IDC_VIEW_OLD_ARTWORK_SOURCES_TEXT,7,129,312,22
+    PUSHBUTTON      "View previously configured artwork sources",IDC_VIEW_OLD_ARTWORK_SOURCES,7,158,178,14
+    PUSHBUTTON      "Go to Display preferences",IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES,7,181,179,14
 END
 
 IDD_ITEM_PROPS_OPTIONS DIALOGEX 0, 0, 268, 387

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -289,6 +289,7 @@
     <ClCompile Include=".\colours_manager_data.cpp" />
     <ClCompile Include=".\columns_v2.cpp" />
     <ClCompile Include="filter_fcl.cpp" />
+    <ClCompile Include="legacy_artwork_config.cpp" />
     <ClCompile Include="ng_playlist\config_object_callbacks.cpp" />
     <ClCompile Include="notification_area_callbacks.cpp" />
     <ClCompile Include="playlist_switcher_title_formatting.cpp" />
@@ -500,6 +501,7 @@
     <ClInclude Include="font_utils.h" />
     <ClInclude Include="functional.h" />
     <ClInclude Include="help.h" />
+    <ClInclude Include="legacy_artwork_config.h" />
     <ClInclude Include="menu_mnemonics.h" />
     <ClInclude Include="migrate.h" />
     <ClInclude Include="panel_menu_item.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -515,6 +515,9 @@
     <ClCompile Include="wic.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="legacy_artwork_config.cpp">
+      <Filter>Artwork view</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include=".\resource.h">
@@ -736,6 +739,9 @@
     </ClInclude>
     <ClInclude Include="functional.h">
       <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="legacy_artwork_config.h">
+      <Filter>Artwork view</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/legacy_artwork_config.cpp
+++ b/foo_ui_columns/legacy_artwork_config.cpp
@@ -1,0 +1,52 @@
+#include "stdafx.h"
+#include "config.h"
+#include "legacy_artwork_config.h"
+
+namespace cui::artwork::legacy {
+
+enum Fb2KArtworkMode {
+    fb2k_artwork_disabled,
+    fb2k_artwork_embedded,
+    fb2k_artwork_embedded_and_external,
+};
+
+constexpr GUID g_guid_fb2k_artwork_mode
+    = {0xa24038c7, 0xc055, 0x45ed, {0xb6, 0x31, 0xcc, 0x8f, 0xd2, 0xa2, 0x24, 0x73}};
+
+constexpr GUID g_guid_cfg_front_scripts = {0xf6e92fcd, 0x7e02, 0x4329, {0x9d, 0xa3, 0xd0, 0x3a, 0xed, 0xd6, 0x6d, 0x7}};
+
+constexpr GUID g_guid_cfg_back_scripts = {0xbd2474fc, 0x2cf9, 0x475f, {0xac, 0xb, 0x26, 0x13, 0x5, 0x41, 0x52, 0x6c}};
+
+constexpr GUID g_guid_cfg_disc_scripts = {0x70d71df4, 0xd1ff, 0x4d19, {0x94, 0x12, 0xb9, 0x49, 0x69, 0xe, 0xd4, 0x3e}};
+
+constexpr GUID g_guid_cfg_artist_scripts
+    = {0xc1e7da7e, 0x1d3a, 0x4f30, {0x83, 0x84, 0xe, 0x47, 0xc4, 0x9b, 0x6d, 0xd9}};
+
+cfg_uint cfg_fb2k_artwork_mode(g_guid_fb2k_artwork_mode, fb2k_artwork_embedded_and_external);
+
+cfg_objList<pfc::string8> cfg_front_scripts(g_guid_cfg_front_scripts);
+cfg_objList<pfc::string8> cfg_back_scripts(g_guid_cfg_back_scripts);
+cfg_objList<pfc::string8> cfg_disc_scripts(g_guid_cfg_disc_scripts);
+cfg_objList<pfc::string8> cfg_artist_scripts(g_guid_cfg_artist_scripts);
+
+cfg_bool has_been_asked_to_reconfigure(
+    {0xb2becac4, 0x9a81, 0x465d, {0x9a, 0x4f, 0x8c, 0x7c, 0x16, 0x86, 0x4e, 0xfb}}, false);
+
+bool any_legacy_sources()
+{
+    auto is_non_empty = [](auto&& source) {
+        auto&& [scripts, _] = source;
+        return scripts->get_count() > 0;
+    };
+    return ranges::any_of(legacy_sources, is_non_empty);
+}
+
+void prompt_to_reconfigure()
+{
+    if (any_legacy_sources() && !has_been_asked_to_reconfigure) {
+        has_been_asked_to_reconfigure = true;
+        cui::prefs::page_main.get_static_instance().show_tab("Artwork");
+    }
+}
+
+} // namespace cui::artwork::legacy

--- a/foo_ui_columns/legacy_artwork_config.h
+++ b/foo_ui_columns/legacy_artwork_config.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace cui::artwork::legacy {
+
+extern cfg_objList<pfc::string8> cfg_front_scripts;
+extern cfg_objList<pfc::string8> cfg_back_scripts;
+extern cfg_objList<pfc::string8> cfg_disc_scripts;
+extern cfg_objList<pfc::string8> cfg_artist_scripts;
+
+constexpr auto legacy_sources = {
+    std::make_tuple(&cui::artwork::legacy::cfg_front_scripts, "Front cover"),
+    std::make_tuple(&cui::artwork::legacy::cfg_back_scripts, "Back cover"),
+    std::make_tuple(&cui::artwork::legacy::cfg_disc_scripts, "Disc cover"),
+    std::make_tuple(&cui::artwork::legacy::cfg_artist_scripts, "Artist picture"),
+};
+
+bool any_legacy_sources();
+void prompt_to_reconfigure();
+
+} // namespace cui::artwork::legacy

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -13,6 +13,7 @@
 #include "notification_area.h"
 #include "status_bar.h"
 #include "migrate.h"
+#include "legacy_artwork_config.h"
 
 RebarWindow* g_rebar_window = nullptr;
 LayoutWindow g_layout_window;
@@ -122,6 +123,8 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook)
         SendMessage(m_wnd, MSG_RUN_INITIAL_SETUP, NULL, NULL);
 
     main_window::config_set_is_first_run();
+
+    fb2k::inMainThread(cui::artwork::legacy::prompt_to_reconfigure);
 
     return m_wnd;
 }

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -318,14 +318,7 @@ void PlaylistView::g_flush_artwork(bool b_redraw, const PlaylistView* p_skip)
         }
     }
 }
-void PlaylistView::g_on_artwork_repositories_change()
-{
-    for (auto& window : g_windows) {
-        if (window->m_artwork_manager) {
-            window->m_artwork_manager->set_script(album_art_ids::cover_front, artwork_panel::cfg_front_scripts);
-        }
-    }
-}
+
 void PlaylistView::g_on_vertical_item_padding_change()
 {
     for (auto& window : g_windows)
@@ -543,7 +536,6 @@ void PlaylistView::notify_on_initialisation()
     m_gdiplus_initialised = (Gdiplus::Ok == Gdiplus::GdiplusStartup(&m_gdiplus_token, &gdiplusStartupInput, nullptr));
     m_artwork_manager = std::make_shared<ArtworkReaderManager>();
     m_artwork_manager->initialise();
-    m_artwork_manager->set_script(album_art_ids::cover_front, artwork_panel::cfg_front_scripts);
 
     m_playlist_api = standard_api_create_t<playlist_manager>();
     m_playlist_cache.initialise_playlist_callback();

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -133,12 +133,9 @@ public:
     bool is_ready() { return !is_thread_open(); }
     const std::unordered_map<GUID, wil::shared_hbitmap>& get_content() const { return m_bitmaps; }
 
-    void initialise(const std::unordered_map<GUID, pfc::list_t<pfc::string8>>& p_repositories,
-        t_size native_artwork_reader_mode, const metadb_handle_ptr& p_handle, t_size cx, t_size cy, COLORREF cr_back,
-        bool b_reflection, BaseArtworkCompletionNotify::ptr_t p_notify,
-        std::shared_ptr<class ArtworkReaderManager> p_manager)
+    void initialise(const metadb_handle_ptr& p_handle, t_size cx, t_size cy, COLORREF cr_back, bool b_reflection,
+        BaseArtworkCompletionNotify::ptr_t p_notify, std::shared_ptr<class ArtworkReaderManager> p_manager)
     {
-        m_repositories = p_repositories;
         m_handle = p_handle;
         m_notify = std::move(p_notify);
         m_cx = cx;
@@ -146,7 +143,6 @@ public:
         m_reflection = b_reflection;
         m_back = cr_back;
         m_manager = std::move(p_manager);
-        m_native_artwork_reader_mode = native_artwork_reader_mode;
     }
     void send_completion_notification(const std::shared_ptr<ArtworkReader>& p_this)
     {
@@ -162,14 +158,12 @@ private:
     unsigned read_artwork(abort_callback& p_abort);
 
     std::unordered_map<GUID, wil::shared_hbitmap> m_bitmaps;
-    std::unordered_map<GUID, pfc::list_t<pfc::string8>> m_repositories;
     t_size m_cx{0}, m_cy{0};
     COLORREF m_back{RGB(255, 255, 255)};
     bool m_reflection{false};
     metadb_handle_ptr m_handle;
     BaseArtworkCompletionNotify::ptr_t m_notify;
     bool m_succeeded{false};
-    t_size m_native_artwork_reader_mode{artwork_panel::fb2k_artwork_embedded_and_external};
     abort_callback_impl m_abort;
     std::shared_ptr<class ArtworkReaderManager> m_manager;
 };
@@ -192,17 +186,6 @@ public:
         t_size i = m_current_readers.get_count();
         for (; i; i--)
             abort_task(i - 1);
-    }
-    void set_script(const GUID& p_what, const pfc::list_t<pfc::string8>& script)
-    {
-        // abort_current_tasks();
-        m_repositories.insert_or_assign(p_what, script);
-    }
-
-    void reset_repository()
-    {
-        abort_current_tasks();
-        m_repositories.clear();
     }
 
     void reset() { abort_current_tasks(); }
@@ -283,8 +266,6 @@ private:
     pfc::list_t<std::shared_ptr<ArtworkReader>> m_aborting_readers;
     pfc::list_t<std::shared_ptr<ArtworkReader>> m_current_readers;
     pfc::list_t<std::shared_ptr<ArtworkReader>> m_pending_readers;
-
-    std::unordered_map<GUID, pfc::list_t<pfc::string8>> m_repositories;
 
     critical_section m_nocover_sync;
     wil::shared_hbitmap m_nocover_bitmap;
@@ -371,7 +352,6 @@ public:
     static void g_on_alternate_selection_change();
     static void g_on_artwork_width_change(const PlaylistView* p_skip = nullptr);
     static void g_flush_artwork(bool b_redraw = false, const PlaylistView* p_skip = nullptr);
-    static void g_on_artwork_repositories_change();
     static void g_on_vertical_item_padding_change();
     static void g_on_show_header_change();
     static void g_on_playback_follows_cursor_change(bool b_val);

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -44,8 +44,7 @@ void ArtworkReaderManager::request(const metadb_handle_ptr& p_handle, std::share
     t_size cy, COLORREF cr_back, bool b_reflection, BaseArtworkCompletionNotify::ptr_t p_notify)
 {
     auto p_new_reader = std::make_shared<ArtworkReader>();
-    p_new_reader->initialise(m_repositories, artwork_panel::cfg_fb2k_artwork_mode, p_handle, cx, cy, cr_back,
-        b_reflection, std::move(p_notify), shared_from_this());
+    p_new_reader->initialise(p_handle, cx, cy, cr_back, b_reflection, std::move(p_notify), shared_from_this());
     m_pending_readers.add_item(p_new_reader);
     p_out = p_new_reader;
     flush_pending();
@@ -135,142 +134,27 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
 
     m_bitmaps.clear();
 
-    bool b_extracter_attempted = false;
-    album_art_extractor_instance_ptr p_extractor;
     static_api_ptr_t<album_art_manager_v2> p_album_art_manager_v2;
 
-    bool b_found = false;
     album_art_data_ptr data;
+    auto artwork_api_v2 = p_album_art_manager_v2->open(
+        pfc::list_single_ref_t<metadb_handle_ptr>(m_handle), pfc::list_single_ref_t<GUID>(artwork_type_id), p_abort);
+
     try {
-        auto repo_iter = m_repositories.find(artwork_type_id);
-        if (repo_iter != m_repositories.end()) {
-            auto& to = repo_iter->second;
-            pfc::string8 path;
-            t_size count = to.get_count();
-            for (t_size i = 0; i < count && !b_found; i++) {
-                if (m_handle->format_title_legacy(nullptr, path, to[i], nullptr)) {
-                    const char* image_extensions[] = {"jpg", "jpeg", "gif", "bmp", "png"};
-
-                    t_size i, count = tabsize(image_extensions);
-
-                    bool b_absolute = path.find_first(':') != pfc_infinite || path.get_ptr()[0] == '\\';
-
-                    pfc::string8 realPath;
-                    if (b_absolute)
-                        realPath = path;
-                    else
-                        realPath << pfc::string_directory(m_handle->get_path()) << "\\" << path;
-
-                    bool b_search
-                        = (realPath.find_first('*') != pfc_infinite) || (realPath.find_first('?') != pfc_infinite);
-                    bool b_search_matched = false;
-
-                    if (b_search) {
-                        const char* pMainPath = realPath;
-                        if (!stricmp_utf8_partial(pMainPath, "file://"))
-                            pMainPath += 7;
-                        pfc::string_formatter search_pattern;
-                        puFindFile pSearcher = uFindFirstFile(search_pattern << pMainPath << ".*");
-                        pfc::string8 searchPath = realPath;
-                        realPath.reset();
-                        if (pSearcher) {
-                            do {
-                                const char* pResult = pSearcher->GetFileName();
-                                for (i = 0; i < count; i++) {
-                                    if (!stricmp_utf8(pfc::string_extension(pResult), image_extensions[i])) {
-                                        realPath << pfc::string_directory(searchPath) << "\\" << pResult;
-                                        b_search_matched = true;
-                                        break;
-                                    }
-                                }
-                            } while (!b_search_matched && pSearcher->FindNext());
-                            delete pSearcher;
-                        }
-                    }
-
-                    if (!b_search || b_search_matched) {
-                        {
-                            file::ptr file;
-                            if (b_search) {
-                                pfc::string8 canPath;
-                                filesystem::g_get_canonical_path(realPath, canPath);
-                                if (!filesystem::g_is_remote_or_unrecognized(canPath))
-                                    filesystem::g_open(file, canPath, filesystem::open_mode_read, p_abort);
-                            } else {
-                                for (i = 0; i < count; i++) {
-                                    pfc::string8 canPath;
-                                    try {
-                                        pfc::string_formatter realPathExt;
-                                        filesystem::g_get_canonical_path(
-                                            realPathExt << realPath << "." << image_extensions[i], canPath);
-                                        if (!filesystem::g_is_remote_or_unrecognized(canPath)) {
-                                            filesystem::g_open(file, canPath, filesystem::open_mode_read, p_abort);
-                                            break;
-                                        }
-                                    } catch (exception_io const&) {
-                                    }
-                                }
-                            }
-                            if (file.is_valid()) {
-                                service_ptr_t<album_art_data_impl> ptr = new service_impl_t<album_art_data_impl>;
-                                ptr->from_stream(
-                                    file.get_ptr(), gsl::narrow<t_size>(file->get_size_ex(p_abort)), p_abort);
-                                b_found = true;
-                                data = ptr;
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        data = artwork_api_v2->query(artwork_type_id, p_abort);
     } catch (const exception_aborted&) {
         throw;
-    } catch (pfc::exception const&) {
+    } catch (exception_io_not_found const&) {
+    } catch (pfc::exception const& e) {
+        console::formatter formatter;
+        formatter << "Requested Album Art entry could not be retrieved: " << e.what();
     }
-#if 1
-    if (!b_found && m_native_artwork_reader_mode == artwork_panel::fb2k_artwork_embedded_and_external) {
-        album_art_extractor_instance_v2::ptr artwork_api_v2
-            = p_album_art_manager_v2->open(pfc::list_single_ref_t<metadb_handle_ptr>(m_handle),
-                pfc::list_single_ref_t<GUID>(artwork_type_id), p_abort);
-        {
-            try {
-                data = artwork_api_v2->query(artwork_type_id, p_abort);
-                b_found = true;
-            } catch (const exception_aborted&) {
-                throw;
-            } catch (exception_io_not_found const&) {
-            } catch (pfc::exception const& e) {
-                console::formatter formatter;
-                formatter << "Requested Album Art entry could not be retrieved: " << e.what();
-            }
-        }
-    } else if (!b_found && m_native_artwork_reader_mode == artwork_panel::fb2k_artwork_embedded) {
-        {
-            try {
-                if (!b_extracter_attempted) {
-                    b_extracter_attempted = true;
-                    p_extractor = artwork_panel::g_get_album_art_extractor_instance(m_handle->get_path(), p_abort);
-                }
-                if (p_extractor.is_valid()) {
-                    data = p_extractor->query(artwork_type_id, p_abort);
-                    b_found = true;
-                }
-            } catch (const exception_aborted&) {
-                throw;
-            } catch (exception_io_not_found const&) {
-            } catch (exception_io const& e) {
-                console::formatter formatter;
-                formatter << "Requested Album Art entry could not be retrieved: " << e.what();
-            }
-        }
-    }
+
     if (data.is_valid()) {
         wil::shared_hbitmap bitmap = g_create_hbitmap_from_data(data, m_cx, m_cy, m_back, m_reflection);
         m_bitmaps.insert_or_assign(artwork_type_id, std::move(bitmap));
         GdiFlush();
     }
-#endif
-#if 1
     if (!m_bitmaps.count(artwork_type_id)) {
         auto bm = m_manager->request_nocover_image(m_cx, m_cy, m_back, m_reflection, p_abort);
         if (bm) {
@@ -278,7 +162,6 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
             GdiFlush();
         }
     }
-#endif
     return 1;
 }
 

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -238,6 +238,10 @@
 #define IDC_DISPLAY_SCRIPT              1173
 #define IDC_SORTING_SCRIPT              1174
 #define IDC_STYLE_SCRIPT                1175
+#define IDC_OPEN_DISPLAY_PREFERENCES    1176
+#define IDC_VIEW_OLD_ARTWORK_SOURCES    1177
+#define IDC_VIEW_OLD_ARTWORK_SOURCES_TEXT 1178
+#define IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES 1179
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -247,7 +251,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        158
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1176
+#define _APS_NEXT_CONTROL_VALUE         1179
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
This removes Columns UI’s own artwork settings as:

- they were redundant, as foobar2000’s own settings on the Display preferences page could also be used
- being able to configure artwork sources in two places was causing confusion

The old setting variables are still in place to allow downgrades and to allow users to manually copy settings to Display preferences.

### Screenshots

#### Without any legacy artwork sources configured

![image](https://user-images.githubusercontent.com/12693549/71749040-42c87300-2e6c-11ea-9028-bd386e0c029c.png)

#### With legacy artwork sources configured

![image](https://user-images.githubusercontent.com/12693549/71749136-802d0080-2e6c-11ea-8043-bc0ffb59aae4.png)

