### PR TITLE
Use common items font in drop-down toolbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   
   (Note that selection colours are currently not used.)
 
+* The DSP preset, Output device, Playback order and ReplayGain mode toolbars now use the common (list items) font configured on the Colour and fonts preferences page. [[#392](https://github.com/reupen/columns_ui/pull/392)]
+
 * A new Output format toolbar was added, allowing the selection of the output bit depth for output devices that don’t use automatic output format selection. [[#389](https://github.com/reupen/columns_ui/pull/389), contributed by [@rplociennik](https://github.com/rplociennik)]
 
 ## 1.7.0-beta.1


### PR DESCRIPTION
This makes the various drop-down toolbars correctly use the 'Common (list items)' font configured in preferences.

(Previously, the system icon font was always used.)

Note that changes to the minimum width and height of the toolbars are not yet handled correctly.