### PR TITLE
Partially revert 'Support per-monitor DPI in various dialogue boxes'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 ### Features
 
-* Some dialogue boxes now support per-monitor DPI on Windows 10. [[#354](https://github.com/reupen/columns_ui/pull/354)]
-
-  (The main window doesn’t as yet support per-monitor DPI.)
-
 * Support for back cover, disc and artist stub images was added to the Artwork view panel. [[#345](https://github.com/reupen/columns_ui/pull/345)]
 
 * The list view scrolling speed when selecting items or using drag and drop was adjusted to be slower, particularly for short lists such as in Buttons options. [[#349](https://github.com/reupen/columns_ui/pull/349)]

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -303,7 +303,7 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
             CommandPickerParam p_data{};
             p_temp.set_data(p_data);
 
-            const auto dialog_result = uih::dpi::modal_dialog_box(IDD_BUTTON_COMMAND_PICKER, wnd,
+            const auto dialog_result = uih::modal_dialog_box(IDD_BUTTON_COMMAND_PICKER, wnd,
                 [&p_temp](auto&&... args) { return p_temp.on_message(std::forward<decltype(args)>(args)...); });
 
             if (dialog_result > 0) {
@@ -451,7 +451,7 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
                     m_selection->m_guid, m_selection->m_subcommand, m_selection->m_type, m_selection->m_filter};
                 p_temp.set_data(p_data);
 
-                const auto dialog_result = uih::dpi::modal_dialog_box(IDD_BUTTON_COMMAND_PICKER, wnd,
+                const auto dialog_result = uih::modal_dialog_box(IDD_BUTTON_COMMAND_PICKER, wnd,
                     [&p_temp](auto&&... args) { return p_temp.on_message(std::forward<decltype(args)>(args)...); });
 
                 if (dialog_result > 0) {

--- a/foo_ui_columns/fcl.cpp
+++ b/foo_ui_columns/fcl.cpp
@@ -356,10 +356,9 @@ void g_import_layout(HWND wnd, const char* path, bool quiet)
 
             FCLDialog pFCLDialog(true, std::move(datasetsguids));
             if (!quiet) {
-                const auto dialog_result
-                    = uih::dpi::modal_dialog_box(IDD_FCL_IMPORT, wnd, [&pFCLDialog](auto&&... args) {
-                          return pFCLDialog.FCLDialogProc(std::forward<decltype(args)>(args)...);
-                      });
+                const auto dialog_result = uih::modal_dialog_box(IDD_FCL_IMPORT, wnd, [&pFCLDialog](auto&&... args) {
+                    return pFCLDialog.FCLDialogProc(std::forward<decltype(args)>(args)...);
+                });
 
                 if (dialog_result <= 0)
                     throw exception_aborted();
@@ -387,10 +386,9 @@ void g_import_layout(HWND wnd, const char* path, bool quiet)
     } catch (const exception_aborted&) {
     } catch (const exception_fcl_dependentpanelmissing&) {
         ImportResultsData data(panel_info, true);
-        const auto wnd_results
-            = uih::dpi::modeless_dialog_box(IDD_RESULTS, wnd, [data{std::move(data)}](auto&&... args) {
-                  return g_ImportResultsProc(data, std::forward<decltype(args)>(args)...);
-              });
+        const auto wnd_results = uih::modeless_dialog_box(IDD_RESULTS, wnd, [data{std::move(data)}](auto&&... args) {
+            return g_ImportResultsProc(data, std::forward<decltype(args)>(args)...);
+        });
         ShowWindow(wnd_results, SW_SHOWNORMAL);
     } catch (const pfc::exception& ex) {
         popup_message::g_show(ex.what(), "Error");
@@ -424,7 +422,7 @@ void g_export_layout(HWND wnd, pfc::string8 path, bool is_quiet)
 {
     FCLDialog pFCLDialog;
     if (!is_quiet) {
-        const auto dialog_result = uih::dpi::modal_dialog_box(IDD_FCL_EXPORT, wnd,
+        const auto dialog_result = uih::modal_dialog_box(IDD_FCL_EXPORT, wnd,
             [&pFCLDialog](auto&&... args) { return pFCLDialog.FCLDialogProc(std::forward<decltype(args)>(args)...); });
 
         if (dialog_result <= 0)

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -176,7 +176,7 @@ void ItemDetailsConfig::run_modeless(HWND wnd, ItemDetails* p_this) &&
 {
     m_modal = false;
     m_this = p_this;
-    uih::dpi::modeless_dialog_box(IDD_ITEM_DETAILS_OPTIONS, wnd, [config{std::move(*this)}](auto&&... args) mutable {
+    uih::modeless_dialog_box(IDD_ITEM_DETAILS_OPTIONS, wnd, [config{std::move(*this)}](auto&&... args) mutable {
         return config.on_message(std::forward<decltype(args)>(args)...);
     });
 }
@@ -184,7 +184,7 @@ void ItemDetailsConfig::run_modeless(HWND wnd, ItemDetails* p_this) &&
 bool ItemDetailsConfig::run_modal(HWND wnd)
 {
     m_modal = true;
-    const auto dialog_result = uih::dpi::modal_dialog_box(IDD_ITEM_DETAILS_OPTIONS, wnd,
+    const auto dialog_result = uih::modal_dialog_box(IDD_ITEM_DETAILS_OPTIONS, wnd,
         [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
     return dialog_result > 0;
 }

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -59,7 +59,7 @@ static BOOL CALLBACK EditViewProc(edit_view_param& state, HWND wnd, UINT msg, WP
 
 static bool run_edit_view(edit_view_param& param, HWND parent)
 {
-    const auto dialog_result = uih::dpi::modal_dialog_box(IDD_EDIT_GROUP, parent,
+    const auto dialog_result = uih::modal_dialog_box(IDD_EDIT_GROUP, parent,
         [&param](auto&&... args) { return EditViewProc(param, std::forward<decltype(args)>(args)...); });
 
     return dialog_result > 0;

--- a/foo_ui_columns/rename_dialog.cpp
+++ b/foo_ui_columns/rename_dialog.cpp
@@ -45,7 +45,7 @@ std::optional<pfc::string8> show_rename_dialog_box(HWND wnd_parent, const char* 
     param.m_title = title;
     param.m_text = initial_text;
 
-    const auto dialog_result = uih::dpi::modal_dialog_box(IDD_RENAME_PLAYLIST, wnd_parent,
+    const auto dialog_result = uih::modal_dialog_box(IDD_RENAME_PLAYLIST, wnd_parent,
         [&param](auto&&... args) { return show_rename_dialog_box_proc(param, std::forward<decltype(args)>(args)...); });
 
     if (dialog_result > 0)

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -97,14 +97,13 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_COMMAND:
         switch (wp) {
         case IDCANCEL: {
-            uih::dpi::with_default_thread_dpi_awareness([&] {
-                cfg_layout.set_preset(cfg_layout.get_active(), m_previous_layout.get_ptr());
-                g_set_global_colour_mode(m_previous_colour_mode);
-                pvt::cfg_show_artwork = m_previous_show_artwork;
-                pvt::cfg_grouping = m_previous_show_grouping;
-                pvt::PlaylistView::g_on_show_artwork_change();
-                pvt::PlaylistView::g_on_groups_change();
-            });
+            cfg_layout.set_preset(cfg_layout.get_active(), m_previous_layout.get_ptr());
+            g_set_global_colour_mode(m_previous_colour_mode);
+            pvt::cfg_show_artwork = m_previous_show_artwork;
+            pvt::cfg_grouping = m_previous_show_grouping;
+            pvt::PlaylistView::g_on_show_artwork_change();
+            pvt::PlaylistView::g_on_groups_change();
+
             DestroyWindow(wnd);
             return 0;
         }
@@ -113,13 +112,12 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             return 0;
         case (CBN_SELCHANGE << 16) | IDC_THEMING: {
             const t_size selection = ComboBox_GetCurSel(HWND(lp));
-            uih::dpi::with_default_thread_dpi_awareness([&] {
-                if (selection == 1)
-                    g_set_global_colour_mode(cui::colours::colour_mode_themed);
-                else if (selection == 0)
-                    g_set_global_colour_mode(cui::colours::colour_mode_system);
-            });
-        } break;
+            if (selection == 1)
+                g_set_global_colour_mode(cui::colours::colour_mode_themed);
+            else if (selection == 0)
+                g_set_global_colour_mode(cui::colours::colour_mode_system);
+            break;
+        }
         case (CBN_SELCHANGE << 16) | IDC_GROUPING: {
             t_size selection = ComboBox_GetCurSel(HWND(lp));
             if (selection >= 2)
@@ -131,12 +129,10 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             if (selection == 0)
                 pvt::cfg_grouping = false;
 
-            uih::dpi::with_default_thread_dpi_awareness([&] {
-                pvt::PlaylistView::g_on_show_artwork_change();
-                pvt::PlaylistView::g_on_groups_change();
-            });
-
-        } break;
+            pvt::PlaylistView::g_on_show_artwork_change();
+            pvt::PlaylistView::g_on_groups_change();
+            break;
+        }
         }
         break;
     case WM_CLOSE:
@@ -153,8 +149,7 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     if ((lpnmlv->uNewState & LVIS_SELECTED) && !(lpnmlv->uOldState & LVIS_SELECTED)) {
                         uie::splitter_item_ptr ptr;
                         m_presets[lpnmlv->iItem].get(ptr);
-                        uih::dpi::with_default_thread_dpi_awareness(
-                            [&] { cfg_layout.set_preset(cfg_layout.get_active(), ptr.get_ptr()); });
+                        cfg_layout.set_preset(cfg_layout.get_active(), ptr.get_ptr());
                     }
                 }
             }
@@ -176,7 +171,7 @@ BOOL QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
 void QuickSetupDialog::g_run()
 {
-    uih::dpi::modeless_dialog_box(
+    uih::modeless_dialog_box(
         IDD_QUICK_SETUP, cui::main_window.get_wnd(), [dialog = std::make_shared<QuickSetupDialog>()](auto&&... args) {
             return dialog->SetupDialogProc(std::forward<decltype(args)>(args)...);
         });

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -379,7 +379,7 @@ static BOOL CALLBACK SpectrumPopupProc(SpectrumAnalyserConfigData& state, HWND w
 bool SpectrumAnalyserVisualisation::show_config_popup(HWND wnd_parent)
 {
     SpectrumAnalyserConfigData param(cr_fore, cr_back, mode, m_scale, m_vertical_scale, this);
-    const auto dialog_result = uih::dpi::modal_dialog_box(IDD_SPECTRUM_ANALYSER_OPTIONS, wnd_parent,
+    const auto dialog_result = uih::modal_dialog_box(IDD_SPECTRUM_ANALYSER_OPTIONS, wnd_parent,
         [&param](auto&&... args) { return SpectrumPopupProc(param, std::forward<decltype(args)>(args)...); });
 
     if (dialog_result > 0) {
@@ -639,7 +639,7 @@ class SpectrumAnalyserVisualisationPanel : public VisualisationPanel {
         SpectrumAnalyserConfigData param(p_temp->cr_fore, p_temp->cr_back, p_temp->mode, p_temp->m_scale, p_temp->m_vertical_scale,
             p_temp.get_ptr(), true, get_frame_style());
 
-        const auto dialog_result = uih::dpi::modal_dialog_box(IDD_SPECTRUM_ANALYSER_OPTIONS, wnd_parent,
+        const auto dialog_result = uih::modal_dialog_box(IDD_SPECTRUM_ANALYSER_OPTIONS, wnd_parent,
             [&param](auto&&... args) { return SpectrumPopupProc(param, std::forward<decltype(args)>(args)...); });
 
         if (dialog_result > 0) {


### PR DESCRIPTION
This partially reverts #354 for the reasons mentioned in https://github.com/reupen/columns_ui/issues/353#issuecomment-752761004.