### PR TITLE
Disable support for tab columns in some panels

### DIFF
--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -81,6 +81,8 @@ class FilterPanel
     friend class FilterSearchToolbar;
 
 public:
+    FilterPanel() : ListViewPanelBase(std::make_unique<uih::lv::DefaultRenderer>(true)) {}
+
     enum { TIMER_QUERY = TIMER_BASE };
 
     enum { config_version_current = 1 };

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -756,7 +756,7 @@ void g_text_out_multiline_font(HDC dc, const RECT& rc_topleft, t_size line_heigh
                     } while (ptrC >= rawText && *ptrC != '\x3');
                     if (ptrC >= rawText && *ptrC == '\x3') {
                         uih::text_out_colours_tab(dc, ptrC, ptrCEnd - ptrC + 1, 0, 0, &rc_line, false, cr_text, false,
-                            false, false && !b_hscroll, uih::ALIGN_LEFT, nullptr, false, false);
+                            false && !b_hscroll, uih::ALIGN_LEFT, nullptr, false, false);
                     }
                     break;
                 }
@@ -819,7 +819,7 @@ void g_text_out_multiline_font(HDC dc, const RECT& rc_topleft, t_size line_heigh
             RECT rc_font = rc_line;
             int extra = RECT_CY(rc_font) - uGetTextHeight(dc);
             rc_font.bottom -= half_padding_size; // extra/4;
-            BOOL ret = uih::text_out_colours_tab(dc, ptr, ptrThisCount, 0, 0, &rc_font, false, cr_text, false, false,
+            BOOL ret = uih::text_out_colours_tab(dc, ptr, ptrThisCount, 0, 0, &rc_font, false, cr_text, false,
                 false && !b_hscroll, uih::ALIGN_LEFT, nullptr, false, false, &width);
             rc_line.left = width; // width == position actually!!
             ptr += ptrThisCount;
@@ -830,8 +830,8 @@ void g_text_out_multiline_font(HDC dc, const RECT& rc_topleft, t_size line_heigh
             RECT rc_font = rc_line;
             int extra = RECT_CY(rc_font) - uGetTextHeight(dc);
             rc_font.bottom -= half_padding_size;
-            uih::text_out_colours_tab(dc, ptr, ptrRemaining, 0, 0, &rc_font, false, cr_text, false, false,
-                false && !b_hscroll, uih::ALIGN_LEFT, nullptr, false, false);
+            uih::text_out_colours_tab(dc, ptr, ptrRemaining, 0, 0, &rc_font, false, cr_text, false, false && !b_hscroll,
+                uih::ALIGN_LEFT, nullptr, false, false);
         }
 
 #if 0

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -502,7 +502,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             if (lpdis->itemData) {
                 pfc::string8& text = *reinterpret_cast<pfc::string8*>(lpdis->itemData);
                 uih::text_out_colours_tab(lpdis->hDC, text, text.length(), 0, uih::scale_dpi_value(3), &rc, FALSE,
-                    GetSysColor(COLOR_MENUTEXT), TRUE, true, false, uih::ALIGN_LEFT);
+                    GetSysColor(COLOR_MENUTEXT), true, false, uih::ALIGN_LEFT);
             }
 
             return TRUE;

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -81,7 +81,7 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, t_size 
         }
         uih::text_out_colours_tab(context.dc, sub_item.text.data(), sub_item.text.size(),
             uih::scale_dpi_value(1) + (column_index == 0 ? indentation : 0), uih::scale_dpi_value(3), &rc_subitem,
-            b_selected, cr_text, true, true, cfg_ellipsis != 0, sub_item.alignment);
+            b_selected, cr_text, true, cfg_ellipsis != 0, sub_item.alignment);
 
         const auto frame_width = uih::scale_dpi_value(1);
 
