### PR TITLE
Improve Item details scroll bar handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## Development version
 
-## Features
+### Features
 
 * SSE2 instructions are now enabled (and hence are now required). [[#329](https://github.com/reupen/columns_ui/pull/329)]
+
+* Items details now tries to preserve the scroll position when adjusting settings. [[#335](https://github.com/reupen/columns_ui/pull/335)]
+
+### Bug fixes
+
+* A bug was fixed where it sometimes wasn't possible to scroll to the very bottom of Items details when both horizontal and vertical scroll bars were visible. [[#335](https://github.com/reupen/columns_ui/pull/335)]
+
+* Miscalculated bottom padding in the background of some dialogues at high DPIs was fixed. [[#334](https://github.com/reupen/columns_ui/pull/334)]
 
 ### Internal changes
 

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -336,7 +336,7 @@ private:
     void on_app_activate(bool b_activated);
 
     void set_handles(const metadb_handle_list& handles);
-    void refresh_contents(bool reset_scroll_position = true);
+    void refresh_contents(bool reset_vertical_scroll_position = false, bool reset_horizontal_scroll_position = false);
     void request_full_file_info();
     void on_full_file_info_request_completion(std::shared_ptr<cui::helpers::FullFileInfoRequest> request);
     void release_aborted_full_file_info_requests();
@@ -354,7 +354,14 @@ private:
 
     void invalidate_all(bool b_update = true);
     void update_now();
-    void update_scrollbar_range(bool b_set_pos = true);
+
+    enum class ScrollbarType {
+        vertical = SB_VERT,
+        horizontal = SB_HORZ,
+    };
+
+    void update_scrollbar(ScrollbarType scrollbar_type, bool reset_position);
+    void update_scrollbars(bool reset_vertical_position, bool reset_horizontal_position);
 
     void on_size();
     void on_size(t_size cx, t_size cy);
@@ -364,6 +371,8 @@ private:
 
     static std::vector<ItemDetails*> g_windows;
 
+    size_t m_last_cx{};
+    size_t m_last_cy{};
     ui_selection_holder::ptr m_selection_holder;
     metadb_handle_list m_handles;
     metadb_handle_list m_selection_handles;

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -60,6 +60,8 @@
 #include "../fbh/stdafx.h"
 #include "../pfc/range_based_for.h"
 
+using namespace uih::literals::spx;
+
 #include "functional.h"
 #include "resource.h"
 


### PR DESCRIPTION
Fixes #331

This rewrites scroll bar-related code in Item details in an effort to improve behaviour when scroll bar information is updated, and fix a problem where it sometimes wasn't possible to scroll to the very bottom if both scroll bars were visible.

This also attempts to preserve the scroll position when changing settings.