### PR TITLE
Add support for dynamic front covers to artwork view panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features
 
+* Support for dynamic internet radio front cover images was added to the Artwork view panel. [[#367](https://github.com/reupen/columns_ui/pull/367)]
+
+  (Requires foobar2000 1.6.6 or newer.)
+
 * Support for back cover, disc and artist stub images was added to the Artwork view panel. [[#345](https://github.com/reupen/columns_ui/pull/345)]
 
 * The list view scrolling speed when selecting items or using drag and drop was adjusted to be slower, particularly for short lists such as in Buttons options. [[#349](https://github.com/reupen/columns_ui/pull/349)]

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -177,7 +177,7 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         auto lpwp = (LPWINDOWPOS)lp;
         if (!(lpwp->flags & SWP_NOSIZE)) {
             flush_cached_bitmap();
-            RedrawWindow(wnd, nullptr, nullptr, RDW_INVALIDATE);
+            invalidate_window();
         }
     } break;
     case WM_LBUTTONDOWN: {
@@ -244,7 +244,7 @@ void ArtworkPanel::on_selection_changed(const pfc::list_base_const_t<metadb_hand
                 m_artwork_loader->request(m_selection_handles[0], new service_impl_t<CompletionNotifyForwarder>(this));
             } else {
                 flush_image();
-                RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
+                invalidate_window();
                 if (m_artwork_loader)
                     m_artwork_loader->reset();
             }
@@ -273,7 +273,7 @@ void ArtworkPanel::on_playback_stop(play_control::t_stop_reason p_reason)
 
         if (!b_set) {
             flush_image();
-            RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
+            invalidate_window();
             if (m_artwork_loader)
                 m_artwork_loader->reset();
         }
@@ -309,7 +309,7 @@ void ArtworkPanel::force_reload_artwork()
         m_artwork_loader->request(handle, new service_impl_t<CompletionNotifyForwarder>(this));
     } else {
         flush_image();
-        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
+        invalidate_window();
         if (m_artwork_loader)
             m_artwork_loader->reset();
     }
@@ -325,7 +325,7 @@ void ArtworkPanel::on_playlist_switch()
             m_artwork_loader->request(handles[0], new service_impl_t<CompletionNotifyForwarder>(this));
         } else {
             flush_image();
-            RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
+            invalidate_window();
             if (m_artwork_loader)
                 m_artwork_loader->reset();
         }
@@ -342,7 +342,7 @@ void ArtworkPanel::on_items_selection_change(const pfc::bit_array& p_affected, c
             m_artwork_loader->request(handles[0], new service_impl_t<CompletionNotifyForwarder>(this));
         } else {
             flush_image();
-            RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
+            invalidate_window();
             if (m_artwork_loader)
                 m_artwork_loader->reset();
         }
@@ -391,12 +391,12 @@ void ArtworkPanel::show_stub_image()
                 pStream.reset();
                 if (m_image->GetLastStatus() == Gdiplus::Ok) {
                     flush_cached_bitmap();
-                    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
+                    invalidate_window();
                 }
             }
         } else {
             flush_image();
-            RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
+            invalidate_window();
         }
     }
 }
@@ -428,7 +428,7 @@ bool ArtworkPanel::refresh_image(t_size index)
     if (!m_image)
         return false;
 
-    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
+    invalidate_window();
     return true;
 }
 