@@ -153,7 +153,7 @@ void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t
     }
 
     uih::text_out_colours_tab(context.dc, text.data(), text.size(), uih::scale_dpi_value(1) + indentation * level,
-        uih::scale_dpi_value(3), &rc, false, cr, true, true, true, uih::ALIGN_LEFT, nullptr, true, true, &text_width);
+        uih::scale_dpi_value(3), &rc, false, cr, true, true, uih::ALIGN_LEFT, nullptr, true, true, &text_width);
 
     auto cx = (LONG)min(text_width, MAXLONG);
 

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -307,7 +307,8 @@ public:
     }
     unsigned get_type() const override { return uie::type_panel; }
 
-    PlaylistSwitcher() : m_playing_playlist(pfc_infinite){};
+    PlaylistSwitcher()
+        : ListViewPanelBase(std::make_unique<uih::lv::DefaultRenderer>(true)), m_playing_playlist(pfc_infinite){};
 
 private:
     contextmenu_manager::ptr m_contextmenu_manager;

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -99,18 +99,18 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             items_text << " selected";
 
         uih::text_out_colours_tab(dc, items_text, -1, uih::scale_dpi_value(1), uih::scale_dpi_value(3), &rc_line_1,
-            false, default_text_colour, false, false, false, uih::ALIGN_LEFT);
+            false, default_text_colour, false, false, uih::ALIGN_LEFT);
         if (m_item_count) {
             pfc::string_formatter formatter;
             uih::text_out_colours_tab(dc, formatter << "Length: " << m_length_text, -1, uih::scale_dpi_value(1),
-                uih::scale_dpi_value(3), &rc_line_2, false, default_text_colour, false, false, false, uih::ALIGN_LEFT);
+                uih::scale_dpi_value(3), &rc_line_2, false, default_text_colour, false, false, uih::ALIGN_LEFT);
         }
 
         if (m_menu_active) {
             {
                 RECT rc_item = rc_line_1;
                 uih::text_out_colours_tab(dc, m_menu_text, -1, uih::scale_dpi_value(1) + placeholder_len,
-                    uih::scale_dpi_value(3), &rc_item, false, default_text_colour, false, false, false, uih::ALIGN_LEFT,
+                    uih::scale_dpi_value(3), &rc_item, false, default_text_colour, false, false, uih::ALIGN_LEFT,
                     nullptr, true, true, nullptr);
             }
         } else {
@@ -122,7 +122,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 RECT rc_item = rc_line_1;
                 // rc_item.right = 4 + placeholder_len + placeholder2_len;
                 uih::text_out_colours_tab(dc, m_track_label, -1, uih::scale_dpi_value(4) + placeholder_len, 0, &rc_item,
-                    false, default_text_colour, false, false, false, uih::ALIGN_LEFT, nullptr, true, true, nullptr);
+                    false, default_text_colour, false, false, uih::ALIGN_LEFT, nullptr, true, true, nullptr);
             }
             if (playing1.get_length()) {
                 pfc::string_list_impl playingstrings;
@@ -130,10 +130,10 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 t_size lines = playingstrings.get_count();
                 if (lines)
                     uih::text_out_colours_tab(dc, playingstrings[0], pfc_infinite, now_playing_x_end, 0, &rc_line_1,
-                        false, default_text_colour, true, true, false, uih::ALIGN_LEFT);
+                        false, default_text_colour, true, false, uih::ALIGN_LEFT);
                 if (lines > 1)
                     uih::text_out_colours_tab(dc, playingstrings[1], pfc_infinite, now_playing_x_end, 0, &rc_line_2,
-                        false, default_text_colour, true, true, false, uih::ALIGN_LEFT);
+                        false, default_text_colour, true, false, uih::ALIGN_LEFT);
             }
         }
 


### PR DESCRIPTION
#313

This disables tab columns in Item properties and some other panels where title formatting isn't used. This is because it doesn't make sense to enable tab columns without title formatting.

ui_helpers was also updated (where the signature of `text_out_colours_tab()` changed slightly).