### PR TITLE
Improve Filter search dark mode and tweak some dark mode colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Internal changes
 
-* Some internal changes were made in advance of support for the Windows 10 dark mode. [[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413), [#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423)]
+* Some internal changes were made in advance of support for the Windows 10 dark mode. [[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413), [#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423), [#424](https://github.com/reupen/columns_ui/pull/424)]
 
 * The component is now compiled using Visual Studio 2022 17.0 and the /std:c++20 compiler option. [[#408](https://github.com/reupen/columns_ui/pull/408), [#409](https://github.com/reupen/columns_ui/pull/409)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features
 
+* The Filter search toolbar is now integrated with the Colours and fonts preferences page, and its font, foreground colour and background colour are now configurable. [[#424](https://github.com/reupen/columns_ui/pull/424)]
+  
+  (Note that selection colours are not supported.)
+
 * The 'View/Show toolbars' menu item is now only shown if the shift key is held down when opening the View menu. [[#410](https://github.com/reupen/columns_ui/pull/410)]
 
 * A warning was added under the 'Show toolbars' option in preferences. [[#410](https://github.com/reupen/columns_ui/pull/410)]

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -50,11 +50,13 @@ enum class DarkColour : COLORREF {
     DARK_900 = create_grey(255),
 };
 
-COLORREF get_dark_colour(ColourID colourId)
+COLORREF get_dark_colour(ColourID colour_id)
 {
-    switch (colourId) {
+    switch (colour_id) {
+    case ColourID::PanelCaptionBackground:
+        return WI_EnumValue(DarkColour::DARK_300);
     case ColourID::TabControlBackground:
-        return WI_EnumValue(DarkColour::DARK_000);
+        return WI_EnumValue(DarkColour::DARK_200);
     case ColourID::TabControlItemBackground:
         return WI_EnumValue(DarkColour::DARK_200);
     case ColourID::TabControlItemText:
@@ -72,24 +74,46 @@ COLORREF get_dark_colour(ColourID colourId)
     }
 }
 
-COLORREF get_light_colour(ColourID colourId)
+wil::unique_hbrush get_dark_colour_brush(ColourID colour_id)
 {
-    // Not yet implemented
-    uBugCheck();
+    return wil::unique_hbrush(CreateSolidBrush(get_dark_colour(colour_id)));
+}
+
+COLORREF get_light_colour(ColourID colour_id)
+{
+    switch (colour_id) {
+    case ColourID::PanelCaptionBackground:
+        return GetSysColor(COLOR_BTNFACE);
+    default:
+        uBugCheck();
+    }
+}
+
+wil::unique_hbrush get_light_colour_brush(ColourID colour_id)
+{
+    switch (colour_id) {
+    case ColourID::PanelCaptionBackground:
+        return wil::unique_hbrush(GetSysColorBrush(COLOR_BTNFACE));
+    default:
+        uBugCheck();
+    }
 }
 
 } // namespace
 
-COLORREF get_colour(ColourID colourId, bool is_dark)
+COLORREF get_colour(ColourID colour_id, bool is_dark)
 {
-    return is_dark ? get_dark_colour(colourId) : get_light_colour(colourId);
+    return is_dark ? get_dark_colour(colour_id) : get_light_colour(colour_id);
 }
 
-LazyResource<wil::unique_hbrush> get_colour_brush(ColourID colour_id, bool is_dark)
+wil::unique_hbrush get_colour_brush(ColourID colour_id, bool is_dark)
 {
-    auto factory
-        = [colour_id, is_dark] { return wil::unique_hbrush(CreateSolidBrush(get_colour(colour_id, is_dark))); };
-    return LazyResource<wil::unique_hbrush>(std::move(factory));
+    return is_dark ? get_dark_colour_brush(colour_id) : get_light_colour_brush(colour_id);
+}
+
+LazyResource<wil::unique_hbrush> get_colour_brush_lazy(ColourID colour_id, bool is_dark)
+{
+    return {[colour_id, is_dark] { return get_colour_brush(colour_id, is_dark); }};
 }
 
 namespace {

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -8,6 +8,7 @@
 namespace cui::dark {
 
 enum class ColourID {
+    PanelCaptionBackground,
     TabControlBackground,
     TabControlItemBackground,
     TabControlItemText,
@@ -54,8 +55,9 @@ private:
 void enable_dark_mode_for_app();
 void enable_top_level_non_client_dark_mode(HWND wnd);
 
-[[nodiscard]] COLORREF get_colour(ColourID colourId, bool is_dark);
-[[nodiscard]] LazyResource<wil::unique_hbrush> get_colour_brush(ColourID colourId, bool is_dark);
+[[nodiscard]] COLORREF get_colour(ColourID colour_id, bool is_dark);
+[[nodiscard]] wil::unique_hbrush get_colour_brush(ColourID colour_id, bool is_dark);
+[[nodiscard]] LazyResource<wil::unique_hbrush> get_colour_brush_lazy(ColourID colour_id, bool is_dark);
 
 [[nodiscard]] COLORREF get_system_colour(int system_colour_id, bool is_dark);
 [[nodiscard]] wil::unique_hbrush get_system_colour_brush(int system_colour_id, bool is_dark);

--- a/foo_ui_columns/dark_mode_tabs.cpp
+++ b/foo_ui_columns/dark_mode_tabs.cpp
@@ -64,10 +64,10 @@ void handle_tab_control_paint(HWND wnd)
     constexpr auto is_dark = true;
     const auto border_colour = get_colour(ColourID::TabControlItemBorder, is_dark);
     const wil::unique_hpen border_pen(CreatePen(PS_SOLID, 1_spx, border_colour));
-    const auto default_item_brush = get_colour_brush(ColourID::TabControlItemBackground, is_dark);
-    const auto hot_item_brush = get_colour_brush(ColourID::TabControlHotItemBackground, is_dark);
-    const auto hot_active_item_brush = get_colour_brush(ColourID::TabControlHotActiveItemBackground, is_dark);
-    const auto active_item_brush = get_colour_brush(ColourID::TabControlActiveItemBackground, is_dark);
+    const auto default_item_brush = get_colour_brush_lazy(ColourID::TabControlItemBackground, is_dark);
+    const auto hot_item_brush = get_colour_brush_lazy(ColourID::TabControlHotItemBackground, is_dark);
+    const auto hot_active_item_brush = get_colour_brush_lazy(ColourID::TabControlHotActiveItemBackground, is_dark);
+    const auto active_item_brush = get_colour_brush_lazy(ColourID::TabControlActiveItemBackground, is_dark);
 
     PAINTSTRUCT ps{};
     const auto dc = wil::BeginPaint(wnd, &ps);
@@ -81,7 +81,7 @@ void handle_tab_control_paint(HWND wnd)
     GetClientRect(wnd, &client_rect);
 
     if (ps.fErase)
-        FillRect(dc.get(), &client_rect, *get_colour_brush(ColourID::TabControlBackground, is_dark));
+        FillRect(dc.get(), &client_rect, *get_colour_brush_lazy(ColourID::TabControlBackground, is_dark));
 
     for (auto&& [index, item] : ranges::views::enumerate(items)) {
         const auto is_new_line = index == 0 || items[index - 1].rc.top != item.rc.top;

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -84,8 +84,6 @@ void g_get_search_bar_sibling_streams(FilterSearchToolbar const* p_serach_bar, p
     }
 }
 
-std::vector<FilterSearchToolbar*> FilterSearchToolbar::s_windows;
-
 namespace {
 uie::window_factory<FilterSearchToolbar> g_filter_search_bar;
 };
@@ -123,12 +121,8 @@ void FilterSearchToolbar::on_show_clear_button_change()
     tbbi.dwMask = TBIF_STATE;
     tbbi.fsState = TBSTATE_ENABLED | (m_show_clear_button ? NULL : TBSTATE_HIDDEN);
     SendMessage(m_wnd_toolbar, TB_SETBUTTONINFO, idc_clear, (LPARAM)&tbbi);
-    // UpdateWindow(m_wnd_toolbar);
-    RECT rc{};
-    SendMessage(m_wnd_toolbar, TB_GETITEMRECT, 1, (LPARAM)(&rc));
 
-    m_toolbar_cx = rc.right;
-    m_toolbar_cy = rc.bottom;
+    recalculate_dimensions();
 
     if (get_host().is_valid())
         get_host()->on_size_limit_change(get_wnd(), uie::size_limit_all);
@@ -246,15 +240,28 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
 {
     switch (msg) {
     case WM_CREATE:
-        m_font.reset(uCreateIconFont());
-        create_edit();
         s_windows.emplace_back(this);
+
+        if (!s_font)
+            s_recreate_font();
+
+        if (!s_background_brush)
+            s_recreate_background_brush();
+
+        create_edit();
+
         break;
     case WM_NCDESTROY:
         s_windows.erase(std::ranges::remove(s_windows, this).begin(), s_windows.end());
+
         if (!core_api::is_shutting_down())
             commit_search_results("");
-        m_font.reset();
+
+        if (s_windows.empty()) {
+            s_font.reset();
+            s_background_brush.reset();
+        }
+
         m_active_handles.remove_all();
         m_active_search_string.reset();
         if (m_imagelist) {
@@ -291,6 +298,17 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
         mmi->ptMaxTrackSize.y = mmi->ptMinTrackSize.y;
     }
         return 0;
+    case WM_CTLCOLOREDIT:
+    case WM_CTLCOLORLISTBOX: {
+        const auto dc = reinterpret_cast<HDC>(wp);
+
+        cui::colours::helper colour_helper(colour_client_id);
+
+        SetTextColor(dc, colour_helper.get_colour(cui::colours::colour_text));
+        SetBkColor(dc, colour_helper.get_colour(cui::colours::colour_background));
+
+        return reinterpret_cast<LRESULT>(s_background_brush.get());
+    }
     case WM_NOTIFY: {
         auto lpnm = (LPNMHDR)lp;
         switch (lpnm->idFrom) {
@@ -461,24 +479,14 @@ void FilterSearchToolbar::create_edit()
     ShowWindow(m_wnd_toolbar, SW_SHOWNORMAL);
     SendMessage(m_wnd_toolbar, TB_AUTOSIZE, 0, 0);
 
-    SendMessage(m_search_editbox, WM_SETFONT, (WPARAM)m_font.get(), MAKELONG(TRUE, 0));
+    SetWindowFont(m_search_editbox, s_font.get(), TRUE);
 
     COMBOBOXINFO cbi;
     memset(&cbi, 0, sizeof(cbi));
     cbi.cbSize = sizeof(cbi);
     SendMessage(m_search_editbox, CB_GETCOMBOBOXINFO, NULL, (LPARAM)&cbi);
 
-    RECT rc;
-    GetClientRect(m_search_editbox, &rc);
-    m_combo_cx += RECT_CX(rc) - RECT_CX(cbi.rcItem);
-
-    GetWindowRect(m_search_editbox, &rc);
-    m_combo_cy = rc.bottom - rc.top;
-
-    SendMessage(m_wnd_toolbar, TB_GETITEMRECT, 1, (LPARAM)(&rc));
-
-    m_toolbar_cx = rc.right;
-    m_toolbar_cy = rc.bottom;
+    recalculate_dimensions();
 
     SetWindowLongPtr(m_search_editbox, GWLP_USERDATA, (LPARAM)(this));
     SetWindowLongPtr(cbi.hwndItem, GWLP_USERDATA, (LPARAM)(this));
@@ -490,10 +498,70 @@ void FilterSearchToolbar::create_edit()
     on_size();
 }
 
+void FilterSearchToolbar::recalculate_dimensions()
+{
+    COMBOBOXINFO cbi{};
+    cbi.cbSize = sizeof(cbi);
+    SendMessage(m_search_editbox, CB_GETCOMBOBOXINFO, NULL, (LPARAM)&cbi);
+
+    RECT client_rect{};
+    GetClientRect(m_search_editbox, &client_rect);
+    m_combo_cx = RECT_CX(client_rect) - RECT_CX(cbi.rcItem);
+
+    RECT window_rect{};
+    GetWindowRect(m_search_editbox, &window_rect);
+    m_combo_cy = window_rect.bottom - window_rect.top;
+
+    SendMessage(m_wnd_toolbar, TB_GETITEMRECT, 1, (LPARAM)(&window_rect));
+
+    m_toolbar_cx = window_rect.right;
+    m_toolbar_cy = window_rect.bottom;
+}
+
 LRESULT WINAPI FilterSearchToolbar::g_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     auto p_this = reinterpret_cast<FilterSearchToolbar*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
     return p_this ? p_this->on_search_edit_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
+}
+
+void FilterSearchToolbar::s_recreate_font()
+{
+    const fonts::helper font_helper(font_client_id);
+    s_font.reset(font_helper.get_font());
+}
+
+void FilterSearchToolbar::s_recreate_background_brush()
+{
+    const colours::helper colour_helper(colour_client_id);
+    s_background_brush.reset(CreateSolidBrush(colour_helper.get_colour(colours::colour_background)));
+}
+
+void FilterSearchToolbar::s_update_colours()
+{
+    s_recreate_background_brush();
+
+    for (auto&& window : s_windows) {
+        const HWND wnd = window->m_search_editbox;
+        if (wnd)
+            RedrawWindow(wnd, nullptr, nullptr, RDW_INVALIDATE);
+    }
+}
+
+void FilterSearchToolbar::s_update_font()
+{
+    s_recreate_font();
+
+    for (auto&& window : s_windows) {
+        const HWND wnd = window->m_search_editbox;
+
+        if (!wnd)
+            continue;
+
+        SetWindowFont(wnd, s_font.get(), TRUE);
+        window->recalculate_dimensions();
+        window->get_host()->on_size_limit_change(window->get_wnd(),
+            uie::size_limit_minimum_height | uie::size_limit_maximum_height | uie::size_limit_minimum_width);
+    }
 }
 
 LRESULT FilterSearchToolbar::on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -433,6 +433,9 @@ void FilterSearchToolbar::create_edit()
         0, 0, 0, 0, get_wnd(), (HMENU)id_toolbar, core_api::get_my_instance(), nullptr);
     // SetWindowTheme(m_wnd_toolbar, L"SearchButton", NULL);
 
+    if (dark::is_dark_mode_enabled())
+        SetWindowTheme(m_wnd_toolbar, L"DarkMode", nullptr);
+
     const unsigned cx = GetSystemMetrics(SM_CXSMICON);
     const unsigned cy = GetSystemMetrics(SM_CYSMICON);
 

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -14,11 +14,11 @@ public:
 
     static void g_initialise_filter_stream(const FilterStream::ptr& p_stream)
     {
-        for (t_size i = 0, count = g_active_instances.get_count(); i < count; i++) {
-            if (!cfg_orderedbysplitters || g_filter_search_bar_has_stream(g_active_instances[i], p_stream)) {
-                if (!g_active_instances[i]->m_active_search_string.is_empty()) {
+        for (auto&& window : s_windows) {
+            if (!cfg_orderedbysplitters || g_filter_search_bar_has_stream(window, p_stream)) {
+                if (!window->m_active_search_string.is_empty()) {
                     p_stream->m_source_overriden = true;
-                    p_stream->m_source_handles = g_active_instances[i]->m_active_handles;
+                    p_stream->m_source_handles = window->m_active_handles;
                     break;
                 }
             }
@@ -67,6 +67,8 @@ private:
 
     using uie::container_uie_window_v2::on_size;
 
+    static std::vector<FilterSearchToolbar*> s_windows;
+
     HWND m_search_editbox{};
     HWND m_wnd_toolbar{};
     HWND m_wnd_last_focused{};
@@ -82,8 +84,6 @@ private:
     int m_combo_cy{};
     int m_toolbar_cx{};
     int m_toolbar_cy{};
-
-    static pfc::ptr_list_t<FilterSearchToolbar> g_active_instances;
 };
 
 }; // namespace cui::panels::filter

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -12,8 +12,8 @@ void FlatSplitterPanel::Panel::PanelContainer::reopen_theme()
 {
     close_theme();
 
-    if (IsThemeActive() && IsAppThemed())
-        m_theme.reset(OpenThemeData(m_wnd, dark::is_dark_mode_enabled() ? L"DarkMode::Toolbar" : L"Rebar"));
+    if (IsThemeActive() && IsAppThemed() && !dark::is_dark_mode_enabled())
+        m_theme.reset(OpenThemeData(m_wnd, L"Rebar"));
 }
 
 void FlatSplitterPanel::Panel::PanelContainer::close_theme()
@@ -133,7 +133,7 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
                     if (m_theme) {
                         DrawThemeBackground(m_theme.get(), dc, 0, 0, &rc_caption, nullptr);
                     } else {
-                        const auto back_brush = dark::get_system_colour_brush(COLOR_BTNFACE, is_dark);
+                        const auto back_brush = dark::get_colour_brush(dark::ColourID::PanelCaptionBackground, is_dark);
                         FillRect(dc, &rc_caption, back_brush.get());
                     }
 


### PR DESCRIPTION
This:

- integrates the Filter search toolbar with Colours and fonts preferences and improves its dark mode
- tweaks the dark mode background colours of the playlist tabs and tab stack, and of panel captions