@@ -441,6 +441,11 @@ void ArtworkPanel::flush_image()
 {
     m_image.reset();
     flush_cached_bitmap();
+}
+
+void ArtworkPanel::invalidate_window() const
+{
+    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
 
 void ArtworkPanel::refresh_cached_bitmap()
@@ -507,7 +512,7 @@ void ArtworkPanel::g_on_colours_change()
 {
     for (auto& window : g_windows) {
         window->flush_cached_bitmap();
-        RedrawWindow(window->get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
+        window->invalidate_window();
     }
 }
 
@@ -712,7 +717,7 @@ void ArtworkPanel::MenuNodePreserveAspectRatio::execute()
     p_this->m_preserve_aspect_ratio = !p_this->m_preserve_aspect_ratio;
     cfg_preserve_aspect_ratio = p_this->m_preserve_aspect_ratio;
     p_this->flush_cached_bitmap();
-    RedrawWindow(p_this->get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_INVALIDATE);
+    p_this->invalidate_window();
 }
 
 bool ArtworkPanel::MenuNodePreserveAspectRatio::get_description(pfc::string_base& p_out) const

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -6,6 +6,7 @@ namespace artwork_panel {
 
 class ArtworkPanel
     : public uie::container_ui_extension_t<>
+    , public now_playing_album_art_notify
     , public play_callback
     , public playlist_callback_single
     , public ui_selection_callback {
@@ -24,6 +25,8 @@ public:
     unsigned get_type() const override;
 
     static void g_on_edge_style_change();
+
+    void on_album_art(album_art_data::ptr data) override;
 
     void on_playback_new_track(metadb_handle_ptr p_track) override;
     void on_playback_stop(play_control::t_stop_reason p_reason) override;
@@ -166,12 +169,13 @@ private:
     bool m_gdiplus_initialised{false};
 
     std::shared_ptr<ArtworkReaderManager> m_artwork_loader;
-    // now_playing_album_art_manager m_nowplaying_artwork_loader;
     std::unique_ptr<Gdiplus::Bitmap> m_image;
     wil::unique_hbitmap m_bitmap;
     t_size m_position{0};
     t_size m_track_mode;
-    bool m_preserve_aspect_ratio, m_lock_type{false};
+    bool m_preserve_aspect_ratio{true};
+    bool m_lock_type{false};
+    bool m_dynamic_artwork_pending{};
     metadb_handle_list m_selection_handles;
 
     static std::vector<ArtworkPanel*> g_windows;

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -164,6 +164,7 @@ private:
     bool refresh_image(t_size index);
     void show_stub_image();
     void flush_image();
+    void invalidate_window() const;
 
     ULONG_PTR m_gdiplus_instance{NULL};
     bool m_gdiplus_initialised{false};

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -14,7 +14,7 @@ public:
 
     ArtworkReader() = default;
 
-    void initialise(const std::vector<GUID>& p_requestIds,
+    void initialise(const std::vector<GUID>& artwork_type_ids,
         const std::unordered_map<GUID, album_art_data_ptr>& p_content_previous, bool read_stub_image,
         const metadb_handle_ptr& p_handle, const completion_notify_ptr& p_notify,
         std::shared_ptr<class ArtworkReaderManager> p_manager);
@@ -25,10 +25,10 @@ protected:
 
 private:
     unsigned read_artwork(abort_callback& p_abort);
-    bool isContentEqual(const std::unordered_map<GUID, album_art_data_ptr>& content1,
+    bool are_contents_equal(const std::unordered_map<GUID, album_art_data_ptr>& content1,
         const std::unordered_map<GUID, album_art_data_ptr>& content2);
 
-    std::vector<GUID> m_requestIds;
+    std::vector<GUID> m_artwork_type_ids;
     std::unordered_map<GUID, album_art_data_ptr> m_content;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
     metadb_handle_ptr m_handle;
@@ -41,31 +41,26 @@ private:
 
 class ArtworkReaderManager : public std::enable_shared_from_this<ArtworkReaderManager> {
 public:
-    void AddType(const GUID& p_what);
+    void set_types(std::vector<GUID> types);
+
+    void request(const metadb_handle_ptr& p_handle, completion_notify_ptr p_notify = nullptr);
+    bool is_ready();
+    void reset();
     void abort_current_task();
-
-    void Reset();
-
-    bool IsReady();
-
-    //! Completion notify code is 1 when content has changed, 0 when content is the same as before the request (like,
-    //! advanced to another track with the same album art data).
-    void Request(const metadb_handle_ptr& p_handle, completion_notify_ptr p_notify = nullptr);
 
     album_art_data_ptr get_image(const GUID& p_what);
     album_art_data_ptr get_stub_image(GUID artwork_type_id);
 
     void deinitialise();
 
-    void on_reader_completion(DWORD ret, const ArtworkReader* ptr);
+    void on_reader_completion(DWORD state, const ArtworkReader* ptr);
     void on_reader_abort(const ArtworkReader* ptr);
 
 private:
     std::vector<std::shared_ptr<ArtworkReader>> m_aborting_readers;
     std::shared_ptr<ArtworkReader> m_current_reader;
-    // album_art_manager_instance_ptr m_api;
 
-    std::vector<GUID> m_requestIds;
+    std::vector<GUID> m_artwork_type_ids;
     std::unordered_map<GUID, album_art_data_ptr> m_content;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
 };

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -5,18 +5,20 @@ namespace artwork_panel {
 class ArtworkReader : public mmh::Thread {
 public:
     bool is_aborting();
+    bool is_from_playback() const { return m_is_from_playback; }
     void abort();
 
     // only called when thread closed
     bool did_succeed();
     const std::unordered_map<GUID, album_art_data_ptr>& get_content() const;
     const std::unordered_map<GUID, album_art_data_ptr>& get_stub_images() const;
+    void set_image(GUID artwork_type_id, album_art_data_ptr data);
 
     ArtworkReader() = default;
 
     void initialise(const std::vector<GUID>& artwork_type_ids,
         const std::unordered_map<GUID, album_art_data_ptr>& p_content_previous, bool read_stub_image,
-        const metadb_handle_ptr& p_handle, const completion_notify_ptr& p_notify,
+        const metadb_handle_ptr& p_handle, bool is_from_playback, const completion_notify_ptr& p_notify,
         std::shared_ptr<class ArtworkReaderManager> p_manager);
     void run_notification_thisthread(DWORD state);
 
@@ -35,6 +37,7 @@ private:
     completion_notify_ptr m_notify;
     bool m_succeeded{false};
     bool m_read_stub_image{true};
+    bool m_is_from_playback{};
     abort_callback_impl m_abort;
     std::shared_ptr<class ArtworkReaderManager> m_manager;
 };
@@ -43,7 +46,7 @@ class ArtworkReaderManager : public std::enable_shared_from_this<ArtworkReaderMa
 public:
     void set_types(std::vector<GUID> types);
 
-    void request(const metadb_handle_ptr& p_handle, completion_notify_ptr p_notify = nullptr);
+    void request(const metadb_handle_ptr& handle, completion_notify_ptr notify, bool is_from_playback = false);
     bool is_ready();
     void reset();
     void abort_current_task();


### PR DESCRIPTION
Resolves #365

This adds support for internet radio front covers to the artwork view panel when foobar2000 1.6.6 or newer is used.

Note that the implementation is somewhat complicated for the reasons described in the linked issue.

Some tidying up of artwork view panel-related code is also included.