### PR TITLE
Correct loading of images with relative paths in the buttons toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 1.4.1
+
+### Bug fixes
+
+* A regression in the buttons toolbar, which may have caused the loading of custom images with relative paths to fail, was fixed. [[#298](https://github.com/reupen/columns_ui/pull/298)]
+
 ## 1.4.0
 
 ### Bug fixes

--- a/foo_ui_columns/buttons_button_image.cpp
+++ b/foo_ui_columns/buttons_button_image.cpp
@@ -34,7 +34,7 @@ void ButtonsToolbar::ButtonImage::load(const Button::CustomImage& p_image)
             GetSystemMetrics(SM_CYSMICON), LR_LOADFROMFILE);
     else {
         try {
-            m_bm = cui::wic::create_hbitmap_from_path(p_image.m_path).release();
+            m_bm = cui::wic::create_hbitmap_from_path(fullPath).release();
         } catch (const std::exception& ex) {
             fbh::print_to_console(u8"Buttons toolbar – loading image failed: ", ex.what());
             m_bm = nullptr;


### PR DESCRIPTION
This fixes a regression in 09be8e50007a49b24b579cc6885d8c3d427a317b where relative paths of custom images in the buttons toolbar were not resolved.

This may have caused them to fail to load if the current working directory wasn't the one expected.

This only affected image file extensions other than `bmp` and `ico`.