### PR TITLE
Always include custom active item frame colours in FCL files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+* Custom Album list panel active item frame colours are now included in exported FCL files. [[#316](https://github.com/reupen/columns_ui/pull/316)]
+
 ## 1.4.1
 
 ### Bug fixes

--- a/foo_ui_columns/colours_manager_data.cpp
+++ b/foo_ui_columns/colours_manager_data.cpp
@@ -191,8 +191,7 @@ void ColoursManagerData::Entry::_export(stream_writer* p_stream, abort_callback&
         out.write_item(identifier_inactive_selection_background, inactive_selection_background);
     }
     out.write_item(identifier_use_custom_active_item_frame, use_custom_active_item_frame);
-    if (use_custom_active_item_frame)
-        out.write_item(identifier_custom_active_item_frame, active_item_frame);
+    out.write_item(identifier_custom_active_item_frame, active_item_frame);
 }
 
 void ColoursManagerData::Entry::write(stream_writer* p_stream, abort_callback& p_abort)


### PR DESCRIPTION
This fixes a bug that was causing custom Album list panel active item frame colours to be omitted from exported FCL files.

This was happening as Album list panel doesn't support turning off the 'Use custom active item frame' option when using custom colours and the exporting code didn't handle this correctly.