### PR TITLE
Add 'Output format' toolbar

### DIFF
--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -122,6 +122,7 @@ void DropDownListToolbar<ToolbarArgs>::refresh_all_items()
     m_items = ToolbarArgs::get_items();
 
     ComboBox_ResetContent(m_wnd_combo);
+    ComboBox_Enable(m_wnd_combo, !ranges::empty(m_items));
 
     // auto&& crashes the VS 2017 15.6 compiler here
     for (auto& [id, name] : m_items) {

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -124,12 +124,17 @@ void DropDownListToolbar<ToolbarArgs>::refresh_all_items()
     ComboBox_ResetContent(m_wnd_combo);
     ComboBox_Enable(m_wnd_combo, !ranges::empty(m_items));
 
-    // auto&& crashes the VS 2017 15.6 compiler here
-    for (auto& [id, name] : m_items) {
-        ComboBox_AddString(m_wnd_combo, pfc::stringcvt::string_wide_from_utf8(name.c_str()));
-        const auto cx = uih::get_text_width(dc, name.c_str(), name.size());
-        m_max_item_width = max(m_max_item_width, cx);
+    if (ranges::empty(m_items) && ToolbarArgs::get_items_empty_text() != nullptr) {
+        ComboBox_AddString(m_wnd_combo, pfc::stringcvt::string_wide_from_utf8(ToolbarArgs::get_items_empty_text()));
+    } else {
+        // auto&& crashes the VS 2017 15.6 compiler here
+        for (auto& [id, name] : m_items) {
+            ComboBox_AddString(m_wnd_combo, pfc::stringcvt::string_wide_from_utf8(name.c_str()));
+            const auto cx = uih::get_text_width(dc, name.c_str(), name.size());
+            m_max_item_width = max(m_max_item_width, cx);
+        }
     }
+
     SelectFont(dc, prev_font);
     ReleaseDC(m_wnd_combo, dc);
 
@@ -139,6 +144,11 @@ void DropDownListToolbar<ToolbarArgs>::refresh_all_items()
 template <class ToolbarArgs>
 void DropDownListToolbar<ToolbarArgs>::update_active_item()
 {
+    if (ranges::empty(m_items) && ToolbarArgs::get_items_empty_text() != nullptr) {
+        ComboBox_SetCurSel(m_wnd_combo, 0);
+        return;
+    }
+
     auto&& id = ToolbarArgs::get_active_item();
     const auto iter = std::find_if(
         m_items.begin(), m_items.end(), [id](auto&& item) { return std::get<typename ToolbarArgs::ID>(item) == id; });

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -124,8 +124,16 @@ void DropDownListToolbar<ToolbarArgs>::refresh_all_items()
     ComboBox_ResetContent(m_wnd_combo);
     ComboBox_Enable(m_wnd_combo, !ranges::empty(m_items));
 
-    if (ranges::empty(m_items) && ToolbarArgs::get_items_empty_text() != nullptr) {
-        ComboBox_AddString(m_wnd_combo, pfc::stringcvt::string_wide_from_utf8(ToolbarArgs::get_items_empty_text()));
+    if (ranges::empty(m_items)) {
+        if (ToolbarArgs::get_items_empty_text() != nullptr) {
+            const auto items_empty_text = ToolbarArgs::get_items_empty_text();
+
+            ComboBox_AddString(m_wnd_combo, pfc::stringcvt::string_wide_from_utf8(items_empty_text));
+            const auto cx = uih::get_text_width(dc, items_empty_text, std::strlen(items_empty_text));
+            m_max_item_width = max(m_max_item_width, cx);
+        } else {
+            m_max_item_width = max(m_max_item_width, initial_width);
+        }
     } else {
         // auto&& crashes the VS 2017 15.6 compiler here
         for (auto& [id, name] : m_items) {

--- a/foo_ui_columns/dsp_preset.cpp
+++ b/foo_ui_columns/dsp_preset.cpp
@@ -33,6 +33,7 @@ struct DspPresetToolbarArgs {
         auto api = dsp_config_manager_v2::get();
         return api->get_selected_preset();
     }
+    static const char* get_items_empty_text() { return nullptr; }
     static void set_active_item(ID id)
     {
         if (!is_available())

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -288,6 +288,7 @@
     <ClCompile Include="legacy_artwork_config.cpp" />
     <ClCompile Include="ng_playlist\config_object_callbacks.cpp" />
     <ClCompile Include="notification_area_callbacks.cpp" />
+    <ClCompile Include="output_format.cpp" />
     <ClCompile Include="playlist_switcher_title_formatting.cpp" />
     <ClCompile Include="rename_dialog.cpp" />
     <ClCompile Include="seekbar_callbacks.cpp" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -85,6 +85,9 @@
     <Filter Include="Output device toolbar">
       <UniqueIdentifier>{08469ea6-bf39-4b2a-8606-f51effa6d7b5}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Output format toolbar">
+      <UniqueIdentifier>{08469ea6-bf39-4b2a-8606-f51effa6d7b6}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Playback order toolbar">
       <UniqueIdentifier>{c5f1100c-2f02-483d-8510-85811a67abb1}</UniqueIdentifier>
     </Filter>
@@ -447,6 +450,9 @@
     </ClCompile>
     <ClCompile Include="output_device.cpp">
       <Filter>Output device toolbar</Filter>
+    </ClCompile>
+    <ClCompile Include="output_format.cpp">
+      <Filter>Output format toolbar</Filter>
     </ClCompile>
     <ClCompile Include=".\order_dropdown.cpp">
       <Filter>Playback order toolbar</Filter>

--- a/foo_ui_columns/order_dropdown.cpp
+++ b/foo_ui_columns/order_dropdown.cpp
@@ -24,6 +24,8 @@ struct PlaybackOrderToolbarArgs {
         return api->playback_order_get_guid(api->playback_order_get_active());
     }
 
+    static const char* get_items_empty_text() { return nullptr; }
+
     static void set_active_item(ID id)
     {
         auto api = playlist_manager_v4::get();

--- a/foo_ui_columns/output_device.cpp
+++ b/foo_ui_columns/output_device.cpp
@@ -30,6 +30,7 @@ struct OutputDeviceToolbarArgs {
         api->getCoreConfig(config);
         return std::make_tuple(config.m_output, config.m_device);
     }
+    static const char* get_items_empty_text() { return nullptr; }
     static void set_active_item(ID id)
     {
         if (!is_available())

--- a/foo_ui_columns/output_format.cpp
+++ b/foo_ui_columns/output_format.cpp
@@ -29,6 +29,7 @@ struct OutputFormatToolbarArgs {
         api->getCoreConfig(config);
         return config.m_bitDepth;
     }
+    static const char* get_items_empty_text() { return "Auto"; }
     static void set_active_item(ID bitDepth)
     {
         auto api = output_manager_v2::get();

--- a/foo_ui_columns/output_format.cpp
+++ b/foo_ui_columns/output_format.cpp
@@ -15,10 +15,12 @@ struct OutputFormatToolbarArgs {
             return ItemList{};
 
         static constexpr auto bit_depths = {8, 16, 24, 32};
-        return bit_depths | ranges::views::filter([](ID bd) {
-            return !(bd == 8 && core_version_info_v2::get()->test_version(1, 6, 7, 0));
-        }) | ranges::views::transform([](ID bd) { return std::make_tuple(bd, std::to_string(bd) + "-bit"); })
+        // clang-format off
+        return bit_depths
+            | ranges::views::filter([](ID bd) { return !(bd == 8 && core_version_info_v2::get()->test_version(1, 6, 7, 0)); })
+            | ranges::views::transform([](ID bd) { return std::make_tuple(bd, std::to_string(bd) + "-bit"); })
             | ranges::to<ItemList>();
+        // clang-format on
     }
     static ID get_active_item()
     {

--- a/foo_ui_columns/output_format.cpp
+++ b/foo_ui_columns/output_format.cpp
@@ -7,12 +7,10 @@ struct OutputFormatToolbarArgs {
     using ItemList = std::vector<std::tuple<ID, std::string>>;
     static auto get_items()
     {
-        outputCoreConfig_t coreConfig;
-        output_manager_v2::get()->getCoreConfig(coreConfig);
+        outputCoreConfig_t config;
+        output_manager_v2::get()->getCoreConfig(config);
 
-        output_entry::ptr output;
-
-        if (!output_entry::g_find(coreConfig.m_output, output)
+        if (output_entry::ptr output; !output_entry::g_find(config.m_output, output)
             || !(output->get_config_flags() & output_entry::flag_needs_bitdepth_config))
             return ItemList{};
 
@@ -25,14 +23,14 @@ struct OutputFormatToolbarArgs {
     static ID get_active_item()
     {
         auto api = output_manager_v2::get();
-        outputCoreConfig_t config{};
+        outputCoreConfig_t config;
         api->getCoreConfig(config);
         return config.m_bitDepth;
     }
     static void set_active_item(ID bitDepth)
     {
         auto api = output_manager_v2::get();
-        outputCoreConfig_t config{};
+        outputCoreConfig_t config;
         api->getCoreConfig(config);
         config.m_bitDepth = bitDepth;
         api->setCoreConfig(config);

--- a/foo_ui_columns/output_format.cpp
+++ b/foo_ui_columns/output_format.cpp
@@ -1,0 +1,58 @@
+#include "stdafx.h"
+
+#include "drop_down_list_toolbar.h"
+
+struct OutputFormatToolbarArgs {
+    using ID = uint32_t;
+    using ItemList = std::vector<std::tuple<ID, std::string>>;
+    static auto get_items()
+    {
+        outputCoreConfig_t coreConfig;
+        output_manager_v2::get()->getCoreConfig(coreConfig);
+
+        output_entry::ptr output;
+
+        if (!output_entry::g_find(coreConfig.m_output, output)
+            || !(output->get_config_flags() & output_entry::flag_needs_bitdepth_config))
+            return ItemList{};
+
+        static constexpr auto bit_depths = {8, 16, 24, 32};
+        return bit_depths | ranges::views::filter([](ID bd) {
+            return !(bd == 8 && core_version_info_v2::get()->test_version(1, 6, 7, 0));
+        }) | ranges::views::transform([](ID bd) { return std::make_tuple(bd, std::to_string(bd) + "-bit"); })
+            | ranges::to<ItemList>();
+    }
+    static ID get_active_item()
+    {
+        auto api = output_manager_v2::get();
+        outputCoreConfig_t config{};
+        api->getCoreConfig(config);
+        return config.m_bitDepth;
+    }
+    static void set_active_item(ID bitDepth)
+    {
+        auto api = output_manager_v2::get();
+        outputCoreConfig_t config{};
+        api->getCoreConfig(config);
+        config.m_bitDepth = bitDepth;
+        api->setCoreConfig(config);
+    }
+    static void get_menu_items(uie::menu_hook_t& p_hook) {}
+    static void on_first_window_created()
+    {
+        auto api = output_manager_v2::get();
+        callback_handle
+            = api->addCallback([] { DropDownListToolbar<OutputFormatToolbarArgs>::s_refresh_all_items_safe(); });
+    }
+    static void on_last_window_destroyed() { callback_handle.release(); }
+    static bool is_available() { return true; }
+    static service_ptr callback_handle;
+    static constexpr bool refresh_on_click = false;
+    static constexpr const wchar_t* class_name{L"columns_ui_output_format_TBWOn9HkOxhkU"};
+    static constexpr const char* name{"Output format"};
+    static constexpr GUID extension_guid{0xa379ccd9, 0xbc38, 0x4e2b, {0x85, 0xd6, 0x97, 0x5d, 0x11, 0x7b, 0xdd, 0xcc}};
+};
+
+service_ptr OutputFormatToolbarArgs::callback_handle;
+
+ui_extension::window_factory<DropDownListToolbar<OutputFormatToolbarArgs>> output_format_toolbar;

--- a/foo_ui_columns/replaygain_mode.cpp
+++ b/foo_ui_columns/replaygain_mode.cpp
@@ -52,6 +52,7 @@ struct ReplayGainModeToolbarArgs {
         auto playback_api = playback_control_v3::get();
         playback_api->restart();
     }
+    static const char* get_items_empty_text() { return nullptr; }
     static void get_menu_items(uie::menu_hook_t& p_hook)
     {
         p_hook.add_node(new cui::panel_helpers::CommandMenuNode{


### PR DESCRIPTION
I recently found myself having to constantly switch between formats while using two different output devices. While this attempt at a toolbar is quite crude (no option for toggling dithering for instance) it should be at least complimentary to the existing 'Output device' toolbar.

Fun fact: unlike output device changes, output format changes are not being tracked and kept in sync on the Preferences/Output page.