### PR TITLE
Work around VS 2019 16.7 compiler error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Development version
 
+### Features
+
 * Support for back cover, disc and artist stub images was added to the Artwork view panel. [[#345](https://github.com/reupen/columns_ui/pull/345)]
 
+### Internal changes
+
 * The `Zc:threadSafeInit-` compiler option is no longer used. [[#340](https://github.com/reupen/columns_ui/pull/340)]
+
+* The component is now compiled using Visual Studio 2019 16.7.
 
 ## 1.6.0
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,0 @@
-<Project>
-  <ItemDefinitionGroup Condition="$(VCToolsVersion) &lt; 14.26">
-    <ClCompile>
-      <AdditionalOptions>-experimental:preprocessor %(AdditionalOptions)</AdditionalOptions>
-    </ClCompile>
-  </ItemDefinitionGroup>
-</Project>

--- a/azure/pipeline.yml
+++ b/azure/pipeline.yml
@@ -1,7 +1,7 @@
 variables:
   solution: vc16/columns_ui-public.sln
   llvmMsBuildArgs: /p:PlatformToolset=ClangCL;UseLldLink=True;VcpkgAutoLink=False;WholeProgramOptimization=False;SpectreMitigation=
-  vc142MsBuildArgs: /p:VCToolsVersion=14.25.28610
+  vc142MsBuildArgs:
   vcpkgInstallArgs: 'ms-gsl range-v3 wil --overlay-ports=$(System.DefaultWorkingDirectory)\ports'
 jobs:
 - template: job-build.yml

--- a/foo_ui_columns/layout_config.cpp
+++ b/foo_ui_columns/layout_config.cpp
@@ -27,7 +27,7 @@ const Preset default_preset = {"Default",
     }}
 };
 
-const std::initializer_list<Preset> quick_setup_presets = {
+const std::array<Preset, 10> quick_setup_presets = {{
     {"Playlist switcher",
         {columns_ui::panels::guid_horizontal_splitter, {
             {columns_ui::panels::guid_vertical_splitter, {
@@ -155,7 +155,7 @@ const std::initializer_list<Preset> quick_setup_presets = {
             }, true, 125},
         }}
     },
-};
+}};
 // clang-format on
 
 uie::window::ptr node_to_window(Node node)


### PR DESCRIPTION
Fixes #327

There seems to be little sign that https://developercommunity.visualstudio.com/content/problem/1139127/internal-compiler-error-vs-1670.html will be resolved soon, so this applies the workaround mentioned in that link.