### PR TITLE
Use WIC to load stub image in Artwork view panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
 * A problem where panels were queried for configuration data too frequently following [#320](https://github.com/reupen/columns_ui/pull/320) was resolved. [[#364](https://github.com/reupen/columns_ui/pull/364)]
 
+* A problem where GDI+ was used to load stub artwork images in the Artwork view panel instead of the Windows Imaging Component (WIC) was fixed [[#371](https://github.com/reupen/columns_ui/pull/371)].
+  
+  (See the change log for version 1.4.0-beta.1 for more details on what this means.)
+
 ### Internal changes
 
 * The `Zc:threadSafeInit-` compiler option is no longer used. [[#340](https://github.com/reupen/columns_ui/pull/340)]

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -164,7 +164,7 @@ private:
     void flush_cached_bitmap();
     bool refresh_image();
     void show_stub_image();
-    void flush_image();
+    void flush_image(bool invalidate = true);
     void invalidate_window() const;
     size_t get_displayed_artwork_type_index() const;
 

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -100,7 +100,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;GDIPVER=0x0110;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
@@ -146,7 +146,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;GDIPVER=0x0110;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
@@ -195,7 +195,7 @@
     <ClCompile>
       <AdditionalOptions>/Zc:preprocessor /Zm125 /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;GDIPVER=0x0110;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -240,7 +240,7 @@
     <ClCompile>
       <AdditionalOptions>/Zc:preprocessor /Zm125 /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WIN32_WINNT=0x0601;GDIPVER=0x0110;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/foo_ui_columns/gdiplus.cpp
+++ b/foo_ui_columns/gdiplus.cpp
@@ -6,15 +6,11 @@ std::unique_ptr<Gdiplus::Bitmap> create_bitmap_from_32bpp_data(
     unsigned width, unsigned height, unsigned stride, const uint8_t* data, size_t size)
 {
     auto bitmap = std::make_unique<Gdiplus::Bitmap>(width, height, PixelFormat32bppARGB);
-
-    if (bitmap->GetLastStatus() != Gdiplus::Ok)
-        return {};
+    check_status(bitmap->GetLastStatus());
 
     Gdiplus::BitmapData image_data{};
     auto status = bitmap->LockBits(nullptr, Gdiplus::ImageLockModeWrite, PixelFormat32bppARGB, &image_data);
-
-    if (status != Gdiplus::Ok)
-        return {};
+    check_status(status);
 
     assert(image_data.Height == height);
     assert(image_data.Width == width);
@@ -29,10 +25,15 @@ std::unique_ptr<Gdiplus::Bitmap> create_bitmap_from_32bpp_data(
     }
 
     status = bitmap->UnlockBits(&image_data);
-    if (status != Gdiplus::Ok)
-        return {};
+    check_status(status);
 
     return bitmap;
+}
+
+std::unique_ptr<Gdiplus::Bitmap> create_bitmap_from_wic_data(const wic::BitmapData& bitmap_data)
+{
+    return create_bitmap_from_32bpp_data(
+        bitmap_data.width, bitmap_data.height, bitmap_data.stride, bitmap_data.data.data(), bitmap_data.data.size());
 }
 
 void check_status(Gdiplus::Status status)

--- a/foo_ui_columns/gdiplus.h
+++ b/foo_ui_columns/gdiplus.h
@@ -11,6 +11,8 @@
 
 #include "stdafx.h"
 
+#include "wic.h"
+
 namespace cui::gdip {
 
 /**
@@ -19,6 +21,8 @@ namespace cui::gdip {
  */
 std::unique_ptr<Gdiplus::Bitmap> create_bitmap_from_32bpp_data(
     unsigned width, unsigned height, unsigned stride, const uint8_t* data, size_t size);
+
+std::unique_ptr<Gdiplus::Bitmap> create_bitmap_from_wic_data(const wic::BitmapData& bitmap_data);
 
 void check_status(Gdiplus::Status status);
 


### PR DESCRIPTION
This fixes an oversight where stub images were still being loaded using GDI+ instead of the Windows Imaging Component in the Artwork view panel.

This was stopping formats such as WebP working for the stub image when appropriate system codecs are installed.