### PR TITLE
Use older VC tool set version on Azure Pipelines

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemDefinitionGroup Condition="$(VCToolsVersion) &lt; 14.26">
+    <ClCompile>
+      <AdditionalOptions>-experimental:preprocessor %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/azure/pipeline.yml
+++ b/azure/pipeline.yml
@@ -1,6 +1,7 @@
 variables:
   solution: vc16/columns_ui-public.sln
   llvmMsBuildArgs: /p:PlatformToolset=ClangCL;UseLldLink=True;VcpkgAutoLink=False;WholeProgramOptimization=False;SpectreMitigation=
+  vc142MsBuildArgs: /p:VCToolsVersion=14.25.28610
   vcpkgInstallArgs: 'ms-gsl range-v3 wil --overlay-ports=$(System.DefaultWorkingDirectory)\ports'
 jobs:
 - template: job-build.yml
@@ -26,6 +27,7 @@ jobs:
       Release:
         configuration: Release
         publish: true
+    msBuildArgs: ${{ variables.vc142MsBuildArgs }}
     name: vs2019_v142
     platform: Win32
     solution: ${{ variables.solution }}


### PR DESCRIPTION
This downgrades the VC tool set version on Azure Pipelines to the one from VS 2019 16.5 due to the 16.7 one currently producing an internal compiler error (and the 16.6 one not being available on Azure Pipelines).