### PR TITLE
Work around inputs using COM apartment-threading in artwork threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+* A problem reading artwork from certain input services, such as the Windows Media input service, was worked around. [[#292](https://github.com/reupen/columns_ui/pull/292)]
+
 ## 1.4.0-beta.1
 
 ### Removals

--- a/foo_ui_columns/artwork_helpers.cpp
+++ b/foo_ui_columns/artwork_helpers.cpp
@@ -191,7 +191,6 @@ DWORD artwork_panel::ArtworkReader::on_thread()
 {
     TRACK_CALL_TEXT("artwork_reader_v2_t::on_thread");
 
-    auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
     bool b_aborted = false;
     DWORD ret = -1;
     try {
@@ -205,7 +204,7 @@ DWORD artwork_panel::ArtworkReader::on_thread()
     } catch (pfc::exception const& e) {
         m_content.clear();
         console::formatter formatter;
-        formatter << "Album Art loading failure: " << e.what();
+        formatter << u8"Artwork view – unhandled error reading artwork: " << e.what();
         ret = -1;
     }
     // send this first so thread gets closed first
@@ -263,7 +262,7 @@ unsigned artwork_panel::ArtworkReader::read_artwork(abort_callback& p_abort)
         } catch (exception_io_not_found const&) {
         } catch (exception_io const& e) {
             console::formatter formatter;
-            formatter << "Requested Album Art entry could not be retrieved: " << e.what();
+            formatter << u8"Artwork view – error loading artwork: " << e.what();
         }
     }
 
@@ -277,7 +276,7 @@ unsigned artwork_panel::ArtworkReader::read_artwork(abort_callback& p_abort)
         } catch (exception_io_not_found const&) {
         } catch (exception_io const& e) {
             console::formatter formatter;
-            formatter << "Requested Album Art entry could not be retrieved: " << e.what();
+            formatter << u8"Artwork view – error loading no-cover image: " << e.what();
         }
         if (!m_emptycover.is_valid() && pvt::g_get_default_nocover_bitmap_data(m_emptycover, p_abort)) {
         }

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -99,7 +99,6 @@ DWORD ArtworkReader::on_thread()
 {
     TRACK_CALL_TEXT("artwork_reader_ng_t::on_thread");
 
-    auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
     bool b_aborted = false;
     DWORD ret = -1;
     try {
@@ -113,7 +112,7 @@ DWORD ArtworkReader::on_thread()
     } catch (pfc::exception const& e) {
         m_bitmaps.clear();
         console::formatter formatter;
-        formatter << "Album Art loading failure: " << e.what();
+        formatter << u8"Playlist view – unhandled error loading artwork: " << e.what();
         ret = -1;
     }
     // send this first so thread gets closed first
@@ -149,8 +148,12 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
     } catch (exception_io_not_found const&) {
     } catch (pfc::exception const& e) {
         console::formatter formatter;
-        formatter << "Requested Album Art entry could not be retrieved: " << e.what();
+        formatter << u8"Playlist view – error loading artwork: " << e.what();
     }
+
+    // Warning: Broken input components can intitialise COM as apartment-threaded. Hence, COM intialisation
+    // is done here, after input components have been called, to avoid conflicts.
+    auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
 
     if (data.is_valid()) {
         wil::shared_hbitmap bitmap = g_create_hbitmap_from_data(data, m_cx, m_cy, m_back, m_reflection);


### PR DESCRIPTION
As it turns out, some input components, including built-in ones, try to initialise COM as apartment-threaded ([despite not knowing if the calling thread meets the requirements](https://docs.microsoft.com/en-gb/windows/win32/com/single-threaded-apartments)).

Artwork-reading threads correctly use the multi-threaded apartment. However, this was not compatible with input components trying to use a single-threaded apartment.

This change delays COM initialisation in playlist view artwork threads until after artwork has been read, to try and avoid conflicts. (This appears to work, but there could well still be other problems since the thread doesn't meet the requirements for apartment-threading.)

Explicit COM intialisation is also removed from the artwork view artwork thread, since it doesn't directly use COM.