### PR TITLE
Replace some usages of pfc containers in uih::ListView

### DIFF
--- a/foo_ui_columns/buttons_config_listview.cpp
+++ b/foo_ui_columns/buttons_config_listview.cpp
@@ -10,12 +10,7 @@ CLIPFORMAT ButtonsToolbar::ConfigParam::ButtonsList::g_clipformat()
 void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_initialisation()
 {
     set_single_selection(true);
-
-    pfc::list_t<uih::ListView::Column> columns;
-    columns.add_item(uih::ListView::Column("Name", 300));
-    columns.add_item(uih::ListView::Column("Type", 150));
-
-    set_columns(columns);
+    set_columns({{"Name", 300}, {"Type", 150}});
 }
 void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_create()
 {

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -19,13 +19,7 @@ public:
         const auto client_width = rc.right - rc.left;
 
         set_single_selection(true);
-        pfc::list_t<Column> columns;
-        columns.set_count(2);
-        columns[0].m_title = "Name";
-        columns[0].m_size = client_width/3;
-        columns[1].m_title = "Field";
-        columns[1].m_size = client_width*2/3;
-        uih::ListView::set_columns(columns);
+        uih::ListView::set_columns({{"Name", client_width / 3}, {"Field", client_width * 2 / 3}});
     };
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse) override

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -768,8 +768,7 @@ void FilterPanel::refresh_groups()
 
 void FilterPanel::refresh_columns()
 {
-    set_columns(pfc::list_single_ref_t<Column>(
-        Column(m_field_data.is_empty() ? "<no field>" : m_field_data.m_name.get_ptr(), 200)));
+    set_columns({{m_field_data.is_empty() ? "<no field>" : m_field_data.m_name.get_ptr(), 200}});
     set_sort_column(0, m_pending_sort_direction);
 }
 

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -197,10 +197,7 @@ void ItemProperties::notify_on_initialisation()
 }
 void ItemProperties::notify_on_create()
 {
-    pfc::list_t<Column> columns;
-    columns.add_item(Column("Field", m_column_name_width, 0));
-    columns.add_item(Column("Value", m_column_field_width, 1));
-    set_columns(columns);
+    set_columns({{"Field", m_column_name_width, 0}, {"Value", m_column_field_width, 1}});
     set_group_count(m_show_group_titles ? 1 : 0);
 
     register_callback();

--- a/foo_ui_columns/item_properties_config_list_view.cpp
+++ b/foo_ui_columns/item_properties_config_list_view.cpp
@@ -42,13 +42,7 @@ bool FieldsList::notify_before_create_inline_edit(
 void FieldsList::notify_on_create()
 {
     set_single_selection(true);
-    pfc::list_t<Column> columns;
-    columns.set_count(2);
-    columns[0].m_title = "Name";
-    columns[0].m_size = 150;
-    columns[1].m_title = "Field";
-    columns[1].m_size = 150;
-    uih::ListView::set_columns(columns);
+    uih::ListView::set_columns({{"Name", 150}, {"Field", 150}});
 
     t_size count = m_fields.get_count();
     pfc::list_t<uih::ListView::InsertItem> items;

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -168,10 +168,10 @@ t_size PlaylistView::column_index_actual_to_display(t_size actual_index)
 void PlaylistView::on_column_widths_change()
 {
     t_size count = m_column_mask.get_count();
-    pfc::list_t<int> widths;
+    std::vector<int> widths;
     for (t_size i = 0; i < count; i++)
         if (m_column_mask[i])
-            widths.add_item(g_columns[i]->width);
+            widths.emplace_back(g_columns[i]->width);
     set_column_widths(widths);
 }
 
@@ -191,7 +191,7 @@ void PlaylistView::refresh_columns()
 
     m_column_data.remove_all();
     m_edit_fields.remove_all();
-    pfc::list_t<Column> columns;
+    std::vector<Column> columns;
 
     pfc::string8 filter;
     pfc::string8 playlist_name;
@@ -224,7 +224,7 @@ void PlaylistView::refresh_columns()
         }
         if (b_valid) {
             ColumnData temp;
-            columns.add_item(Column(source->name, source->width, source->parts, (uih::alignment)source->align));
+            columns.emplace_back(source->name, source->width, source->parts, (uih::alignment)source->align);
             p_compiler->compile_safe(temp.m_display_script, source->spec);
             if (source->use_custom_colour)
                 p_compiler->compile_safe(temp.m_style_script, source->colour_spec);

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -45,7 +45,7 @@ void PlaylistSwitcher::add_items(t_size base, t_size count)
 
 void PlaylistSwitcher::refresh_columns()
 {
-    set_columns(pfc::list_single_ref_t<Column>(Column("Name", 100)));
+    set_columns({{"Name", 100}});
 }
 
 void PlaylistSwitcher::move_selection(int delta)


### PR DESCRIPTION
This updates ui_helpers following the replacement of some uses of `const pfc::list_base_const_t<uih::ListView::Column>&` with `std::vector<uih::ListView::Column>`.