### PR TITLE
Explicitly initialise COM in artwork reader threads

### DIFF
--- a/foo_ui_columns/artwork_helpers.cpp
+++ b/foo_ui_columns/artwork_helpers.cpp
@@ -190,6 +190,8 @@ bool artwork_panel::ArtworkReader::isContentEqual(const std::unordered_map<GUID,
 DWORD artwork_panel::ArtworkReader::on_thread()
 {
     TRACK_CALL_TEXT("artwork_reader_v2_t::on_thread");
+
+    auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
     bool b_aborted = false;
     DWORD ret = -1;
     try {

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -98,6 +98,8 @@ public:
 DWORD ArtworkReader::on_thread()
 {
     TRACK_CALL_TEXT("artwork_reader_ng_t::on_thread");
+
+    auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
     bool b_aborted = false;
     DWORD ret = -1;
     try {


### PR DESCRIPTION
The artwork reader threads were [implicitly using the process's multi-threaded apartment](https://devblogs.microsoft.com/oldnewthing/20130419-00/?p=4613).

This adds explicit COM initialisation on these threads to avoid any undesirable behaviour from relying on the implicit MTA.