### PR TITLE
Fix stale panel data being copied when copying panels in live editing

### DIFF
--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -169,8 +169,8 @@ public:
     void import_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort) override;
     void export_config(stream_writer* p_writer, abort_callback& p_abort) const override;
 
+    void refresh_child_data(abort_callback& aborter = fb2k::noAbort) const;
     void set_config(stream_reader* config, t_size p_size, abort_callback& p_abort) override;
-
     void get_config(stream_writer* out, abort_callback& p_abort) const override;
 
     void on_child_position_change();
@@ -179,7 +179,7 @@ private:
     static HFONT g_font;
 
     GUID m_child_guid{};
-    pfc::array_t<t_uint8> m_child_data;
+    mutable pfc::array_t<t_uint8> m_child_data;
     service_ptr_t<WindowHost> m_host;
     ui_extension::window_ptr m_child;
     HWND m_child_wnd{nullptr};

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -137,6 +137,7 @@ private:
 
         void set_from_splitter_item(const uie::splitter_item_t* p_source);
 
+        void refresh_child_data(abort_callback& aborter = fb2k::noAbort);
         void _export(stream_writer* out, abort_callback& p_abort);
         void write(stream_writer* out, abort_callback& p_abort);
         void import(stream_reader* t, abort_callback& p_abort);

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -164,6 +164,8 @@ bool TabStackPanel::PanelList::find_by_wnd(HWND wnd, unsigned& p_out)
 
 uie::splitter_item_full_v2_t* TabStackPanel::Panel::create_splitter_item()
 {
+    refresh_child_data();
+
     auto ret = new uie::splitter_item_full_v2_impl_t;
     ret->set_panel_guid(m_guid);
     ret->set_panel_config_from_ptr(m_child_data.get_ptr(), m_child_data.get_size());
@@ -208,6 +210,12 @@ void TabStackPanel::Panel::destroy()
     m_interface.release();
 }
 
+void TabStackPanel::Panel::refresh_child_data(abort_callback& p_abort)
+{
+    if (m_child.is_valid())
+        m_child_data = m_child->get_config_as_array(p_abort);
+}
+
 void TabStackPanel::Panel::read(stream_reader* t, abort_callback& p_abort)
 {
     t->read_lendian_t(m_guid, p_abort);
@@ -221,10 +229,7 @@ void TabStackPanel::Panel::read(stream_reader* t, abort_callback& p_abort)
 
 void TabStackPanel::Panel::write(stream_writer* out, abort_callback& p_abort)
 {
-    if (m_child.is_valid()) {
-        m_child_data.set_size(0);
-        m_child->get_config_to_array(m_child_data, p_abort);
-    }
+    refresh_child_data(p_abort);
     out->write_lendian_t(m_guid, p_abort);
     out->write_lendian_t(m_child_data.get_size(), p_abort);
     out->write(m_child_data.get_ptr(), m_child_data.get_size(), p_abort);

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -92,8 +92,8 @@ public:
 
         void destroy();
 
+        void refresh_child_data(abort_callback& p_abort = fb2k::noAbort);
         void read(stream_reader* t, abort_callback& p_abort);
-
         void write(stream_writer* out, abort_callback& p_abort);
         void _export(stream_writer* out, abort_callback& p_abort);
         void import(stream_reader* t, abort_callback& p_abort);


### PR DESCRIPTION
This fixes bugs in the standard splitter panels that caused stale panel configuration data to be copied when a panel was copy and pasted in live editing.