### PR TITLE
Respect show ellipses setting in playlist view group titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 * The Filter panel no longer focuses the first playlist item when using any of the send to playlist commands or actions. This improves compatibility with shuffle playback modes when 'Playback follows cursor' is enabled. [[#352](https://github.com/reupen/columns_ui/pull/352)]
 
+* In the playlist view, group titles now respect the 'Display ellipses in truncated text' option.
+
 ### Bug fixes
 
 * A bug causing misbehaviour of colour codes or a possible crash after scrolling in the Item details panel was fixed. [[#372](https://github.com/reupen/columns_ui/pull/372)]

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -153,7 +153,8 @@ void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t
     }
 
     uih::text_out_colours_tab(context.dc, text.data(), text.size(), uih::scale_dpi_value(1) + indentation * level,
-        uih::scale_dpi_value(3), &rc, false, cr, true, true, uih::ALIGN_LEFT, nullptr, true, true, &text_width);
+        uih::scale_dpi_value(3), &rc, false, cr, true, cfg_ellipsis != 0, uih::ALIGN_LEFT, nullptr, true, true,
+        &text_width);
 
     auto cx = (LONG)min(text_width, MAXLONG);
 


### PR DESCRIPTION
This makes group titles in the playlist view respect the 'Display ellipses in truncated text' playlist view option.