### PR TITLE
Fix inability to create working buttons for some File operations commands 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 * A bug causing misbehaviour of colour codes or a possible crash after scrolling in the Item details panel was fixed. [[#372](https://github.com/reupen/columns_ui/pull/372)]
 
+* The inability to create functioning buttons for certain File operations context menu commands was fixed. [[#379](https://github.com/reupen/columns_ui/pull/379)]
+
 * A problem where panels were queried for configuration data too frequently following [#320](https://github.com/reupen/columns_ui/pull/320) was resolved. [[#364](https://github.com/reupen/columns_ui/pull/364)]
 
 * A problem where GDI+ was used to load stub artwork images in the Artwork view panel instead of the Windows Imaging Component (WIC) was fixed [[#371](https://github.com/reupen/columns_ui/pull/371)].

--- a/foo_ui_columns/buttons_command_picker.cpp
+++ b/foo_ui_columns/buttons_command_picker.cpp
@@ -57,7 +57,7 @@ bool CommandPickerData::__populate_commands_recur(
             }
             return true;
         }
-        if (p_node->get_type() == contextmenu_item_node::TYPE_COMMAND && !b_root) {
+        if (p_node->get_type() == contextmenu_item_node::TYPE_COMMAND && p_node->get_guid() != GUID{}) {
             auto p_data = std::make_unique<CommandData>(data);
             p_data->m_subcommand = p_node->get_guid();
             p_node->get_description(p_data->m_desc);

--- a/foo_ui_columns/buttons_command_picker.cpp
+++ b/foo_ui_columns/buttons_command_picker.cpp
@@ -43,33 +43,37 @@ bool CommandPickerData::__populate_mainmenu_dynamic_recur(
 bool CommandPickerData::__populate_commands_recur(
     CommandData& data, std::list<std::string> name_parts, contextmenu_item_node* p_node, bool b_root)
 {
-    if (p_node) {
-        pfc::string8 name = menu_helpers::get_context_menu_node_name(p_node);
-        if (!name.is_empty())
-            name_parts.emplace_back(name);
+    if (!p_node)
+        return false;
 
-        if (p_node->get_type() == contextmenu_item_node::TYPE_POPUP) {
-            const unsigned child_count = p_node->get_children_count();
+    pfc::string8 name = menu_helpers::get_context_menu_node_name(p_node);
 
-            for (unsigned child = 0; child < child_count; child++) {
-                contextmenu_item_node* p_child = p_node->get_child(child);
-                __populate_commands_recur(data, name_parts, p_child, false);
-            }
-            return true;
+    if (!name.is_empty())
+        name_parts.emplace_back(name);
+
+    if (p_node->get_type() == contextmenu_item_node::TYPE_POPUP) {
+        const unsigned child_count = p_node->get_children_count();
+
+        for (unsigned child = 0; child < child_count; child++) {
+            contextmenu_item_node* p_child = p_node->get_child(child);
+            __populate_commands_recur(data, name_parts, p_child, false);
         }
-        if (p_node->get_type() == contextmenu_item_node::TYPE_COMMAND && p_node->get_guid() != GUID{}) {
-            auto p_data = std::make_unique<CommandData>(data);
-            p_data->m_subcommand = p_node->get_guid();
-            p_node->get_description(p_data->m_desc);
-
-            auto& data_item = m_data.emplace_back(std::move(p_data));
-
-            const auto path = mmh::join(name_parts, "/");
-            unsigned idx = uSendMessageText(wnd_command, LB_ADDSTRING, 0, path.c_str());
-            SendMessage(wnd_command, LB_SETITEMDATA, idx, reinterpret_cast<LPARAM>(data_item.get()));
-            return true;
-        }
+        return true;
     }
+
+    if (p_node->get_type() == contextmenu_item_node::TYPE_COMMAND && p_node->get_guid() != GUID{}) {
+        auto p_data = std::make_unique<CommandData>(data);
+        p_data->m_subcommand = p_node->get_guid();
+        p_node->get_description(p_data->m_desc);
+
+        auto& data_item = m_data.emplace_back(std::move(p_data));
+
+        const auto path = mmh::join(name_parts, "/");
+        const unsigned idx = uSendMessageText(wnd_command, LB_ADDSTRING, 0, path.c_str());
+        SendMessage(wnd_command, LB_SETITEMDATA, idx, reinterpret_cast<LPARAM>(data_item.get()));
+        return true;
+    }
+
     return false;
 }
 


### PR DESCRIPTION
Fixes #378

This fixes a problem where it wasn't possible to create a functioning button for the 'File operations/Rename to...' context menu command on current versions of foobar2000, and for other File operations context menu commands on older versions of foobar2000.

Note that any existing non-functioning buttons will need to have the relevant command re-selected in order for the button to function correctly.

