### PR TITLE
Fix misbehaviour when clicking on artwork view panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Support for back cover, disc and artist stub images was added to the Artwork view panel. [[#345](https://github.com/reupen/columns_ui/pull/345)]
 
-* In the Artwork view panel, when the artwork type is not locked and the panel automatically switches to a different artwork type, it now returns to the previously selected artwork type once it’s available again. [[#368](https://github.com/reupen/columns_ui/pull/368)]
+* In the Artwork view panel, when the artwork type is not locked and the panel automatically switches to a different artwork type, it now returns to the previously selected artwork type once it’s available again. [[#368](https://github.com/reupen/columns_ui/pull/368), [#381](https://github.com/reupen/columns_ui/pull/381)]
 
 * A 'Reload artwork' command was added to the artwork view context menu. This forces a reload of artwork from the file system using current settings. [[#351](https://github.com/reupen/columns_ui/pull/351)]
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -162,7 +162,7 @@ private:
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     void refresh_cached_bitmap();
     void flush_cached_bitmap();
-    bool refresh_image();
+    bool refresh_image(std::optional<size_t> artwork_type_index_override = {});
     void show_stub_image();
     void flush_image(bool invalidate = true);
     void invalidate_window() const;


### PR DESCRIPTION
#380

This corrects some misbehaviour introduced in #368 when clicking on the artwork view panel to change artwork type.

It also makes a small tweak the the 'Lock artwork type' context menu command so that it always freezes the currently displayed artwork type when the setting is transitioned from disabled to enabled.