### PR TITLE
Add dark modes for playlist tabs and tab stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Internal changes
 
-* Some internal changes were made in advance of support for the Windows 10 dark mode. [[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413), [#415](https://github.com/reupen/columns_ui/pull/415)]
+* Some internal changes were made in advance of support for the Windows 10 dark mode. [[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413), [#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423)]
 
 * The component is now compiled using Visual Studio 2022 17.0 and the /std:c++20 compiler option. [[#408](https://github.com/reupen/columns_ui/pull/408), [#409](https://github.com/reupen/columns_ui/pull/409)]
 

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -7,14 +7,57 @@
 
 namespace cui::dark {
 
+enum class ColourID {
+    TabControlBackground,
+    TabControlItemBackground,
+    TabControlItemText,
+    TabControlItemBorder,
+    TabControlActiveItemBackground,
+    TabControlHotItemBackground,
+    TabControlHotActiveItemBackground,
+};
+
+template <class Object>
+class LazyObject {
+public:
+    LazyObject(std::function<Object()> factory) : m_factory(factory) {}
+
+    Object& operator*() const
+    {
+        if (!m_object)
+            m_object = m_factory();
+
+        return *m_object;
+    }
+
+private:
+    mutable std::optional<Object> m_object;
+    std::function<Object()> m_factory;
+};
+
+template <class Resource>
+class LazyResource {
+public:
+    LazyResource(std::function<Resource()> factory) : m_resource(factory) {}
+
+    auto operator*() const { return (*m_resource).get(); }
+
+private:
+    mutable LazyObject<Resource> m_resource;
+};
+
 /**
  * Temporary compile-time flag controlling whether dark mode is enabled.
  */
-bool is_dark_mode_enabled();
+[[nodiscard]] bool is_dark_mode_enabled();
 
 void enable_dark_mode_for_app();
 void enable_top_level_non_client_dark_mode(HWND wnd);
-COLORREF get_system_colour(int system_colour_id, bool is_dark);
-wil::unique_hbrush get_system_colour_brush(int system_colour_id, bool is_dark);
+
+[[nodiscard]] COLORREF get_colour(ColourID colourId, bool is_dark);
+[[nodiscard]] LazyResource<wil::unique_hbrush> get_colour_brush(ColourID colourId, bool is_dark);
+
+[[nodiscard]] COLORREF get_system_colour(int system_colour_id, bool is_dark);
+[[nodiscard]] wil::unique_hbrush get_system_colour_brush(int system_colour_id, bool is_dark);
 
 } // namespace cui::dark

--- a/foo_ui_columns/dark_mode_tabs.cpp
+++ b/foo_ui_columns/dark_mode_tabs.cpp
@@ -1,0 +1,133 @@
+#include "stdafx.h"
+#include "dark_mode.h"
+
+namespace cui::dark {
+
+namespace {
+
+struct Tab {
+    std::wstring text;
+    RECT rc{};
+    bool is_active{};
+    bool is_hot{};
+};
+
+auto get_tab_hot_item_index(HWND wnd)
+{
+    TCHITTESTINFO tchti{};
+    GetMessagePos(&tchti.pt);
+    MapWindowPoints(HWND_DESKTOP, wnd, &tchti.pt, 1);
+
+    return TabCtrl_HitTest(wnd, &tchti);
+}
+
+std::vector<Tab> get_tabs(HWND wnd)
+{
+    const auto active_item_index = TabCtrl_GetCurSel(wnd);
+    const auto hot_item_index = get_tab_hot_item_index(wnd);
+    const auto item_count = TabCtrl_GetItemCount(wnd);
+    std::array<wchar_t, 1024> buffer{};
+
+    TCITEM tci_default{};
+    tci_default.mask = TCIF_TEXT;
+    tci_default.pszText = buffer.data();
+    tci_default.cchTextMax = buffer.size();
+
+    // clang-format off
+    return ranges::views::iota(0, item_count)
+        | ranges::views::transform([&](auto index) {
+            TCITEM tci{tci_default};
+            TabCtrl_GetItem(wnd, index, &tci);
+
+            RECT rc{};
+            TabCtrl_GetItemRect(wnd, index, &rc);
+
+            const bool is_active = index == active_item_index;
+            const bool is_hot = index == hot_item_index;
+
+            return Tab{{buffer.data(), wcsnlen(buffer.data(), buffer.size())}, rc, is_active, is_hot};})
+        | ranges::to<std::vector>()
+        | ranges::actions::stable_sort([](auto&& left, auto&& right) {
+            if (left.rc.top == right.rc.top)
+                return left.is_active < right.is_active;
+            return left.rc.top < right.rc.top;
+        });
+    // clang-format on
+}
+
+} // namespace
+
+void handle_tab_control_paint(HWND wnd)
+{
+    const auto items = get_tabs(wnd);
+
+    constexpr auto is_dark = true;
+    const auto border_colour = get_colour(ColourID::TabControlItemBorder, is_dark);
+    const wil::unique_hpen border_pen(CreatePen(PS_SOLID, 1_spx, border_colour));
+    const auto default_item_brush = get_colour_brush(ColourID::TabControlItemBackground, is_dark);
+    const auto hot_item_brush = get_colour_brush(ColourID::TabControlHotItemBackground, is_dark);
+    const auto hot_active_item_brush = get_colour_brush(ColourID::TabControlHotActiveItemBackground, is_dark);
+    const auto active_item_brush = get_colour_brush(ColourID::TabControlActiveItemBackground, is_dark);
+
+    PAINTSTRUCT ps{};
+    const auto dc = wil::BeginPaint(wnd, &ps);
+    const auto _select_font = wil::SelectObject(dc.get(), GetWindowFont(wnd));
+    const auto _select_pen = wil::SelectObject(dc.get(), border_pen.get());
+
+    SetTextColor(dc.get(), get_colour(ColourID::TabControlItemText, is_dark));
+    SetBkMode(dc.get(), TRANSPARENT);
+
+    RECT client_rect{};
+    GetClientRect(wnd, &client_rect);
+
+    if (ps.fErase)
+        FillRect(dc.get(), &client_rect, *get_colour_brush(ColourID::TabControlBackground, is_dark));
+
+    for (auto&& [index, item] : ranges::views::enumerate(items)) {
+        const auto is_new_line = index == 0 || items[index - 1].rc.top != item.rc.top;
+
+        auto item_rect = item.rc;
+        if (item.is_active) {
+            item_rect.top -= 1_spx;
+            // Scale and round 0.5 for these two
+            item_rect.left -= uih::scale_dpi_value(1, USER_DEFAULT_SCREEN_DPI * 2);
+            item_rect.right += uih::scale_dpi_value(1, USER_DEFAULT_SCREEN_DPI * 2);
+        }
+
+        RECT _intersect_rect{};
+        if (!IntersectRect(&_intersect_rect, &ps.rcPaint, &item_rect))
+            continue;
+
+        const auto item_back_brush = [&] {
+            if (item.is_hot && item.is_active)
+                return *hot_active_item_brush;
+
+            if (item.is_hot)
+                return *hot_item_brush;
+
+            if (item.is_active)
+                return *active_item_brush;
+
+            return *default_item_brush;
+        }();
+        FillRect(dc.get(), &item_rect, item_back_brush);
+
+        MoveToEx(dc.get(), item_rect.right, item_rect.bottom, nullptr);
+        LineTo(dc.get(), item_rect.right, item_rect.top);
+        LineTo(dc.get(), item_rect.left, item_rect.top);
+        if (is_new_line || item.is_active) {
+            LineTo(dc.get(), item_rect.left, item_rect.bottom);
+        }
+
+        SIZE sz{};
+        GetTextExtentPoint32(dc.get(), item.text.data(), gsl::narrow<int>(item.text.length()), &sz);
+
+        // Position using original rect, but shift up 1px if it's the active tab
+        const auto x = item.rc.left + (RECT_CX(item.rc) - sz.cx) / 2;
+        const auto y = item.rc.top + (RECT_CY(item.rc) - sz.cy) / 2 - (item.is_active ? 1_spx : 0);
+
+        ExtTextOut(dc.get(), x, y, ETO_CLIPPED, &item_rect, item.text.data(), item.text.length(), nullptr);
+    }
+}
+
+} // namespace cui::dark

--- a/foo_ui_columns/dark_mode_tabs.h
+++ b/foo_ui_columns/dark_mode_tabs.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace cui::dark {
+
+void handle_tab_control_paint(HWND wnd);
+
+} // namespace cui::dark

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -300,6 +300,7 @@
     <ClCompile Include=".\colours_manager_data.cpp" />
     <ClCompile Include=".\columns_v2.cpp" />
     <ClCompile Include="dark_mode.cpp" />
+    <ClCompile Include="dark_mode_tabs.cpp" />
     <ClCompile Include="filter_fcl.cpp" />
     <ClCompile Include="legacy_artwork_config.cpp" />
     <ClCompile Include="ng_playlist\config_object_callbacks.cpp" />
@@ -510,6 +511,7 @@
     <ClInclude Include=".\mw_drop_target.h" />
     <ClInclude Include="button_items.h" />
     <ClInclude Include="dark_mode.h" />
+    <ClInclude Include="dark_mode_tabs.h" />
     <ClInclude Include="filter_config_var.h" />
     <ClInclude Include="filter_utils.h" />
     <ClInclude Include="font_utils.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -530,6 +530,9 @@
     <ClCompile Include="dark_mode.cpp">
       <Filter>Dark mode</Filter>
     </ClCompile>
+    <ClCompile Include="dark_mode_tabs.cpp">
+      <Filter>Dark mode</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include=".\resource.h">
@@ -756,6 +759,9 @@
       <Filter>Artwork view</Filter>
     </ClInclude>
     <ClInclude Include="dark_mode.h">
+      <Filter>Dark mode</Filter>
+    </ClInclude>
+    <ClInclude Include="dark_mode_tabs.h">
       <Filter>Dark mode</Filter>
     </ClInclude>
   </ItemGroup>

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #include "playlist_tabs.h"
-#include "main_window.h"
+
+#include "dark_mode.h"
+#include "dark_mode_tabs.h"
 #include "playlist_manager_utils.h"
 
 namespace cui::panels::playlist_tabs {
@@ -258,6 +260,18 @@ const GUID PlaylistTabs::extension_guid
 LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
+    case WM_ERASEBKGND:
+        if (!dark::is_dark_mode_enabled())
+            break;
+
+        return FALSE;
+    case WM_PAINT: {
+        if (!dark::is_dark_mode_enabled())
+            break;
+
+        dark::handle_tab_control_paint(wnd);
+        return 0;
+    }
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
     case WM_KEYDOWN: {

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -1,6 +1,9 @@
 #include "stdafx.h"
 #include "splitter_tabs.h"
 
+#include "dark_mode.h"
+#include "dark_mode_tabs.h"
+
 namespace cui::panels::tab_stack {
 
 // {6F000FC4-3F86-4fc5-80EA-F7AA4D9551E6}
@@ -912,6 +915,18 @@ LRESULT WINAPI TabStackPanel::g_hook_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM 
 LRESULT WINAPI TabStackPanel::on_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
+    case WM_ERASEBKGND:
+        if (!dark::is_dark_mode_enabled())
+            break;
+
+        return FALSE;
+    case WM_PAINT: {
+        if (!dark::is_dark_mode_enabled())
+            break;
+
+        dark::handle_tab_control_paint(wnd);
+        return 0;
+    }
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
     case WM_KEYDOWN: {


### PR DESCRIPTION
This adds dark mode support to the playlist tabs and tab stack panels.

Unfortunately, the Windows tab control does not feature a native dark mode, and its owner-drawn mode is very limited, and so its own painting logic is overridden here.

The left/right buttons to scroll left and right when the tab control is in single row mode remain in a light mode.