### PR TITLE
Improve Filter panel compatibility with 'Playback follows cursor'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * A 'Reload artwork' command was added to the artwork view context menu. This forces a reload of artwork from the file system using current settings. [[#351](https://github.com/reupen/columns_ui/pull/351)]
 
+* The Filter panel no longer focuses the first playlist item when using any of the send to playlist commands or actions. This improves compatibility with shuffle playback modes when 'Playback follows cursor' is enabled. [[#352](https://github.com/reupen/columns_ui/pull/352)]
+
 ### Internal changes
 
 * The `Zc:threadSafeInit-` compiler option is no longer used. [[#340](https://github.com/reupen/columns_ui/pull/340)]

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -582,15 +582,16 @@ void FilterPanel::do_items_action(const pfc::bit_array& p_nodes, Action action)
         playlist_api->playlist_add_items(index, handles, pfc::bit_array_false());
     else {
         playlist_api->playlist_clear_selection(index);
+        const auto item_index = playlist_api->playlist_get_item_count(index);
         playlist_api->playlist_add_items(index, handles, pfc::bit_array_true());
+        playlist_api->playlist_set_focus_item(index, item_index);
     }
-    playlist_api->playlist_set_focus_item(index, playlist_api->playlist_get_item_count(index) - handles.get_count());
 
     if (action != action_add_to_active) {
         playlist_api->set_active_playlist(index);
         if (action == action_send_to_autosend_play || action == action_send_to_new_play) {
             playlist_api->set_playing_playlist(index);
-            playback_api->play_start(play_control::track_command_default);
+            playback_api->start(play_control::track_command_default);
         }
     }
 }


### PR DESCRIPTION
This stops the Filter panel from focusing the first playlist item when using any of the send to playlist actions.

This improves compatibility with shuffle playback modes when 'Playback follows cursor' is enabled.

There is no change to the behaviour of the 'Add to active playlist' action.