### PR TITLE
Ignore zero-length artwork images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 1.4.0
+
+### Bug fixes
+
+* Zero-length artwork images are now ignored. (Previously, an error was logged in the console when they were encountered.) [[#294](https://github.com/reupen/columns_ui/pull/294)]
+
 ## 1.4.0-rc.1
 
 ### Bug fixes

--- a/foo_ui_columns/artwork_helpers.cpp
+++ b/foo_ui_columns/artwork_helpers.cpp
@@ -256,7 +256,8 @@ unsigned artwork_panel::ArtworkReader::read_artwork(abort_callback& p_abort)
     for (auto&& artwork_id : m_requestIds) {
         try {
             album_art_data_ptr data = artwork_api_v2->query(artwork_id, p_abort);
-            m_content.insert_or_assign(artwork_id, data);
+            if (data->get_size() > 0)
+                m_content.insert_or_assign(artwork_id, data);
         } catch (const exception_aborted&) {
             throw;
         } catch (exception_io_not_found const&) {

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -155,7 +155,7 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
     // is done here, after input components have been called, to avoid conflicts.
     auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
 
-    if (data.is_valid()) {
+    if (data.is_valid() && data->get_size() > 0) {
         wil::shared_hbitmap bitmap = g_create_hbitmap_from_data(data, m_cx, m_cy, m_back, m_reflection);
         m_bitmaps.insert_or_assign(artwork_type_id, std::move(bitmap));
         GdiFlush();


### PR DESCRIPTION
In some cases (possibly something to do with zip files), the foobar2000 album art API returns zero-length image data.

This ignores any such images, rather than trying to decode them (which, of course, fails).