### PR TITLE
Add cui::fonts::manager_v2 implementation

### DIFF
--- a/foo_ui_columns/fonts_manager_data.cpp
+++ b/foo_ui_columns/fonts_manager_data.cpp
@@ -189,10 +189,10 @@ void FontsManagerData::Entry::read_extra_data(stream_reader* stream, abort_callb
     limited_reader.read_lendian_t(font_description.point_size_tenths, aborter);
 }
 
-LOGFONT FontsManagerData::Entry::get_normalised_font()
+LOGFONT FontsManagerData::Entry::get_normalised_font(unsigned dpi)
 {
     LOGFONT lf{font_description.log_font};
-    lf.lfHeight = -MulDiv(font_description.point_size_tenths, uih::get_system_dpi_cached().cy, 720);
+    lf.lfHeight = -MulDiv(font_description.point_size_tenths, dpi, 720);
     return lf;
 }
 

--- a/foo_ui_columns/fonts_manager_data.h
+++ b/foo_ui_columns/fonts_manager_data.h
@@ -20,7 +20,7 @@ public:
         cui::fonts::FontDescription font_description{};
         cui::fonts::font_mode_t font_mode{cui::fonts::font_mode_system};
 
-        LOGFONT get_normalised_font();
+        LOGFONT get_normalised_font(unsigned dpi = uih::get_system_dpi_cached().cy);
 
         void write(stream_writer* p_stream, abort_callback& p_abort);
         void write_extra_data(stream_writer* p_stream, abort_callback& p_abort);

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -16,10 +16,10 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         uih::list_view_set_explorer_theme(wnd_lv);
 
         const auto monitor = MonitorFromWindow(wnd, MONITOR_DEFAULTTONEAREST);
-        MONITORINFO monitor_info_ex{};
-        monitor_info_ex.cbSize = sizeof(MONITORINFO);
-        if (GetMonitorInfo(monitor, &monitor_info_ex)) {
-            const auto& rc_work = monitor_info_ex.rcWork;
+        MONITORINFO monitor_info{};
+        monitor_info.cbSize = sizeof(MONITORINFO);
+        if (GetMonitorInfo(monitor, &monitor_info)) {
+            const auto& rc_work = monitor_info.rcWork;
 
             RECT rc_dialog{};
             GetWindowRect(wnd, &rc_dialog);


### PR DESCRIPTION
This adds an implementation of the new `cui::fonts::manager_v2` service with custom DPI support.

This can be used to handle font sizes correctly when supporting per-monitor DPI.

