### PR TITLE
Add no-items text to DSP preset toolbar when no presets exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * A new Output format toolbar was added, allowing the selection of the output bit depth for output devices that don’t use automatic output format selection. [[#389](https://github.com/reupen/columns_ui/pull/389), contributed by [@rplociennik](https://github.com/rplociennik)]
 
+* The DSP preset toolbar now displays the text '(no DSP presets exist)' if no DSP presets have been created. [[#395](https://github.com/reupen/columns_ui/pull/395)]
+
 ### Bug fixes
 
 * The minimum widths of the DSP preset and Output device toolbars now update if the list of DSP presets or output devices changes. [[#393](https://github.com/reupen/columns_ui/pull/393)]

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -145,10 +145,10 @@ void DropDownListToolbar<ToolbarArgs>::refresh_all_items()
     ComboBox_Enable(m_wnd_combo, !ranges::empty(m_items));
 
     if (ranges::empty(m_items)) {
-        if (ToolbarArgs::get_items_empty_text() != nullptr) {
-            const auto items_empty_text = ToolbarArgs::get_items_empty_text();
-
-            ComboBox_AddString(m_wnd_combo, pfc::stringcvt::string_wide_from_utf8(items_empty_text));
+        if (!ToolbarArgs::no_items_text.empty()) {
+            ComboBox_AddString(m_wnd_combo,
+                pfc::stringcvt::string_wide_from_utf8(
+                    ToolbarArgs::no_items_text.data(), ToolbarArgs::no_items_text.length()));
         }
     } else {
         for (auto&& [id, name] : m_items) {
@@ -209,7 +209,7 @@ int DropDownListToolbar<ToolbarArgs>::calculate_max_item_width()
 template <class ToolbarArgs>
 void DropDownListToolbar<ToolbarArgs>::update_active_item()
 {
-    if (ranges::empty(m_items) && ToolbarArgs::get_items_empty_text() != nullptr) {
+    if (ranges::empty(m_items) && !ToolbarArgs::no_items_text.empty()) {
         ComboBox_SetCurSel(m_wnd_combo, 0);
         return;
     }

--- a/foo_ui_columns/dsp_preset.cpp
+++ b/foo_ui_columns/dsp_preset.cpp
@@ -33,7 +33,6 @@ struct DspPresetToolbarArgs {
         auto api = dsp_config_manager_v2::get();
         return api->get_selected_preset();
     }
-    static const char* get_items_empty_text() { return nullptr; }
     static void set_active_item(ID id)
     {
         if (!is_available())
@@ -51,6 +50,7 @@ struct DspPresetToolbarArgs {
     static constexpr void on_last_window_destroyed() {}
     static bool is_available() { return static_api_test_t<dsp_config_manager_v2>(); }
     static constexpr bool refresh_on_click = true;
+    static constexpr auto no_items_text = "(no DSP presets exist)"sv;
     static constexpr const wchar_t* class_name{L"columns_ui_dsp_preset_TB7ds8Gd8SMzVA"};
     static constexpr const char* name{"DSP preset"};
     static constexpr GUID extension_guid{0x9bd325a4, 0xb2e6, 0x47ad, {0x9b, 0x54, 0x8d, 0xa3, 0x5f, 0x42, 0x78, 0x49}};

--- a/foo_ui_columns/order_dropdown.cpp
+++ b/foo_ui_columns/order_dropdown.cpp
@@ -24,8 +24,6 @@ struct PlaybackOrderToolbarArgs {
         return api->playback_order_get_guid(api->playback_order_get_active());
     }
 
-    static const char* get_items_empty_text() { return nullptr; }
-
     static void set_active_item(ID id)
     {
         auto api = playlist_manager_v4::get();
@@ -42,6 +40,7 @@ struct PlaybackOrderToolbarArgs {
     static constexpr void on_last_window_destroyed() {}
     static constexpr bool is_available() { return true; }
     static constexpr bool refresh_on_click = false;
+    static constexpr auto no_items_text = ""sv;
     static constexpr const wchar_t* class_name{L"columns_ui_playback_order_i3z1Bci1KNo"};
     static constexpr const char* name{"Playback order"};
     static constexpr GUID extension_guid{0xaba09e7e, 0x9c95, 0x443e, {0xbd, 0xfc, 0x4, 0x9d, 0x66, 0xb3, 0x24, 0xa0}};

--- a/foo_ui_columns/output_device.cpp
+++ b/foo_ui_columns/output_device.cpp
@@ -30,7 +30,6 @@ struct OutputDeviceToolbarArgs {
         api->getCoreConfig(config);
         return std::make_tuple(config.m_output, config.m_device);
     }
-    static const char* get_items_empty_text() { return nullptr; }
     static void set_active_item(ID id)
     {
         if (!is_available())
@@ -60,6 +59,7 @@ struct OutputDeviceToolbarArgs {
     static bool is_available() { return static_api_test_t<output_manager_v2>(); }
     static service_ptr callback_handle;
     static constexpr bool refresh_on_click = true;
+    static constexpr auto no_items_text = ""sv;
     static constexpr const wchar_t* class_name{L"columns_ui_output_device_DQLvIKXzFVY"};
     static constexpr const char* name{"Output device"};
     static constexpr GUID extension_guid{0xc25e4fe6, 0xb9a0, 0x48c3, {0xa4, 0xc0, 0x44, 0x3d, 0x69, 0xda, 0xd3, 0x6d}};

--- a/foo_ui_columns/output_format.cpp
+++ b/foo_ui_columns/output_format.cpp
@@ -29,7 +29,6 @@ struct OutputFormatToolbarArgs {
         api->getCoreConfig(config);
         return config.m_bitDepth;
     }
-    static const char* get_items_empty_text() { return "Auto"; }
     static void set_active_item(ID bitDepth)
     {
         auto api = output_manager_v2::get();
@@ -49,6 +48,7 @@ struct OutputFormatToolbarArgs {
     static bool is_available() { return true; }
     static service_ptr callback_handle;
     static constexpr bool refresh_on_click = false;
+    static constexpr auto no_items_text = "Auto"sv;
     static constexpr const wchar_t* class_name{L"columns_ui_output_format_TBWOn9HkOxhkU"};
     static constexpr const char* name{"Output format"};
     static constexpr GUID extension_guid{0xa379ccd9, 0xbc38, 0x4e2b, {0x85, 0xd6, 0x97, 0x5d, 0x11, 0x7b, 0xdd, 0xcc}};

--- a/foo_ui_columns/replaygain_mode.cpp
+++ b/foo_ui_columns/replaygain_mode.cpp
@@ -52,7 +52,6 @@ struct ReplayGainModeToolbarArgs {
         auto playback_api = playback_control_v3::get();
         playback_api->restart();
     }
-    static const char* get_items_empty_text() { return nullptr; }
     static void get_menu_items(uie::menu_hook_t& p_hook)
     {
         p_hook.add_node(new cui::panel_helpers::CommandMenuNode{
@@ -75,6 +74,7 @@ struct ReplayGainModeToolbarArgs {
     static bool is_available() { return static_api_test_t<replaygain_manager_v2>(); }
     static std::unique_ptr<ReplayGainCoreSettingsNotifyLambda> callback;
     static constexpr bool refresh_on_click = false;
+    static constexpr auto no_items_text = ""sv;
     static constexpr const wchar_t* class_name{L"columns_ui_replaygain_mode_-bdvzDNKnwDniA"};
     static constexpr const char* name{"ReplayGain mode"};
     static constexpr GUID extension_guid{0xad9a81f7, 0x723a, 0x4cce, {0x87, 0xb6, 0x13, 0x39, 0xb, 0xda, 0xc2, 0x16}};


### PR DESCRIPTION
This makes the DSP preset toolbar display the text '(no DSP presets exist)' when no DSP presets have been created.

It also refactors how the drop-down list toolbar no-items text works slightly.