### PR TITLE
Avoid querying panel configuration data unnecessarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 * The Filter panel no longer focuses the first playlist item when using any of the send to playlist commands or actions. This improves compatibility with shuffle playback modes when 'Playback follows cursor' is enabled. [[#352](https://github.com/reupen/columns_ui/pull/352)]
 
+### Bug fixes
+
+* A problem where panels were queried for configuration data too frequently following [#320](https://github.com/reupen/columns_ui/pull/320) was resolved. [[#364](https://github.com/reupen/columns_ui/pull/364)]
+
 ### Internal changes
 
 * The `Zc:threadSafeInit-` compiler option is no longer used. [[#340](https://github.com/reupen/columns_ui/pull/340)]

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -490,7 +490,6 @@ uie::splitter_item_t* PlaylistTabs::get_panel(unsigned index) const
     auto ptr = new uie::splitter_item_simple_t;
     ptr->set_panel_guid(m_child_guid);
 
-    refresh_child_data();
     ptr->set_panel_config_from_ptr(m_child_data.get_ptr(), m_child_data.get_size());
 
     if (index == 0 && m_child_guid != pfc::guid_null) {

--- a/foo_ui_columns/splitter_panel.cpp
+++ b/foo_ui_columns/splitter_panel.cpp
@@ -209,7 +209,6 @@ void FlatSplitterPanel::Panel::set_from_splitter_item(const uie::splitter_item_t
 
 uie::splitter_item_full_v2_t* FlatSplitterPanel::Panel::create_splitter_item(bool b_set_ptr /*= true*/)
 {
-    refresh_child_data();
     auto ret = new uie::splitter_item_full_v2_impl_t;
     ret->m_autohide = m_autohide;
     ret->m_caption_orientation = m_caption_orientation;

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -164,8 +164,6 @@ bool TabStackPanel::PanelList::find_by_wnd(HWND wnd, unsigned& p_out)
 
 uie::splitter_item_full_v2_t* TabStackPanel::Panel::create_splitter_item()
 {
-    refresh_child_data();
-
     auto ret = new uie::splitter_item_full_v2_impl_t;
     ret->set_panel_guid(m_guid);
     ret->set_panel_config_from_ptr(m_child_data.get_ptr(), m_child_data.get_size());

--- a/foo_ui_columns/splitter_utils.cpp
+++ b/foo_ui_columns/splitter_utils.cpp
@@ -9,6 +9,8 @@ auto normalise_splitter_item(const uie::splitter_item_t* item)
     auto normalised_item = std::make_unique<uie::splitter_item_full_v3_impl_t>();
 
     normalised_item->set_panel_guid(item->get_panel_guid());
+    normalised_item->set_window_ptr(item->get_window_ptr());
+
     stream_writer_memblock panel_data;
     item->get_panel_config(&panel_data);
     normalised_item->set_panel_config_from_ptr(panel_data.m_data.get_ptr(), panel_data.m_data.get_size());
@@ -67,10 +69,9 @@ pfc::array_t<t_uint8> serialise_splitter_item(const uie::splitter_item_full_v3_i
     item->get_title(title);
     writer.write_string(title.get_ptr(), aborter);
 
-    stream_writer_memblock panel_data;
-    item->get_panel_config(&panel_data);
-    writer.write_lendian_t(panel_data.m_data.get_size(), aborter);
-    writer.write(panel_data.m_data.get_ptr(), panel_data.m_data.get_size(), aborter);
+    auto panel_data = item->get_panel_config_to_array(true);
+    writer.write_lendian_t(panel_data.get_size(), aborter);
+    writer.write(panel_data.get_ptr(), panel_data.get_size(), aborter);
 
     writer.write_lendian_t(item->m_extra_data_format_id, aborter);
     writer.write_lendian_t(item->m_extra_data.get_size(), aborter);


### PR DESCRIPTION
This reworks the changes that were made in #320 so that the standard splitters no longer refresh a panel's configuration data when `splitter_window::get_panel()` is called.

This is to avoid panel configuration data being unnecessarily queried at strange moments (e.g. when the main window becomes inactive).

Instead, a refresh is done when a panel is being copied, which still fixes the original problem of stale configuration data being copied when a panel is copied during live editing.