### PR TITLE
Return to selected artwork type after automatic switch in artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 * Support for back cover, disc and artist stub images was added to the Artwork view panel. [[#345](https://github.com/reupen/columns_ui/pull/345)]
 
+* In the Artwork view panel, when the artwork type is not locked and the panel automatically switches to a different artwork type, it now returns to the previously selected artwork type once it’s available again. [[#368](https://github.com/reupen/columns_ui/pull/368)]
+
 * The list view scrolling speed when selecting items or using drag and drop was adjusted to be slower, particularly for short lists such as in Buttons options. [[#349](https://github.com/reupen/columns_ui/pull/349)]
 
 * The Item properties and Item details panels now expand and align tab characters. [[#350](https://github.com/reupen/columns_ui/pull/350)]

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -162,10 +162,11 @@ private:
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     void refresh_cached_bitmap();
     void flush_cached_bitmap();
-    bool refresh_image(t_size index);
+    bool refresh_image();
     void show_stub_image();
     void flush_image();
     void invalidate_window() const;
+    size_t get_displayed_artwork_type_index() const;
 
     ULONG_PTR m_gdiplus_instance{NULL};
     bool m_gdiplus_initialised{false};
@@ -173,8 +174,9 @@ private:
     std::shared_ptr<ArtworkReaderManager> m_artwork_loader;
     std::unique_ptr<Gdiplus::Bitmap> m_image;
     wil::unique_hbitmap m_bitmap;
-    t_size m_position{0};
-    t_size m_track_mode;
+    size_t m_selected_artwork_type_index{0};
+    std::optional<size_t> m_artwork_type_override_index{};
+    size_t m_track_mode;
     bool m_preserve_aspect_ratio{true};
     bool m_lock_type{false};
     bool m_dynamic_artwork_pending{};


### PR DESCRIPTION
This amends the logic in the Artwork view panel when the artwork type is not locked, so that if the panel switches to a different artwork type due to the selected artwork type not being available, the panel returns to the selected artwork type once it’s available again.