### PR TITLE
Add 'Reload artwork' context menu command to artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * The Item properties and Item details panels now expand and align tab characters. [[#350](https://github.com/reupen/columns_ui/pull/350)]
 
+* A 'Reload artwork' command was added to the artwork view context menu. This forces a reload of artwork from the file system using current settings. [[#351](https://github.com/reupen/columns_ui/pull/351)]
+
 ### Internal changes
 
 * The `Zc:threadSafeInit-` compiler option is no longer used. [[#340](https://github.com/reupen/columns_ui/pull/340)]

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -63,11 +63,14 @@ void ArtworkPanel::get_config(stream_writer* p_writer, abort_callback& p_abort) 
 
 void ArtworkPanel::get_menu_items(ui_extension::menu_hook_t& p_hook)
 {
-    p_hook.add_node(ui_extension::menu_node_ptr(new MenuNodeTypePopup(this)));
-    p_hook.add_node(ui_extension::menu_node_ptr(new MenuNodeSourcePopup(this)));
-    p_hook.add_node(ui_extension::menu_node_ptr(new MenuNodePreserveAspectRatio(this)));
-    p_hook.add_node(ui_extension::menu_node_ptr(new MenuNodeLockType(this)));
-    p_hook.add_node(ui_extension::menu_node_ptr(new MenuNodeOptions()));
+    p_hook.add_node(uie::menu_node_ptr(new uie::simple_command_menu_node("Reload artwork",
+        "Reloads the currently displayed artwork.", 0, [this, self = ptr{this}] { force_reload_artwork(); })));
+    p_hook.add_node(uie::menu_node_ptr(new uie::menu_node_separator_t()));
+    p_hook.add_node(uie::menu_node_ptr(new MenuNodeTypePopup(this)));
+    p_hook.add_node(uie::menu_node_ptr(new MenuNodeSourcePopup(this)));
+    p_hook.add_node(uie::menu_node_ptr(new MenuNodePreserveAspectRatio(this)));
+    p_hook.add_node(uie::menu_node_ptr(new MenuNodeLockType(this)));
+    p_hook.add_node(uie::menu_node_ptr(new MenuNodeOptions()));
 }
 
 ArtworkPanel::ArtworkPanel() : m_track_mode(cfg_track_mode), m_preserve_aspect_ratio(cfg_preserve_aspect_ratio){};


### PR DESCRIPTION
Resolves #346

This adds a 'Reload artwork' command to the artwork view panel.

This can be used to force a reload of artwork following e.g. configuration changes.