### PR TITLE
Show unset and blank values in Item properties more clearly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@
 
 * In the Artwork view panel, when the artwork type is not locked and the panel automatically switches to a different artwork type, it now returns to the previously selected artwork type once it’s available again. [[#368](https://github.com/reupen/columns_ui/pull/368)]
 
+* A 'Reload artwork' command was added to the artwork view context menu. This forces a reload of artwork from the file system using current settings. [[#351](https://github.com/reupen/columns_ui/pull/351)]
+
 * The list view scrolling speed when selecting items or using drag and drop was adjusted to be slower, particularly for short lists such as in Buttons options. [[#349](https://github.com/reupen/columns_ui/pull/349)]
 
 * The Item properties and Item details panels now expand and align tab characters. [[#350](https://github.com/reupen/columns_ui/pull/350)]
 
-* A 'Reload artwork' command was added to the artwork view context menu. This forces a reload of artwork from the file system using current settings. [[#351](https://github.com/reupen/columns_ui/pull/351)]
+* When multiple tracks are selected and some of them have a value for a particular metadata field and some do not, the Item properties panel now makes this clearer by appending '(not set)' to the list of values for that field. [[#370](https://github.com/reupen/columns_ui/pull/370)]
+
+* The Item properties panel now shows '(blank)' for a metadata field if it’s set but the value is an empty string. [[#370](https://github.com/reupen/columns_ui/pull/370)]
 
 * The Filter panel no longer focuses the first playlist item when using any of the send to playlist commands or actions. This improves compatibility with shuffle playback modes when 'Playback follows cursor' is enabled. [[#352](https://github.com/reupen/columns_ui/pull/352)]
 

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -259,8 +259,10 @@ public:
 
         const t_size field_index = info->meta_find(field);
 
-        if (field_index == (std::numeric_limits<size_t>::max)())
+        if (field_index == (std::numeric_limits<size_t>::max)()) {
+            m_some_values_missing = true;
             return true;
+        }
 
         const t_size value_count = info->meta_enum_value_count(field_index);
 
@@ -273,6 +275,7 @@ public:
 
     std::vector<std::string> m_values;
     bool m_truncated{false};
+    bool m_some_values_missing{};
 
 private:
     void add_value(const char* p_value)
@@ -487,7 +490,13 @@ void ItemProperties::refresh_contents()
         t_size count_values = aggregator.m_values.size();
 
         for (t_size j = 0; j < count_values; j++) {
-            temp << aggregator.m_values[j].c_str();
+            auto&& value = aggregator.m_values[j];
+
+            if (value.length() > 0)
+                temp << value.c_str();
+            else
+                temp << "(blank)";
+
             if (j + 1 != count_values)
                 temp << "; ";
         }
@@ -495,6 +504,8 @@ void ItemProperties::refresh_contents()
         if (aggregator.m_truncated)
             temp << "; "
                     "\xe2\x80\xa6";
+        else if (count_values > 0 && aggregator.m_some_values_missing)
+            temp << "; (not set)";
 
         item.m_subitems[1] = temp;
         item.m_groups[0] = "Metadata";


### PR DESCRIPTION
Resolves #357

This makes Item properties append a '(not set)' to the values for a metadata field when:

- multiple tracks are selected
- only some of them have a value for a particular metadata field
- the number of values for that field is no more than the maximum number of values displayed (in which case an ellipsis is appended instead)

Additionally, a small change was made to show '(blank)' for metadata fields that are set to an empty string. (Fields containing only white space could also be more clearly shown, but that isn't tackled here.)