### PR TITLE
Remove redundant qualifiers and semicolons

### DIFF
--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -77,7 +77,7 @@ void ArtworkPanel::get_menu_items(ui_extension::menu_hook_t& p_hook)
     p_hook.add_node(uie::menu_node_ptr(new MenuNodeOptions()));
 }
 
-ArtworkPanel::ArtworkPanel() : m_track_mode(cfg_track_mode), m_preserve_aspect_ratio(cfg_preserve_aspect_ratio){};
+ArtworkPanel::ArtworkPanel() : m_track_mode(cfg_track_mode), m_preserve_aspect_ratio(cfg_preserve_aspect_ratio) {}
 
 void ArtworkPanel::g_on_edge_style_change()
 {
@@ -546,20 +546,20 @@ class ArtworkColoursClient : public colours::client {
 public:
     static const GUID g_guid;
 
-    const GUID& get_client_guid() const override { return g_guid_colour_client; };
-    void get_name(pfc::string_base& p_out) const override { p_out = "Artwork view"; };
+    const GUID& get_client_guid() const override { return g_guid_colour_client; }
+    void get_name(pfc::string_base& p_out) const override { p_out = "Artwork view"; }
 
-    t_size get_supported_colours() const override { return colours::colour_flag_background; }; // bit-mask
-    t_size get_supported_bools() const override { return 0; }; // bit-mask
-    bool get_themes_supported() const override { return false; };
+    t_size get_supported_colours() const override { return colours::colour_flag_background; } // bit-mask
+    t_size get_supported_bools() const override { return 0; } // bit-mask
+    bool get_themes_supported() const override { return false; }
 
-    void on_colour_changed(t_size mask) const override { ArtworkPanel::g_on_colours_change(); };
-    void on_bool_changed(t_size mask) const override{};
+    void on_colour_changed(t_size mask) const override { ArtworkPanel::g_on_colours_change(); }
+    void on_bool_changed(t_size mask) const override {}
 };
 
 namespace {
 colours::client::factory<ArtworkColoursClient> g_appearance_client_impl;
-};
+}
 
 ArtworkPanel::CompletionNotifyForwarder::CompletionNotifyForwarder(ArtworkPanel* p_this) : m_this(p_this) {}
 
@@ -798,4 +798,4 @@ bool ArtworkPanel::MenuNodeLockType::get_display_data(pfc::string_base& p_out, u
     return true;
 }
 
-}; // namespace cui::artwork_panel
+} // namespace cui::artwork_panel

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -142,15 +142,12 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     switch (msg) {
     case WM_CREATE: {
         Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-        m_gdiplus_initialised
-            = (Gdiplus::Ok == Gdiplus::GdiplusStartup(&m_gdiplus_instance, &gdiplusStartupInput, nullptr));
+        m_gdiplus_initialised = (Gdiplus::Ok == GdiplusStartup(&m_gdiplus_instance, &gdiplusStartupInput, nullptr));
         m_artwork_loader = std::make_shared<ArtworkReaderManager>();
         now_playing_album_art_notify_manager::get()->add(this);
         m_artwork_loader->set_types(g_artwork_types);
-        static_api_ptr_t<play_callback_manager>()->register_callback(this,
-            play_callback::flag_on_playback_new_track | play_callback::flag_on_playback_stop
-                | play_callback::flag_on_playback_edited,
-            false);
+        static_api_ptr_t<play_callback_manager>()->register_callback(
+            this, flag_on_playback_new_track | flag_on_playback_stop | flag_on_playback_edited, false);
         static_api_ptr_t<playlist_manager_v3>()->register_callback(this, playlist_callback_flags);
         g_ui_selection_manager_register_callback_no_now_playing_fallback(this);
         force_reload_artwork();
@@ -224,8 +221,7 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 SelectBitmap(dcc, bm_old);
                 DeleteDC(dcc);
             } else {
-                auto background_colour
-                    = cui::colours::helper(g_guid_colour_client).get_colour(cui::colours::colour_background);
+                auto background_colour = colours::helper(g_guid_colour_client).get_colour(colours::colour_background);
                 const wil::unique_hbrush background_brush(CreateSolidBrush(background_colour));
                 FillRect(ps.hdc, &rc, background_brush.get());
             }
@@ -348,7 +344,7 @@ void ArtworkPanel::on_playlist_switch()
     }
 }
 
-void ArtworkPanel::on_items_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_state)
+void ArtworkPanel::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state)
 {
     if (g_track_mode_includes_playlist(m_track_mode)
         && (!g_track_mode_includes_auto(m_track_mode) || !static_api_ptr_t<play_control>()->is_playing())) {
@@ -414,8 +410,8 @@ void ArtworkPanel::show_stub_image()
     }
 
     try {
-        const auto bitmap_data = cui::wic::decode_image_data(data->get_ptr(), data->get_size());
-        m_image = cui::gdip::create_bitmap_from_wic_data(bitmap_data);
+        const auto bitmap_data = wic::decode_image_data(data->get_ptr(), data->get_size());
+        m_image = gdip::create_bitmap_from_wic_data(bitmap_data);
     } catch (const std::exception& ex) {
         fbh::print_to_console(u8"Artwork panel – loading stub image failed: "_pcc, ex.what());
     }
@@ -441,8 +437,8 @@ bool ArtworkPanel::refresh_image(std::optional<size_t> artwork_type_index_overri
         return false;
 
     try {
-        const auto bitmap_data = cui::wic::decode_image_data(data->get_ptr(), data->get_size());
-        m_image = cui::gdip::create_bitmap_from_wic_data(bitmap_data);
+        const auto bitmap_data = wic::decode_image_data(data->get_ptr(), data->get_size());
+        m_image = gdip::create_bitmap_from_wic_data(bitmap_data);
     } catch (const std::exception& ex) {
         fbh::print_to_console(u8"Artwork panel – loading image failed: "_pcc, ex.what());
         return false;
@@ -500,7 +496,7 @@ void ArtworkPanel::refresh_cached_bitmap()
         graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHighQuality);
         graphics.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
 
-        COLORREF cr = cui::colours::helper(g_guid_colour_client).get_colour(cui::colours::colour_background);
+        COLORREF cr = colours::helper(g_guid_colour_client).get_colour(colours::colour_background);
         Gdiplus::SolidBrush br(Gdiplus::Color(LOBYTE(LOWORD(cr)), HIBYTE(LOWORD(cr)), LOBYTE(HIWORD(cr))));
         err = graphics.FillRectangle(&br, 0, 0, cx, cy);
 
@@ -546,14 +542,14 @@ std::vector<ArtworkPanel*> ArtworkPanel::g_windows;
 
 uie::window_factory<ArtworkPanel> g_artwork_panel;
 
-class ArtworkColoursClient : public cui::colours::client {
+class ArtworkColoursClient : public colours::client {
 public:
     static const GUID g_guid;
 
     const GUID& get_client_guid() const override { return g_guid_colour_client; };
     void get_name(pfc::string_base& p_out) const override { p_out = "Artwork view"; };
 
-    t_size get_supported_colours() const override { return cui::colours::colour_flag_background; }; // bit-mask
+    t_size get_supported_colours() const override { return colours::colour_flag_background; }; // bit-mask
     t_size get_supported_bools() const override { return 0; }; // bit-mask
     bool get_themes_supported() const override { return false; };
 
@@ -562,7 +558,7 @@ public:
 };
 
 namespace {
-cui::colours::client::factory<ArtworkColoursClient> g_appearance_client_impl;
+colours::client::factory<ArtworkColoursClient> g_appearance_client_impl;
 };
 
 ArtworkPanel::CompletionNotifyForwarder::CompletionNotifyForwarder(ArtworkPanel* p_this) : m_this(p_this) {}
@@ -630,7 +626,7 @@ bool ArtworkPanel::MenuNodeTrackMode::get_description(pfc::string_base& p_out) c
 bool ArtworkPanel::MenuNodeTrackMode::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = get_name(m_source);
-    p_displayflags = (m_source == p_this->m_track_mode) ? ui_extension::menu_node_t::state_radiochecked : 0;
+    p_displayflags = (m_source == p_this->m_track_mode) ? state_radiochecked : 0;
     return true;
 }
 
@@ -758,13 +754,13 @@ bool ArtworkPanel::MenuNodePreserveAspectRatio::get_display_data(
     pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Preserve aspect ratio";
-    p_displayflags = (p_this->m_preserve_aspect_ratio) ? ui_extension::menu_node_t::state_checked : 0;
+    p_displayflags = (p_this->m_preserve_aspect_ratio) ? state_checked : 0;
     return true;
 }
 
 void ArtworkPanel::MenuNodeOptions::execute()
 {
-    cui::prefs::page_main.get_static_instance().show_tab("Artwork");
+    prefs::page_main.get_static_instance().show_tab("Artwork");
 }
 
 bool ArtworkPanel::MenuNodeOptions::get_description(pfc::string_base& p_out) const
@@ -798,7 +794,7 @@ bool ArtworkPanel::MenuNodeLockType::get_description(pfc::string_base& p_out) co
 bool ArtworkPanel::MenuNodeLockType::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Lock artwork type";
-    p_displayflags = (p_this->m_lock_type) ? ui_extension::menu_node_t::state_checked : 0;
+    p_displayflags = (p_this->m_lock_type) ? state_checked : 0;
     return true;
 }
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -43,7 +43,7 @@ public:
 
     enum { playlist_callback_flags = flag_on_items_selection_change | flag_on_playlist_switch };
     void on_playlist_switch() override;
-    void on_item_focus_change(t_size p_from, t_size p_to) override{};
+    void on_item_focus_change(t_size p_from, t_size p_to) override {}
 
     void on_items_added(
         t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override
@@ -102,7 +102,6 @@ private:
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
         MenuNodeArtworkType(ArtworkPanel* p_wnd, t_size p_value);
-        ;
     };
 
     class MenuNodeSourcePopup : public ui_extension::menu_node_popup_t {

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -41,24 +41,21 @@ public:
     void on_playback_time(double p_time) override {}
     void on_volume_change(float p_new_val) override {}
 
-    enum {
-        playlist_callback_flags
-        = playlist_callback_single::flag_on_items_selection_change | playlist_callback_single::flag_on_playlist_switch
-    };
+    enum { playlist_callback_flags = flag_on_items_selection_change | flag_on_playlist_switch };
     void on_playlist_switch() override;
     void on_item_focus_change(t_size p_from, t_size p_to) override{};
 
-    void on_items_added(t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const pfc::bit_array& p_selection) override
+    void on_items_added(
+        t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override
     {
     }
     void on_items_reordered(const t_size* p_order, t_size p_count) override {}
-    void on_items_removing(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
-    void on_items_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
-    void on_items_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_state) override;
-    void on_items_modified(const pfc::bit_array& p_mask) override {}
-    void on_items_modified_fromplayback(const pfc::bit_array& p_mask, play_control::t_display_level p_level) override {}
-    void on_items_replaced(const pfc::bit_array& p_mask,
+    void on_items_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
+    void on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override;
+    void on_items_modified(const bit_array& p_mask) override {}
+    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override {}
+    void on_items_replaced(const bit_array& p_mask,
         const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override
     {
     }

--- a/foo_ui_columns/artwork_helpers.cpp
+++ b/foo_ui_columns/artwork_helpers.cpp
@@ -290,7 +290,7 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
 
         if (m_stub_images.find(album_art_ids::cover_front) == m_stub_images.end()) {
             album_art_data_ptr data;
-            cui::panels::playlist_view::g_get_default_nocover_bitmap_data(data, p_abort);
+            panels::playlist_view::g_get_default_nocover_bitmap_data(data, p_abort);
 
             if (data.is_valid())
                 m_stub_images.insert_or_assign(album_art_ids::cover_front, data);

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -81,4 +81,4 @@ public:
     std::shared_ptr<ArtworkReaderManager> m_manager;
 };
 
-}; // namespace cui::artwork_panel
+} // namespace cui::artwork_panel

--- a/foo_ui_columns/button_items.h
+++ b/foo_ui_columns/button_items.h
@@ -48,14 +48,14 @@ struct LiveLayoutEditingButtonArgs {
 using LiveLayoutEditingButton = PushButton<LiveLayoutEditingButtonArgs>;
 
 struct ShowGroupsButtonArgs {
-    static bool state() { return cui::panels::playlist_view::cfg_grouping; }
+    static bool state() { return panels::playlist_view::cfg_grouping; }
     static constexpr GUID id = main_menu::commands::show_groups_id;
 };
 
 using ShowGroupsButton = PushButton<ShowGroupsButtonArgs>;
 
 struct ShowArtworkButtonArgs {
-    static bool state() { return cui::panels::playlist_view::cfg_show_artwork; }
+    static bool state() { return panels::playlist_view::cfg_show_artwork; }
     static constexpr GUID id = main_menu::commands::show_artwork_id;
 };
 

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -33,7 +33,7 @@ unsigned ButtonsToolbar::get_type() const
 
 void ButtonsToolbar::import_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
 {
-    ButtonsToolbar::ConfigParam param;
+    ConfigParam param;
     param.m_selection = nullptr;
     param.m_child = nullptr;
     param.m_active = 0;
@@ -73,7 +73,7 @@ void ButtonsToolbar::reset_buttons(std::vector<Button>& p_buttons)
         {{}, TYPE_SEPARATOR, SHOW_IMAGE, nullptr},
         {standard_commands::guid_main_open, TYPE_MENU_ITEM_MAIN, SHOW_IMAGE, nullptr},
         {{}, TYPE_SEPARATOR, SHOW_IMAGE, nullptr},
-        {cui::main_menu::commands::toggle_live_editing_id, TYPE_MENU_ITEM_MAIN, SHOW_TEXT, "Live layout editing"},
+        {main_menu::commands::toggle_live_editing_id, TYPE_MENU_ITEM_MAIN, SHOW_TEXT, "Live layout editing"},
     };
 
     p_buttons.clear();
@@ -143,7 +143,7 @@ void ButtonsToolbar::create_toolbar()
 
         SIZE sz = {0, 0};
 
-        pfc::bit_array_bittable mask(count);
+        bit_array_bittable mask(count);
 
         for (n = 0; n < count; n++) {
             if (m_buttons[n].m_type != TYPE_SEPARATOR) {
@@ -321,8 +321,7 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     if (msg == WM_CREATE) {
         wnd_host = wnd;
         Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-        m_gdiplus_initialised
-            = (Gdiplus::Ok == Gdiplus::GdiplusStartup(&m_gdiplus_instance, &gdiplusStartupInput, nullptr));
+        m_gdiplus_initialised = (Gdiplus::Ok == GdiplusStartup(&m_gdiplus_instance, &gdiplusStartupInput, nullptr));
         initialised = true;
         create_toolbar();
 

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -43,7 +43,7 @@ void ButtonsToolbar::import_config(stream_reader* p_reader, t_size p_size, abort
     param.import_from_stream(p_reader, false, p_abort);
 
     configure(param.m_buttons, param.m_text_below, param.m_appearance);
-};
+}
 
 void ButtonsToolbar::export_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
@@ -95,7 +95,7 @@ void ButtonsToolbar::reset_buttons(std::vector<Button>& p_buttons)
 ButtonsToolbar::ButtonsToolbar()
 {
     reset_buttons(m_buttons);
-};
+}
 
 ButtonsToolbar::~ButtonsToolbar() = default;
 

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -177,7 +177,7 @@ public:
             void notify_on_initialisation() override;
             void notify_on_create() override;
             void notify_on_destroy() override;
-            void notify_on_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_status,
+            void notify_on_selection_change(const bit_array& p_affected, const bit_array& p_status,
                 notification_source_t p_notification_source) override;
             bool do_drag_drop(WPARAM wp) override;
 

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -80,7 +80,7 @@ public:
         class ButtonStateCallback : public uie::button_callback {
             void on_button_state_change(unsigned p_new_state) override; // see t_button_state
 
-            void on_command_state_change(unsigned p_new_state) override{};
+            void on_command_state_change(unsigned p_new_state) override {}
 
             service_ptr_t<ButtonsToolbar> m_this;
             unsigned id{0};
@@ -182,7 +182,7 @@ public:
             bool do_drag_drop(WPARAM wp) override;
 
         public:
-            ButtonsList(ConfigParam& p_param) : m_param(p_param){};
+            ButtonsList(ConfigParam& p_param) : m_param(p_param) {}
         } m_button_list;
 
         modal_dialog_scope m_scope;

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -32,7 +32,7 @@ void ButtonsToolbar::Button::ButtonStateCallback::set_id(const unsigned i)
     id = i;
 }
 
-void ButtonsToolbar::Button::set(const ButtonsToolbar::Button& p_source)
+void ButtonsToolbar::Button::set(const Button& p_source)
 {
     m_guid = p_source.m_guid;
     m_subcommand = p_source.m_subcommand;
@@ -69,8 +69,7 @@ void ButtonsToolbar::Button::write(stream_writer* out, abort_callback& p_abort) 
         out->write_string(m_text, p_abort);
 }
 
-void ButtonsToolbar::Button::read(
-    ButtonsToolbar::ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort)
+void ButtonsToolbar::Button::read(ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort)
 {
     *this = Button{};
 

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -15,7 +15,7 @@ void ButtonsToolbar::Button::ButtonStateCallback::on_button_state_change(unsigne
     else
         state = state & ~TBSTATE_PRESSED;
     SendMessage(m_this->wnd_toolbar, TB_SETSTATE, id, MAKELONG(state, 0));
-};
+}
 
 ButtonsToolbar::Button::ButtonStateCallback& ButtonsToolbar::Button::ButtonStateCallback::operator=(
     const ButtonStateCallback& p_source)

--- a/foo_ui_columns/buttons_button_image.cpp
+++ b/foo_ui_columns/buttons_button_image.cpp
@@ -28,15 +28,15 @@ void ButtonsToolbar::ButtonImage::load(const Button::CustomImage& p_image)
     pfc::string8 fullPath;
     p_image.get_path(fullPath);
 
-    if (!_stricmp(pfc::string_extension(fullPath), "bmp")) // Gdiplus vs 32bpp
+    if (!_stricmp(string_extension(fullPath), "bmp")) // Gdiplus vs 32bpp
         m_bm = (HBITMAP)uLoadImage(
             core_api::get_my_instance(), fullPath, IMAGE_BITMAP, 0, 0, LR_DEFAULTSIZE | LR_LOADFROMFILE);
-    else if (!_stricmp(pfc::string_extension(fullPath), "ico"))
+    else if (!_stricmp(string_extension(fullPath), "ico"))
         m_icon = (HICON)uLoadImage(core_api::get_my_instance(), fullPath, IMAGE_ICON, GetSystemMetrics(SM_CXSMICON),
             GetSystemMetrics(SM_CYSMICON), LR_LOADFROMFILE);
     else {
         try {
-            m_bm = cui::wic::create_hbitmap_from_path(fullPath).release();
+            m_bm = wic::create_hbitmap_from_path(fullPath).release();
         } catch (const std::exception& ex) {
             fbh::print_to_console(u8"Buttons toolbar – loading image failed: "_pcc, ex.what());
             m_bm = nullptr;

--- a/foo_ui_columns/buttons_config_droptarget.cpp
+++ b/foo_ui_columns/buttons_config_droptarget.cpp
@@ -88,7 +88,7 @@ HRESULT STDMETHODCALLTYPE ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListD
         // console::formatter() << pfc::format_hex(hr);
     }
     if (m_button_list_view->get_wnd()) {
-        uih::ListView::HitTestResult hi;
+        HitTestResult hi;
 
         {
             POINT ptt = pti;
@@ -145,7 +145,7 @@ HRESULT STDMETHODCALLTYPE ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListD
         *pdwEffect = DROPEFFECT_MOVE;
         const t_size old_index = m_button_list_view->get_selected_item_single(); // meh
 
-        uih::ListView::HitTestResult hi;
+        HitTestResult hi;
 
         POINT ptt = pt;
         ScreenToClient(m_button_list_view->get_wnd(), &ptt);
@@ -171,7 +171,7 @@ HRESULT STDMETHODCALLTYPE ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListD
             for (t_size i = old_index; i != new_index; i += step)
                 std::swap(perm[i], perm[i + step]);
 
-            mmh::destructive_reorder(m_button_list_view->m_param.m_buttons, perm);
+            destructive_reorder(m_button_list_view->m_param.m_buttons, perm);
 
             // blaarrgg, designed in the dark ages
             m_button_list_view->m_param.m_selection = &m_button_list_view->m_param.m_buttons[new_index];
@@ -188,8 +188,7 @@ HRESULT STDMETHODCALLTYPE ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListD
     m_button_list_view->destroy_timer_scroll_down();
     return S_OK;
 }
-ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListDropTarget::ButtonsListDropTarget(
-    ButtonsToolbar::ConfigParam::ButtonsList* p_blv)
+ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListDropTarget::ButtonsListDropTarget(ButtonsList* p_blv)
     : drop_ref_count(0)
     , last_rmb(false)
     , m_button_list_view(p_blv)

--- a/foo_ui_columns/buttons_config_listview.cpp
+++ b/foo_ui_columns/buttons_config_listview.cpp
@@ -24,7 +24,7 @@ void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_destroy()
     RevokeDragDrop(get_wnd());
 }
 void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_selection_change(
-    const pfc::bit_array& p_affected, const pfc::bit_array& p_status, notification_source_t p_notification_source)
+    const bit_array& p_affected, const bit_array& p_status, notification_source_t p_notification_source)
 {
     t_size index = get_selected_item_single();
     m_param.on_selection_change(index);

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -340,8 +340,8 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
                     _T("This will reset all your buttons to the default buttons. Continue?"), _T("Reset buttons"),
                     MB_YESNO)
                 == IDYES) {
-                m_button_list.remove_items(pfc::bit_array_true());
-                ButtonsToolbar::reset_buttons(m_buttons);
+                m_button_list.remove_items(bit_array_true());
+                reset_buttons(m_buttons);
                 populate_buttons_list();
             }
         } break;
@@ -421,7 +421,7 @@ BOOL ButtonsToolbar::ConfigParam::ConfigPopupProc(HWND wnd, UINT msg, WPARAM wp,
                 pfc::string8 path;
                 if (uGetOpenFileName(wnd, "fcb Files (*.fcb)|*.fcb|All Files (*.*)|*.*", 0, "fcb", "Open file", nullptr,
                         path, FALSE)) {
-                    m_button_list.remove_items(pfc::bit_array_true());
+                    m_button_list.remove_items(bit_array_true());
 
                     HWND wnd_show = GetDlgItem(wnd, IDC_SHOW);
                     HWND wnd_text = GetDlgItem(wnd, IDC_TEXT_LOCATION);

--- a/foo_ui_columns/buttons_custom_image.cpp
+++ b/foo_ui_columns/buttons_custom_image.cpp
@@ -7,7 +7,7 @@ void ButtonsToolbar::Button::CustomImage::get_path(pfc::string8& p_out) const
 {
     p_out.reset();
 
-    bool b_absolute = pfc::string_find_first(m_path, ':') != pfc_infinite
+    bool b_absolute = string_find_first(m_path, ':') != pfc_infinite
         || (m_path.length() > 1 && m_path.get_ptr()[0] == '\\' && m_path.get_ptr()[1] == '\\');
     bool b_relative_to_drive = !b_absolute && m_path.get_ptr()[0] == '\\';
 
@@ -20,7 +20,7 @@ void ButtonsToolbar::Button::CustomImage::get_path(pfc::string8& p_out) const
         if (index_colon != pfc_infinite)
             p_out.add_string(fb2kexe.get_ptr(), index_colon + 1);
     } else if (!b_absolute)
-        p_out << pfc::string_directory(fb2kexe) << "\\";
+        p_out << string_directory(fb2kexe) << "\\";
     p_out += m_path;
 }
 void ButtonsToolbar::Button::CustomImage::write(stream_writer* out, abort_callback& p_abort) const
@@ -266,7 +266,7 @@ void ButtonsToolbar::Button::CustomImage::write_to_file(stream_writer& p_file, b
                 filesystem::g_get_canonical_path(realPath, canPath);
                 filesystem::g_open(p_image, canPath, filesystem::open_mode_read, p_abort);
 
-                const auto name = pfc::string_filename_ext(m_path);
+                const auto name = string_filename_ext(m_path);
 
                 t_filesize imagesize = p_image->get_size(p_abort);
 
@@ -304,7 +304,7 @@ void ButtonsToolbar::Button::CustomImage::write_to_file(stream_writer& p_file, b
                 service_ptr_t<file> p_image;
                 filesystem::g_open(p_image, m_mask_path, filesystem::open_mode_read, p_abort);
 
-                const auto name = pfc::string_filename_ext(m_mask_path);
+                const auto name = string_filename_ext(m_mask_path);
 
                 t_filesize imagesize = p_image->get_size(p_abort);
 

--- a/foo_ui_columns/buttons_stock.cpp
+++ b/foo_ui_columns/buttons_stock.cpp
@@ -63,12 +63,12 @@
 namespace cui::button_items {
 
 __DEFINE_MENU_BUTTON(
-    a, standard_commands::guid_main_stop_after_current, standard_config_objects::bool_playlist_stop_after_current);
+    a, standard_commands::guid_main_stop_after_current, standard_config_objects::bool_playlist_stop_after_current)
 __DEFINE_MENU_BUTTON(
-    b, standard_commands::guid_main_playback_follows_cursor, standard_config_objects::bool_playback_follows_cursor);
+    b, standard_commands::guid_main_playback_follows_cursor, standard_config_objects::bool_playback_follows_cursor)
 __DEFINE_MENU_BUTTON(
-    c, standard_commands::guid_main_cursor_follows_playback, standard_config_objects::bool_cursor_follows_playback);
-__DEFINE_MENU_BUTTON(d, standard_commands::guid_main_always_on_top, standard_config_objects::bool_ui_always_on_top);
+    c, standard_commands::guid_main_cursor_follows_playback, standard_config_objects::bool_cursor_follows_playback)
+__DEFINE_MENU_BUTTON(d, standard_commands::guid_main_always_on_top, standard_config_objects::bool_ui_always_on_top)
 
 /**Defines icons for buttons */
 template <const GUID& MenutItemID, INT IconID>
@@ -116,7 +116,7 @@ class ButtonBlank : public ui_extension::custom_button {
     }
     void get_name(pfc::string_base& p_out) const override { p_out = "Blanking button"; }
     unsigned get_button_state() const override { return NULL; }
-    void execute(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) override{};
+    void execute(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) override {}
     uie::t_button_guid get_guid_type() const override { return uie::BUTTON_GUID_BUTTON; }
 };
 

--- a/foo_ui_columns/buttons_stock.cpp
+++ b/foo_ui_columns/buttons_stock.cpp
@@ -80,7 +80,7 @@ class ButtonMenuItemWithBitmap : public uie::button_v2 {
     {
         auto icon = (HICON)LoadImage(
             core_api::get_my_instance(), MAKEINTRESOURCE(IconID), IMAGE_ICON, cx_hint, cy_hint, NULL);
-        handle_type = uie::button_v2::handle_type_icon;
+        handle_type = handle_type_icon;
         return (HANDLE)icon;
     }
 };

--- a/foo_ui_columns/callbacks_config.cpp
+++ b/foo_ui_columns/callbacks_config.cpp
@@ -3,7 +3,7 @@
 
 class AlwaysOnTopNotifyReceiver : public config_object_notify {
     unsigned get_watched_object_count() override { return 1; }
-    GUID get_watched_object(unsigned p_index) override { return standard_config_objects::bool_ui_always_on_top; };
+    GUID get_watched_object(unsigned p_index) override { return standard_config_objects::bool_ui_always_on_top; }
     void on_watched_object_changed(const service_ptr_t<config_object>& p_object) override
     {
         if (cui::main_window.get_wnd()) {

--- a/foo_ui_columns/colours_manager_data.cpp
+++ b/foo_ui_columns/colours_manager_data.cpp
@@ -101,14 +101,13 @@ ColoursManagerData::Entry::Entry(bool b_global /*= false*/)
 
 void ColoursManagerData::Entry::reset_colors()
 {
-    text = cui::colours::g_get_system_color(cui::colours::colour_text);
-    selection_text = cui::colours::g_get_system_color(cui::colours::colour_selection_text);
-    inactive_selection_text = cui::colours::g_get_system_color(cui::colours::colour_inactive_selection_text);
-    background = cui::colours::g_get_system_color(cui::colours::colour_background);
-    selection_background = cui::colours::g_get_system_color(cui::colours::colour_selection_background);
-    inactive_selection_background
-        = cui::colours::g_get_system_color(cui::colours::colour_inactive_selection_background);
-    active_item_frame = cui::colours::g_get_system_color(cui::colours::colour_active_item_frame);
+    text = g_get_system_color(cui::colours::colour_text);
+    selection_text = g_get_system_color(cui::colours::colour_selection_text);
+    inactive_selection_text = g_get_system_color(cui::colours::colour_inactive_selection_text);
+    background = g_get_system_color(cui::colours::colour_background);
+    selection_background = g_get_system_color(cui::colours::colour_selection_background);
+    inactive_selection_background = g_get_system_color(cui::colours::colour_inactive_selection_background);
+    active_item_frame = g_get_system_color(cui::colours::colour_active_item_frame);
     group_foreground = NULL;
     group_background = NULL;
     use_custom_active_item_frame = false;

--- a/foo_ui_columns/columns_v2.cpp
+++ b/foo_ui_columns/columns_v2.cpp
@@ -125,7 +125,7 @@ void ConfigColumns::get_data_raw(stream_writer* out, abort_callback& p_abort)
 
 void ConfigColumns::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort)
 {
-    pfc::list_t<PlaylistViewColumn::ptr> items;
+    list_t<PlaylistViewColumn::ptr> items;
     ColumnStreamVersion streamVersion = ColumnStreamVersion::streamVersion0;
 
     t_uint32 num;

--- a/foo_ui_columns/columns_v2.h
+++ b/foo_ui_columns/columns_v2.h
@@ -35,7 +35,9 @@ public:
         , filter(p_filter_string)
         , parts(p_parts)
         , show(b_show)
-        , edit_field(p_edit_field){};
+        , edit_field(p_edit_field)
+    {
+    }
 };
 
 enum class ColumnStreamVersion {

--- a/foo_ui_columns/columns_v2.h
+++ b/foo_ui_columns/columns_v2.h
@@ -113,7 +113,7 @@ public:
                 (*this)[i]->width = entries[i]->width;
     }
 
-    void set_widths(const pfc::list_base_const_t<t_size>& widths)
+    void set_widths(const list_base_const_t<t_size>& widths)
     {
         // remove_all();
         t_size count = get_count();

--- a/foo_ui_columns/commandline.cpp
+++ b/foo_ui_columns/commandline.cpp
@@ -30,7 +30,9 @@ public:
     CommandLineSingleFileHelper(const char* error_title, const char* no_files_error, const char* too_many_files_error)
         : m_error_title{error_title}
         , m_no_files_error{no_files_error}
-        , m_too_many_files_error{too_many_files_error} {};
+        , m_too_many_files_error{too_many_files_error}
+    {
+    }
     void reset() { m_files.clear(); }
     void add_file(const char* url) { m_files.emplace_back(url); }
     bool validate_files()

--- a/foo_ui_columns/config.cpp
+++ b/foo_ui_columns/config.cpp
@@ -55,7 +55,7 @@ const GUID& config_get_main_guid()
 {
     return g_guid_columns_ui_preferences_page;
 }
-}; // namespace columns
+} // namespace columns
 
 namespace cui {
 namespace prefs {

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -137,11 +137,11 @@ public:
     void register_common_callback(cui::colours::common_callback* p_callback) override
     {
         g_colours_manager_data.register_common_callback(p_callback);
-    };
+    }
     void deregister_common_callback(cui::colours::common_callback* p_callback) override
     {
         g_colours_manager_data.deregister_common_callback(p_callback);
-    };
+    }
 
 private:
 };
@@ -274,7 +274,7 @@ namespace {
 service_factory_single_t<ColoursManager> g_colours_manager;
 service_factory_t<FontsManager> g_fonts_manager;
 service_factory_t<FontsManager2> g_fonts_manager_v2;
-}; // namespace
+} // namespace
 
 cui::colours::colour_mode_t g_get_global_colour_mode()
 {
@@ -482,7 +482,7 @@ class ColoursDataSet : public cui::fcl::dataset {
 
 namespace {
 service_factory_t<ColoursDataSet> g_fcl_colours_t;
-};
+}
 
 class FontsDataSet : public cui::fcl::dataset {
     enum { stream_version = 0 };
@@ -593,7 +593,7 @@ class FontsDataSet : public cui::fcl::dataset {
 
 namespace {
 service_factory_t<FontsDataSet> g_fcl_fonts_t;
-};
+}
 
 // {15FD4FF9-0622-4077-BFBB-DF0102B6A068}
 const GUID ColoursManagerData::g_cfg_guid = {0x15fd4ff9, 0x622, 0x4077, {0xbf, 0xbb, 0xdf, 0x1, 0x2, 0xb6, 0xa0, 0x68}};

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -20,7 +20,7 @@ struct ColumnTimes {
 
 class EditColumnWindowOptions : public ColumnTab {
 public:
-    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
+    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; }
     using self_t = EditColumnWindowOptions;
     HWND create(HWND wnd) override
     {
@@ -32,7 +32,9 @@ public:
         : initialising(false)
         , editproc(nullptr)
         , m_wnd(nullptr)
-        , m_column(std::move(column)){};
+        , m_column(std::move(column))
+    {
+    }
 
     bool initialising;
     WNDPROC editproc;
@@ -234,7 +236,7 @@ class DisplayScriptTab : public ColumnTab {
 public:
     using SelfType = DisplayScriptTab;
 
-    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
+    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; }
 
     HWND create(HWND wnd) override
     {
@@ -325,7 +327,7 @@ class StyleScriptTab : public ColumnTab {
 public:
     using SelfType = StyleScriptTab;
 
-    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
+    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; }
 
     HWND create(HWND wnd) override
     {
@@ -422,7 +424,7 @@ class SortingScriptTab : public ColumnTab {
 public:
     using SelfType = SortingScriptTab;
 
-    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; };
+    void get_column(PlaylistViewColumn::ptr& p_out) override { p_out = m_column; }
 
     HWND create(HWND wnd) override
     {

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -6,7 +6,7 @@
 class FieldList : public uih::ListView {
 public:
     t_size m_edit_index, m_edit_column;
-    FieldList() : m_edit_index(pfc_infinite), m_edit_column(pfc_infinite){};
+    FieldList() : m_edit_index(pfc_infinite), m_edit_column(pfc_infinite) {}
 
     void execute_default_action(t_size index, t_size column, bool b_keyboard, bool b_ctrl) override
     {
@@ -20,12 +20,12 @@ public:
 
         set_single_selection(true);
         set_columns({{"Name", client_width / 3}, {"Field", client_width * 2 / 3}});
-    };
+    }
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse) override
     {
         return column <= 1 && indices.get_count() == 1;
-    };
+    }
     bool notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
         pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override
     {
@@ -40,7 +40,7 @@ public:
             return true;
         }
         return false;
-    };
+    }
     void notify_save_inline_edit(const char* value) override
     {
         if (m_edit_index < cui::panels::filter::cfg_field_list.get_count()) {

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -19,7 +19,7 @@ public:
         const auto client_width = rc.right - rc.left;
 
         set_single_selection(true);
-        uih::ListView::set_columns({{"Name", client_width / 3}, {"Field", client_width * 2 / 3}});
+        set_columns({{"Name", client_width / 3}, {"Field", client_width * 2 / 3}});
     };
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse) override
@@ -52,7 +52,7 @@ public:
                 if (m_edit_column == 0)
                     cui::panels::filter::cfg_field_list.fix_name(valueReal);
                 dest = valueReal;
-                pfc::list_t<uih::ListView::SizedInsertItem<2, 0>> items;
+                pfc::list_t<SizedInsertItem<2, 0>> items;
                 items.set_count(1);
                 {
                     items[0].m_subitems[0] = cui::panels::filter::cfg_field_list[m_edit_index].m_name;
@@ -93,7 +93,7 @@ public:
     {
         m_initialising = true;
 
-        m_field_list.remove_items(pfc::bit_array_true());
+        m_field_list.remove_items(bit_array_true());
         pfc::list_t<uih::ListView::InsertItem> items;
         t_size count = cui::panels::filter::cfg_field_list.get_count();
         get_insert_items(0, count, items);
@@ -179,7 +179,7 @@ public:
             } break;
             case IDC_REMOVE: {
                 if (m_field_list.get_selection_count(2) == 1) {
-                    pfc::bit_array_bittable mask(m_field_list.get_item_count());
+                    bit_array_bittable mask(m_field_list.get_item_count());
                     m_field_list.get_selection_state(mask);
                     // bool b_found = false;
                     t_size index = 0;

--- a/foo_ui_columns/config_host.cpp
+++ b/foo_ui_columns/config_host.cpp
@@ -86,7 +86,7 @@ void PreferencesTabHelper::on_initdialog(HWND wnd)
     m_wnd = wnd;
     m_title_font = create_default_title_font();
 
-    const auto children = cui::helpers::get_child_windows(wnd, [this, wnd](HWND wnd_child) {
+    const auto children = helpers::get_child_windows(wnd, [this, wnd](HWND wnd_child) {
         return GetAncestor(wnd_child, GA_PARENT) == wnd
             && m_title_ctrl_ids.find(GetDlgCtrlID(wnd_child)) != m_title_ctrl_ids.end();
     });

--- a/foo_ui_columns/config_host.h
+++ b/foo_ui_columns/config_host.h
@@ -62,7 +62,7 @@ public:
 
     bool reset_query() override { return false; }
 
-    void reset() override{};
+    void reset() override {}
 
     bool get_help_url(pfc::string_base& p_out) override
     {

--- a/foo_ui_columns/config_items.cpp
+++ b/foo_ui_columns/config_items.cpp
@@ -180,5 +180,5 @@ void config_reset_inline_metafield_edit_mode()
 t_uint32 config_get_inline_metafield_edit_mode_default_value()
 {
     return mode_columns;
-};
-}; // namespace main_window
+}
+} // namespace main_window

--- a/foo_ui_columns/config_items.h
+++ b/foo_ui_columns/config_items.h
@@ -34,4 +34,4 @@ void config_reset_activate_target_playlist_on_dropped_items();
 bool config_get_activate_target_playlist_on_dropped_items();
 bool config_get_activate_target_playlist_on_dropped_items_default_value();
 void config_set_activate_target_playlist_on_dropped_items(bool b_val);
-}; // namespace main_window
+} // namespace main_window

--- a/foo_ui_columns/config_vars.h
+++ b/foo_ui_columns/config_vars.h
@@ -33,10 +33,14 @@ public:
         *this = temp;
     }
     explicit ConfigMenuItem(const GUID& p_guid, const MenuItemIdentifier& p_val)
-        : cfg_struct_t<MenuItemIdentifier>(p_guid, p_val){};
+        : cfg_struct_t<MenuItemIdentifier>(p_guid, p_val)
+    {
+    }
     explicit ConfigMenuItem(const GUID& p_guid, const GUID& p_val, const GUID& psub = pfc::guid_null)
-        : cfg_struct_t<MenuItemIdentifier>(p_guid, MenuItemIdentifier{p_val, psub}){};
-    explicit ConfigMenuItem(const GUID& p_guid) : cfg_struct_t<MenuItemIdentifier>(p_guid, MenuItemIdentifier{}){};
+        : cfg_struct_t<MenuItemIdentifier>(p_guid, MenuItemIdentifier{p_val, psub})
+    {
+    }
+    explicit ConfigMenuItem(const GUID& p_guid) : cfg_struct_t<MenuItemIdentifier>(p_guid, MenuItemIdentifier{}) {}
 };
 
 namespace settings {

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -51,7 +51,7 @@ public:
     void update_active_item_safe();
 
     const GUID& get_extension_guid() const override { return ToolbarArgs::extension_guid; }
-    unsigned get_type() const override { return ui_extension::type_toolbar; };
+    unsigned get_type() const override { return ui_extension::type_toolbar; }
     void get_name(pfc::string_base& out) const override { out = ToolbarArgs::name; }
     void get_category(pfc::string_base& out) const override { out.set_string("Toolbars"); }
     bool is_available(const uie::window_host_ptr& p_host) const override { return ToolbarArgs::is_available(); }

--- a/foo_ui_columns/fcl.cpp
+++ b/foo_ui_columns/fcl.cpp
@@ -409,7 +409,7 @@ class ExportFeedbackReceiver
     : public cui::fcl::t_export_feedback
     , public pfc::list_t<GUID> {
 public:
-    void add_required_panels(const pfc::list_base_const_t<GUID>& panels) override { add_items(panels); }
+    void add_required_panels(const list_base_const_t<GUID>& panels) override { add_items(panels); }
     t_size find_or_add_guid(const GUID& guid)
     {
         t_size index = find_item(guid);

--- a/foo_ui_columns/fcl.cpp
+++ b/foo_ui_columns/fcl.cpp
@@ -39,7 +39,7 @@ public:
         HTREEITEM item{nullptr};
         cui::fcl::group_ptr group;
         bool checked{true};
-        Node(HTREEITEM pitem, cui::fcl::group_ptr ptr) : item(pitem), group(std::move(ptr)){};
+        Node(HTREEITEM pitem, cui::fcl::group_ptr ptr) : item(pitem), group(std::move(ptr)) {}
         Node() = default;
     };
     // cui::fcl::group_list m_groups;
@@ -201,7 +201,7 @@ class ImportResultsData {
 public:
     PanelInfoList m_items;
     bool m_aborted;
-    ImportResultsData(PanelInfoList items, bool baborted) : m_items(std::move(items)), m_aborted(baborted){};
+    ImportResultsData(PanelInfoList items, bool baborted) : m_items(std::move(items)), m_aborted(baborted) {}
 };
 
 BOOL g_ImportResultsProc(const ImportResultsData& data, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -258,7 +258,7 @@ BOOL g_ImportResultsProc(const ImportResultsData& data, HWND wnd, UINT msg, WPAR
     return FALSE;
 }
 
-PFC_DECLARE_EXCEPTION(exception_fcl_dependentpanelmissing, pfc::exception, "Missing dependent panel(s)");
+PFC_DECLARE_EXCEPTION(exception_fcl_dependentpanelmissing, pfc::exception, "Missing dependent panel(s)")
 
 void g_import_layout(HWND wnd, const char* path, bool quiet)
 {

--- a/foo_ui_columns/fcl_layout.cpp
+++ b/foo_ui_columns/fcl_layout.cpp
@@ -67,7 +67,7 @@ cui::fcl::dataset_factory<LayoutDataSet> g_export_layout_t;
 
 namespace cui::rebar {
 
-class ToolbarLayoutDataSet : public cui::fcl::dataset_v2 {
+class ToolbarLayoutDataSet : public fcl::dataset_v2 {
     void get_name(pfc::string_base& p_out) const override { p_out = "Toolbars"; }
     const GUID& get_guid() const override
     {
@@ -75,13 +75,13 @@ class ToolbarLayoutDataSet : public cui::fcl::dataset_v2 {
         static const GUID guid = {0x2f802663, 0xbd1, 0x4d3d, {0xae, 0x7e, 0x6, 0x63, 0x0, 0x7a, 0x9c, 0x2b}};
         return guid;
     }
-    const GUID& get_group() const override { return cui::fcl::groups::toolbars; }
-    void get_data(stream_writer* p_writer, t_uint32 type, cui::fcl::t_export_feedback& feedback,
+    const GUID& get_group() const override { return fcl::groups::toolbars; }
+    void get_data(stream_writer* p_writer, t_uint32 type, fcl::t_export_feedback& feedback,
         abort_callback& p_abort) const override
     {
         g_cfg_rebar.export_config(p_writer, type, feedback, p_abort);
     }
-    void set_data(stream_reader* p_reader, t_size size, t_uint32 type, cui::fcl::t_import_feedback& feedback,
+    void set_data(stream_reader* p_reader, t_size size, t_uint32 type, fcl::t_import_feedback& feedback,
         abort_callback& p_abort) override
     {
         pfc::list_t<GUID> panels;
@@ -95,7 +95,7 @@ class ToolbarLayoutDataSet : public cui::fcl::dataset_v2 {
     [[nodiscard]] double get_import_priority() const override { return -100.0; }
 };
 
-cui::fcl::dataset_factory<ToolbarLayoutDataSet> g_export_toolbars_t;
+fcl::dataset_factory<ToolbarLayoutDataSet> g_export_toolbars_t;
 
 } // namespace cui::rebar
 

--- a/foo_ui_columns/fcl_titles.cpp
+++ b/foo_ui_columns/fcl_titles.cpp
@@ -5,12 +5,12 @@
 
 namespace cui::panels::playlist_view {
 
-cui::fcl::group_impl_factory fclgroupcolumns(
-    cui::fcl::groups::titles_playlist_view, "Playlist Scripts", "Playlist Scripts", cui::fcl::groups::title_scripts);
-cui::fcl::group_impl_factory fclgroupcommon(
-    cui::fcl::groups::titles_common, "Common Scripts", "Common Scripts", cui::fcl::groups::title_scripts);
+fcl::group_impl_factory fclgroupcolumns(
+    fcl::groups::titles_playlist_view, "Playlist Scripts", "Playlist Scripts", fcl::groups::title_scripts);
+fcl::group_impl_factory fclgroupcommon(
+    fcl::groups::titles_common, "Common Scripts", "Common Scripts", fcl::groups::title_scripts);
 
-class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
+class PlaylistViewColumnsDataSet : public fcl::dataset {
     enum ItemID {
         identifier_column,
     };
@@ -32,14 +32,14 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
 
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Columns"; }
-    const GUID& get_group() const override { return cui::fcl::groups::titles_playlist_view; }
+    const GUID& get_group() const override { return fcl::groups::titles_playlist_view; }
     const GUID& get_guid() const override
     {
         // {2415AAE7-7F5E-4ad8-94E2-1E730A2139EF}
         static const GUID guid = {0x2415aae7, 0x7f5e, 0x4ad8, {0x94, 0xe2, 0x1e, 0x73, 0xa, 0x21, 0x39, 0xef}};
         return guid;
     }
-    void get_data(stream_writer* p_writer, t_uint32 type, cui::fcl::t_export_feedback& feedback,
+    void get_data(stream_writer* p_writer, t_uint32 type, fcl::t_export_feedback& feedback,
         abort_callback& p_abort) const override
     {
         fbh::fcl::Writer out(p_writer, p_abort);
@@ -68,7 +68,7 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
             out.write_item(identifier_column, sw.m_data.get_ptr(), sw.m_data.get_size());
         }
     }
-    void set_data(stream_reader* p_reader, t_size stream_size, t_uint32 type, cui::fcl::t_import_feedback& feedback,
+    void set_data(stream_reader* p_reader, t_size stream_size, t_uint32 type, fcl::t_import_feedback& feedback,
         abort_callback& p_abort) override
     {
         fbh::fcl::Reader reader(p_reader, stream_size, p_abort);
@@ -159,9 +159,9 @@ class PlaylistViewColumnsDataSet : public cui::fcl::dataset {
     }
 };
 
-cui::fcl::dataset_factory<PlaylistViewColumnsDataSet> g_export_columns_t;
+fcl::dataset_factory<PlaylistViewColumnsDataSet> g_export_columns_t;
 
-class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
+class PlaylistViewGroupsDataSet : public fcl::dataset {
     enum ItemID {
         identifier_groups,
         identifier_show_groups,
@@ -179,14 +179,14 @@ class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
 
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Groups"; }
-    const GUID& get_group() const override { return cui::fcl::groups::titles_playlist_view; }
+    const GUID& get_group() const override { return fcl::groups::titles_playlist_view; }
     const GUID& get_guid() const override
     {
         // {A89F68C6-B40A-4200-BA2A-68999F704FFD}
         static const GUID guid = {0xa89f68c6, 0xb40a, 0x4200, {0xba, 0x2a, 0x68, 0x99, 0x9f, 0x70, 0x4f, 0xfd}};
         return guid;
     }
-    void get_data(stream_writer* p_writer, t_uint32 type, cui::fcl::t_export_feedback& feedback,
+    void get_data(stream_writer* p_writer, t_uint32 type, fcl::t_export_feedback& feedback,
         abort_callback& p_abort) const override
     {
         fbh::fcl::Writer out(p_writer, p_abort);
@@ -218,7 +218,7 @@ class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
 
         out.write_item(identifier_groups, groups_sw.m_data.get_ptr(), groups_sw.m_data.get_size());
     }
-    void set_data(stream_reader* p_reader, t_size stream_size, t_uint32 type, cui::fcl::t_import_feedback& feedback,
+    void set_data(stream_reader* p_reader, t_size stream_size, t_uint32 type, fcl::t_import_feedback& feedback,
         abort_callback& p_abort) override
     {
         fbh::fcl::Reader reader(p_reader, stream_size, p_abort);
@@ -303,9 +303,9 @@ class PlaylistViewGroupsDataSet : public cui::fcl::dataset {
     }
 };
 
-cui::fcl::dataset_factory<PlaylistViewGroupsDataSet> g_export_groups_t;
+fcl::dataset_factory<PlaylistViewGroupsDataSet> g_export_groups_t;
 
-class PlaylistViewMiscDataSet : public cui::fcl::dataset {
+class PlaylistViewMiscDataSet : public fcl::dataset {
     enum ItemID {
         identifier_global_script,
         identifier_style_script,
@@ -316,14 +316,14 @@ class PlaylistViewMiscDataSet : public cui::fcl::dataset {
         identifier_use_globals,
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Colours"; }
-    const GUID& get_group() const override { return cui::fcl::groups::titles_playlist_view; }
+    const GUID& get_group() const override { return fcl::groups::titles_playlist_view; }
     const GUID& get_guid() const override
     {
         // {190F4811-899A-4366-A181-FF5161FC1C77}
         static const GUID guid = {0x190f4811, 0x899a, 0x4366, {0xa1, 0x81, 0xff, 0x51, 0x61, 0xfc, 0x1c, 0x77}};
         return guid;
     }
-    void get_data(stream_writer* p_writer, t_uint32 type, cui::fcl::t_export_feedback& feedback,
+    void get_data(stream_writer* p_writer, t_uint32 type, fcl::t_export_feedback& feedback,
         abort_callback& p_abort) const override
     {
         fbh::fcl::Writer out(p_writer, p_abort);
@@ -336,7 +336,7 @@ class PlaylistViewMiscDataSet : public cui::fcl::dataset {
         out.write_item(identifier_use_dates, static_cast<int32_t>(true));
         out.write_item(identifier_use_globals, cfg_global);
     }
-    void set_data(stream_reader* p_reader, t_size stream_size, t_uint32 type, cui::fcl::t_import_feedback& feedback,
+    void set_data(stream_reader* p_reader, t_size stream_size, t_uint32 type, fcl::t_import_feedback& feedback,
         abort_callback& p_abort) override
     {
         fbh::fcl::Reader reader(p_reader, stream_size, p_abort);
@@ -379,9 +379,9 @@ class PlaylistViewMiscDataSet : public cui::fcl::dataset {
     }
 };
 
-cui::fcl::dataset_factory<PlaylistViewMiscDataSet> g_export_pview_t;
+fcl::dataset_factory<PlaylistViewMiscDataSet> g_export_pview_t;
 
-class TitlesDataSet : public cui::fcl::dataset {
+class TitlesDataSet : public fcl::dataset {
     enum ItemID {
         identifier_main_window_title,
         identifier_status_bar,
@@ -390,14 +390,14 @@ class TitlesDataSet : public cui::fcl::dataset {
         identifier_playlist,
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Titles"; }
-    const GUID& get_group() const override { return cui::fcl::groups::titles_common; }
+    const GUID& get_group() const override { return fcl::groups::titles_common; }
     const GUID& get_guid() const override
     {
         // {9AF6A28B-3EFF-4d1a-AD81-FA1759F1D66C}
         static const GUID guid = {0x9af6a28b, 0x3eff, 0x4d1a, {0xad, 0x81, 0xfa, 0x17, 0x59, 0xf1, 0xd6, 0x6c}};
         return guid;
     }
-    void get_data(stream_writer* p_writer, t_uint32 type, cui::fcl::t_export_feedback& feedback,
+    void get_data(stream_writer* p_writer, t_uint32 type, fcl::t_export_feedback& feedback,
         abort_callback& p_abort) const override
     {
         fbh::fcl::Writer out(p_writer, p_abort);
@@ -406,7 +406,7 @@ class TitlesDataSet : public cui::fcl::dataset {
         out.write_item(identifier_notification_icon_tooltip, main_window::config_notification_icon_script.get());
         out.write_item(identifier_main_window_title, main_window::config_main_window_title_script.get());
     }
-    void set_data(stream_reader* p_reader, t_size stream_size, t_uint32 type, cui::fcl::t_import_feedback& feedback,
+    void set_data(stream_reader* p_reader, t_size stream_size, t_uint32 type, fcl::t_import_feedback& feedback,
         abort_callback& p_abort) override
     {
         fbh::fcl::Reader reader(p_reader, stream_size, p_abort);
@@ -440,6 +440,6 @@ class TitlesDataSet : public cui::fcl::dataset {
     }
 };
 
-cui::fcl::dataset_factory<TitlesDataSet> g_export_titles_t;
+fcl::dataset_factory<TitlesDataSet> g_export_titles_t;
 
 } // namespace cui::panels::playlist_view

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -486,7 +486,7 @@ bool FilterPanel::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM 
     uie::window_ptr p_this = this;
     bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
     return ret;
-};
+}
 
 void FilterPanel::get_selection_handles(
     metadb_handle_list_t<pfc::alloc_fast_aggressive>& p_out, bool fallback, bool b_sort)

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -188,7 +188,7 @@ void FilterPanel::g_on_edgestyle_change()
 void FilterPanel::g_on_font_items_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_filter_items_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_filter_items_font_client, lf);
     for (auto& window : g_windows) {
         window->set_font(&lf);
     }
@@ -197,7 +197,7 @@ void FilterPanel::g_on_font_items_change()
 void FilterPanel::g_on_font_header_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_filter_header_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_filter_header_font_client, lf);
     for (auto& window : g_windows) {
         window->set_header_font(&lf);
     }
@@ -317,7 +317,7 @@ void FilterPanel::get_windows(pfc::list_base_t<FilterPanel*>& windows)
             }
         }
         mmh::Permutation permutation(windows.get_count());
-        mmh::sort_get_permutation(indices.get_ptr(), permutation, (pfc::compare_t<t_size, t_size>), true, false);
+        sort_get_permutation(indices.get_ptr(), permutation, (pfc::compare_t<t_size, t_size>), true, false);
         windows.reorder(permutation.data());
     }
 }
@@ -358,10 +358,10 @@ void FilterPanel::g_create_field_data(const Field& field, FieldData& p_out)
 
 void FilterPanel::g_load_fields()
 {
-    t_size count = cui::panels::filter::cfg_field_list.get_count();
+    t_size count = cfg_field_list.get_count();
     g_field_data.set_count(count);
     for (t_size i = 0; i < count; i++) {
-        const Field& field = cui::panels::filter::cfg_field_list[i];
+        const Field& field = cfg_field_list[i];
         g_create_field_data(field, g_field_data[i]);
     }
 }
@@ -516,12 +516,12 @@ void FilterPanel::get_selection_handles(
 
 void FilterPanel::do_selection_action(Action action)
 {
-    pfc::bit_array_bittable mask(m_nodes.get_count());
+    bit_array_bittable mask(m_nodes.get_count());
     get_selection_state(mask);
     do_items_action(mask, action);
 }
 
-void FilterPanel::do_items_action(const pfc::bit_array& p_nodes, Action action)
+void FilterPanel::do_items_action(const bit_array& p_nodes, Action action)
 {
     metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
     handles.prealloc(m_nodes.get_count());
@@ -581,11 +581,11 @@ void FilterPanel::do_items_action(const pfc::bit_array& p_nodes, Action action)
     sort_tracks(handles);
 
     if (action != action_add_to_active)
-        playlist_api->playlist_add_items(index, handles, pfc::bit_array_false());
+        playlist_api->playlist_add_items(index, handles, bit_array_false());
     else {
         playlist_api->playlist_clear_selection(index);
         const auto item_index = playlist_api->playlist_get_item_count(index);
-        playlist_api->playlist_add_items(index, handles, pfc::bit_array_true());
+        playlist_api->playlist_add_items(index, handles, bit_array_true());
         playlist_api->playlist_set_focus_item(index, item_index);
     }
 
@@ -608,7 +608,7 @@ bool FilterPanel::notify_on_middleclick(bool on_item, t_size index)
 {
     if (cfg_middleclickaction && on_item && index < m_nodes.get_count()) {
         auto action = static_cast<Action>(cfg_middleclickaction.get_value() - 1);
-        do_items_action(pfc::bit_array_one(index), action);
+        do_items_action(bit_array_one(index), action);
         return true;
     }
     return false;
@@ -644,7 +644,7 @@ void FilterPanel::send_results_to_playlist(bool b_play)
     playlist_api->playlist_clear(index);
 
     sort_tracks(handles);
-    playlist_api->playlist_add_items(index, handles, pfc::bit_array_false());
+    playlist_api->playlist_add_items(index, handles, bit_array_false());
 
     playlist_api->set_active_playlist(index);
     if (b_play) {
@@ -655,7 +655,7 @@ void FilterPanel::send_results_to_playlist(bool b_play)
     //    playlist_api->remove_playlist(index+1);
 }
 void FilterPanel::notify_on_selection_change(
-    const pfc::bit_array& p_affected, const pfc::bit_array& p_status, notification_source_t p_notification_source)
+    const bit_array& p_affected, const bit_array& p_status, notification_source_t p_notification_source)
 {
     update_subsequent_filters();
     if (m_selection_holder.is_valid()) {
@@ -706,7 +706,7 @@ void Node::ensure_handles_sorted()
 void Node::remove_handles(metadb_handle_list_cref to_remove)
 {
     pfc::array_staticsize_t<bool> remove_mask(m_handles.get_count());
-    pfc::fill_array_t(remove_mask, false);
+    fill_array_t(remove_mask, false);
 
     m_handles_sorted = false;
     mmh::in_place_sort(m_handles, pfc::compare_t<metadb_handle_ptr, metadb_handle_ptr>, false);
@@ -787,9 +787,9 @@ void FilterPanel::notify_on_initialisation()
     set_show_sort_indicators(cfg_show_sort_indicators);
 
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_filter_items_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_filter_items_font_client, lf);
     set_font(&lf);
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_filter_header_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_filter_header_font_client, lf);
     set_header_font(&lf);
 
     t_size index = g_windows.size();
@@ -906,25 +906,25 @@ pfc::list_t<FilterStream::ptr> FilterPanel::g_streams;
 const GUID AppearanceClient::g_guid = {0x4d6774af, 0xc292, 0x44ac, {0x8a, 0x8f, 0x3b, 0x8, 0x55, 0xdc, 0xbd, 0xf4}};
 
 namespace {
-cui::colours::client::factory<AppearanceClient> g_appearance_client_impl;
+colours::client::factory<AppearanceClient> g_appearance_client_impl;
 }
 
-class FilterItemFontClient : public cui::fonts::client {
+class FilterItemFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_filter_items_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel: Items"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { FilterPanel::g_on_font_items_change(); }
 };
 
-class FilterHeaderFontClient : public cui::fonts::client {
+class FilterHeaderFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_filter_header_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel: Column titles"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { FilterPanel::g_on_font_header_change(); }
 };

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -8,11 +8,11 @@ class AppearanceClient : public colours::client {
 public:
     static const GUID g_guid;
 
-    const GUID& get_client_guid() const override { return g_guid; };
-    void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel"; };
+    const GUID& get_client_guid() const override { return g_guid; }
+    void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel"; }
     t_size get_supported_colours() const override { return colours::colour_flag_all; }
     t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; }
-    bool get_themes_supported() const override { return true; };
+    bool get_themes_supported() const override { return true; }
     void on_colour_changed(t_size mask) const override;
     void on_bool_changed(t_size mask) const override {}
 };
@@ -220,4 +220,4 @@ private:
     ui_status_text_override::ptr m_status_text_override;
 };
 
-}; // namespace cui::panels::filter
+} // namespace cui::panels::filter

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -4,14 +4,14 @@
 
 namespace cui::panels::filter {
 
-class AppearanceClient : public cui::colours::client {
+class AppearanceClient : public colours::client {
 public:
     static const GUID g_guid;
 
     const GUID& get_client_guid() const override { return g_guid; };
     void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel"; };
-    t_size get_supported_colours() const override { return cui::colours::colour_flag_all; }
-    t_size get_supported_bools() const override { return cui::colours::bool_flag_use_custom_active_item_frame; }
+    t_size get_supported_colours() const override { return colours::colour_flag_all; }
+    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; }
     bool get_themes_supported() const override { return true; };
     void on_colour_changed(t_size mask) const override;
     void on_bool_changed(t_size mask) const override {}
@@ -164,7 +164,7 @@ private:
         metadb_handle_list_t<pfc::alloc_fast_aggressive>& p_out, bool fallback = true, bool b_sort = false);
     bool get_nothing_or_all_node_selected() { return get_selection_count(1) == 0 || get_item_selected(0); }
     void do_selection_action(Action action = action_send_to_autosend);
-    void do_items_action(const pfc::bit_array& p_nodes, Action action = action_send_to_autosend);
+    void do_items_action(const bit_array& p_nodes, Action action = action_send_to_autosend);
     void send_results_to_playlist(bool b_play = false);
 
     void update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>& p_data);
@@ -181,8 +181,8 @@ private:
     void move_selection(int delta) override {}
     void notify_update_item_data(t_size index) override;
     bool notify_on_middleclick(bool on_item, t_size index) override;
-    void notify_on_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_status,
-        notification_source_t p_notification_source) override;
+    void notify_on_selection_change(
+        const bit_array& p_affected, const bit_array& p_status, notification_source_t p_notification_source) override;
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse) override;
     bool notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,

--- a/foo_ui_columns/filter_inline_edit.cpp
+++ b/foo_ui_columns/filter_inline_edit.cpp
@@ -8,7 +8,7 @@ bool FilterPanel::notify_before_create_inline_edit(
 {
     return !m_field_data.m_use_script && !m_field_data.m_fields.empty() && column == 0 && indices.get_count() == 1
         && indices[0] != 0;
-};
+}
 bool FilterPanel::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
     pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
 {
@@ -24,7 +24,7 @@ bool FilterPanel::notify_create_inline_edit(const pfc::list_base_const_t<t_size>
         return true;
     }
     return false;
-};
+}
 void FilterPanel::notify_save_inline_edit(const char* value)
 {
     static_api_ptr_t<metadb_io_v2> tagger_api;
@@ -73,12 +73,12 @@ void FilterPanel::notify_save_inline_edit(const char* value)
                 nullptr);
         }
     }
-};
+}
 void FilterPanel::notify_exit_inline_edit()
 {
     m_edit_fields.clear();
     m_edit_handles.remove_all();
     m_edit_previous_value.reset();
-};
+}
 
 } // namespace cui::panels::filter

--- a/foo_ui_columns/filter_items.cpp
+++ b/foo_ui_columns/filter_items.cpp
@@ -319,7 +319,7 @@ size_t FilterPanel::make_data_entries(const metadb_handle_list_t<pfc::alloc_fast
                 pfc::string8_fastalloc buffer;
                 buffer.prealloc(32);
                 tracks_ptr[i]->format_title(nullptr, buffer, to, nullptr);
-                if (b_show_empty || pfc::strlen_max(buffer, 1)) {
+                if (b_show_empty || strlen_max(buffer, 1)) {
                     const size_t node_index = node_count++;
                     pp_out[node_index].m_handle = tracks_ptr[i];
                     pp_out[node_index].m_text.set_size(pfc::stringcvt::estimate_utf8_to_wide_quick(buffer));
@@ -397,7 +397,7 @@ void FilterPanel::populate_list(const metadb_handle_list_t<pfc::alloc_fast>& han
 
     const auto node_count = make_data_entries(handles, data_entries, g_showemptyitems);
 
-    pfc::list_t<uih::ListView::InsertItem, pfc::alloc_fast_aggressive> items;
+    pfc::list_t<InsertItem, pfc::alloc_fast_aggressive> items;
     items.prealloc(node_count);
 
     DataEntry* p_data = data_entries.get_ptr();
@@ -435,7 +435,7 @@ void FilterPanel::notify_sort_column(t_size index, bool b_descending, bool b_sel
         mmh::Permutation sort_permuation(node_count - 1);
         const auto* nodes = m_nodes.get_ptr();
         ++nodes;
-        mmh::sort_get_permutation(nodes, sort_permuation, Node::g_compare_ptr_with_node, false, b_descending, true);
+        sort_get_permutation(nodes, sort_permuation, Node::g_compare_ptr_with_node, false, b_descending, true);
 
         m_nodes.reorder_partial(1, sort_permuation.data(), node_count - 1);
 

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -86,7 +86,7 @@ void g_get_search_bar_sibling_streams(FilterSearchToolbar const* p_serach_bar, p
 
 namespace {
 uie::window_factory<FilterSearchToolbar> g_filter_search_bar;
-};
+}
 
 void FilterSearchToolbar::set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
 {
@@ -97,7 +97,7 @@ void FilterSearchToolbar::set_config(stream_reader* p_reader, t_size p_size, abo
             p_reader->read_lendian_t(m_show_clear_button, p_abort);
         }
     }
-};
+}
 void FilterSearchToolbar::get_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
     p_writer->write_lendian_t(t_size(config_version_current), p_abort);

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -36,7 +36,7 @@ void g_send_metadb_handles_to_playlist(tHandles& handles, bool b_play = false)
     playlist_api->playlist_clear(index);
 
     sort_tracks(handles);
-    playlist_api->playlist_add_items(index, handles, pfc::bit_array_false());
+    playlist_api->playlist_add_items(index, handles, bit_array_false());
 
     playlist_api->set_active_playlist(index);
     if (b_play) {
@@ -64,7 +64,7 @@ void g_get_search_bar_sibling_streams(FilterSearchToolbar const* p_serach_bar, p
 
             uie::splitter_window_ptr p_splitter;
 
-            if (p_window->get_extension_guid() == cui::panels::guid_filter) {
+            if (p_window->get_extension_guid() == guid_filter) {
                 auto* p_filter = static_cast<FilterPanel*>(p_window.get_ptr());
                 if (!p_out.have_item(p_filter->m_stream))
                     p_out.add_item(p_filter->m_stream);
@@ -302,10 +302,10 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
     case WM_CTLCOLORLISTBOX: {
         const auto dc = reinterpret_cast<HDC>(wp);
 
-        cui::colours::helper colour_helper(colour_client_id);
+        colours::helper colour_helper(colour_client_id);
 
-        SetTextColor(dc, colour_helper.get_colour(cui::colours::colour_text));
-        SetBkColor(dc, colour_helper.get_colour(cui::colours::colour_background));
+        SetTextColor(dc, colour_helper.get_colour(colours::colour_text));
+        SetBkColor(dc, colour_helper.get_colour(colours::colour_background));
 
         return reinterpret_cast<LRESULT>(s_background_brush.get());
     }
@@ -582,7 +582,7 @@ LRESULT FilterSearchToolbar::on_search_edit_message(HWND wnd, UINT msg, WPARAM w
     case WM_KEYDOWN:
         switch (wp) {
         case VK_TAB: {
-            uie::window::g_on_tab(wnd);
+            g_on_tab(wnd);
         }
         // return 0;
         break;

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -122,4 +122,4 @@ private:
     int m_toolbar_cy{};
 };
 
-}; // namespace cui::panels::filter
+} // namespace cui::panels::filter

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -27,7 +27,7 @@ public:
 
     void get_name(pfc::string_base& out) const override { out = "Filter search"; }
 
-    const GUID& get_extension_guid() const override { return cui::toolbars::guid_filter_search_bar; }
+    const GUID& get_extension_guid() const override { return toolbars::guid_filter_search_bar; }
 
     void get_category(pfc::string_base& out) const override { out = "Toolbars"; }
 
@@ -36,19 +36,19 @@ public:
     t_uint32 get_flags() const override { return flag_default_flags_plus_transparent_background; }
 
 private:
-    class FontClient : public cui::fonts::client {
+    class FontClient : public fonts::client {
         const GUID& get_client_guid() const override { return font_client_id; }
         void get_name(pfc::string_base& p_out) const override { p_out = "Filter search"; }
-        cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+        fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
         void on_font_changed() const override { s_update_font(); }
     };
 
-    class ColourClient : public cui::colours::client {
+    class ColourClient : public colours::client {
         const GUID& get_client_guid() const override { return colour_client_id; }
         void get_name(pfc::string_base& p_out) const override { p_out = "Filter search"; }
         size_t get_supported_colours() const override
         {
-            return cui::colours::colour_flag_text | cui::colours::colour_flag_background;
+            return colours::colour_flag_text | colours::colour_flag_background;
         }
         size_t get_supported_bools() const override { return 0; }
         bool get_themes_supported() const override { return false; }
@@ -71,7 +71,7 @@ private:
     static void s_update_colours();
     static void s_update_font();
 
-    const GUID& get_class_guid() override { return cui::toolbars::guid_filter_search_bar; }
+    const GUID& get_class_guid() override { return toolbars::guid_filter_search_bar; }
 
     void set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort) override;
     void get_config(stream_writer* p_writer, abort_callback& p_abort) const override;

--- a/foo_ui_columns/filter_utils.h
+++ b/foo_ui_columns/filter_utils.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <filter_config_var.h>
+#include "filter_config_var.h"
 
 namespace cui::panels::filter {
 

--- a/foo_ui_columns/font_utils.cpp
+++ b/foo_ui_columns/font_utils.cpp
@@ -12,7 +12,7 @@ void FontDescription::estimate_point_size()
 
 void ConfigFontDescription::get_data_raw(stream_writer* stream, abort_callback& aborter)
 {
-    cui::fonts::write_font(stream, m_font_description.log_font, aborter);
+    write_font(stream, m_font_description.log_font, aborter);
     stream->write_lendian_t(m_font_description.point_size_tenths, aborter);
 }
 

--- a/foo_ui_columns/fonts_manager_data.cpp
+++ b/foo_ui_columns/fonts_manager_data.cpp
@@ -9,7 +9,7 @@ FontsManagerData::FontsManagerData() : cfg_var(g_cfg_guid)
     uGetIconFont(&m_common_items_entry->font_description.log_font);
     m_common_items_entry->font_description.estimate_point_size();
 
-    m_common_labels_entry = std::make_shared<FontsManagerData::Entry>();
+    m_common_labels_entry = std::make_shared<Entry>();
     uGetMenuFont(&m_common_labels_entry->font_description.log_font);
     m_common_labels_entry->font_description.estimate_point_size();
 }
@@ -41,7 +41,7 @@ void FontsManagerData::find_by_guid(const GUID& p_guid, entry_ptr_t& p_out)
         }
     }
     {
-        p_out = std::make_shared<FontsManagerData::Entry>();
+        p_out = std::make_shared<Entry>();
         p_out->guid = p_guid;
         cui::fonts::client::ptr ptr;
         if (cui::fonts::client::create_by_guid(p_guid, ptr)) {

--- a/foo_ui_columns/get_msg_hook.cpp
+++ b/foo_ui_columns/get_msg_hook.cpp
@@ -60,9 +60,9 @@ bool GetMsgHook::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM
 
 void GetMsgHook::register_hook()
 {
-    uih::register_message_hook(uih::MessageHookType::type_get_message, this);
+    register_message_hook(uih::MessageHookType::type_get_message, this);
 }
 void GetMsgHook::deregister_hook()
 {
-    uih::deregister_message_hook(uih::MessageHookType::type_get_message, this);
+    deregister_message_hook(uih::MessageHookType::type_get_message, this);
 }

--- a/foo_ui_columns/helpers.h
+++ b/foo_ui_columns/helpers.h
@@ -33,7 +33,7 @@ class WindowEnum_t {
 public:
     void run() { EnumWindows(&g_EnumWindowsProc, (LPARAM)this); }
     pfc::list_t<HWND, pfc::alloc_fast> m_wnd_list;
-    WindowEnum_t(HWND wnd_owner) : m_wnd_owner(wnd_owner){};
+    WindowEnum_t(HWND wnd_owner) : m_wnd_owner(wnd_owner) {}
 };
 
 std::vector<HWND> get_child_windows(HWND wnd, std::function<bool(HWND)> filter = nullptr);

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -177,7 +177,6 @@ public:
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
         MenuNodeTrackMode(ItemDetails* p_wnd, t_size p_value);
-        ;
     };
 
     class MenuNodeSourcePopup : public ui_extension::menu_node_popup_t {
@@ -188,7 +187,6 @@ public:
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
         MenuNodeSourcePopup(ItemDetails* p_wnd);
-        ;
     };
 
     class MenuNodeAlignment : public ui_extension::menu_node_command_t {
@@ -201,7 +199,6 @@ public:
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
         MenuNodeAlignment(ItemDetails* p_wnd, t_size p_value);
-        ;
     };
 
     class MenuNodeAlignmentPopup : public ui_extension::menu_node_popup_t {
@@ -212,7 +209,6 @@ public:
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
         MenuNodeAlignmentPopup(ItemDetails* p_wnd);
-        ;
     };
 
     class MenuNodeOptions : public ui_extension::menu_node_command_t {
@@ -223,7 +219,6 @@ public:
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
         MenuNodeOptions(ItemDetails* p_wnd);
-        ;
     };
     class MenuNodeHorizontalScrolling : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemDetails> p_this;
@@ -233,7 +228,6 @@ public:
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
         MenuNodeHorizontalScrolling(ItemDetails* p_wnd);
-        ;
     };
 
     class MenuNodeWordWrap : public ui_extension::menu_node_command_t {
@@ -244,7 +238,6 @@ public:
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
         MenuNodeWordWrap(ItemDetails* p_wnd);
-        ;
     };
 
     // UIE funcs

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -137,7 +137,7 @@ class ItemDetails
     , public play_callback
     , public playlist_callback_single
     , public metadb_io_callback_dynamic {
-    class MessageWindow : public ui_helpers::container_window {
+    class MessageWindow : public container_window {
         class_data& get_class_data() const override;
         LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     };
@@ -281,15 +281,15 @@ public:
     void on_playlist_switch() override;
     void on_item_focus_change(t_size p_from, t_size p_to) override;
 
-    void on_items_added(t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const pfc::bit_array& p_selection) override;
+    void on_items_added(
+        t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override;
     void on_items_reordered(const t_size* p_order, t_size p_count) override;
-    void on_items_removing(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
-    void on_items_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
-    void on_items_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_state) override;
-    void on_items_modified(const pfc::bit_array& p_mask) override;
-    void on_items_modified_fromplayback(const pfc::bit_array& p_mask, play_control::t_display_level p_level) override;
-    void on_items_replaced(const pfc::bit_array& p_mask,
+    void on_items_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
+    void on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override;
+    void on_items_modified(const bit_array& p_mask) override;
+    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override;
+    void on_items_replaced(const bit_array& p_mask,
         const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override;
     void on_item_ensure_visible(t_size p_idx) override;
 
@@ -329,7 +329,7 @@ private:
     void set_handles(const metadb_handle_list& handles);
     void refresh_contents(bool reset_vertical_scroll_position = false, bool reset_horizontal_scroll_position = false);
     void request_full_file_info();
-    void on_full_file_info_request_completion(std::shared_ptr<cui::helpers::FullFileInfoRequest> request);
+    void on_full_file_info_request_completion(std::shared_ptr<helpers::FullFileInfoRequest> request);
     void release_aborted_full_file_info_requests();
     void release_all_full_file_info_requests();
 
@@ -368,8 +368,8 @@ private:
     metadb_handle_list m_handles;
     metadb_handle_list m_selection_handles;
     std::shared_ptr<file_info_impl> m_full_file_info;
-    std::shared_ptr<cui::helpers::FullFileInfoRequest> m_full_file_info_request;
-    std::vector<std::shared_ptr<cui::helpers::FullFileInfoRequest>> m_aborting_full_file_info_requests;
+    std::shared_ptr<helpers::FullFileInfoRequest> m_full_file_info_request;
+    std::vector<std::shared_ptr<helpers::FullFileInfoRequest>> m_aborting_full_file_info_requests;
     bool m_full_file_info_requested{};
     bool m_callback_registered{false};
     bool m_nowplaying_active{false};

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -40,7 +40,7 @@ BOOL CALLBACK ItemDetailsConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LPARA
         ComboBox_SetCurSel(wnd_combo, m_vertical_alignment);
 
         LOGFONT lf;
-        static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_item_details_font_client, lf);
+        static_api_ptr_t<fonts::manager>()->get_font(g_guid_item_details_font_client, lf);
         m_font_code_generator.initialise(lf, wnd, IDC_FONT_CODE);
 
         colour_code_gen(wnd, IDC_COLOUR_CODE, false, true);

--- a/foo_ui_columns/item_details_font.cpp
+++ b/foo_ui_columns/item_details_font.cpp
@@ -208,13 +208,13 @@ public:
     t_size get_supported_colours() const override
     {
         return colours::colour_flag_background | colours::colour_flag_text;
-    }; // bit-mask
-    t_size get_supported_bools() const override { return 0; }; // bit-mask
+    } // bit-mask
+    t_size get_supported_bools() const override { return 0; } // bit-mask
 
-    bool get_themes_supported() const override { return false; };
+    bool get_themes_supported() const override { return false; }
 
-    void on_bool_changed(t_size mask) const override{};
-    void on_colour_changed(t_size mask) const override { ItemDetails::g_on_colours_change(); };
+    void on_bool_changed(t_size mask) const override {}
+    void on_colour_changed(t_size mask) const override { ItemDetails::g_on_colours_change(); }
 };
 
 namespace {

--- a/foo_ui_columns/item_details_font.cpp
+++ b/foo_ui_columns/item_details_font.cpp
@@ -126,7 +126,7 @@ void FontCodeGenerator::initialise(const LOGFONT& p_lf_default, HWND parent, UIN
 
 void FontCodeGenerator::run(HWND parent, UINT edit)
 {
-    if (auto font_description = cui::fonts::select_font(parent, m_lf); font_description) {
+    if (auto font_description = fonts::select_font(parent, m_lf); font_description) {
         m_lf = font_description->log_font;
         uSendDlgItemMessageText(parent, edit, WM_SETTEXT, 0, StringFontCode(m_lf));
     }
@@ -190,24 +190,24 @@ void g_parse_font_format_string(const wchar_t* str, t_size len, RawFont& p_out)
     }
 }
 
-class ItemDetailsFontClient : public cui::fonts::client {
+class ItemDetailsFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_item_details_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Item details"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { ItemDetails::g_on_font_change(); }
 };
 
-class ItemDetailsColoursClient : public cui::colours::client {
+class ItemDetailsColoursClient : public colours::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_item_details_colour_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Item details"; }
 
     t_size get_supported_colours() const override
     {
-        return cui::colours::colour_flag_background | cui::colours::colour_flag_text;
+        return colours::colour_flag_background | colours::colour_flag_text;
     }; // bit-mask
     t_size get_supported_bools() const override { return 0; }; // bit-mask
 

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -422,8 +422,8 @@ void g_text_out_multiline_font(HDC dc, RECT rc_placement, const wchar_t* text, c
                     } while (ptr >= text && *ptr != '\x3');
                     if (ptr >= text && code_end != ptr && *ptr == '\x3') {
                         utf8_converter.convert(ptr, code_end - ptr + 1);
-                        uih::text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_line, false, cr_text,
-                            false, false, uih::ALIGN_LEFT, nullptr, false, false);
+                        text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_line, false, cr_text, false,
+                            false, uih::ALIGN_LEFT, nullptr, false, false);
                     }
                     break;
                 }
@@ -485,8 +485,8 @@ void g_text_out_multiline_font(HDC dc, RECT rc_placement, const wchar_t* text, c
             rc_font.bottom -= half_padding_size;
 
             utf8_converter.convert(text_ptr, num_characters_to_render);
-            BOOL ret = uih::text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_font, false, cr_text,
-                false, false, uih::ALIGN_LEFT, nullptr, false, false, &end_x_position, rc_line.left - left_padding);
+            BOOL ret = text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_font, false, cr_text, false,
+                false, uih::ALIGN_LEFT, nullptr, false, false, &end_x_position, rc_line.left - left_padding);
             rc_line.left = end_x_position;
             text_ptr += num_characters_to_render;
             num_characters_remaining -= num_characters_to_render;
@@ -497,7 +497,7 @@ void g_text_out_multiline_font(HDC dc, RECT rc_placement, const wchar_t* text, c
             rc_font.bottom -= half_padding_size;
 
             utf8_converter.convert(text_ptr, num_characters_remaining);
-            uih::text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_font, false, cr_text, false, false,
+            text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_font, false, cr_text, false, false,
                 uih::ALIGN_LEFT, nullptr, false, false, nullptr, rc_line.left - left_padding);
         }
 

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -57,7 +57,7 @@ const GUID ItemPropertiesColoursClient::g_guid
 
 namespace {
 colours::client::factory<ItemPropertiesColoursClient> g_appearance_client_impl;
-};
+}
 
 void ItemProperties::g_redraw_all()
 {

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -56,7 +56,7 @@ const GUID ItemPropertiesColoursClient::g_guid
     = {0x862f8a37, 0x16e0, 0x4a74, {0xb2, 0x7e, 0x2b, 0x73, 0xdb, 0x56, 0x7d, 0xf}};
 
 namespace {
-cui::colours::client::factory<ItemPropertiesColoursClient> g_appearance_client_impl;
+colours::client::factory<ItemPropertiesColoursClient> g_appearance_client_impl;
 };
 
 void ItemProperties::g_redraw_all()
@@ -76,7 +76,7 @@ LRESULT ItemProperties::MessageWindow::on_message(HWND wnd, UINT msg, WPARAM wp,
     case WM_CREATE:
         break;
     case WM_ACTIVATEAPP:
-        ItemProperties::g_on_app_activate(wp != 0);
+        g_on_app_activate(wp != 0);
         break;
     case WM_DESTROY:
         break;
@@ -190,11 +190,11 @@ void ItemProperties::notify_on_initialisation()
     set_use_dark_mode(dark::is_dark_mode_enabled());
     set_autosize(m_autosizing_columns);
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
     set_font(&lf);
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
     set_header_font(&lf);
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
     set_group_font(&lf);
     set_edge_style(m_edge_style);
     set_show_header(m_show_column_titles);
@@ -207,7 +207,7 @@ void ItemProperties::notify_on_create()
 
     register_callback();
     static_api_ptr_t<play_callback_manager>()->register_callback(
-        this, play_callback::flag_on_playback_stop | play_callback::flag_on_playback_new_track, true);
+        this, flag_on_playback_stop | flag_on_playback_new_track, true);
     static_api_ptr_t<metadb_io_v3>()->register_callback(this);
     refresh_contents();
 
@@ -462,7 +462,7 @@ void ItemProperties::refresh_contents()
     std::vector<MetadataFieldValueAggregator> metadata_aggregators;
     metadata_aggregators.resize(field_count);
 
-    pfc::list_t<uih::ListView::InsertItem> items;
+    pfc::list_t<InsertItem> items;
     t_size i;
     t_size count = m_handles.get_count();
 
@@ -487,7 +487,7 @@ void ItemProperties::refresh_contents()
         auto& field = m_fields[i];
         auto& aggregator = metadata_aggregators[i];
 
-        uih::ListView::InsertItem item(2, 1);
+        InsertItem item(2, 1);
         pfc::string8 temp;
         item.m_subitems[0] = field.m_name_friendly;
         temp.reset();
@@ -533,7 +533,7 @@ void ItemProperties::refresh_contents()
 
     for (auto&& [section, values] : track_properties) {
         for (auto&& value : values) {
-            uih::ListView::InsertItem item(2, 1);
+            InsertItem item(2, 1);
             item.m_subitems[0] = value.m_name;
             item.m_subitems[1] = value.m_value;
             item.m_groups[0] = section.c_str();
@@ -545,15 +545,15 @@ void ItemProperties::refresh_contents()
     t_size new_count = items.get_count();
 
     if (new_count && old_count) {
-        pfc::list_t<uih::ListView::InsertItem> items_replace;
+        pfc::list_t<InsertItem> items_replace;
         items_replace.add_items_fromptr(items.get_ptr(), min(new_count, old_count));
-        uih::ListView::replace_items(0, items_replace);
+        replace_items(0, items_replace);
     }
 
     if (new_count > old_count) {
-        uih::ListView::insert_items(old_count, items.get_count() - old_count, items.get_ptr() + old_count);
+        insert_items(old_count, items.get_count() - old_count, items.get_ptr() + old_count);
     } else if (new_count < old_count) {
-        uih::ListView::remove_items(pfc::bit_array_range(new_count, old_count - new_count));
+        remove_items(bit_array_range(new_count, old_count - new_count));
     }
 
     if (b_redraw)
@@ -641,39 +641,39 @@ void ItemProperties::on_tracking_mode_change()
     refresh_contents();
 }
 
-class ItemsFontClientItemProperties : public cui::fonts::client {
+class ItemsFontClientItemProperties : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_selection_properties_items_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Item properties: Items"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { ItemProperties::g_on_font_items_change(); }
 };
 
-class HeaderFontClientItemProperties : public cui::fonts::client {
+class HeaderFontClientItemProperties : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_selection_properties_header_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Item properties: Column titles"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { ItemProperties::g_on_font_header_change(); }
 };
 
-class GroupClientItemProperties : public cui::fonts::client {
+class GroupClientItemProperties : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_selection_properties_group_font_client; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Item properties: Group titles"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { ItemProperties::g_on_font_groups_change(); }
 };
 void ItemProperties::g_on_font_items_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
     for (auto& window : g_windows) {
         window->set_font(&lf);
     }
@@ -682,7 +682,7 @@ void ItemProperties::g_on_font_items_change()
 void ItemProperties::g_on_font_groups_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
     for (auto& window : g_windows) {
         window->set_group_font(&lf);
     }
@@ -691,7 +691,7 @@ void ItemProperties::g_on_font_groups_change()
 void ItemProperties::g_on_font_header_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
     for (auto& window : g_windows) {
         window->set_header_font(&lf);
     }
@@ -887,7 +887,7 @@ bool ItemProperties::show_config_popup(HWND wnd_parent)
                 m_show_group_titles = dialog.m_show_groups;
                 cfg_selection_poperties_show_group_titles = m_show_group_titles;
 
-                remove_items(pfc::bit_array_true());
+                remove_items(bit_array_true());
                 set_group_count(m_show_group_titles ? 1 : 0);
             }
 
@@ -955,7 +955,7 @@ bool ItemProperties::ModeNodeAutosize::get_description(pfc::string_base& p_out) 
 bool ItemProperties::ModeNodeAutosize::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Auto-sizing columns";
-    p_displayflags = (p_this->m_autosizing_columns) ? ui_extension::menu_node_t::state_checked : 0;
+    p_displayflags = (p_this->m_autosizing_columns) ? state_checked : 0;
     return true;
 }
 
@@ -980,7 +980,7 @@ bool ItemProperties::MenuNodeTrackMode::get_description(pfc::string_base& p_out)
 bool ItemProperties::MenuNodeTrackMode::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = get_name(m_source);
-    p_displayflags = (m_source == p_this->m_tracking_mode) ? ui_extension::menu_node_t::state_radiochecked : 0;
+    p_displayflags = (m_source == p_this->m_tracking_mode) ? state_radiochecked : 0;
     return true;
 }
 

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -19,7 +19,7 @@ public:
     pfc::string8 m_name;
     pfc::string8 m_name_friendly;
 
-    Field(const char* friendly, const char* field) : m_name(field), m_name_friendly(friendly){};
+    Field(const char* friendly, const char* field) : m_name(field), m_name_friendly(friendly) {}
     Field() = default;
 };
 
@@ -46,18 +46,18 @@ class ItemPropertiesColoursClient : public colours::client {
 public:
     static const GUID g_guid;
 
-    const GUID& get_client_guid() const override { return g_guid; };
+    const GUID& get_client_guid() const override { return g_guid; }
 
-    void get_name(pfc::string_base& p_out) const override { p_out = "Item properties"; };
+    void get_name(pfc::string_base& p_out) const override { p_out = "Item properties"; }
 
-    t_size get_supported_colours() const override { return colours::colour_flag_all; }; // bit-mask
+    t_size get_supported_colours() const override { return colours::colour_flag_all; } // bit-mask
 
-    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; }; // bit-mask
-    bool get_themes_supported() const override { return true; };
+    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; } // bit-mask
+    bool get_themes_supported() const override { return true; }
 
     void on_colour_changed(t_size mask) const override;
 
-    void on_bool_changed(t_size mask) const override{};
+    void on_bool_changed(t_size mask) const override {}
 };
 
 class ItemPropertiesConfig {
@@ -124,7 +124,6 @@ public:
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
         MenuNodeTrackMode(ItemProperties* p_wnd, t_size p_value);
-        ;
     };
     class ModeNodeAutosize : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemProperties> p_this;
@@ -134,7 +133,6 @@ public:
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
         ModeNodeAutosize(ItemProperties* p_wnd);
-        ;
     };
     class MenuNodeSourcePopup : public ui_extension::menu_node_popup_t {
         pfc::list_t<ui_extension::menu_node_ptr> m_items;
@@ -144,7 +142,6 @@ public:
         unsigned get_children_count() const override;
         void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override;
         MenuNodeSourcePopup(ItemProperties* p_wnd);
-        ;
     };
 
     void get_menu_items(ui_extension::menu_hook_t& p_hook) override;

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -29,7 +29,7 @@ public:
     pfc::list_t<Field>& m_fields;
     FieldsList(pfc::list_t<Field>& p_fields);
 
-    void get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& items);
+    void get_insert_items(t_size base, t_size count, pfc::list_t<InsertItem>& items);
     void notify_on_create() override;
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse) override;
@@ -42,7 +42,7 @@ private:
 
 t_size g_get_info_section_id_by_name(const char* p_name);
 
-class ItemPropertiesColoursClient : public cui::colours::client {
+class ItemPropertiesColoursClient : public colours::client {
 public:
     static const GUID g_guid;
 
@@ -50,12 +50,9 @@ public:
 
     void get_name(pfc::string_base& p_out) const override { p_out = "Item properties"; };
 
-    t_size get_supported_colours() const override { return cui::colours::colour_flag_all; }; // bit-mask
+    t_size get_supported_colours() const override { return colours::colour_flag_all; }; // bit-mask
 
-    t_size get_supported_bools() const override
-    {
-        return cui::colours::bool_flag_use_custom_active_item_frame;
-    }; // bit-mask
+    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; }; // bit-mask
     bool get_themes_supported() const override { return true; };
 
     void on_colour_changed(t_size mask) const override;

--- a/foo_ui_columns/item_properties_config.cpp
+++ b/foo_ui_columns/item_properties_config.cpp
@@ -137,7 +137,7 @@ BOOL CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
         } break;
         case IDC_REMOVE: {
             if (m_field_list.get_selection_count(2) == 1) {
-                pfc::bit_array_bittable mask(m_field_list.get_item_count());
+                bit_array_bittable mask(m_field_list.get_item_count());
                 m_field_list.get_selection_state(mask);
                 // bool b_found = false;
                 t_size index = 0;

--- a/foo_ui_columns/item_properties_config_list_view.cpp
+++ b/foo_ui_columns/item_properties_config_list_view.cpp
@@ -7,7 +7,7 @@ void FieldsList::notify_save_inline_edit(const char* value)
 {
     if (m_edit_index < m_fields.get_count()) {
         (m_edit_column ? m_fields[m_edit_index].m_name : m_fields[m_edit_index].m_name_friendly) = value;
-        pfc::list_t<uih::ListView::SizedInsertItem<2, 0>> items;
+        pfc::list_t<SizedInsertItem<2, 0>> items;
         items.set_count(1);
         items[0].m_subitems[0] = m_fields[m_edit_index].m_name_friendly;
         items[0].m_subitems[1] = m_fields[m_edit_index].m_name;
@@ -44,15 +44,15 @@ bool FieldsList::notify_before_create_inline_edit(
 void FieldsList::notify_on_create()
 {
     set_single_selection(true);
-    uih::ListView::set_columns({{"Name", 150}, {"Field", 150}});
+    set_columns({{"Name", 150}, {"Field", 150}});
 
     t_size count = m_fields.get_count();
-    pfc::list_t<uih::ListView::InsertItem> items;
+    pfc::list_t<InsertItem> items;
     get_insert_items(0, count, items);
     insert_items(0, count, items.get_ptr());
 }
 
-void FieldsList::get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& items)
+void FieldsList::get_insert_items(t_size base, t_size count, pfc::list_t<InsertItem>& items)
 {
     items.set_count(count);
     for (t_size i = 0; i < count; i++) {

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -225,16 +225,16 @@ bool LayoutWindow::get_layout_editing_active()
 void LayoutWindow::enter_layout_editing_mode()
 {
     if (get_wnd()) {
-        uih::register_message_hook(uih::MessageHookType::type_get_message, this);
-        uih::register_message_hook(uih::MessageHookType::type_mouse, this);
+        register_message_hook(uih::MessageHookType::type_get_message, this);
+        register_message_hook(uih::MessageHookType::type_mouse, this);
     }
     //__enter_layout_editing_mode_recur(m_child);
 }
 
 void LayoutWindow::exit_layout_editing_mode()
 {
-    uih::deregister_message_hook(uih::MessageHookType::type_get_message, this);
-    uih::deregister_message_hook(uih::MessageHookType::type_mouse, this);
+    deregister_message_hook(uih::MessageHookType::type_get_message, this);
+    deregister_message_hook(uih::MessageHookType::type_mouse, this);
     //__exit_layout_editing_mode_recur(m_child);
 }
 
@@ -619,7 +619,7 @@ void LayoutWindow::run_live_edit_base(const LiveEditData& p_data)
     HMENU menu = CreatePopupMenu();
     PanelList panel_list;
     pfc::list_t<uie::window::ptr> supported_panels(panel_list);
-    pfc::bit_array_bittable mask_remove(supported_panels.get_count());
+    bit_array_bittable mask_remove(supported_panels.get_count());
     if (p_container_v2.is_valid())
         p_container_v2->get_supported_panels(supported_panels, mask_remove);
     supported_panels.remove_mask(mask_remove);
@@ -938,8 +938,8 @@ LRESULT LayoutWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 #endif
     case WM_DESTROY:
         destroy_child();
-        uih::deregister_message_hook(uih::MessageHookType::type_get_message, this);
-        uih::deregister_message_hook(uih::MessageHookType::type_mouse, this);
+        deregister_message_hook(uih::MessageHookType::type_get_message, this);
+        deregister_message_hook(uih::MessageHookType::type_mouse, this);
         break;
     }
     return DefWindowProc(wnd, msg, wp, lp);

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -562,7 +562,7 @@ public:
         while (e.next(l)) {
             add_item(l);
         }
-    };
+    }
 };
 
 void g_get_panels_info(const pfc::list_t<uie::window::ptr>& p_panels, uie::window_info_list_simple& p_out)

--- a/foo_ui_columns/layout_config.cpp
+++ b/foo_ui_columns/layout_config.cpp
@@ -208,7 +208,8 @@ ConfigLayout::Preset preset_to_config_preset(Preset preset)
 ConfigLayout::ConfigLayout(const GUID& p_guid)
     : cfg_var(p_guid)
     , m_active(0) //, m_initialised(false)
-    {};
+{
+}
 
 void ConfigLayout::Preset::write(stream_writer* out, abort_callback& p_abort)
 {

--- a/foo_ui_columns/layout_config.cpp
+++ b/foo_ui_columns/layout_config.cpp
@@ -17,141 +17,141 @@ struct Preset {
 
 // clang-format off
 const Preset default_preset = {"Default",
-    {columns_ui::panels::guid_horizontal_splitter, {
-        {columns_ui::panels::guid_vertical_splitter, {
-            {columns_ui::panels::guid_playlist_switcher},
+    {panels::guid_horizontal_splitter, {
+        {panels::guid_vertical_splitter, {
+            {panels::guid_playlist_switcher},
         }, true},
-        {columns_ui::panels::guid_vertical_splitter, {
-            {columns_ui::panels::guid_playlist_view_v2},
+        {panels::guid_vertical_splitter, {
+            {panels::guid_playlist_view_v2},
         }},
     }}
 };
 
 const std::array<Preset, 10> quick_setup_presets = {{
     {"Playlist switcher",
-        {columns_ui::panels::guid_horizontal_splitter, {
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_playlist_switcher},
+        {panels::guid_horizontal_splitter, {
+            {panels::guid_vertical_splitter, {
+                {panels::guid_playlist_switcher},
             }, true},
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_playlist_view_v2},
+            {panels::guid_vertical_splitter, {
+                {panels::guid_playlist_view_v2},
             }},
         }}
     },
     {"Playlist switcher + Filters",
-        {columns_ui::panels::guid_horizontal_splitter, {
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_playlist_switcher},
+        {panels::guid_horizontal_splitter, {
+            {panels::guid_vertical_splitter, {
+                {panels::guid_playlist_switcher},
             }, true},
-            {columns_ui::panels::guid_vertical_splitter,{
-                {columns_ui::panels::guid_horizontal_splitter, {
-                    {columns_ui::panels::guid_filter},
-                    {columns_ui::panels::guid_filter},
-                    {columns_ui::panels::guid_filter},
+            {panels::guid_vertical_splitter,{
+                {panels::guid_horizontal_splitter, {
+                    {panels::guid_filter},
+                    {panels::guid_filter},
+                    {panels::guid_filter},
                 }, true},
-                {columns_ui::panels::guid_playlist_view_v2},
+                {panels::guid_playlist_view_v2},
             }},
         }}
     },
     {"Playlist switcher + Artwork",
-        {columns_ui::panels::guid_horizontal_splitter, {
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_playlist_switcher},
-                {columns_ui::panels::guid_artwork_view, {}, true}
+        {panels::guid_horizontal_splitter, {
+            {panels::guid_vertical_splitter, {
+                {panels::guid_playlist_switcher},
+                {panels::guid_artwork_view, {}, true}
             }, true},
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_playlist_view_v2},
+            {panels::guid_vertical_splitter, {
+                {panels::guid_playlist_view_v2},
             }},
         }}
     },
     {"Playlist switcher + Artwork + Filters",
-        {columns_ui::panels::guid_horizontal_splitter, {
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_playlist_switcher},
-                {columns_ui::panels::guid_artwork_view, {}, true}
+        {panels::guid_horizontal_splitter, {
+            {panels::guid_vertical_splitter, {
+                {panels::guid_playlist_switcher},
+                {panels::guid_artwork_view, {}, true}
             }, true},
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_horizontal_splitter, {
-                    {columns_ui::panels::guid_filter},
-                    {columns_ui::panels::guid_filter},
-                    {columns_ui::panels::guid_filter},
+            {panels::guid_vertical_splitter, {
+                {panels::guid_horizontal_splitter, {
+                    {panels::guid_filter},
+                    {panels::guid_filter},
+                    {panels::guid_filter},
                 }, true},
-                {columns_ui::panels::guid_playlist_view_v2},
+                {panels::guid_playlist_view_v2},
             }},
         }}
     },
     {"Playlist switcher + Item details + Artwork ",
-        {columns_ui::panels::guid_horizontal_splitter, {
-            {columns_ui::panels::guid_vertical_splitter, {{columns_ui::panels::guid_playlist_switcher}}, true},
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_playlist_view_v2},
-                {columns_ui::panels::guid_horizontal_splitter, {
-                    {columns_ui::panels::guid_item_details},
-                    {columns_ui::panels::guid_artwork_view, {}, true, 125},
+        {panels::guid_horizontal_splitter, {
+            {panels::guid_vertical_splitter, {{panels::guid_playlist_switcher}}, true},
+            {panels::guid_vertical_splitter, {
+                {panels::guid_playlist_view_v2},
+                {panels::guid_horizontal_splitter, {
+                    {panels::guid_item_details},
+                    {panels::guid_artwork_view, {}, true, 125},
                 }, true, 125},
             }},
         }}
     },
     {"Playlist switcher + Filters + Item details + Artwork ",
-        {columns_ui::panels::guid_horizontal_splitter, {
-            {columns_ui::panels::guid_vertical_splitter, {{columns_ui::panels::guid_playlist_switcher}}, true},
-            {columns_ui::panels::guid_vertical_splitter, {
-                {columns_ui::panels::guid_horizontal_splitter, {
-                    {columns_ui::panels::guid_filter},
-                    {columns_ui::panels::guid_filter},
-                    {columns_ui::panels::guid_filter},
+        {panels::guid_horizontal_splitter, {
+            {panels::guid_vertical_splitter, {{panels::guid_playlist_switcher}}, true},
+            {panels::guid_vertical_splitter, {
+                {panels::guid_horizontal_splitter, {
+                    {panels::guid_filter},
+                    {panels::guid_filter},
+                    {panels::guid_filter},
                 }, true},
-                {columns_ui::panels::guid_playlist_view_v2},
-                {columns_ui::panels::guid_horizontal_splitter, {
-                    {columns_ui::panels::guid_item_details},
-                    {columns_ui::panels::guid_artwork_view, {}, true, 125},
+                {panels::guid_playlist_view_v2},
+                {panels::guid_horizontal_splitter, {
+                    {panels::guid_item_details},
+                    {panels::guid_artwork_view, {}, true, 125},
                 }, true, 125},
             }},
         }}
     },
     {"Playlist tabs",
-        {columns_ui::panels::guid_vertical_splitter, {
-            {columns_ui::panels::guid_playlist_tabs, {
-                {columns_ui::panels::guid_playlist_view_v2},
+        {panels::guid_vertical_splitter, {
+            {panels::guid_playlist_tabs, {
+                {panels::guid_playlist_view_v2},
             }},
         }}
     },
     {"Playlist tabs + Filters",
-        {columns_ui::panels::guid_vertical_splitter, {
-            {columns_ui::panels::guid_horizontal_splitter, {
-                {columns_ui::panels::guid_filter},
-                {columns_ui::panels::guid_filter},
-                {columns_ui::panels::guid_filter},
+        {panels::guid_vertical_splitter, {
+            {panels::guid_horizontal_splitter, {
+                {panels::guid_filter},
+                {panels::guid_filter},
+                {panels::guid_filter},
             }, true},
-            {columns_ui::panels::guid_playlist_tabs, {
-                {columns_ui::panels::guid_playlist_view_v2},
+            {panels::guid_playlist_tabs, {
+                {panels::guid_playlist_view_v2},
             }},
         }}
     },
     {"Playlist tabs + Item details + Artwork",
-        {columns_ui::panels::guid_vertical_splitter, {
-            {columns_ui::panels::guid_playlist_tabs, {
-                {columns_ui::panels::guid_playlist_view_v2},
+        {panels::guid_vertical_splitter, {
+            {panels::guid_playlist_tabs, {
+                {panels::guid_playlist_view_v2},
             }},
-            {columns_ui::panels::guid_horizontal_splitter, {
-                {columns_ui::panels::guid_item_details},
-                {columns_ui::panels::guid_artwork_view, {}, true, 125},
+            {panels::guid_horizontal_splitter, {
+                {panels::guid_item_details},
+                {panels::guid_artwork_view, {}, true, 125},
             }, true, 125},
         }}
     },
     {"Playlist tabs + Filters + Item details + Artwork",
-        {columns_ui::panels::guid_vertical_splitter, {
-            {columns_ui::panels::guid_horizontal_splitter, {
-                {columns_ui::panels::guid_filter},
-                {columns_ui::panels::guid_filter},
-                {columns_ui::panels::guid_filter},
+        {panels::guid_vertical_splitter, {
+            {panels::guid_horizontal_splitter, {
+                {panels::guid_filter},
+                {panels::guid_filter},
+                {panels::guid_filter},
             }, true},
-            {columns_ui::panels::guid_playlist_tabs, {
-                {columns_ui::panels::guid_playlist_view_v2},
+            {panels::guid_playlist_tabs, {
+                {panels::guid_playlist_view_v2},
             }},
-            {columns_ui::panels::guid_horizontal_splitter, {
-                {columns_ui::panels::guid_item_details},
-                {columns_ui::panels::guid_artwork_view, {}, true, 125},
+            {panels::guid_horizontal_splitter, {
+                {panels::guid_item_details},
+                {panels::guid_artwork_view, {}, true, 125},
             }, true, 125},
         }}
     },
@@ -269,7 +269,7 @@ t_size ConfigLayout::add_preset(const char* p_name, t_size len)
 {
     Preset temp;
     temp.m_name.set_string(p_name, len);
-    temp.m_guid = columns_ui::panels::guid_playlist_view_v2;
+    temp.m_guid = cui::panels::guid_playlist_view_v2;
     return m_presets.add_item(temp);
 }
 void ConfigLayout::save_active_preset()

--- a/foo_ui_columns/legacy_artwork_config.cpp
+++ b/foo_ui_columns/legacy_artwork_config.cpp
@@ -45,7 +45,7 @@ void prompt_to_reconfigure()
 {
     if (any_legacy_sources() && !has_been_asked_to_reconfigure) {
         has_been_asked_to_reconfigure = true;
-        cui::prefs::page_main.get_static_instance().show_tab("Artwork");
+        prefs::page_main.get_static_instance().show_tab("Artwork");
     }
 }
 

--- a/foo_ui_columns/legacy_artwork_config.h
+++ b/foo_ui_columns/legacy_artwork_config.h
@@ -8,10 +8,10 @@ extern cfg_objList<pfc::string8> cfg_disc_scripts;
 extern cfg_objList<pfc::string8> cfg_artist_scripts;
 
 constexpr auto legacy_sources = {
-    std::make_tuple(&cui::artwork::legacy::cfg_front_scripts, "Front cover"),
-    std::make_tuple(&cui::artwork::legacy::cfg_back_scripts, "Back cover"),
-    std::make_tuple(&cui::artwork::legacy::cfg_disc_scripts, "Disc cover"),
-    std::make_tuple(&cui::artwork::legacy::cfg_artist_scripts, "Artist picture"),
+    std::make_tuple(&cfg_front_scripts, "Front cover"),
+    std::make_tuple(&cfg_back_scripts, "Back cover"),
+    std::make_tuple(&cfg_disc_scripts, "Disc cover"),
+    std::make_tuple(&cfg_artist_scripts, "Artist picture"),
 };
 
 bool any_legacy_sources();

--- a/foo_ui_columns/legacy_config.cpp
+++ b/foo_ui_columns/legacy_config.cpp
@@ -15,21 +15,21 @@ class LegacyPlaylistViewColoursClient : public cui::colours::client {
 public:
     static const GUID g_guid;
 
-    const GUID& get_client_guid() const override { return g_guid; };
+    const GUID& get_client_guid() const override { return g_guid; }
 
-    void get_name(pfc::string_base& p_out) const override { p_out = "Legacy playlist"; };
+    void get_name(pfc::string_base& p_out) const override { p_out = "Legacy playlist"; }
 
-    t_size get_supported_colours() const override { return cui::colours::colour_flag_all; }; // bit-mask
+    t_size get_supported_colours() const override { return cui::colours::colour_flag_all; } // bit-mask
 
     t_size get_supported_bools() const override
     {
         return cui::colours::bool_flag_use_custom_active_item_frame;
-    }; // bit-mask
-    bool get_themes_supported() const override { return true; };
+    } // bit-mask
+    bool get_themes_supported() const override { return true; }
 
-    void on_colour_changed(t_size mask) const override{};
+    void on_colour_changed(t_size mask) const override {}
 
-    void on_bool_changed(t_size mask) const override{};
+    void on_bool_changed(t_size mask) const override {}
 };
 
 // {0CF29D60-1262-4f55-A6E1-BC4AE6579D19}

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -33,7 +33,7 @@ public:
     }
 
     bool is_available(const uie::window_host_ptr&) const override { return true; }
-    HWND get_wnd() const override { return uih::ListView::get_wnd(); }
+    HWND get_wnd() const override { return ListView::get_wnd(); }
 
     const uie::window_host_ptr& get_host() const { return m_window_host; }
 

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -6,7 +6,9 @@ class ListViewPanelBase
     , public t_window {
 public:
     ListViewPanelBase(std::unique_ptr<uih::lv::RendererBase> renderer = std::make_unique<uih::lv::DefaultRenderer>())
-        : ListView(std::move(renderer)){};
+        : ListView(std::move(renderer))
+    {
+    }
 
     HWND create_or_transfer_window(
         HWND parent, const uie::window_host_ptr& host, const ui_helpers::window_position_t& p_position) override

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -353,48 +353,51 @@ public:
             set_part_sizes(cui::status_bar::t_part_length);
         }
     }
-    void on_items_reordered(const unsigned* order,
-        unsigned count) override{}; // changes selection too; doesnt actually change set of items that are selected or
-                                    // item having focus, just changes their order
-    void FB2KAPI on_items_removing(const bit_array& p_mask, unsigned p_old_count,
-        unsigned p_new_count) override{}; // called before actually removing them
+    void on_items_reordered(const unsigned* order, unsigned count) override {
+    } // changes selection too; doesnt actually change set of items that are selected or
+      // item having focus, just changes their order
+    void FB2KAPI on_items_removing(const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override {
+    } // called before actually removing them
     void FB2KAPI on_items_removed(const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override
     {
         if (cui::main_window.get_wnd()) {
             set_part_sizes(cui::status_bar::t_part_length);
         }
-    };
+    }
     void on_items_selection_change(const bit_array& affected, const bit_array& state) override
     {
         if (cui::main_window.get_wnd()) {
             set_part_sizes(cui::status_bar::t_part_length);
         }
     }
-    void on_item_focus_change(unsigned from, unsigned to)
-        override{}; // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
+    void on_item_focus_change(unsigned from, unsigned to) override {
+    } // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
     void FB2KAPI on_items_modified(const bit_array& p_mask) override {}
-    void FB2KAPI on_items_modified_fromplayback(
-        const bit_array& p_mask, play_control::t_display_level p_level) override{};
+    void FB2KAPI on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override
+    {
+    }
     void on_items_replaced(const bit_array& p_mask,
-        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override{};
-    void on_item_ensure_visible(unsigned idx) override{};
+        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override
+    {
+    }
+    void on_item_ensure_visible(unsigned idx) override {}
 
     void on_playlist_switch() override
     {
         if (cui::main_window.get_wnd()) {
             set_part_sizes(cui::status_bar::t_parts_all);
         }
-    };
-    void on_playlist_renamed(const char* p_new_name, unsigned p_new_name_len) override{};
+    }
+    void on_playlist_renamed(const char* p_new_name, unsigned p_new_name_len) override {}
     void on_playlist_locked(bool p_locked) override
     {
         if (cui::main_window.get_wnd())
             if (g_status && main_window::config_get_status_show_lock())
                 set_part_sizes(cui::status_bar::t_parts_all);
-    };
+    }
 
-    void on_default_format_changed() override{};
-    void on_playback_order_changed(unsigned p_new_index) override{};
+    void on_default_format_changed() override {}
+    void on_playback_order_changed(unsigned p_new_index) override {}
 
     unsigned get_flags() override { return flag_all; }
 };

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -92,7 +92,7 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook)
         | WS_CLIPSIBLINGS | WS_THICKFRAME;
 
     m_wnd = CreateWindowEx(ex_styles, main_window_class_name, _T("foobar2000"), styles, left, top, cx, cy, nullptr,
-        nullptr, core_api::get_my_instance(), &cui::main_window);
+        nullptr, core_api::get_my_instance(), &main_window);
 
     main_window::on_transparency_enabled_change();
 
@@ -125,7 +125,7 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook)
 
     main_window::config_set_is_first_run();
 
-    fb2k::inMainThread(cui::artwork::legacy::prompt_to_reconfigure);
+    fb2k::inMainThread(artwork::legacy::prompt_to_reconfigure);
 
     return m_wnd;
 }
@@ -134,13 +134,13 @@ void cui::MainWindow::shutdown()
 {
     DestroyWindow(m_wnd);
     UnregisterClass(main_window_class_name, core_api::get_my_instance());
-    cui::status_bar::volume_popup_window.class_release();
+    status_bar::volume_popup_window.class_release();
     m_wnd = nullptr;
     g_status = nullptr;
     if (g_icon)
         DestroyIcon(g_icon);
     g_icon = nullptr;
-    cui::status_bar::destroy_icon();
+    status_bar::destroy_icon();
 }
 
 void cui::MainWindow::on_query_capability()
@@ -237,8 +237,7 @@ void cui::MainWindow::on_create()
     InitCommonControlsEx(&icex);
 
     Gdiplus::GdiplusStartupInput gdiplusStartupInput{};
-    m_gdiplus_initialised
-        = (Gdiplus::Ok == Gdiplus::GdiplusStartup(&m_gdiplus_instance, &gdiplusStartupInput, nullptr));
+    m_gdiplus_initialised = (Gdiplus::Ok == GdiplusStartup(&m_gdiplus_instance, &gdiplusStartupInput, nullptr));
 
     if (dark::is_dark_mode_enabled()) {
         dark::enable_dark_mode_for_app();
@@ -318,7 +317,7 @@ void cui::MainWindow::resize_child_windows()
             EndDeferWindowPos(dwp);
 
             if (g_status) {
-                cui::status_bar::set_part_sizes(cui::status_bar::t_parts_none);
+                set_part_sizes(status_bar::t_parts_none);
             }
         }
     }
@@ -346,44 +345,44 @@ bool process_keydown(UINT msg, LPARAM lp, WPARAM wp, bool playlist, bool keyb)
 class MainWindowPlaylistCallback : public playlist_callback_single_static {
 public:
     void on_items_added(
-        unsigned start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const pfc::bit_array& p_selection)
+        unsigned start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
         override // inside any of these methods, you can call IPlaylist APIs to get exact info about what happened (but
                  // only methods that read playlist state, not those that modify it)
     {
         if (cui::main_window.get_wnd()) {
-            cui::status_bar::set_part_sizes(cui::status_bar::t_part_length);
+            set_part_sizes(cui::status_bar::t_part_length);
         }
     }
     void on_items_reordered(const unsigned* order,
         unsigned count) override{}; // changes selection too; doesnt actually change set of items that are selected or
                                     // item having focus, just changes their order
-    void FB2KAPI on_items_removing(const pfc::bit_array& p_mask, unsigned p_old_count,
+    void FB2KAPI on_items_removing(const bit_array& p_mask, unsigned p_old_count,
         unsigned p_new_count) override{}; // called before actually removing them
-    void FB2KAPI on_items_removed(const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override
+    void FB2KAPI on_items_removed(const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override
     {
         if (cui::main_window.get_wnd()) {
-            cui::status_bar::set_part_sizes(cui::status_bar::t_part_length);
+            set_part_sizes(cui::status_bar::t_part_length);
         }
     };
-    void on_items_selection_change(const pfc::bit_array& affected, const pfc::bit_array& state) override
+    void on_items_selection_change(const bit_array& affected, const bit_array& state) override
     {
         if (cui::main_window.get_wnd()) {
-            cui::status_bar::set_part_sizes(cui::status_bar::t_part_length);
+            set_part_sizes(cui::status_bar::t_part_length);
         }
     }
     void on_item_focus_change(unsigned from, unsigned to)
         override{}; // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
-    void FB2KAPI on_items_modified(const pfc::bit_array& p_mask) override {}
+    void FB2KAPI on_items_modified(const bit_array& p_mask) override {}
     void FB2KAPI on_items_modified_fromplayback(
-        const pfc::bit_array& p_mask, play_control::t_display_level p_level) override{};
-    void on_items_replaced(const pfc::bit_array& p_mask,
+        const bit_array& p_mask, play_control::t_display_level p_level) override{};
+    void on_items_replaced(const bit_array& p_mask,
         const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override{};
     void on_item_ensure_visible(unsigned idx) override{};
 
     void on_playlist_switch() override
     {
         if (cui::main_window.get_wnd()) {
-            cui::status_bar::set_part_sizes(cui::status_bar::t_parts_all);
+            set_part_sizes(cui::status_bar::t_parts_all);
         }
     };
     void on_playlist_renamed(const char* p_new_name, unsigned p_new_name_len) override{};
@@ -391,13 +390,13 @@ public:
     {
         if (cui::main_window.get_wnd())
             if (g_status && main_window::config_get_status_show_lock())
-                cui::status_bar::set_part_sizes(cui::status_bar::t_parts_all);
+                set_part_sizes(cui::status_bar::t_parts_all);
     };
 
     void on_default_format_changed() override{};
     void on_playback_order_changed(unsigned p_new_index) override{};
 
-    unsigned get_flags() override { return playlist_callback_single::flag_all; }
+    unsigned get_flags() override { return flag_all; }
 };
 static service_factory_single_t<MainWindowPlaylistCallback> asdf2;
 

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -20,7 +20,7 @@ enum ColourID {
     COLOUR_SELECTED_TEXT_NO_FOCUS,
     COLOUR_FRAME,
 };
-};
+}
 
 COLORREF get_default_colour(colours::ColourID index, bool themed = false);
 

--- a/foo_ui_columns/menu_helpers.cpp
+++ b/foo_ui_columns/menu_helpers.cpp
@@ -319,4 +319,4 @@ std::string mainpath_from_guid(GUID p_guid, GUID p_subguid, bool b_short)
     }
     return "Unknown command";
 }
-}; // namespace menu_helpers
+} // namespace menu_helpers

--- a/foo_ui_columns/menu_helpers.h
+++ b/foo_ui_columns/menu_helpers.h
@@ -21,7 +21,7 @@ bool maingroupname_from_guid(GUID p_guid, pfc::string_base& p_out, GUID& parento
 bool mainmenunode_subguid_to_path(
     const mainmenu_node::ptr& ptr_node, const GUID& p_subguid, pfc::string8& p_out, bool b_is_root = false);
 std::string mainpath_from_guid(GUID p_guid, GUID p_subguid, bool b_short = false);
-}; // namespace menu_helpers
+} // namespace menu_helpers
 
 struct MenuItemIdentifier {
     GUID m_command{};

--- a/foo_ui_columns/menu_items.cpp
+++ b/foo_ui_columns/menu_items.cpp
@@ -50,26 +50,26 @@ static const MainMenuCommand activate_now_playing{activate_now_playing_id, "Acti
 
 static const MainMenuCommand show_groups{show_groups_id, "Show groups", "Shows or hides playlist view groups.",
     [] {
-        cui::panels::playlist_view::cfg_grouping = !cui::panels::playlist_view::cfg_grouping;
-        cui::panels::playlist_view::PlaylistView::g_on_groups_change();
+        panels::playlist_view::cfg_grouping = !panels::playlist_view::cfg_grouping;
+        panels::playlist_view::PlaylistView::g_on_groups_change();
     },
-    [] { return static_cast<bool>(cui::panels::playlist_view::cfg_grouping); }};
+    [] { return static_cast<bool>(panels::playlist_view::cfg_grouping); }};
 
 static const MainMenuCommand show_artwork{show_artwork_id, "Show artwork",
     "Shows or hides playlist view artwork in groups.",
     [] {
-        cui::panels::playlist_view::cfg_show_artwork = !cui::panels::playlist_view::cfg_show_artwork;
-        cui::panels::playlist_view::PlaylistView::g_on_show_artwork_change();
+        panels::playlist_view::cfg_show_artwork = !panels::playlist_view::cfg_show_artwork;
+        panels::playlist_view::PlaylistView::g_on_show_artwork_change();
     },
-    [] { return cui::panels::playlist_view::cfg_show_artwork.get(); }};
+    [] { return panels::playlist_view::cfg_show_artwork.get(); }};
 
 static const MainMenuCommand decrease_font{
     {0xf2bc9f43, 0xf709, 0x4f6f, {0x9c, 0x65, 0x78, 0x73, 0x3b, 0x8, 0xc7, 0x77}}, "Decrease font size",
-    "Decreases the playlist view font size.", [] { cui::panels::playlist_view::set_font_size(false); }};
+    "Decreases the playlist view font size.", [] { panels::playlist_view::set_font_size(false); }};
 
 static const MainMenuCommand increase_font{
     {0x8553d7fd, 0xebc5, 0x4ae7, {0xaa, 0x28, 0xb2, 0x6, 0xfe, 0x94, 0xa0, 0xb4}}, "Increase font size",
-    "Increases the playlist font size.", [] { cui::panels::playlist_view::set_font_size(true); }};
+    "Increases the playlist font size.", [] { panels::playlist_view::set_font_size(true); }};
 
 static const MainMenuCommand show_status_bar{
     {0x5f944522, 0x843b, 0x43d2, {0x87, 0x14, 0xe3, 0xca, 0x1b, 0x78, 0x2b, 0x1f}}, "Show status bar",
@@ -196,7 +196,7 @@ class MainMenuLayoutPresets : public mainmenu_commands {
     bool get_display(t_uint32 p_index, pfc::string_base& p_text, t_uint32& p_flags) override
     {
         if (g_layout_window.get_wnd()) {
-            p_flags = p_index == cfg_layout.get_active() ? mainmenu_commands::flag_checked : 0;
+            p_flags = p_index == cfg_layout.get_active() ? flag_checked : 0;
             get_name(p_index, p_text);
             return true;
         }
@@ -211,7 +211,7 @@ class MainMenuLayoutPresets : public mainmenu_commands {
     }
 
     GUID get_parent() override { return groups::view_layout_presets; }
-    t_uint32 get_sort_priority() override { return mainmenu_commands::sort_priority_dontcare; }
+    t_uint32 get_sort_priority() override { return sort_priority_dontcare; }
 };
 static mainmenu_commands_factory_t<MainMenuLayoutPresets> mainmenu_commands_layout_presets;
 } // namespace commands

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -114,7 +114,7 @@ public:
 
     bool on_menuchar(unsigned short chr) override;
 
-    unsigned get_type() const override { return ui_extension::type_toolbar; };
+    unsigned get_type() const override { return ui_extension::type_toolbar; }
 
     bool is_menu_focused() const override;
     HWND get_previous_focus_window() const override;
@@ -125,7 +125,7 @@ public:
 
 bool MenuToolbar::hooked = false;
 
-MenuToolbar::MenuToolbar() : p_manager(nullptr){};
+MenuToolbar::MenuToolbar() : p_manager(nullptr) {}
 
 MenuToolbar::~MenuToolbar() = default;
 

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -419,7 +419,7 @@ void MenuToolbar::make_menu(unsigned idx)
 
     hooked = true;
     //    p_hooked_menu = this;
-    uih::register_message_hook(uih::MessageHookType::type_message_filter, this);
+    register_message_hook(uih::MessageHookType::type_message_filter, this);
     // msghook = uSetWindowsHookEx(WH_MSGFILTER, menu_hook_t_proc, 0, GetCurrentThreadId());
     service_ptr_t<mainmenu_manager> p_menu = standard_api_create_t<mainmenu_manager>();
 
@@ -499,7 +499,7 @@ void MenuToolbar::make_menu(unsigned idx)
     }
 
     // UnhookWindowsHookEx(msghook); // hook may not be freed instantly, so dont make msghook = 0
-    uih::deregister_message_hook(uih::MessageHookType::type_message_filter, this);
+    deregister_message_hook(uih::MessageHookType::type_message_filter, this);
     hooked = false;
     // p_hooked_menu=0;
 

--- a/foo_ui_columns/migrate.cpp
+++ b/foo_ui_columns/migrate.cpp
@@ -8,8 +8,8 @@ cfg_bool has_migrated_to_v100({0xba7516e5, 0xd1f1, 0x4784, {0xa6, 0x93, 0x62, 0x
 bool replace_legacy_playlist(uie::splitter_item_t* splitter_item)
 {
 #pragma warning(suppress : 4996)
-    if (splitter_item->get_panel_guid() == cui::panels::guid_playlist_view) {
-        splitter_item->set_panel_guid(cui::panels::guid_playlist_view_v2);
+    if (splitter_item->get_panel_guid() == panels::guid_playlist_view) {
+        splitter_item->set_panel_guid(panels::guid_playlist_view_v2);
         return true;
     }
 

--- a/foo_ui_columns/mw_drop_target.cpp
+++ b/foo_ui_columns/mw_drop_target.cpp
@@ -75,7 +75,7 @@ HRESULT STDMETHODCALLTYPE MainWindowDropTarget::Drop(
 
         playlist_api->activeplaylist_undo_backup();
         playlist_api->activeplaylist_clear_selection();
-        playlist_api->activeplaylist_insert_items(idx, data, pfc::bit_array_true());
+        playlist_api->activeplaylist_insert_items(idx, data, bit_array_true());
 
         data.remove_all();
     }

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -155,7 +155,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (!uih::are_keyboard_cues_enabled())
             SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_INITIALIZE, UISF_HIDEFOCUS), NULL);
 
-        cui::status_bar::statusbartext = core_version_info::g_get_version_string();
+        status_bar::statusbartext = core_version_info::g_get_version_string();
         set_title(core_version_info_v2::get()->get_name());
         if (cfg_show_systray)
             create_systray_icon();
@@ -180,7 +180,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             DeregisterShellHookWindow(wnd);
 
         rebar::destroy_rebar(false);
-        cui::status_bar::destroy_window();
+        status_bar::destroy_window();
         m_taskbar_list.reset();
         RevokeDragDrop(m_wnd);
         destroy_systray_icon();
@@ -192,7 +192,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             ImageList_Destroy(g_imagelist_taskbar);
         break;
     case WM_CLOSE:
-        if (cui::config::advbool_close_to_notification_icon.get()) {
+        if (config::advbool_close_to_notification_icon.get()) {
             cfg_go_to_tray = true;
             ShowWindow(wnd, SW_MINIMIZE);
         } else
@@ -232,7 +232,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     contextmenu_node* node
                         = statusbar_contextmenus::g_main_nowplaying->find_by_id(id - statusbar_contextmenus::ID_BASE);
                     if (node)
-                        set = node->get_description(cui::status_bar::menudesc);
+                        set = node->get_description(status_bar::menudesc);
                 }
 
                 if (systray_contextmenus::g_main_nowplaying.is_valid() && id < systray_contextmenus::ID_BASE_FILE_PREFS
@@ -240,18 +240,18 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     contextmenu_node* node = systray_contextmenus::g_main_nowplaying->find_by_id(
                         id - systray_contextmenus::ID_NOW_PLAYING_BASE);
                     if (node)
-                        set = node->get_description(cui::status_bar::menudesc);
+                        set = node->get_description(status_bar::menudesc);
                 } else if (systray_contextmenus::g_menu_file_prefs.is_valid()
                     && id < systray_contextmenus::ID_BASE_FILE_EXIT) {
                     set = systray_contextmenus::g_menu_file_prefs->get_description(
-                        id - systray_contextmenus::ID_BASE_FILE_PREFS, cui::status_bar::menudesc);
+                        id - systray_contextmenus::ID_BASE_FILE_PREFS, status_bar::menudesc);
                 } else if (systray_contextmenus::g_menu_file_exit.is_valid()
                     && id < systray_contextmenus::ID_BASE_PLAYBACK) {
                     set = systray_contextmenus::g_menu_file_exit->get_description(
-                        id - systray_contextmenus::ID_BASE_FILE_EXIT, cui::status_bar::menudesc);
+                        id - systray_contextmenus::ID_BASE_FILE_EXIT, status_bar::menudesc);
                 } else if (systray_contextmenus::g_menu_playback.is_valid()) {
                     set = systray_contextmenus::g_menu_playback->get_description(
-                        id - systray_contextmenus::ID_BASE_PLAYBACK, cui::status_bar::menudesc);
+                        id - systray_contextmenus::ID_BASE_PLAYBACK, status_bar::menudesc);
                 }
 
                 status_bar::set_show_menu_item_description(set);
@@ -508,7 +508,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
             if (lpdis->itemData) {
                 pfc::string8& text = *reinterpret_cast<pfc::string8*>(lpdis->itemData);
-                uih::text_out_colours_tab(lpdis->hDC, text, text.length(), 0, uih::scale_dpi_value(3), &rc, FALSE,
+                text_out_colours_tab(lpdis->hDC, text, text.length(), 0, uih::scale_dpi_value(3), &rc, FALSE,
                     GetSysColor(COLOR_MENUTEXT), true, false, uih::ALIGN_LEFT);
             }
 
@@ -550,9 +550,9 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (rebar::g_rebar_window)
             rebar::g_rebar_window->on_themechanged();
         if (g_status) {
-            cui::status_bar::destroy_theme_handle();
-            cui::status_bar::create_theme_handle();
-            cui::status_bar::set_part_sizes(cui::status_bar::t_parts_none);
+            status_bar::destroy_theme_handle();
+            status_bar::create_theme_handle();
+            set_part_sizes(status_bar::t_parts_none);
         }
         break;
     case WM_KEYDOWN:
@@ -589,7 +589,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             return TRUE;
         } else if (lp == WM_MOUSEMOVE) {
         } else if (lp == WM_XBUTTONUP) {
-            if (cui::config::advbool_notification_icon_x_buttons.get()) {
+            if (config::advbool_notification_icon_x_buttons.get()) {
                 if (g_last_sysray_x1_down && !g_last_sysray_x2_down)
                     standard_commands::main_previous();
                 if (g_last_sysray_x2_down && !g_last_sysray_x1_down)
@@ -796,12 +796,12 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                         break;
                     }
                 }
-                if (cfg_show_vol && /*lpnm->dwItemSpec*/ part == cui::status_bar::u_vol_pos) {
-                    if (!cui::status_bar::volume_popup_window.get_wnd()) {
+                if (cfg_show_vol && /*lpnm->dwItemSpec*/ part == status_bar::u_vol_pos) {
+                    if (!status_bar::volume_popup_window.get_wnd()) {
                         // caption vertical. alt-f4 send crazy with two??
                         RECT rc_status;
                         GetWindowRect(lpnmm->hdr.hwndFrom, &rc_status);
-                        HWND wndvol = cui::status_bar::volume_popup_window.create(wnd);
+                        HWND wndvol = status_bar::volume_popup_window.create(wnd);
                         POINT pt = lpnmm->pt;
                         ClientToScreen(lpnmm->hdr.hwndFrom, &pt);
                         int cx = volume_popup_t::g_get_caption_size() + 26_spx + 2 * 1_spx;
@@ -839,13 +839,13 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 unsigned long part = lpnmm->dwItemSpec;
 
                 if (part == 0)
-                    cui::helpers::execute_main_menu_command(cfg_statusdbl);
+                    helpers::execute_main_menu_command(cfg_statusdbl);
                 // standard_commands::main_highlight_playing();
-                else if (cfg_show_vol && part == cui::status_bar::u_vol_pos) {
+                else if (cfg_show_vol && part == status_bar::u_vol_pos) {
                     // static_api_ptr_t<ui_control>()->show_preferences(preferences_page::guid_playback);
-                } else if (cfg_show_seltime && part == cui::status_bar::u_length_pos) {
+                } else if (cfg_show_seltime && part == status_bar::u_length_pos) {
                     static_api_ptr_t<playlist_manager>()->activeplaylist_set_selection(
-                        pfc::bit_array_true(), pfc::bit_array_true());
+                        bit_array_true(), bit_array_true());
                 }
             } break;
             }

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -45,9 +45,9 @@ ConfigGroups g_groups(g_groups_guid);
 
 cfg_bool cfg_artwork_reflection(g_artwork_reflection, true);
 
-fbh::ConfigBool cfg_grouping(g_guid_grouping, true, [](auto&&) { cui::button_items::ShowGroupsButton::s_on_change(); });
+fbh::ConfigBool cfg_grouping(g_guid_grouping, true, [](auto&&) { button_items::ShowGroupsButton::s_on_change(); });
 fbh::ConfigBool cfg_show_artwork(
-    g_show_artwork_guid, false, [](auto&&) { cui::button_items::ShowArtworkButton::s_on_change(); });
+    g_show_artwork_guid, false, [](auto&&) { button_items::ShowArtworkButton::s_on_change(); });
 fbh::ConfigUint32DpiAware cfg_artwork_width(g_artwork_width_guid, 100);
 
 void ConfigGroups::swap(t_size index1, t_size index2)
@@ -85,12 +85,12 @@ void ConfigGroups::remove_group(t_size index)
 void set_font_size(bool up)
 {
     LOGFONT lf_ng;
-    static_api_ptr_t<cui::fonts::manager> api;
-    api->get_font(cui::panels::playlist_view::g_guid_items_font, lf_ng);
+    static_api_ptr_t<fonts::manager> api;
+    api->get_font(g_guid_items_font, lf_ng);
 
-    cui::fonts::get_next_font_size_step(lf_ng, up);
+    fonts::get_next_font_size_step(lf_ng, up);
 
-    api->set_font(cui::panels::playlist_view::g_guid_items_font, lf_ng);
+    api->set_font(g_guid_items_font, lf_ng);
 }
 
 PlaylistView::PlaylistView()
@@ -103,7 +103,7 @@ void PlaylistView::populate_list()
 {
     metadb_handle_list_t<pfc::alloc_fast_aggressive> data;
     m_playlist_api->activeplaylist_get_all_items(data);
-    on_items_added(0, data, pfc::bit_array_false());
+    on_items_added(0, data, bit_array_false());
 }
 void PlaylistView::refresh_groups(bool b_update_columns)
 {
@@ -284,7 +284,7 @@ void PlaylistView::update_items(t_size index, t_size count)
             get_item(i + index)->get_group(j)->m_style_data.release();
         get_item(i + index)->m_style_data.set_count(0);
     }
-    uih::ListView::update_items(index, count);
+    ListView::update_items(index, count);
 }
 void PlaylistView::g_on_autosize_change()
 {
@@ -330,21 +330,21 @@ void PlaylistView::g_on_vertical_item_padding_change()
 void PlaylistView::g_on_font_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_items_font, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_items_font, lf);
     for (auto& window : g_windows)
         window->set_font(&lf);
 }
 void PlaylistView::g_on_header_font_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_header_font, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_header_font, lf);
     for (auto& window : g_windows)
         window->set_header_font(&lf);
 }
 void PlaylistView::g_on_group_header_font_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_group_header_font, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_group_header_font, lf);
     for (auto& window : g_windows)
         window->set_group_font(&lf);
 }
@@ -433,7 +433,7 @@ void PlaylistView::notify_sort_column(t_size index, bool b_descending, bool b_se
 
         bool extra = m_script_global.is_valid() && cfg_global_sort;
 
-        pfc::bit_array_bittable mask(count);
+        bit_array_bittable mask(count);
         if (b_selection_only)
             m_playlist_api->activeplaylist_get_selection_mask(mask);
 
@@ -522,11 +522,11 @@ void PlaylistView::notify_on_initialisation()
         config_object::g_get_data_bool_simple(standard_config_objects::bool_playback_follows_cursor, false));
     set_vertical_item_padding(settings::playlist_view_item_padding);
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_items_font, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_items_font, lf);
     set_font(&lf);
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_header_font, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_header_font, lf);
     set_header_font(&lf);
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_group_header_font, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_group_header_font, lf);
     set_group_font(&lf);
     set_sorting_enabled(cfg_header_hottrack != 0);
     set_show_sort_indicators(cfg_show_sort_arrows != 0);
@@ -536,13 +536,13 @@ void PlaylistView::notify_on_initialisation()
     set_allow_header_rearrange(true);
 
     Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-    m_gdiplus_initialised = (Gdiplus::Ok == Gdiplus::GdiplusStartup(&m_gdiplus_token, &gdiplusStartupInput, nullptr));
+    m_gdiplus_initialised = (Gdiplus::Ok == GdiplusStartup(&m_gdiplus_token, &gdiplusStartupInput, nullptr));
     m_artwork_manager = std::make_shared<ArtworkReaderManager>();
     m_artwork_manager->initialise();
 
     m_playlist_api = standard_api_create_t<playlist_manager>();
     m_playlist_cache.initialise_playlist_callback();
-    initialise_playlist_callback(playlist_callback::flag_on_playlist_activate);
+    initialise_playlist_callback(flag_on_playlist_activate);
 
     refresh_columns();
     refresh_groups();
@@ -698,16 +698,16 @@ bool PlaylistView::notify_on_contextmenu_header(const POINT& pt, const HDHITTEST
         TabColumns::get_instance().show_column(column_index_display_to_actual(index));
     } else if (cmd == IDM_AUTOSIZE) {
         cfg_nohscroll = cfg_nohscroll == 0;
-        cui::panels::playlist_view::PlaylistView::g_on_autosize_change();
+        g_on_autosize_change();
     } else if (cmd == IDM_PREFS) {
         static_api_ptr_t<ui_control>()->show_preferences(columns::config_get_playlist_view_guid());
     } else if (cmd == IDM_ARTWORK) {
         cfg_show_artwork = !cfg_show_artwork;
-        cui::panels::playlist_view::PlaylistView::g_on_show_artwork_change();
+        g_on_show_artwork_change();
     } else if (cmd >= IDM_CUSTOM_BASE) {
         if (t_size(cmd - IDM_CUSTOM_BASE) < g_columns.get_count()) {
             g_columns[cmd - IDM_CUSTOM_BASE]->show = !g_columns[cmd - IDM_CUSTOM_BASE]->show; // g_columns
-            cui::panels::playlist_view::PlaylistView::g_on_columns_change();
+            g_on_columns_change();
         }
     }
     return true;
@@ -935,12 +935,12 @@ const style_data_t& PlaylistView::get_style_data(t_size index)
 }
 bool PlaylistView::notify_on_middleclick(bool on_item, t_size index)
 {
-    return cui::playlist_item_helpers::MiddleClickActionManager::run(cfg_playlist_middle_action, on_item, index);
+    return playlist_item_helpers::MiddleClickActionManager::run(cfg_playlist_middle_action, on_item, index);
 }
 bool PlaylistView::notify_on_doubleleftclick_nowhere()
 {
     if (cfg_playlist_double.get_value().m_command != pfc::guid_null)
-        return cui::helpers::execute_main_menu_command(cfg_playlist_double);
+        return helpers::execute_main_menu_command(cfg_playlist_double);
     return false;
 }
 
@@ -952,7 +952,7 @@ void PlaylistView::get_insert_items(
     metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
     handles.prealloc(count);
 
-    pfc::bit_array_range bit_table(start, count);
+    bit_array_range bit_table(start, count);
     m_playlist_api->activeplaylist_get_items(handles, bit_table);
 
     const auto group_count = m_scripts.get_count();
@@ -1044,19 +1044,19 @@ void PlaylistView::storage_set_focus_item(t_size index)
     pfc::vartoggle_t<bool> tog(m_ignore_callback, true);
     static_api_ptr_t<playlist_manager>()->activeplaylist_set_focus_item(index);
 }
-void PlaylistView::storage_get_selection_state(pfc::bit_array_var& out)
+void PlaylistView::storage_get_selection_state(bit_array_var& out)
 {
     static_api_ptr_t<playlist_manager>()->activeplaylist_get_selection_mask(out);
 }
 bool PlaylistView::storage_set_selection_state(
-    const pfc::bit_array& p_affected, const pfc::bit_array& p_status, pfc::bit_array_var* p_changed)
+    const bit_array& p_affected, const bit_array& p_status, bit_array_var* p_changed)
 {
     pfc::vartoggle_t<bool> tog(m_ignore_callback, true);
 
     static_api_ptr_t<playlist_manager> api;
 
     t_size count = api->activeplaylist_get_item_count();
-    pfc::bit_array_bittable previous_state(count);
+    bit_array_bittable previous_state(count);
 
     api->activeplaylist_get_selection_mask(previous_state);
 
@@ -1141,32 +1141,32 @@ const GUID g_guid_header_font = {0x30fbd64c, 0x2031, 0x4f0b, {0xa9, 0x37, 0xf2, 
 // {FB127FFA-1B35-4572-9C1A-4B96A5C5D537}
 const GUID g_guid_group_header_font = {0xfb127ffa, 0x1b35, 0x4572, {0x9c, 0x1a, 0x4b, 0x96, 0xa5, 0xc5, 0xd5, 0x37}};
 
-class PlaylistViewItemFontClient : public cui::fonts::client {
+class PlaylistViewItemFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_items_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view: Items"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { PlaylistView::g_on_font_change(); }
 };
 
-class PlaylistViewHeaderFontClient : public cui::fonts::client {
+class PlaylistViewHeaderFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_header_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view: Column titles"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { PlaylistView::g_on_header_font_change(); }
 };
 
-class PlaylistViewGroupFontClient : public cui::fonts::client {
+class PlaylistViewGroupFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_group_header_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view: Group titles"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { PlaylistView::g_on_group_header_font_change(); }
 };
@@ -1177,7 +1177,7 @@ PlaylistViewGroupFontClient::factory<PlaylistViewGroupFontClient> g_font_group_h
 
 void ColoursClient::on_colour_changed(t_size mask) const
 {
-    if (cfg_show_artwork && cfg_artwork_reflection && (mask & (cui::colours::colour_flag_background)))
+    if (cfg_show_artwork && cfg_artwork_reflection && (mask & (colours::colour_flag_background)))
         PlaylistView::g_flush_artwork();
     PlaylistView::g_update_all_items();
 }

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -26,7 +26,7 @@ void set_font_size(bool up);
 
 class BasePlaylistCallback : public playlist_callback {
 public:
-    void initialise_playlist_callback(t_uint32 p_flags = playlist_callback::flag_all)
+    void initialise_playlist_callback(t_uint32 p_flags = flag_all)
     {
         static_api_ptr_t<playlist_manager>()->register_callback(this, p_flags);
     }
@@ -34,31 +34,26 @@ public:
     void set_callback_flags(t_uint32 p_flags) { static_api_ptr_t<playlist_manager>()->modify_callback(this, p_flags); }
     // dummy implementations - avoid possible pure virtual function calls!
     void on_items_added(t_size p_playlist, t_size p_start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const pfc::bit_array& p_selection) override
+        const bit_array& p_selection) override
     {
     }
     void on_items_reordered(t_size p_playlist, const t_size* p_order, t_size p_count) override {}
-    void on_items_removing(
-        t_size p_playlist, const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
+    void on_items_removing(t_size p_playlist, const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
     {
     }
-    void on_items_removed(
-        t_size p_playlist, const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
+    void on_items_removed(t_size p_playlist, const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
     {
     }
-    void on_items_selection_change(
-        t_size p_playlist, const pfc::bit_array& p_affected, const pfc::bit_array& p_state) override
-    {
-    }
+    void on_items_selection_change(t_size p_playlist, const bit_array& p_affected, const bit_array& p_state) override {}
     void on_item_focus_change(t_size p_playlist, t_size p_from, t_size p_to) override {}
 
-    void on_items_modified(t_size p_playlist, const pfc::bit_array& p_mask) override {}
+    void on_items_modified(t_size p_playlist, const bit_array& p_mask) override {}
     void on_items_modified_fromplayback(
-        t_size p_playlist, const pfc::bit_array& p_mask, play_control::t_display_level p_level) override
+        t_size p_playlist, const bit_array& p_mask, play_control::t_display_level p_level) override
     {
     }
 
-    void on_items_replaced(t_size p_playlist, const pfc::bit_array& p_mask,
+    void on_items_replaced(t_size p_playlist, const bit_array& p_mask,
         const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) override
     {
     }
@@ -68,8 +63,8 @@ public:
     void on_playlist_activate(t_size p_old, t_size p_new) override {}
     void on_playlist_created(t_size p_index, const char* p_name, t_size p_name_len) override {}
     void on_playlists_reorder(const t_size* p_order, t_size p_count) override {}
-    void on_playlists_removing(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
-    void on_playlists_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
+    void on_playlists_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
+    void on_playlists_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
     void on_playlist_renamed(t_size p_index, const char* p_new_name, t_size p_new_name_len) override {}
 
     void on_default_format_changed() override {}
@@ -86,7 +81,7 @@ class PlaylistCache
         this->insert_item(item_t(), p_index);
     }
     void on_playlists_reorder(const t_size* p_order, t_size p_count) override { this->reorder(p_order); }
-    void on_playlists_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
+    void on_playlists_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
     {
         this->remove_mask(p_mask);
     }
@@ -273,7 +268,7 @@ private:
     t_size m_nocover_cx{0}, m_nocover_cy{0};
 };
 
-class ColoursClient : public cui::colours::client {
+class ColoursClient : public colours::client {
 public:
     static const GUID g_guid;
 
@@ -281,11 +276,8 @@ public:
 
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view"; };
 
-    t_size get_supported_colours() const override { return cui::colours::colour_flag_all; }; // bit-mask
-    t_size get_supported_bools() const override
-    {
-        return cui::colours::bool_flag_use_custom_active_item_frame;
-    }; // bit-mask
+    t_size get_supported_colours() const override { return colours::colour_flag_all; }; // bit-mask
+    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; }; // bit-mask
     bool get_themes_supported() const override { return true; };
 
     void on_colour_changed(t_size mask) const override;
@@ -328,7 +320,7 @@ class PlaylistView
             case WM_CREATE:
                 break;
             case WM_TIMECHANGE:
-                PlaylistView::g_on_time_change();
+                g_on_time_change();
                 break;
             case WM_DESTROY:
                 break;
@@ -483,7 +475,7 @@ private:
 
     Group* storage_create_group() override { return new PlaylistViewGroup; }
 
-    PlaylistViewItem* get_item(t_size index) { return static_cast<PlaylistViewItem*>(uih::ListView::get_item(index)); }
+    PlaylistViewItem* get_item(t_size index) { return static_cast<PlaylistViewItem*>(ListView::get_item(index)); }
 
     void notify_update_item_data(t_size index) override;
 
@@ -492,19 +484,19 @@ private:
     void flush_items();
     void reset_items();
 
-    void on_items_added(unsigned start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const pfc::bit_array& p_selection) override;
+    void on_items_added(
+        unsigned start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override;
     void on_items_reordered(const t_size* p_order, t_size p_count) override;
 
-    void on_items_removing(const pfc::bit_array& p_mask, t_size p_old_count,
+    void on_items_removing(const bit_array& p_mask, t_size p_old_count,
         t_size p_new_count) override{}; // called before actually removing them
-    void on_items_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
-    void on_items_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_state) override;
+    void on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override;
     void on_item_focus_change(t_size p_from, t_size p_to) override;
-    void on_items_modified(const pfc::bit_array& p_mask) override;
-    void on_items_modified_fromplayback(const pfc::bit_array& p_mask, play_control::t_display_level p_level) override;
-    void on_items_replaced(const pfc::bit_array& p_mask,
-        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override;
+    void on_items_modified(const bit_array& p_mask) override;
+    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override;
+    void on_items_replaced(
+        const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) override;
     void on_item_ensure_visible(t_size p_idx) override;
     void on_playlist_switch() override;
     void on_playlist_renamed(const char* p_new_name, t_size p_new_name_len) override;
@@ -583,7 +575,7 @@ private:
         t_size act_from = column_index_display_to_actual(index_from);
         t_size act_to = column_index_display_to_actual(index_to);
         g_columns.move(act_from, act_to);
-        cui::panels::playlist_view::PlaylistView::g_on_columns_change();
+        g_on_columns_change();
     }
 
     bool notify_on_timer(UINT_PTR timerid) override
@@ -625,9 +617,9 @@ private:
     void notify_sort_column(t_size index, bool b_descending, bool b_selection_only) override;
     t_size storage_get_focus_item() override;
     void storage_set_focus_item(t_size index) override;
-    void storage_get_selection_state(pfc::bit_array_var& out) override;
-    bool storage_set_selection_state(const pfc::bit_array& p_affected, const pfc::bit_array& p_status,
-        pfc::bit_array_var* p_changed = nullptr) override;
+    void storage_get_selection_state(bit_array_var& out) override;
+    bool storage_set_selection_state(
+        const bit_array& p_affected, const bit_array& p_status, bit_array_var* p_changed = nullptr) override;
     bool storage_get_item_selected(t_size index) override;
     t_size storage_get_selection_count(t_size max) override;
 
@@ -727,7 +719,7 @@ public:
 
 private:
     BOOL ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
 };
 } // namespace cui::panels::playlist_view
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -272,22 +272,22 @@ class ColoursClient : public colours::client {
 public:
     static const GUID g_guid;
 
-    const GUID& get_client_guid() const override { return g_guid; };
+    const GUID& get_client_guid() const override { return g_guid; }
 
-    void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view"; };
+    void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view"; }
 
-    t_size get_supported_colours() const override { return colours::colour_flag_all; }; // bit-mask
-    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; }; // bit-mask
-    bool get_themes_supported() const override { return true; };
+    t_size get_supported_colours() const override { return colours::colour_flag_all; } // bit-mask
+    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; } // bit-mask
+    bool get_themes_supported() const override { return true; }
 
     void on_colour_changed(t_size mask) const override;
 
-    void on_bool_changed(t_size mask) const override{};
+    void on_bool_changed(t_size mask) const override {}
 };
 
 class PlaylistViewRenderer : public uih::lv::DefaultRenderer {
 public:
-    PlaylistViewRenderer(class PlaylistView* playlist_view) : m_playlist_view{playlist_view} {};
+    PlaylistViewRenderer(class PlaylistView* playlist_view) : m_playlist_view{playlist_view} {}
 
     void render_group_info(uih::lv::RendererContext context, t_size index, RECT rc) override;
 
@@ -388,7 +388,6 @@ private:
         wil::shared_hbitmap m_artwork_bitmap; // cached for display
 
         PlaylistViewGroup() = default;
-        ;
     };
 
     class PlaylistViewItem : public Item {
@@ -488,8 +487,8 @@ private:
         unsigned start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override;
     void on_items_reordered(const t_size* p_order, t_size p_count) override;
 
-    void on_items_removing(const bit_array& p_mask, t_size p_old_count,
-        t_size p_new_count) override{}; // called before actually removing them
+    void on_items_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {
+    } // called before actually removing them
     void on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
     void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override;
     void on_item_focus_change(t_size p_from, t_size p_to) override;
@@ -501,11 +500,11 @@ private:
     void on_playlist_switch() override;
     void on_playlist_renamed(const char* p_new_name, t_size p_new_name_len) override;
 
-    void on_default_format_changed() override{};
+    void on_default_format_changed() override {}
 
-    void on_playback_order_changed(t_size p_new_index) override{};
+    void on_playback_order_changed(t_size p_new_index) override {}
 
-    void on_playlist_locked(bool p_locked) override{};
+    void on_playlist_locked(bool p_locked) override {}
 
     // Temp fix to avoid playlist_callback virtual functions being hidden by those of
     // playlist_callback_single
@@ -568,7 +567,7 @@ private:
             g_columns[act]->width = new_width;
             g_on_column_widths_change(this);
         }
-    };
+    }
 
     void notify_on_header_rearrange(t_size index_from, t_size index_to) override
     {
@@ -585,13 +584,13 @@ private:
             return true;
         }
         return false;
-    };
+    }
 
     void on_time_change()
     {
         update_items(0, get_item_count());
         set_day_timer();
-    };
+    }
 
     bool m_day_timer_active{false};
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -281,8 +281,8 @@ wil::unique_hbitmap g_create_hbitmap_from_data(
 {
     std::unique_ptr<Gdiplus::Bitmap> bitmap;
     try {
-        const auto bitmap_data = cui::wic::decode_image_data(data->get_ptr(), data->get_size());
-        bitmap = cui::gdip::create_bitmap_from_wic_data(bitmap_data);
+        const auto bitmap_data = wic::decode_image_data(data->get_ptr(), data->get_size());
+        bitmap = gdip::create_bitmap_from_wic_data(bitmap_data);
     } catch (const std::exception& ex) {
         fbh::print_to_console(u8"Playlist view – loading image failed: "_pcc, ex.what());
         return nullptr;
@@ -314,8 +314,8 @@ wil::shared_hbitmap PlaylistView::request_group_artwork(t_size index_item)
         m_playlist_api->activeplaylist_get_item_handle(handle, index_item);
         std::shared_ptr<ArtworkReader> p_reader;
         m_artwork_manager->request(handle, p_reader, cx, cy,
-            cui::colours::helper(ColoursClient::g_guid).get_colour(cui::colours::colour_background),
-            cfg_artwork_reflection, std::move(ptr));
+            colours::helper(ColoursClient::g_guid).get_colour(colours::colour_background), cfg_artwork_reflection,
+            std::move(ptr));
         group->m_artwork_load_attempted = true;
         return nullptr;
     }

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -30,8 +30,8 @@ for (t_size i = 0; i < p_count; i++) {
 }
 } // namespace cui::panels::playlist_view
 }
-; // changes selection too; doesnt actually change set of items that are selected or item having focus, just changes
-  // their order
+// changes selection too; doesnt actually change set of items that are selected or item having focus, just changes
+// their order
 
 void PlaylistView::on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count)
 {
@@ -53,14 +53,14 @@ void PlaylistView::on_items_selection_change(
     if (!m_ignore_callback) {
         RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
     }
-};
+}
 void PlaylistView::on_item_focus_change(/*t_size p_playlist, */ t_size p_from, t_size p_to)
 {
     // if (p_playlist==0)
     if (!m_ignore_callback) {
         on_focus_change(p_from, p_to);
     }
-}; // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
+} // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
 
 void PlaylistView::on_items_modified(/*t_size p_playlist, */ const bit_array& p_mask){// if (p_playlist==0)
     {clear_sort_column();
@@ -79,7 +79,7 @@ for (t_size i = 0; i < count; i++) {
 }
 }
 }
-;
+
 void PlaylistView::on_items_modified_fromplayback(
     /*t_size p_playlist, */ const bit_array& p_mask, play_control::t_display_level p_level)
 {
@@ -96,19 +96,18 @@ void PlaylistView::on_items_modified_fromplayback(
             }
         }
     }
-};
+}
 
 void PlaylistView::on_items_replaced(
     /*t_size p_playlist, */ const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
 {
     on_items_modified(p_mask);
-};
+}
 
 void PlaylistView::on_item_ensure_visible(/*t_size p_playlist, */ t_size p_idx){// if (p_playlist==0)
     {ensure_visible(p_idx);
 }
 }
-;
 
 void PlaylistView::on_playlist_switch()
 {
@@ -144,7 +143,7 @@ void PlaylistView::on_playlist_switch()
     populate_list();
     if (!b_scrolled && focus != pfc_infinite)
         ensure_visible(focus);
-};
+}
 void PlaylistView::on_playlist_renamed(const char* p_new_name, t_size p_new_name_len)
 {
     clear_sort_column();
@@ -152,5 +151,5 @@ void PlaylistView::on_playlist_renamed(const char* p_new_name, t_size p_new_name
     refresh_groups();
     refresh_columns();
     populate_list();
-};
+}
 }

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -3,7 +3,7 @@
 
 namespace cui::panels::playlist_view {
 void PlaylistView::on_items_added(/*unsigned p_playlist, */ unsigned start,
-    const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const pfc::bit_array& p_selection)
+    const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
 {
     /*(if (p_playlist == 0)*/
     {
@@ -33,7 +33,7 @@ for (t_size i = 0; i < p_count; i++) {
 ; // changes selection too; doesnt actually change set of items that are selected or item having focus, just changes
   // their order
 
-void PlaylistView::on_items_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count)
+void PlaylistView::on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count)
 {
     clear_sort_column();
 
@@ -47,7 +47,7 @@ void PlaylistView::on_items_removed(const pfc::bit_array& p_mask, t_size p_old_c
 }
 
 void PlaylistView::on_items_selection_change(
-    /*t_size p_playlist, */ const pfc::bit_array& p_affected, const pfc::bit_array& p_state)
+    /*t_size p_playlist, */ const bit_array& p_affected, const bit_array& p_state)
 {
     /*(if (p_playlist == 0)*/
     if (!m_ignore_callback) {
@@ -62,7 +62,7 @@ void PlaylistView::on_item_focus_change(/*t_size p_playlist, */ t_size p_from, t
     }
 }; // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
 
-void PlaylistView::on_items_modified(/*t_size p_playlist, */ const pfc::bit_array& p_mask){// if (p_playlist==0)
+void PlaylistView::on_items_modified(/*t_size p_playlist, */ const bit_array& p_mask){// if (p_playlist==0)
     {clear_sort_column();
 t_size count = m_playlist_api->activeplaylist_get_item_count();
 
@@ -81,7 +81,7 @@ for (t_size i = 0; i < count; i++) {
 }
 ;
 void PlaylistView::on_items_modified_fromplayback(
-    /*t_size p_playlist, */ const pfc::bit_array& p_mask, play_control::t_display_level p_level)
+    /*t_size p_playlist, */ const bit_array& p_mask, play_control::t_display_level p_level)
 {
     if (!core_api::is_shutting_down()) {
         t_size count = m_playlist_api->activeplaylist_get_item_count();
@@ -98,8 +98,8 @@ void PlaylistView::on_items_modified_fromplayback(
     }
 };
 
-void PlaylistView::on_items_replaced(/*t_size p_playlist, */ const pfc::bit_array& p_mask,
-    const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data)
+void PlaylistView::on_items_replaced(
+    /*t_size p_playlist, */ const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
 {
     on_items_modified(p_mask);
 };

--- a/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
@@ -77,7 +77,7 @@ bool paste(HWND wnd, size_t index)
     data.to_handles(handles, b_native, GetAncestor(wnd, GA_ROOT));
     playlist_api->activeplaylist_undo_backup();
     playlist_api->activeplaylist_clear_selection();
-    playlist_api->activeplaylist_insert_items(index, handles, pfc::bit_array_true());
+    playlist_api->activeplaylist_insert_items(index, handles, bit_array_true());
     return true;
 };
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
@@ -79,6 +79,6 @@ bool paste(HWND wnd, size_t index)
     playlist_api->activeplaylist_clear_selection();
     playlist_api->activeplaylist_insert_items(index, handles, bit_array_true());
     return true;
-};
+}
 
 } // namespace playlist_utils

--- a/foo_ui_columns/ng_playlist/ng_playlist_dropsource.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_dropsource.cpp
@@ -79,6 +79,8 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropSource::GiveFeedback(DWORD dwEffect)
 PlaylistViewDropSource::PlaylistViewDropSource(PlaylistView* playlist, DWORD initial_key_state)
     : refcount(0)
     , p_playlist(playlist)
-    , m_initial_key_state(initial_key_state){};
+    , m_initial_key_state(initial_key_state)
+{
+}
 
 } // namespace cui::panels::playlist_view

--- a/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
@@ -277,7 +277,7 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::Drop(
                     playlist_api->activeplaylist_reorder_items(permutation_move.data(), permutation_move.size());
                 } else {
                     playlist_api->activeplaylist_clear_selection();
-                    t_size index_insert = playlist_api->activeplaylist_insert_items(idx, data, pfc::bit_array_true());
+                    t_size index_insert = playlist_api->activeplaylist_insert_items(idx, data, bit_array_true());
                     playlist_api->activeplaylist_set_focus_item(index_insert);
                     if (p_playlist->m_dragging && *pdwEffect == DROPEFFECT_MOVE) {
                         playlist_api->playlist_remove_items(p_playlist->m_dragging_initial_playlist,
@@ -306,7 +306,7 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::Drop(
                             bool b_redraw = p_playlist->disable_redrawing();
                             playlist_api->playlist_clear_selection(m_insertIndexTracker.m_playlist);
                             t_size index_insert = playlist_api->playlist_insert_items(m_insertIndexTracker.m_playlist,
-                                m_insertIndexTracker.m_item, p_items, pfc::bit_array_true());
+                                m_insertIndexTracker.m_item, p_items, bit_array_true());
                             playlist_api->playlist_set_focus_item(
                                 m_insertIndexTracker.m_playlist, m_insertIndexTracker.m_item);
                             if (b_redraw)

--- a/foo_ui_columns/ng_playlist/ng_playlist_groups.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist_groups.h
@@ -7,7 +7,9 @@ public:
     Group(const char* p_string, PlaylistFilterType p_filter_type = FILTER_NONE, const char* p_filter = "")
         : string(p_string)
         , filter_type(p_filter_type)
-        , filter_playlists(p_filter){};
+        , filter_playlists(p_filter)
+    {
+    }
     Group() = default;
     void write(stream_writer* p_stream, abort_callback& p_abort)
     {
@@ -43,7 +45,7 @@ public:
     ConfigGroups(const GUID& p_guid) : cfg_var(p_guid)
     {
         add_group(Group("$if2(%album artist%,<no artist>)[ / %album%]"), false);
-    };
+    }
 
 private:
     void get_data_raw(stream_writer* p_stream, abort_callback& p_abort) override

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -31,7 +31,7 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, t_size 
     std::vector<uih::lv::RendererSubItem> sub_items, int indentation, bool b_selected, bool b_window_focused,
     bool b_highlight, bool should_hide_focus, bool b_focused, RECT rc)
 {
-    cui::colours::helper p_helper(ColoursClient::g_guid);
+    colours::helper p_helper(ColoursClient::g_guid);
 
     int theme_state = NULL;
     if (b_selected)
@@ -84,7 +84,7 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, t_size 
 
             FillRect(context.dc, &rc_subitem, wil::unique_hbrush(CreateSolidBrush(cr_back)).get());
         }
-        uih::text_out_colours_tab(context.dc, sub_item.text.data(), sub_item.text.size(),
+        text_out_colours_tab(context.dc, sub_item.text.data(), sub_item.text.size(),
             uih::scale_dpi_value(1) + (column_index == 0 ? indentation : 0), uih::scale_dpi_value(3), &rc_subitem,
             b_selected, cr_text, true, cfg_ellipsis != 0, sub_item.alignment);
 
@@ -136,7 +136,7 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, t_size 
 void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t item_index, size_t group_index,
     std::string_view text, int indentation, t_size level, RECT rc)
 {
-    cui::colours::helper p_helper(ColoursClient::g_guid);
+    colours::helper p_helper(ColoursClient::g_guid);
     bool b_theme_enabled = p_helper.get_themed();
 
     int text_width = NULL;
@@ -157,7 +157,7 @@ void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t
         FillRect(context.dc, &rc, br.get());
     }
 
-    uih::text_out_colours_tab(context.dc, text.data(), text.size(), uih::scale_dpi_value(1) + indentation * level,
+    text_out_colours_tab(context.dc, text.data(), text.size(), uih::scale_dpi_value(1) + indentation * level,
         uih::scale_dpi_value(3), &rc, false, cr, true, cfg_ellipsis != 0, uih::ALIGN_LEFT, nullptr, true, true,
         &text_width);
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
@@ -32,12 +32,11 @@ SharedCellStyleData::~SharedCellStyleData()
 
 CellStyleData CellStyleData::g_create_default()
 {
-    cui::colours::helper p_helper(ColoursClient::g_guid);
-    return CellStyleData(p_helper.get_colour(cui::colours::colour_text),
-        p_helper.get_colour(cui::colours::colour_selection_text), p_helper.get_colour(cui::colours::colour_background),
-        p_helper.get_colour(cui::colours::colour_selection_background),
-        p_helper.get_colour(cui::colours::colour_inactive_selection_text),
-        p_helper.get_colour(cui::colours::colour_inactive_selection_background));
+    colours::helper p_helper(ColoursClient::g_guid);
+    return CellStyleData(p_helper.get_colour(colours::colour_text), p_helper.get_colour(colours::colour_selection_text),
+        p_helper.get_colour(colours::colour_background), p_helper.get_colour(colours::colour_selection_background),
+        p_helper.get_colour(colours::colour_inactive_selection_text),
+        p_helper.get_colour(colours::colour_inactive_selection_background));
 }
 
 bool StyleTitleformatHook::process_field(
@@ -113,7 +112,7 @@ bool StyleTitleformatHook::process_field(
                 return true;
             }
             if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "themed", pfc_infinite)) {
-                cui::colours::helper p_helper(ColoursClient::g_guid);
+                colours::helper p_helper(ColoursClient::g_guid);
                 if (p_helper.get_themed()) {
                     p_out->write(titleformat_inputtypes::unknown, "1", 1);
                     p_found_flag = true;

--- a/foo_ui_columns/ng_playlist/ng_playlist_style.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist_style.h
@@ -38,7 +38,7 @@ public:
         use_frame_bottom = in->use_frame_bottom;
     }
 
-    CellStyleData() : use_frame_left(false), use_frame_top(false), use_frame_right(false), use_frame_bottom(false){};
+    CellStyleData() : use_frame_left(false), use_frame_top(false), use_frame_right(false), use_frame_bottom(false) {}
 
     CellStyleData(COLORREF text, COLORREF text_sel, COLORREF back, COLORREF back_sel, COLORREF text_no_focus,
         COLORREF sel_no_focus)
@@ -110,6 +110,8 @@ public:
         : p_default_colours(vars)
         , p_colours(vars)
         , m_index(index)
-        , m_is_group(b_is_group){};
+        , m_is_group(b_is_group)
+    {
+    }
 };
 } // namespace cui::panels::playlist_view

--- a/foo_ui_columns/order_dropdown.cpp
+++ b/foo_ui_columns/order_dropdown.cpp
@@ -53,27 +53,31 @@ ui_extension::window_factory<DropDownListToolbar<PlaybackOrderToolbarArgs>> play
 
 class OrderToolbarPlaylistCallback : public playlist_callback_single_static {
 public:
-    void on_items_added(t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const bit_array& p_selection) override{};
-    void on_items_reordered(const t_size* p_order, t_size p_count) override{};
-    void on_items_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override{};
-    void on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override{};
-    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override{};
-    void on_item_focus_change(t_size p_from, t_size p_to) override{};
-    void on_items_modified(const bit_array& p_mask) override{};
-    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override{};
+    void on_items_added(
+        t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override
+    {
+    }
+    void on_items_reordered(const t_size* p_order, t_size p_count) override {}
+    void on_items_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
+    void on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override {}
+    void on_item_focus_change(t_size p_from, t_size p_to) override {}
+    void on_items_modified(const bit_array& p_mask) override {}
+    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override {}
     void on_items_replaced(const bit_array& p_mask,
-        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override{};
-    void on_item_ensure_visible(t_size p_idx) override{};
-    void on_playlist_switch() override{};
-    void on_playlist_renamed(const char* p_new_name, t_size p_new_name_len) override{};
-    void on_playlist_locked(bool p_locked) override{};
-    void on_default_format_changed() override{};
+        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override
+    {
+    }
+    void on_item_ensure_visible(t_size p_idx) override {}
+    void on_playlist_switch() override {}
+    void on_playlist_renamed(const char* p_new_name, t_size p_new_name_len) override {}
+    void on_playlist_locked(bool p_locked) override {}
+    void on_default_format_changed() override {}
     void on_playback_order_changed(t_size p_new_index) override
     {
         DropDownListToolbar<PlaybackOrderToolbarArgs>::s_update_active_item_safe();
     }
-    unsigned get_flags() override { return flag_on_playback_order_changed; };
+    unsigned get_flags() override { return flag_on_playback_order_changed; }
 };
 
 service_factory_single_t<OrderToolbarPlaylistCallback> order_toolbar_playlist_callback;

--- a/foo_ui_columns/playlist_item_helpers.cpp
+++ b/foo_ui_columns/playlist_item_helpers.cpp
@@ -8,7 +8,7 @@ void action_remove_track(bool on_item, unsigned idx)
     if (on_item) {
         static_api_ptr_t<playlist_manager> api;
         api->activeplaylist_undo_backup();
-        api->activeplaylist_remove_items(pfc::bit_array_one(idx));
+        api->activeplaylist_remove_items(bit_array_one(idx));
     }
 }
 

--- a/foo_ui_columns/playlist_manager_utils.cpp
+++ b/foo_ui_columns/playlist_manager_utils.cpp
@@ -37,7 +37,7 @@ bool check_clipboard()
     hr = api->check_dataobject_playlists(pDO.get());
     return SUCCEEDED(hr);
 }
-bool cut(const pfc::bit_array& mask)
+bool cut(const bit_array& mask)
 {
     static_api_ptr_t<playlist_manager> m_playlist_api;
     static_api_ptr_t<ole_interaction> api;
@@ -61,14 +61,14 @@ bool cut(const pfc::list_base_const_t<t_size>& indices)
     static_api_ptr_t<playlist_manager> m_playlist_api;
     t_size count = indices.get_count();
     t_size playlist_count = m_playlist_api->get_playlist_count();
-    pfc::bit_array_bittable mask(playlist_count);
+    bit_array_bittable mask(playlist_count);
     for (t_size i = 0; i < count; i++) {
         if (indices[i] < playlist_count)
             mask.set(indices[i], true);
     }
     return cut(mask);
 };
-bool copy(const pfc::bit_array& mask)
+bool copy(const bit_array& mask)
 {
     static_api_ptr_t<playlist_manager> m_playlist_api;
     static_api_ptr_t<ole_interaction> api;
@@ -85,7 +85,7 @@ bool copy(const pfc::list_base_const_t<t_size>& indices)
     static_api_ptr_t<playlist_manager> m_playlist_api;
     t_size count = indices.get_count();
     t_size playlist_count = m_playlist_api->get_playlist_count();
-    pfc::bit_array_bittable mask(playlist_count);
+    bit_array_bittable mask(playlist_count);
     for (t_size i = 0; i < count; i++) {
         if (indices[i] < playlist_count)
             mask.set(indices[i], true);
@@ -122,7 +122,7 @@ bool paste(HWND wnd, t_size index_insert)
         data.get_entry_name(i, name);
         data.get_entry_content(i, handles);
         index_insert = m_playlist_api->create_playlist(name, pfc_infinite, index_insert);
-        m_playlist_api->playlist_insert_items(index_insert, 0, handles, pfc::bit_array_false());
+        m_playlist_api->playlist_insert_items(index_insert, 0, handles, bit_array_false());
         index_insert++;
     }
     return true;

--- a/foo_ui_columns/playlist_manager_utils.cpp
+++ b/foo_ui_columns/playlist_manager_utils.cpp
@@ -67,7 +67,7 @@ bool cut(const pfc::list_base_const_t<t_size>& indices)
             mask.set(indices[i], true);
     }
     return cut(mask);
-};
+}
 bool copy(const bit_array& mask)
 {
     static_api_ptr_t<playlist_manager> m_playlist_api;
@@ -91,7 +91,7 @@ bool copy(const pfc::list_base_const_t<t_size>& indices)
             mask.set(indices[i], true);
     }
     return copy(mask);
-};
+}
 bool paste(HWND wnd, t_size index_insert)
 {
     static_api_ptr_t<playlist_manager> m_playlist_api;
@@ -126,5 +126,5 @@ bool paste(HWND wnd, t_size index_insert)
         index_insert++;
     }
     return true;
-};
+}
 } // namespace playlist_manager_utils

--- a/foo_ui_columns/playlist_manager_utils.h
+++ b/foo_ui_columns/playlist_manager_utils.h
@@ -6,7 +6,7 @@ void rename_playlist(size_t index, HWND wnd_parent);
 bool check_clipboard();
 bool cut(const pfc::list_base_const_t<t_size>& indices);
 bool copy(const pfc::list_base_const_t<t_size>& indices);
-bool cut(const pfc::bit_array& mask);
-bool copy(const pfc::bit_array& mask);
+bool cut(const bit_array& mask);
+bool copy(const bit_array& mask);
 bool paste(HWND wnd, t_size index_insert);
 } // namespace playlist_manager_utils

--- a/foo_ui_columns/playlist_search.h
+++ b/foo_ui_columns/playlist_search.h
@@ -234,4 +234,4 @@ private:
 
 #endif
 
-#endif _COLUMNS_PLAYLIST_SEARCH_H_
+#endif //_COLUMNS_PLAYLIST_SEARCH_H_

--- a/foo_ui_columns/playlist_switcher.cpp
+++ b/foo_ui_columns/playlist_switcher.cpp
@@ -12,12 +12,12 @@ cfg_struct_t<LOGFONT> cfg_plist_font(
 const GUID g_guid_playlist_switcher_font
     = {0x70a5c273, 0x67ab, 0x4bb6, {0xb6, 0x1c, 0xf7, 0x97, 0x5a, 0x68, 0x71, 0xfd}};
 
-class PlaylistSwitcherFontClient : public cui::fonts::client {
+class PlaylistSwitcherFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_playlist_switcher_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist switcher"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
 
     void on_font_changed() const override { PlaylistSwitcher::g_on_font_items_change(); }
 };

--- a/foo_ui_columns/playlist_switcher.h
+++ b/foo_ui_columns/playlist_switcher.h
@@ -6,16 +6,16 @@ class PlaylistSwitcherColoursClient : public colours::client {
 public:
     static const GUID g_guid;
 
-    const GUID& get_client_guid() const override { return g_guid; };
+    const GUID& get_client_guid() const override { return g_guid; }
 
-    void get_name(pfc::string_base& p_out) const override { p_out = "Playlist switcher"; };
+    void get_name(pfc::string_base& p_out) const override { p_out = "Playlist switcher"; }
 
-    t_size get_supported_colours() const override { return colours::colour_flag_all; }; // bit-mask
-    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; }; // bit-mask
-    bool get_themes_supported() const override { return true; };
+    t_size get_supported_colours() const override { return colours::colour_flag_all; } // bit-mask
+    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; } // bit-mask
+    bool get_themes_supported() const override { return true; }
 
     void on_colour_changed(t_size mask) const override;
-    void on_bool_changed(t_size mask) const override{};
+    void on_bool_changed(t_size mask) const override {}
 };
 
 } // namespace cui::panels::playlist_switcher

--- a/foo_ui_columns/playlist_switcher.h
+++ b/foo_ui_columns/playlist_switcher.h
@@ -2,7 +2,7 @@
 
 namespace cui::panels::playlist_switcher {
 
-class PlaylistSwitcherColoursClient : public cui::colours::client {
+class PlaylistSwitcherColoursClient : public colours::client {
 public:
     static const GUID g_guid;
 
@@ -10,11 +10,8 @@ public:
 
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist switcher"; };
 
-    t_size get_supported_colours() const override { return cui::colours::colour_flag_all; }; // bit-mask
-    t_size get_supported_bools() const override
-    {
-        return cui::colours::bool_flag_use_custom_active_item_frame;
-    }; // bit-mask
+    t_size get_supported_colours() const override { return colours::colour_flag_all; }; // bit-mask
+    t_size get_supported_bools() const override { return colours::bool_flag_use_custom_active_item_frame; }; // bit-mask
     bool get_themes_supported() const override { return true; };
 
     void on_colour_changed(t_size mask) const override;

--- a/foo_ui_columns/playlist_switcher_callbacks.cpp
+++ b/foo_ui_columns/playlist_switcher_callbacks.cpp
@@ -35,12 +35,12 @@ void PlaylistSwitcher::on_playlist_activate(t_size p_old, t_size p_new)
         ensure_visible(p_new);
     } else
         set_selection_state(bit_array_true(), bit_array_false(), false);
-};
+}
 void PlaylistSwitcher::on_playlist_created(t_size p_index, const char* p_name, t_size p_name_len)
 {
     refresh_playing_playlist();
     add_items(p_index, 1);
-};
+}
 void PlaylistSwitcher::on_playlists_reorder(const t_size* p_order, t_size p_count)
 {
     refresh_playing_playlist();
@@ -55,7 +55,7 @@ void PlaylistSwitcher::on_playlists_reorder(const t_size* p_order, t_size p_coun
     t_size index = m_playlist_api->get_active_playlist();
     if (index != pfc_infinite)
         set_item_selected_single(index, false);
-};
+}
 void PlaylistSwitcher::on_playlists_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count)
 {
     refresh_playing_playlist();
@@ -64,25 +64,25 @@ void PlaylistSwitcher::on_playlists_removed(const bit_array& p_mask, t_size p_ol
 void PlaylistSwitcher::on_playlist_renamed(t_size p_index, const char* p_new_name, t_size p_new_name_len)
 {
     refresh_items(p_index, 1);
-};
+}
 
 void PlaylistSwitcher::on_playlist_locked(t_size p_playlist, bool p_locked)
 {
     refresh_items(p_playlist, 1);
-};
+}
 
 void PlaylistSwitcher::on_playback_starting(play_control::t_track_command p_command, bool p_paused)
 {
     on_playing_playlist_change(get_playing_playlist());
-};
+}
 void PlaylistSwitcher::on_playback_new_track(metadb_handle_ptr p_track)
 {
     on_playing_playlist_change(get_playing_playlist());
-};
+}
 void PlaylistSwitcher::on_playback_stop(play_control::t_stop_reason p_reason)
 {
     if (p_reason != play_control::stop_reason_shutting_down)
         on_playing_playlist_change(get_playing_playlist());
-};
+}
 
 } // namespace cui::panels::playlist_switcher

--- a/foo_ui_columns/playlist_switcher_callbacks.cpp
+++ b/foo_ui_columns/playlist_switcher_callbacks.cpp
@@ -4,23 +4,23 @@
 namespace cui::panels::playlist_switcher {
 
 void PlaylistSwitcher::on_items_added(t_size p_playlist, t_size p_start,
-    const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const pfc::bit_array& p_selection)
+    const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
 {
     refresh_items(p_playlist, 1);
 }
 void PlaylistSwitcher::on_items_removed(
-    t_size p_playlist, const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count)
+    t_size p_playlist, const bit_array& p_mask, t_size p_old_count, t_size p_new_count)
 {
     refresh_items(p_playlist, 1);
 }
 
-void PlaylistSwitcher::on_items_modified(t_size p_playlist, const pfc::bit_array& p_mask)
+void PlaylistSwitcher::on_items_modified(t_size p_playlist, const bit_array& p_mask)
 {
     refresh_items(p_playlist, 1);
 }
 
 void PlaylistSwitcher::on_items_replaced(
-    t_size p_playlist, const pfc::bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
+    t_size p_playlist, const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
 {
     refresh_items(p_playlist, 1);
 }
@@ -34,7 +34,7 @@ void PlaylistSwitcher::on_playlist_activate(t_size p_old, t_size p_new)
         set_item_selected_single(p_new, false);
         ensure_visible(p_new);
     } else
-        set_selection_state(pfc::bit_array_true(), pfc::bit_array_false(), false);
+        set_selection_state(bit_array_true(), bit_array_false(), false);
 };
 void PlaylistSwitcher::on_playlist_created(t_size p_index, const char* p_name, t_size p_name_len)
 {
@@ -56,7 +56,7 @@ void PlaylistSwitcher::on_playlists_reorder(const t_size* p_order, t_size p_coun
     if (index != pfc_infinite)
         set_item_selected_single(index, false);
 };
-void PlaylistSwitcher::on_playlists_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count)
+void PlaylistSwitcher::on_playlists_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count)
 {
     refresh_playing_playlist();
     remove_items(p_mask);

--- a/foo_ui_columns/playlist_switcher_drop_source.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_source.cpp
@@ -5,7 +5,7 @@ namespace cui::panels::playlist_switcher {
 
 bool PlaylistSwitcher::do_drag_drop(WPARAM wp)
 {
-    pfc::bit_array_bittable mask(get_item_count());
+    bit_array_bittable mask(get_item_count());
     get_selection_state(mask);
 
     playlist_dataobject_desc_impl data;

--- a/foo_ui_columns/playlist_switcher_drop_source.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_source.cpp
@@ -75,6 +75,8 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropSource::GiveFeedback(DWORD dwEff
 PlaylistSwitcher::DropSource::DropSource(PlaylistSwitcher* p_window, DWORD initial_key_state)
     : refcount(0)
     , m_window(p_window)
-    , m_initial_key_state(initial_key_state){};
+    , m_initial_key_state(initial_key_state)
+{
+}
 
 } // namespace cui::panels::playlist_switcher

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -14,7 +14,7 @@ bool g_query_dataobj_supports_format(CLIPFORMAT cf, IDataObject* pDataObj)
     fe.tymed = TYMED_HGLOBAL;
 
     return S_OK == pDataObj->QueryGetData(&fe); // Don't want S_FALSE ?
-};
+}
 
 bool g_get_folder_name(IDataObject* pDataObj, pfc::string8& p_out)
 {
@@ -434,7 +434,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
                         }
                         void on_aborted() override {}
 
-                        DelayedDropTargetProcesser() : m_insertIndexTracker(false){};
+                        DelayedDropTargetProcesser() : m_insertIndexTracker(false) {}
                     };
 
                     service_ptr_t<DelayedDropTargetProcesser> ptr = new service_impl_t<DelayedDropTargetProcesser>;

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -43,10 +43,10 @@ bool g_get_folder_name(IDataObject* pDataObj, pfc::string8& p_out)
                 uDragQueryFile((HDROP)sm.hGlobal, 0, temp);
                 DWORD att = uGetFileAttributes(temp);
                 if (att != INVALID_FILE_ATTRIBUTES && (att & FILE_ATTRIBUTE_DIRECTORY)) {
-                    p_out.set_string(pfc::string_filename_ext(temp));
+                    p_out.set_string(string_filename_ext(temp));
                     ret = true;
                 } else {
-                    p_out.set_string(pfc::string_filename(temp));
+                    p_out.set_string(string_filename(temp));
                     ret = true;
                 }
             }
@@ -151,7 +151,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::DragOver(DWORD grfKeySta
     pti.y = ptl.y;
     pti.x = ptl.x;
     if (m_window->get_wnd()) {
-        uih::ListView::HitTestResult hi;
+        HitTestResult hi;
 
         {
             POINT ptt = pti;
@@ -292,7 +292,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
         bool process = !ui_drop_item_callback::g_on_drop(pDataObj);
 
         if (process) {
-            uih::ListView::HitTestResult hi;
+            HitTestResult hi;
             {
                 POINT ptt = pti;
                 ScreenToClient(m_window->get_wnd(), &ptt);
@@ -426,7 +426,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
                                 }
 
                                 playlist_api->playlist_add_items(
-                                    m_insertIndexTracker.m_playlist, p_items, pfc::bit_array_true());
+                                    m_insertIndexTracker.m_playlist, p_items, bit_array_true());
 
                                 if (main_window::config_get_activate_target_playlist_on_dropped_items())
                                     playlist_api->set_active_playlist(m_insertIndexTracker.m_playlist);

--- a/foo_ui_columns/playlist_switcher_inline_edit.cpp
+++ b/foo_ui_columns/playlist_switcher_inline_edit.cpp
@@ -7,7 +7,7 @@ bool PlaylistSwitcher::notify_before_create_inline_edit(
     const pfc::list_base_const_t<t_size>& indices, unsigned column, bool b_source_mouse)
 {
     return column == 0 && indices.get_count() == 1;
-};
+}
 bool PlaylistSwitcher::notify_create_inline_edit(const pfc::list_base_const_t<t_size>& indices, unsigned column,
     pfc::string_base& p_text, t_size& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
 {
@@ -19,7 +19,7 @@ bool PlaylistSwitcher::notify_create_inline_edit(const pfc::list_base_const_t<t_
         return true;
     }
     return false;
-};
+}
 void PlaylistSwitcher::notify_save_inline_edit(const char* value)
 {
     if (m_edit_playlist && m_edit_playlist->m_playlist != pfc_infinite) {

--- a/foo_ui_columns/playlist_switcher_shortcut_menu.cpp
+++ b/foo_ui_columns/playlist_switcher_shortcut_menu.cpp
@@ -144,7 +144,7 @@ bool PlaylistSwitcher::notify_on_contextmenu(const POINT& pt, bool from_keyboard
                     autoplaylist->show_ui(index);
                 break;
             case ID_RECYCLER_CLEAR:
-                m_playlist_api->recycler_purge(pfc::bit_array_true());
+                m_playlist_api->recycler_purge(bit_array_true());
                 break;
             case ID_CUT:
                 if (b_index_valid)

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -12,19 +12,19 @@ const GUID PlaylistSwitcher::g_guid_font
 
 std::vector<PlaylistSwitcher*> PlaylistSwitcher::g_windows;
 
-void PlaylistSwitcher::get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& p_out)
+void PlaylistSwitcher::get_insert_items(t_size base, t_size count, pfc::list_t<InsertItem>& p_out)
 {
     p_out.set_count(count);
 
     for (t_size i = 0; i < count; i++) {
         p_out[i].m_subitems.resize(1);
-        p_out[i].m_subitems[0].set_string(cui::format_playlist_title(i + base));
+        p_out[i].m_subitems[0].set_string(format_playlist_title(i + base));
     }
 }
 
 void PlaylistSwitcher::refresh_all_items()
 {
-    remove_items(pfc::bit_array_true());
+    remove_items(bit_array_true());
 
     add_items(0, m_playlist_api->get_playlist_count());
 
@@ -35,14 +35,14 @@ void PlaylistSwitcher::refresh_all_items()
 
 void PlaylistSwitcher::refresh_items(t_size base, t_size count, bool b_update)
 {
-    pfc::list_t<uih::ListView::InsertItem> items_insert;
+    pfc::list_t<InsertItem> items_insert;
     get_insert_items(base, count, items_insert);
     replace_items(base, items_insert);
 }
 
 void PlaylistSwitcher::add_items(t_size base, t_size count)
 {
-    pfc::list_t<uih::ListView::InsertItem> items_insert;
+    pfc::list_t<InsertItem> items_insert;
     get_insert_items(base, count, items_insert);
     insert_items(base, items_insert.get_count(), items_insert.get_ptr());
 }
@@ -105,7 +105,7 @@ void PlaylistSwitcher::g_refresh_all_items()
 void PlaylistSwitcher::g_on_font_items_change()
 {
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_font, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_font, lf);
     for (auto& window : g_windows) {
         window->set_font(&lf);
     }
@@ -120,7 +120,7 @@ void PlaylistSwitcher::notify_on_initialisation()
     set_vertical_item_padding(settings::playlist_switcher_item_padding);
 
     LOGFONT lf;
-    static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_font, lf);
+    static_api_ptr_t<fonts::manager>()->get_font(g_guid_font, lf);
     set_font(&lf);
 };
 void PlaylistSwitcher::notify_on_create()
@@ -134,8 +134,8 @@ void PlaylistSwitcher::notify_on_create()
 
     refresh_all_items();
 
-    m_playlist_api->register_callback(this, playlist_callback::flag_all);
-    standard_api_create_t<play_callback_manager>()->register_callback(this, play_callback::flag_on_playback_all, false);
+    m_playlist_api->register_callback(this, flag_all);
+    standard_api_create_t<play_callback_manager>()->register_callback(this, flag_on_playback_all, false);
 
     wil::com_ptr_t<DropTarget> drop_target = new DropTarget(this);
     RegisterDragDrop(get_wnd(), drop_target.get());

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -122,7 +122,7 @@ void PlaylistSwitcher::notify_on_initialisation()
     LOGFONT lf;
     static_api_ptr_t<fonts::manager>()->get_font(g_guid_font, lf);
     set_font(&lf);
-};
+}
 void PlaylistSwitcher::notify_on_create()
 {
     m_playlist_api = standard_api_create_t<playlist_manager_v3>();

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -110,7 +110,7 @@ public:
         return false;
     }
 
-    void get_insert_items(t_size base, t_size count, pfc::list_t<uih::ListView::InsertItem>& p_out);
+    void get_insert_items(t_size base, t_size count, pfc::list_t<InsertItem>& p_out);
     void refresh_all_items();
     void refresh_items(t_size base, t_size count, bool b_update = true);
     void add_items(t_size base, t_size count);
@@ -207,14 +207,14 @@ public:
             static_api_ptr_t<play_control>()->start();
         }
     }
-    void notify_on_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_status,
-        notification_source_t p_notification_source) override
+    void notify_on_selection_change(
+        const bit_array& p_affected, const bit_array& p_status, notification_source_t p_notification_source) override
     {
         if (p_notification_source != notification_source_rmb) {
             t_size numSelected = get_selection_count(2);
 
             if (numSelected == 1) {
-                pfc::bit_array_bittable mask(get_item_count());
+                bit_array_bittable mask(get_item_count());
                 get_selection_state(mask);
                 t_size index = 0;
                 t_size count = get_item_count();
@@ -256,23 +256,19 @@ public:
     void refresh_playing_playlist() { m_playing_playlist = get_playing_playlist(); }
 
     void on_items_added(t_size p_playlist, t_size p_start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const pfc::bit_array& p_selection) override;
+        const bit_array& p_selection) override;
     void on_items_reordered(t_size p_playlist, const t_size* p_order, t_size p_count) override{};
     void on_items_removing(
-        t_size p_playlist, const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override{};
-    void on_items_removed(
-        t_size p_playlist, const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
-    void on_items_selection_change(
-        t_size p_playlist, const pfc::bit_array& p_affected, const pfc::bit_array& p_state) override
-    {
-    }
+        t_size p_playlist, const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override{};
+    void on_items_removed(t_size p_playlist, const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
+    void on_items_selection_change(t_size p_playlist, const bit_array& p_affected, const bit_array& p_state) override {}
     void on_item_focus_change(t_size p_playlist, t_size p_from, t_size p_to) override {}
 
-    void on_items_modified(t_size p_playlist, const pfc::bit_array& p_mask) override;
+    void on_items_modified(t_size p_playlist, const bit_array& p_mask) override;
     void on_items_modified_fromplayback(
-        t_size p_playlist, const pfc::bit_array& p_mask, play_control::t_display_level p_level) override{};
+        t_size p_playlist, const bit_array& p_mask, play_control::t_display_level p_level) override{};
 
-    void on_items_replaced(t_size p_playlist, const pfc::bit_array& p_mask,
+    void on_items_replaced(t_size p_playlist, const bit_array& p_mask,
         const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) override;
 
     void on_item_ensure_visible(t_size p_playlist, t_size p_idx) override{};
@@ -280,8 +276,8 @@ public:
     void on_playlist_activate(t_size p_old, t_size p_new) override;
     void on_playlist_created(t_size p_index, const char* p_name, t_size p_name_len) override;
     void on_playlists_reorder(const t_size* p_order, t_size p_count) override;
-    void on_playlists_removing(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override{};
-    void on_playlists_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
+    void on_playlists_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override{};
+    void on_playlists_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
     void on_playlist_renamed(t_size p_index, const char* p_new_name, t_size p_new_name_len) override;
 
     void on_default_format_changed() override{};
@@ -299,7 +295,7 @@ public:
     void on_playback_time(double p_time) override{};
     void on_volume_change(float p_new_val) override{};
 
-    const GUID& get_extension_guid() const override { return cui::panels::guid_playlist_switcher; }
+    const GUID& get_extension_guid() const override { return guid_playlist_switcher; }
     void get_name(pfc::string_base& out) const override { out = "Playlist switcher"; }
     void get_category(pfc::string_base& out) const override { out = "Panels"; }
     bool get_short_name(pfc::string_base& out) const override

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -140,7 +140,7 @@ public:
         uie::window_ptr p_this = this;
         bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
         return ret;
-    };
+    }
 
     bool notify_on_middleclick(bool on_item, t_size index) override
     {
@@ -257,43 +257,46 @@ public:
 
     void on_items_added(t_size p_playlist, t_size p_start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
         const bit_array& p_selection) override;
-    void on_items_reordered(t_size p_playlist, const t_size* p_order, t_size p_count) override{};
-    void on_items_removing(
-        t_size p_playlist, const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override{};
+    void on_items_reordered(t_size p_playlist, const t_size* p_order, t_size p_count) override {}
+    void on_items_removing(t_size p_playlist, const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
+    {
+    }
     void on_items_removed(t_size p_playlist, const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
     void on_items_selection_change(t_size p_playlist, const bit_array& p_affected, const bit_array& p_state) override {}
     void on_item_focus_change(t_size p_playlist, t_size p_from, t_size p_to) override {}
 
     void on_items_modified(t_size p_playlist, const bit_array& p_mask) override;
     void on_items_modified_fromplayback(
-        t_size p_playlist, const bit_array& p_mask, play_control::t_display_level p_level) override{};
+        t_size p_playlist, const bit_array& p_mask, play_control::t_display_level p_level) override
+    {
+    }
 
     void on_items_replaced(t_size p_playlist, const bit_array& p_mask,
         const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) override;
 
-    void on_item_ensure_visible(t_size p_playlist, t_size p_idx) override{};
+    void on_item_ensure_visible(t_size p_playlist, t_size p_idx) override {}
 
     void on_playlist_activate(t_size p_old, t_size p_new) override;
     void on_playlist_created(t_size p_index, const char* p_name, t_size p_name_len) override;
     void on_playlists_reorder(const t_size* p_order, t_size p_count) override;
-    void on_playlists_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override{};
+    void on_playlists_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
     void on_playlists_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override;
     void on_playlist_renamed(t_size p_index, const char* p_new_name, t_size p_new_name_len) override;
 
-    void on_default_format_changed() override{};
-    void on_playback_order_changed(t_size p_new_index) override{};
+    void on_default_format_changed() override {}
+    void on_playback_order_changed(t_size p_new_index) override {}
     void on_playlist_locked(t_size p_playlist, bool p_locked) override;
 
     void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override;
     void on_playback_new_track(metadb_handle_ptr p_track) override;
     void on_playback_stop(play_control::t_stop_reason p_reason) override;
-    void on_playback_seek(double p_time) override{};
-    void on_playback_pause(bool p_state) override{};
-    void on_playback_edited(metadb_handle_ptr p_track) override{};
-    void on_playback_dynamic_info(const file_info& p_info) override{};
-    void on_playback_dynamic_info_track(const file_info& p_info) override{};
-    void on_playback_time(double p_time) override{};
-    void on_volume_change(float p_new_val) override{};
+    void on_playback_seek(double p_time) override {}
+    void on_playback_pause(bool p_state) override {}
+    void on_playback_edited(metadb_handle_ptr p_track) override {}
+    void on_playback_dynamic_info(const file_info& p_info) override {}
+    void on_playback_dynamic_info_track(const file_info& p_info) override {}
+    void on_playback_time(double p_time) override {}
+    void on_volume_change(float p_new_val) override {}
 
     const GUID& get_extension_guid() const override { return guid_playlist_switcher; }
     void get_name(pfc::string_base& out) const override { out = "Playlist switcher"; }
@@ -307,7 +310,9 @@ public:
 
     PlaylistSwitcher()
         : ListViewPanelBase(std::make_unique<uih::lv::DefaultRenderer>(true))
-        , m_playing_playlist(pfc_infinite){};
+        , m_playing_playlist(pfc_infinite)
+    {
+    }
 
 private:
     contextmenu_manager::ptr m_contextmenu_manager;

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -70,7 +70,7 @@ bool PlaylistTabs::is_point_ours(HWND wnd_point, const POINT& pt_screen, pfc::li
         }
     }
     return false;
-};
+}
 
 void PlaylistTabs::on_font_change()
 {

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -99,29 +99,29 @@ public:
     };
 
     void FB2KAPI on_items_removing(
-        unsigned p_playlist, const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override;
+        unsigned p_playlist, const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override;
     ; // called before actually removing them
     void FB2KAPI on_items_removed(
-        unsigned p_playlist, const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override;
+        unsigned p_playlist, const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override;
 
     void on_playlist_activate(unsigned p_old, unsigned p_new) override;
 
     void on_playlists_reorder(const unsigned* p_order, unsigned p_count) override;
     void on_playlist_created(unsigned p_index, const char* p_name, unsigned p_name_len) override;
-    void on_playlists_removed(const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override;
+    void on_playlists_removed(const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override;
     void on_playlist_renamed(unsigned p_index, const char* p_new_name, unsigned p_new_name_len) override;
 
     void on_items_added(
-        unsigned int, unsigned int, const pfc::list_base_const_t<metadb_handle_ptr>&, const pfc::bit_array&) override;
+        unsigned int, unsigned int, const pfc::list_base_const_t<metadb_handle_ptr>&, const bit_array&) override;
     void on_items_reordered(unsigned int, const unsigned int*, unsigned int) override;
-    void on_items_selection_change(unsigned int, const pfc::bit_array&, const pfc::bit_array&) override;
+    void on_items_selection_change(unsigned int, const bit_array&, const bit_array&) override;
     void on_item_focus_change(unsigned int, unsigned int, unsigned int) override;
-    void on_items_modified(unsigned int, const pfc::bit_array&) override;
-    void on_items_modified_fromplayback(unsigned int, const pfc::bit_array&, play_control::t_display_level) override;
+    void on_items_modified(unsigned int, const bit_array&) override;
+    void on_items_modified_fromplayback(unsigned int, const bit_array&, play_control::t_display_level) override;
     void on_items_replaced(
-        unsigned int, const pfc::bit_array&, const pfc::list_base_const_t<t_on_items_replaced_entry>&) override;
+        unsigned int, const bit_array&, const pfc::list_base_const_t<t_on_items_replaced_entry>&) override;
     void on_item_ensure_visible(unsigned int, unsigned int) override;
-    void on_playlists_removing(const pfc::bit_array&, unsigned int, unsigned int) override;
+    void on_playlists_removing(const bit_array&, unsigned int, unsigned int) override;
     void on_default_format_changed() override;
     void on_playback_order_changed(unsigned int) override;
     void on_playlist_locked(unsigned int, bool) override;
@@ -155,10 +155,9 @@ public:
     void create_child();
     void destroy_child();
 
-    bool is_point_ours(
-        HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<uie::window::ptr>& p_hierarchy) override;
+    bool is_point_ours(HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<window::ptr>& p_hierarchy) override;
     void get_supported_panels(
-        const pfc::list_base_const_t<uie::window::ptr>& p_windows, pfc::bit_array_var& p_mask_unsupported) override;
+        const pfc::list_base_const_t<window::ptr>& p_windows, bit_array_var& p_mask_unsupported) override;
 
     void insert_panel(unsigned index, const uie::splitter_item_t* p_item) override;
     void remove_panel(unsigned index) override;

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -30,14 +30,13 @@ public:
         virtual bool get_show_shortcuts() const;
 
         void on_size_limit_change(HWND wnd, unsigned flags) override;
-        ;
 
         const GUID& get_host_guid() const override;
 
         bool override_status_text_create(service_ptr_t<ui_status_text_override>& p_out) override;
 
         void relinquish_ownership(HWND wnd) override;
-        ;
+
         void set_this(PlaylistTabs* ptr);
 
     private:
@@ -100,7 +99,7 @@ public:
 
     void FB2KAPI on_items_removing(
         unsigned p_playlist, const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override;
-    ; // called before actually removing them
+    // called before actually removing them
     void FB2KAPI on_items_removed(
         unsigned p_playlist, const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override;
 

--- a/foo_ui_columns/playlist_tabs_drop_target.cpp
+++ b/foo_ui_columns/playlist_tabs_drop_target.cpp
@@ -266,10 +266,10 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Drop(
                             {
                                 uDragQueryFile((HDROP)sm.hGlobal, 0, temp);
                                 if (uGetFileAttributes(temp) & FILE_ATTRIBUTE_DIRECTORY) {
-                                    playlist_name.set_string(pfc::string_filename_ext(temp));
+                                    playlist_name.set_string(string_filename_ext(temp));
                                     named = true;
                                 } else {
-                                    playlist_name.set_string(pfc::string_filename(temp));
+                                    playlist_name.set_string(string_filename(temp));
                                     named = true;
 #if 0
                                     pfc::string_extension ext(temp);
@@ -310,13 +310,13 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Drop(
                 else
                     new_idx = playlist_api->create_playlist(playlist_name, pfc_infinite, newPlaylistIndex);
 
-                playlist_api->playlist_add_items(new_idx, data, pfc::bit_array_false());
+                playlist_api->playlist_add_items(new_idx, data, bit_array_false());
                 if (main_window::config_get_activate_target_playlist_on_dropped_items())
                     playlist_api->set_active_playlist(new_idx);
 
             } else {
                 playlist_api->playlist_clear_selection(target_index);
-                playlist_api->playlist_insert_items(target_index, idx, data, pfc::bit_array_true());
+                playlist_api->playlist_insert_items(target_index, idx, data, bit_array_true());
                 if (main_window::config_get_activate_target_playlist_on_dropped_items())
                     playlist_api->set_active_playlist(target_index);
             }

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -48,7 +48,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             m_host->set_this(this);
             create_child();
         }
-        static_api_ptr_t<playlist_manager>()->register_callback(this, playlist_callback::flag_all);
+        static_api_ptr_t<playlist_manager>()->register_callback(this, flag_all);
         break;
     }
 
@@ -143,7 +143,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 pfc::string8 blah;
 
                 if (id >= ID_CUSTOM_BASE) {
-                    ::contextmenu_node* node = p_manager->find_by_id(id - ID_CUSTOM_BASE);
+                    contextmenu_node* node = p_manager->find_by_id(id - ID_CUSTOM_BASE);
                     if (node)
                         set = node->get_description(blah);
                 } else if (id == ID_SWITCH) {
@@ -363,7 +363,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                                 autoplaylist->show_ui(position_tracker.m_playlist);
                             break;
                         case ID_RECYCLER_CLEAR:
-                            playlist_api->recycler_purge(pfc::bit_array_true());
+                            playlist_api->recycler_purge(bit_array_true());
                             break;
                         case ID_CUT:
                             if (b_index_valid)
@@ -396,7 +396,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                             metadb_handle_list data;
                             playlist_api->playlist_add_items(playlist_api->create_playlist(pfc::string8("Untitled"), -1,
                                                                  playlist_api->get_playlist_count()),
-                                data, pfc::bit_array_false());
+                                data, bit_array_false());
                         } break;
                         case ID_SAVE: {
                             pfc::string8 name;

--- a/foo_ui_columns/playlist_view_tfhooks.h
+++ b/foo_ui_columns/playlist_view_tfhooks.h
@@ -30,7 +30,7 @@ public:
     void add_item(const char* p_name, unsigned p_name_length, const char* p_value, unsigned p_value_length)
     {
         auto var = new GlobalVariable(p_name, p_name_length, p_value, p_value_length);
-        pfc::ptr_list_t<GlobalVariable>::add_item(var);
+        ptr_list_t<GlobalVariable>::add_item(var);
     }
     ~GlobalVariableList() { delete_all(); }
 };

--- a/foo_ui_columns/playlist_view_tfhooks.h
+++ b/foo_ui_columns/playlist_view_tfhooks.h
@@ -88,7 +88,7 @@ public:
         return false;
     }
 
-    SetGlobalTitleformatHook(GlobalVariableList& vars) : p_vars(vars){};
+    SetGlobalTitleformatHook(GlobalVariableList& vars) : p_vars(vars) {}
 };
 
 class DateTitleformatHook : public titleformat_hook {
@@ -100,7 +100,7 @@ public:
         titleformat_text_out* p_out, const char* p_name, unsigned p_name_length, bool& p_found_flag) override;
     bool process_function(titleformat_text_out* p_out, const char* p_name, unsigned p_name_length,
         titleformat_hook_function_params* p_params, bool& p_found_flag) override;
-    DateTitleformatHook(const SYSTEMTIME* st = nullptr) : p_st(st){};
+    DateTitleformatHook(const SYSTEMTIME* st = nullptr) : p_st(st) {}
 };
 
 class SplitterTitleformatHook : public titleformat_hook {
@@ -110,7 +110,9 @@ public:
         : m_hook1(p_hook1)
         , m_hook2(p_hook2)
         , m_hook3(p_hook3)
-        , m_hook4(p_hook4){};
+        , m_hook4(p_hook4)
+    {
+    }
     bool process_field(
         titleformat_text_out* p_out, const char* p_name, unsigned p_name_length, bool& p_found_flag) override;
     bool process_function(titleformat_text_out* p_out, const char* p_name, unsigned p_name_length,
@@ -133,6 +135,6 @@ public:
         titleformat_hook_function_params* p_params, bool& p_found_flag) override
     {
         return false;
-    };
+    }
     PlaylistNameTitleformatHook() = default;
 };

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -258,7 +258,7 @@ static const GUID rebar_guid = {0x3d3c8d68, 0x3ab9, 0x4ad5, {0xa4, 0xfa, 0x22, 0
 
 class RebarWindowHost : public ui_extension::window_host_with_control {
 public:
-    void get_name(pfc::string_base& out) const override { out.set_string("Columns UI/Toolbars"); };
+    void get_name(pfc::string_base& out) const override { out.set_string("Columns UI/Toolbars"); }
 
     bool is_available() const override { return g_rebar_window != nullptr; }
 
@@ -269,14 +269,14 @@ public:
         if (g_rebar_window) {
             g_rebar_window->add_band(in, width);
         }
-    };
+    }
 
     void insert_extension(ui_extension::window_ptr& p_ext, unsigned height, unsigned width) override
     {
         if (g_rebar_window) {
             g_rebar_window->add_band(p_ext->get_extension_guid(), width, p_ext);
         }
-    };
+    }
 
     unsigned is_resize_supported(HWND wnd) const override { return ui_extension::size_width; }
 
@@ -309,7 +309,7 @@ public:
                 g_rebar_window->update_band(index);
             }
         }
-    };
+    }
 
     const GUID& get_host_guid() const override { return rebar_guid; }
 
@@ -322,14 +322,14 @@ public:
     virtual bool on_key(UINT msg, LPARAM lp, WPARAM wp, bool process_keyboard_shortcuts)
     {
         return process_keydown(msg, lp, wp, false, process_keyboard_shortcuts);
-    };
+    }
 
     void relinquish_ownership(HWND wnd) override
     {
         if (g_rebar_window) {
             g_rebar_window->delete_band(wnd, false);
         }
-    };
+    }
 };
 
 ui_extension::window_host_factory_single<RebarWindowHost> g_ui_ext_host_rebar;

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -48,7 +48,7 @@ void create_rebar()
 }
 
 void ConfigRebar::export_config(
-    stream_writer* p_out, t_uint32 mode, cui::fcl::t_export_feedback& feedback, abort_callback& p_abort)
+    stream_writer* p_out, t_uint32 mode, fcl::t_export_feedback& feedback, abort_callback& p_abort)
 {
     enum { stream_version = 0 };
     p_out->write_lendian_t((t_uint32)stream_version, p_abort);
@@ -85,19 +85,19 @@ void ConfigRebar::import_config(
             panels.add_item(item.m_guid);
         new_entries.push_back(std::move(item));
     }
-    if (cui::main_window.get_wnd())
+    if (main_window.get_wnd())
         destroy_rebar();
 
     m_entries = new_entries;
     cfg_band_cache.reset();
 
-    if (cui::main_window.get_wnd()) {
+    if (main_window.get_wnd()) {
         create_rebar();
         if (g_rebar) {
             ShowWindow(g_rebar, SW_SHOWNORMAL);
             UpdateWindow(g_rebar);
         }
-        cui::main_window.resize_child_windows();
+        main_window.resize_child_windows();
     }
 }
 
@@ -245,11 +245,11 @@ void ConfigRebar::set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abo
 void ConfigRebar::reset()
 {
     m_entries = {
-        {cui::toolbars::guid_menu, 9999},
-        {cui::toolbars::guid_buttons, 100, true},
-        {cui::toolbars::guid_seek_bar, 9999},
-        {cui::toolbars::guid_playback_order, 100},
-        {cui::toolbars::guid_spectrum_analyser, 125},
+        {toolbars::guid_menu, 9999},
+        {toolbars::guid_buttons, 100, true},
+        {toolbars::guid_seek_bar, 9999},
+        {toolbars::guid_playback_order, 100},
+        {toolbars::guid_spectrum_analyser, 125},
     };
 }
 
@@ -347,7 +347,7 @@ HWND RebarWindow::init()
         rv = wnd_rebar = CreateWindowEx(WS_EX_TOOLWINDOW | WS_EX_CONTROLPARENT, REBARCLASSNAME, nullptr,
             WS_BORDER | WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | RBS_VARHEIGHT | RBS_DBLCLKTOGGLE | RBS_AUTOSIZE
                 | RBS_BANDBORDERS | CCS_NODIVIDER | CCS_NOPARENTALIGN | 0,
-            0, 0, 0, 0, cui::main_window.get_wnd(), (HMENU)ID_REBAR, core_api::get_my_instance(), nullptr);
+            0, 0, 0, 0, main_window.get_wnd(), (HMENU)ID_REBAR, core_api::get_my_instance(), nullptr);
 
         if (dark::is_dark_mode_enabled())
             m_toolbar_theme.reset(OpenThemeData(wnd_rebar, L"DarkMode::Toolbar"));
@@ -474,7 +474,7 @@ std::optional<LRESULT> RebarWindow::handle_custom_draw(const LPNMCUSTOMDRAW lpnm
 {
     switch (lpnmcd->dwDrawStage) {
     case CDDS_PREERASE:
-        if (!(cui::dark::is_dark_mode_enabled() && m_toolbar_theme))
+        if (!(dark::is_dark_mode_enabled() && m_toolbar_theme))
             return {};
 
         COLORREF cr{RGB(255, 0, 0)};
@@ -519,7 +519,7 @@ void RebarWindow::save_bands()
         }
 
         if (!b_death)
-            mmh::destructive_reorder(m_bands, order);
+            destructive_reorder(m_bands, order);
         refresh_bands(false);
     }
 }

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -45,7 +45,7 @@ private:
     void set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort) override;
 
 public:
-    explicit ConfigBandCache(const GUID& p_guid) : cfg_var(p_guid) { reset(); };
+    explicit ConfigBandCache(const GUID& p_guid) : cfg_var(p_guid) { reset(); }
     void get_band_cache(BandCache& out);
     void set_band_cache(BandCache& in);
     void reset();
@@ -65,7 +65,7 @@ public:
     void import_config(
         stream_reader* p_reader, t_size size, t_uint32 mode, pfc::list_base_t<GUID>& panels, abort_callback& p_abort);
 
-    explicit ConfigRebar(const GUID& p_guid) : cfg_var(p_guid) { reset(); };
+    explicit ConfigRebar(const GUID& p_guid) : cfg_var(p_guid) { reset(); }
 
     const std::vector<RebarBandState>& get_rebar_info() { return m_entries; }
 

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -61,8 +61,7 @@ private:
     void set_data_raw(stream_reader* p_reader, unsigned p_sizehint, abort_callback& p_abort) override;
 
 public:
-    void export_config(
-        stream_writer* p_out, t_uint32 mode, cui::fcl::t_export_feedback& feedback, abort_callback& p_abort);
+    void export_config(stream_writer* p_out, t_uint32 mode, fcl::t_export_feedback& feedback, abort_callback& p_abort);
     void import_config(
         stream_reader* p_reader, t_size size, t_uint32 mode, pfc::list_base_t<GUID>& panels, abort_callback& p_abort);
 

--- a/foo_ui_columns/rebar_band.cpp
+++ b/foo_ui_columns/rebar_band.cpp
@@ -15,10 +15,10 @@ void RebarBandState::export_to_fcl_stream(stream_writer* writer, t_uint32 fcl_ty
         } catch (const exception_io&) {
         } // FIXME: Why?
     } else
-        throw cui::fcl::exception_missing_panel();
+        throw fcl::exception_missing_panel();
 
     stream_writer_memblock w;
-    if (fcl_type == cui::fcl::type_public)
+    if (fcl_type == fcl::type_public)
         ptr->export_config(&w, aborter);
     else
         ptr->get_config(&w, aborter);
@@ -45,7 +45,7 @@ void RebarBandState::import_from_fcl_stream(stream_reader* reader, t_uint32 fcl_
         data.set_size(mem_size);
         reader->read(data.get_ptr(), mem_size, aborter);
 
-        if (fcl_type == cui::fcl::type_public) {
+        if (fcl_type == fcl::type_public) {
             uie::window_ptr ptr;
 
             if (uie::window::create_by_guid(m_guid, ptr)) {

--- a/foo_ui_columns/seekbar.cpp
+++ b/foo_ui_columns/seekbar.cpp
@@ -18,7 +18,7 @@ void SeekBarToolbar::SeekBarTrackbarCallback::on_position_change(unsigned pos, b
 void SeekBarToolbar::SeekBarTrackbarCallback::get_tooltip_text(unsigned pos, uih::TrackbarString& out)
 {
     out = pfc::stringcvt::string_os_from_utf8(pfc::format_time_ex(pos / 10.0, 1));
-};
+}
 
 void SeekBarToolbar::update_seekbars(bool positions_only)
 {
@@ -118,7 +118,6 @@ void SeekBarToolbar::update_seek()
 }
 
 SeekBarToolbar::SeekBarToolbar() = default;
-;
 
 SeekBarToolbar::~SeekBarToolbar()
 {
@@ -198,7 +197,7 @@ void SeekBarToolbar::get_category(pfc::string_base& out) const
 unsigned SeekBarToolbar::get_type() const
 {
     return ui_extension::type_toolbar;
-};
+}
 
 ui_extension::window_factory<SeekBarToolbar> blue;
 

--- a/foo_ui_columns/seekbar.cpp
+++ b/foo_ui_columns/seekbar.cpp
@@ -148,7 +148,7 @@ LRESULT SeekBarToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             update_seek_timer();
         }
 
-        SeekBarToolbar::update_seek_timer();
+        update_seek_timer();
         ShowWindow(wnd_seekbar, SW_SHOWNORMAL);
         break;
     }

--- a/foo_ui_columns/splitter.cpp
+++ b/foo_ui_columns/splitter.cpp
@@ -40,7 +40,7 @@ class VerticalSplitterPanel : public FlatSplitterPanel {
 uie::window_factory<HorizontalSplitterPanel> g_splitter_window_horizontal;
 uie::window_factory<VerticalSplitterPanel> g_splitter_window_vertical;
 
-FlatSplitterPanel::Panel::ptr FlatSplitterPanel::Panel::null_ptr = FlatSplitterPanel::Panel::ptr();
+FlatSplitterPanel::Panel::ptr FlatSplitterPanel::Panel::null_ptr = ptr();
 
 #if 0
 template <orientation_t t_orientation>

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -48,7 +48,6 @@ public:
         void get_children(pfc::list_base_t<window::ptr>& p_out) override;
 
         void on_size_limit_change(HWND wnd, unsigned flags) override;
-        ;
 
         // unsigned get_orientation();
         Orientation get_orientation() const;
@@ -82,7 +81,6 @@ private:
         unsigned min_width{0};
         unsigned max_width{0};
         SizeLimit() = default;
-        ;
     };
     class Panel : public std::enable_shared_from_this<Panel> {
     public:
@@ -93,7 +91,7 @@ private:
             enum { MSG_AUTOHIDE_END = WM_USER + 2 };
 
             PanelContainer(Panel* p_panel);
-            ;
+
             ~PanelContainer();
             void set_window_ptr(FlatSplitterPanel* p_ptr);
             void enter_autohide_hook();

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -45,7 +45,7 @@ public:
         const GUID& get_host_guid() const override;
 
         bool get_keyboard_shortcuts_enabled() const override;
-        void get_children(pfc::list_base_t<uie::window::ptr>& p_out) override;
+        void get_children(pfc::list_base_t<window::ptr>& p_out) override;
 
         void on_size_limit_change(HWND wnd, unsigned flags) override;
         ;
@@ -69,10 +69,9 @@ public:
         void relinquish_ownership(HWND wnd) override;
     };
 
-    bool is_point_ours(
-        HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<uie::window::ptr>& p_hierarchy) override;
+    bool is_point_ours(HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<window::ptr>& p_hierarchy) override;
     void get_supported_panels(
-        const pfc::list_base_const_t<uie::window::ptr>& p_windows, pfc::bit_array_var& p_mask_unsupported) override;
+        const pfc::list_base_const_t<window::ptr>& p_windows, bit_array_var& p_mask_unsupported) override;
 
     static void g_on_size_change();
 
@@ -88,7 +87,7 @@ private:
     class Panel : public std::enable_shared_from_this<Panel> {
     public:
         class PanelContainer
-            : public ui_helpers::container_window
+            : public container_window
             , private fbh::LowLevelMouseHookManager::HookCallback {
         public:
             enum { MSG_AUTOHIDE_END = WM_USER + 2 };

--- a/foo_ui_columns/splitter_panel.cpp
+++ b/foo_ui_columns/splitter_panel.cpp
@@ -107,7 +107,7 @@ void FlatSplitterPanel::Panel::import(stream_reader* t, abort_callback& p_abort)
     t->read_lendian_t(m_use_custom_title, p_abort);
     t->read_string(m_custom_title, p_abort);
 
-    if (uie::window::create_by_guid(m_guid, m_child)) {
+    if (create_by_guid(m_guid, m_child)) {
         try {
             m_child->import_config_from_ptr(data.get_ptr(), data.get_size(), p_abort);
         } catch (const exception_io&) {
@@ -160,8 +160,8 @@ void FlatSplitterPanel::Panel::_export(stream_writer* out, abort_callback& p_abo
     stream_writer_memblock child_exported_data;
     uie::window_ptr ptr = m_child;
     if (!ptr.is_valid()) {
-        if (!uie::window::create_by_guid(m_guid, ptr))
-            throw cui::fcl::exception_missing_panel();
+        if (!create_by_guid(m_guid, ptr))
+            throw fcl::exception_missing_panel();
         try {
             ptr->set_config_from_ptr(m_child_data.get_ptr(), m_child_data.get_size(), p_abort);
         } catch (const exception_io&) {

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -133,7 +133,7 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
                     if (m_theme) {
                         DrawThemeBackground(m_theme.get(), dc, 0, 0, &rc_caption, nullptr);
                     } else {
-                        const auto back_brush = dark::get_colour_brush(dark::ColourID::PanelCaptionBackground, is_dark);
+                        const auto back_brush = get_colour_brush(dark::ColourID::PanelCaptionBackground, is_dark);
                         FillRect(dc, &rc_caption, back_brush.get());
                     }
 

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -29,7 +29,7 @@ public:
     {
         unsigned index;
         if (m_this->m_panels.find_by_wnd(wnd, index)) {
-            std::shared_ptr<TabStackPanel::Panel> p_ext = m_this->m_panels[index];
+            std::shared_ptr<Panel> p_ext = m_this->m_panels[index];
             MINMAXINFO mmi;
             memset(&mmi, 0, sizeof(MINMAXINFO));
             mmi.ptMaxTrackSize.x = MAXLONG;
@@ -115,7 +115,7 @@ public:
     {
         unsigned index;
         if (m_this->m_active_panels.find_by_wnd(wnd, index)) {
-            std::shared_ptr<TabStackPanel::Panel> p_ext = m_this->m_active_panels[index];
+            std::shared_ptr<Panel> p_ext = m_this->m_active_panels[index];
 
             {
                 /*if (GetAncestor(wnd, GA_PARENT) == m_this->get_wnd())
@@ -141,13 +141,13 @@ public:
 ui_extension::window_host_factory<TabStackPanel::TabStackSplitterHost> g_splitter_tabs_host;
 
 void TabStackPanel::get_supported_panels(
-    const pfc::list_base_const_t<uie::window::ptr>& p_windows, pfc::bit_array_var& p_mask_unsupported)
+    const pfc::list_base_const_t<window::ptr>& p_windows, bit_array_var& p_mask_unsupported)
 {
     service_ptr_t<service_base> temp;
     g_splitter_tabs_host.instance_create(temp);
     uie::window_host_ptr ptr;
     if (temp->service_query_t(ptr))
-        (static_cast<TabStackPanel::TabStackSplitterHost*>(ptr.get_ptr()))->set_window_ptr(this);
+        (static_cast<TabStackSplitterHost*>(ptr.get_ptr()))->set_window_ptr(this);
     t_size count = p_windows.get_count();
     for (t_size i = 0; i < count; i++)
         p_mask_unsupported.set(i, !p_windows[i]->is_available(ptr));
@@ -242,8 +242,8 @@ void TabStackPanel::Panel::_export(stream_writer* out, abort_callback& p_abort)
     stream_writer_memblock child_exported_data;
     uie::window_ptr ptr = m_child;
     if (!ptr.is_valid()) {
-        if (!uie::window::create_by_guid(m_guid, ptr))
-            throw cui::fcl::exception_missing_panel();
+        if (!create_by_guid(m_guid, ptr))
+            throw fcl::exception_missing_panel();
         try {
             ptr->set_config_from_ptr(m_child_data.get_ptr(), m_child_data.get_size(), p_abort);
         } catch (const exception_io&) {
@@ -269,7 +269,7 @@ void TabStackPanel::Panel::import(stream_reader* t, abort_callback& p_abort)
     t->read_lendian_t(m_use_custom_title, p_abort);
     t->read_string(m_custom_title, p_abort);
 
-    if (uie::window::create_by_guid(m_guid, m_child)) {
+    if (create_by_guid(m_guid, m_child)) {
         try {
             m_child->import_config_from_ptr(data.get_ptr(), data.get_size(), p_abort);
         } catch (const exception_io&) {
@@ -319,18 +319,18 @@ uie::splitter_item_t* TabStackPanel::get_panel(unsigned index) const
 
 bool TabStackPanel::get_config_item_supported(unsigned index, const GUID& p_type) const
 {
-    return p_type == uie::splitter_window::bool_use_custom_title || p_type == uie::splitter_window::string_custom_title;
+    return p_type == bool_use_custom_title || p_type == string_custom_title;
 }
 
 bool TabStackPanel::get_config_item(
     unsigned index, const GUID& p_type, stream_writer* p_out, abort_callback& p_abort) const
 {
     if (index < m_panels.get_count()) {
-        if (p_type == uie::splitter_window::bool_use_custom_title) {
+        if (p_type == bool_use_custom_title) {
             p_out->write_lendian_t(m_panels[index]->m_use_custom_title, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::string_custom_title) {
+        if (p_type == string_custom_title) {
             p_out->write_string(m_panels[index]->m_custom_title, p_abort);
             return true;
         }
@@ -342,11 +342,11 @@ bool TabStackPanel::set_config_item(
     unsigned index, const GUID& p_type, stream_reader* p_source, abort_callback& p_abort)
 {
     if (index < m_panels.get_count()) {
-        if (p_type == uie::splitter_window::bool_use_custom_title) {
+        if (p_type == bool_use_custom_title) {
             p_source->read_lendian_t(m_panels[index]->m_use_custom_title, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::string_custom_title) {
+        if (p_type == string_custom_title) {
             p_source->read_string(m_panels[index]->m_custom_title, p_abort);
             return true;
         }
@@ -517,7 +517,7 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
         if (wp == VK_TAB) {
-            ui_extension::window::g_on_tab(wnd);
+            g_on_tab(wnd);
             return 0;
         }
         SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
@@ -666,7 +666,7 @@ void TabStackPanel::refresh_children()
 
             bool b_new = false;
             if (!p_ext.is_valid()) {
-                ui_extension::window::create_by_guid(m_panels[n]->m_guid, p_ext);
+                create_by_guid(m_panels[n]->m_guid, p_ext);
                 b_new = true;
             }
 
@@ -816,7 +816,7 @@ void TabStackPanel::remove_panel(unsigned index)
 
 void TabStackPanel::create_tabs()
 {
-    g_font.reset(static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_splitter_tabs));
+    g_font.reset(static_api_ptr_t<fonts::manager>()->get_font(g_guid_splitter_tabs));
     RECT rc;
     GetClientRect(get_wnd(), &rc);
     DWORD flags = WS_CHILD | WS_TABSTOP | TCS_HOTTRACK | TCS_TABS | TCS_MULTILINE
@@ -851,7 +851,7 @@ void TabStackPanel::on_font_change()
             SendMessage(m_wnd_tabs, WM_SETFONT, (WPARAM)0, MAKELPARAM(0, 0));
         }
 
-        g_font.reset(static_api_ptr_t<cui::fonts::manager>()->get_font(g_guid_splitter_tabs));
+        g_font.reset(static_api_ptr_t<fonts::manager>()->get_font(g_guid_splitter_tabs));
 
         if (m_wnd_tabs) {
             SendMessage(m_wnd_tabs, WM_SETFONT, (WPARAM)g_font.get(), MAKELPARAM(1, 0));
@@ -934,7 +934,7 @@ LRESULT WINAPI TabStackPanel::on_hooked_message(HWND wnd, UINT msg, WPARAM wp, L
             && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
         if (wp == VK_TAB) {
-            ui_extension::window::g_on_tab(wnd);
+            g_on_tab(wnd);
             return 0;
         }
         SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
@@ -996,12 +996,12 @@ LRESULT WINAPI TabStackPanel::on_hooked_message(HWND wnd, UINT msg, WPARAM wp, L
     return uCallWindowProc(m_tab_proc, wnd, msg, wp, lp);
 }
 
-class TabStackFontClient : public cui::fonts::client {
+class TabStackFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return g_guid_splitter_tabs; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Tab stack"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_labels; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_labels; }
 
     void on_font_changed() const override { TabStackPanel::g_on_font_change(); }
 };

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -46,7 +46,7 @@ public:
 
             m_this->on_size_changed();
         }
-    };
+    }
 
     unsigned is_resize_supported(HWND wnd) const override { return false; }
 
@@ -303,19 +303,19 @@ void TabStackPanel::get_category(pfc::string_base& p_out) const
 unsigned TabStackPanel::get_type() const
 {
     return ui_extension::type_layout | uie::type_splitter;
-};
+}
 
 unsigned TabStackPanel::get_panel_count() const
 {
     return m_panels.get_count();
-};
+}
 uie::splitter_item_t* TabStackPanel::get_panel(unsigned index) const
 {
     if (index < m_panels.get_count()) {
         return m_panels[index]->create_splitter_item();
     }
     return nullptr;
-};
+}
 
 bool TabStackPanel::get_config_item_supported(unsigned index, const GUID& p_type) const
 {
@@ -352,7 +352,7 @@ bool TabStackPanel::set_config_item(
         }
     }
     return false;
-};
+}
 
 void TabStackPanel::set_config(stream_reader* config, t_size p_size, abort_callback& p_abort)
 {
@@ -373,7 +373,7 @@ void TabStackPanel::set_config(stream_reader* config, t_size p_size, abort_callb
             }
         }
     }
-};
+}
 void TabStackPanel::get_config(stream_writer* out, abort_callback& p_abort) const
 {
     out->write_lendian_t((t_uint32)stream_version_current, p_abort);
@@ -383,7 +383,7 @@ void TabStackPanel::get_config(stream_writer* out, abort_callback& p_abort) cons
     for (unsigned n = 0; n < count; n++) {
         m_panels[n]->write(out, p_abort);
     }
-};
+}
 
 void TabStackPanel::export_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
@@ -394,7 +394,7 @@ void TabStackPanel::export_config(stream_writer* p_writer, abort_callback& p_abo
     for (unsigned n = 0; n < count; n++) {
         m_panels[n]->_export(p_writer, p_abort);
     }
-};
+}
 
 void TabStackPanel::import_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
 {
@@ -413,7 +413,7 @@ void TabStackPanel::import_config(stream_reader* p_reader, t_size p_size, abort_
             m_panels.add_item(temp);
         }
     }
-};
+}
 
 void clip_sizelimit(uie::size_limit_t& mmi)
 {
@@ -778,7 +778,7 @@ void TabStackPanel::insert_panel(unsigned index, const uie::splitter_item_t* p_i
         if (get_wnd())
             refresh_children();
     }
-};
+}
 
 void TabStackPanel::replace_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
@@ -799,7 +799,7 @@ void TabStackPanel::replace_panel(unsigned index, const uie::splitter_item_t* p_
         if (get_wnd())
             refresh_children();
     }
-};
+}
 
 void TabStackPanel::remove_panel(unsigned index)
 {
@@ -812,7 +812,7 @@ void TabStackPanel::remove_panel(unsigned index)
         m_panels[index]->destroy();
         m_panels.remove_by_idx(index);
     }
-};
+}
 
 void TabStackPanel::create_tabs()
 {
@@ -896,7 +896,7 @@ void TabStackPanel::on_active_tab_changing(t_size index_from)
         //}
         ShowWindow(m_active_panels[index_from]->m_wnd, SW_HIDE);
     }
-};
+}
 void TabStackPanel::on_active_tab_changed(t_size index_to)
 {
     if (index_to < m_active_panels.get_count() && m_active_panels[index_to]->m_wnd) {

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -16,7 +16,7 @@ public:
     void remove_panel(unsigned index) override;
     void replace_panel(unsigned index, const uie::splitter_item_t* p_item) override;
 
-    bool is_point_ours(HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<uie::window::ptr>& p_hierarchy) override
+    bool is_point_ours(HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<window::ptr>& p_hierarchy) override
     {
         if (wnd_point == get_wnd() || IsChild(get_wnd(), wnd_point)) {
             if (wnd_point == get_wnd() || wnd_point == m_wnd_tabs) {
@@ -28,7 +28,7 @@ public:
                 uie::splitter_window_v2_ptr sptr;
                 if (m_panels[i]->m_child.is_valid()) {
                     if (m_panels[i]->m_child->service_query_t(sptr)) {
-                        pfc::list_t<uie::window::ptr> temp;
+                        pfc::list_t<window::ptr> temp;
                         temp.add_item(this);
                         if (sptr->is_point_ours(wnd_point, pt_screen, temp)) {
                             p_hierarchy.add_items(temp);
@@ -46,7 +46,7 @@ public:
     }
 
     void get_supported_panels(
-        const pfc::list_base_const_t<uie::window::ptr>& p_windows, pfc::bit_array_var& p_mask_unsupported) override;
+        const pfc::list_base_const_t<window::ptr>& p_windows, bit_array_var& p_mask_unsupported) override;
     unsigned get_panel_count() const override;
     uie::splitter_item_t* get_panel(unsigned index) const override;
 

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -72,7 +72,6 @@ public:
         unsigned min_width{0};
         unsigned max_width{0};
         SizeLimit() = default;
-        ;
     };
     class Panel {
     public:

--- a/foo_ui_columns/splitter_window.cpp
+++ b/foo_ui_columns/splitter_window.cpp
@@ -73,7 +73,7 @@ void FlatSplitterPanel::refresh_children()
             bool b_new = false;
 
             if (!p_ext.is_valid()) {
-                ui_extension::window::create_by_guid(m_panels[n]->m_guid, p_ext);
+                create_by_guid(m_panels[n]->m_guid, p_ext);
                 b_new = true;
             }
 
@@ -125,7 +125,7 @@ void FlatSplitterPanel::refresh_children()
                         mmi.ptMaxTrackSize.x = MAXLONG;
                         mmi.ptMaxTrackSize.y = MAXLONG;
                         SendMessage(wnd_panel, WM_GETMINMAXINFO, 0, (LPARAM)&mmi);
-                        cui::helpers::clip_minmaxinfo(mmi);
+                        helpers::clip_minmaxinfo(mmi);
 
                         m_panels[n]->m_wnd = wnd_host;
                         m_panels[n]->m_wnd_child = wnd_panel;
@@ -672,7 +672,7 @@ void FlatSplitterPanel::start_autohide_dehide(unsigned p_panel, bool b_next_too)
 }
 
 void FlatSplitterPanel::get_supported_panels(
-    const pfc::list_base_const_t<uie::window::ptr>& p_windows, pfc::bit_array_var& p_mask_unsupported)
+    const pfc::list_base_const_t<window::ptr>& p_windows, bit_array_var& p_mask_unsupported)
 {
     service_ptr_t<service_base> temp;
     g_splitter_host_vert.instance_create(temp);
@@ -685,7 +685,7 @@ void FlatSplitterPanel::get_supported_panels(
 }
 
 bool FlatSplitterPanel::is_point_ours(
-    HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<uie::window::ptr>& p_hierarchy)
+    HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<window::ptr>& p_hierarchy)
 {
     if (wnd_point == get_wnd() || IsChild(get_wnd(), wnd_point)) {
         if (wnd_point == get_wnd()) {
@@ -697,7 +697,7 @@ bool FlatSplitterPanel::is_point_ours(
             uie::splitter_window_v2_ptr sptr;
             if (m_panels[i]->m_child.is_valid()) {
                 if (m_panels[i]->m_child->service_query_t(sptr)) {
-                    pfc::list_t<uie::window::ptr> temp;
+                    pfc::list_t<window::ptr> temp;
                     temp.add_item(this);
                     if (sptr->is_point_ours(wnd_point, pt_screen, temp)) {
                         p_hierarchy.add_items(temp);
@@ -726,7 +726,7 @@ bool FlatSplitterPanel::set_config_item(
     unsigned index, const GUID& p_type, stream_reader* p_source, abort_callback& p_abort)
 {
     if (is_index_valid(index)) {
-        if (p_type == uie::splitter_window::bool_show_caption) {
+        if (p_type == bool_show_caption) {
             p_source->read_object_t(m_panels[index]->m_show_caption, p_abort);
             if (get_wnd()) {
                 get_host()->on_size_limit_change(get_wnd(), uie::size_limit_all);
@@ -735,33 +735,33 @@ bool FlatSplitterPanel::set_config_item(
             }
             return true;
         }
-        if (p_type == uie::splitter_window::bool_hidden) {
+        if (p_type == bool_hidden) {
             if (!m_panels[index]->m_autohide)
                 p_source->read_object_t(m_panels[index]->m_hidden, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::bool_autohide) {
+        if (p_type == bool_autohide) {
             p_source->read_object_t(m_panels[index]->m_autohide, p_abort);
             m_panels[index]->m_hidden = m_panels[index]->m_autohide;
             return true;
         }
-        if (p_type == uie::splitter_window::bool_locked) {
+        if (p_type == bool_locked) {
             if (get_wnd())
                 save_sizes();
             p_source->read_object_t(m_panels[index]->m_locked, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::uint32_orientation) {
+        if (p_type == uint32_orientation) {
             p_source->read_object_t(m_panels[index]->m_caption_orientation, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::uint32_size) {
+        if (p_type == uint32_size) {
             uint32_t size;
             p_source->read_object_t(size, p_abort);
             m_panels[index]->m_size = size;
             return true;
         }
-        if (p_type == uie::splitter_window::size_and_dpi) {
+        if (p_type == size_and_dpi) {
             uie::size_and_dpi sad;
             p_source->read_object_t(sad.size, p_abort);
             p_source->read_object_t(sad.dpi, p_abort);
@@ -769,15 +769,15 @@ bool FlatSplitterPanel::set_config_item(
             m_panels[index]->m_size.dpi = sad.dpi;
             return true;
         }
-        if (p_type == uie::splitter_window::bool_show_toggle_area && get_orientation() == horizontal) {
+        if (p_type == bool_show_toggle_area && get_orientation() == horizontal) {
             p_source->read_object_t(m_panels[index]->m_show_toggle_area, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::bool_use_custom_title) {
+        if (p_type == bool_use_custom_title) {
             p_source->read_object_t(m_panels[index]->m_use_custom_title, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::string_custom_title) {
+        if (p_type == string_custom_title) {
             p_source->read_string(m_panels[index]->m_custom_title, p_abort);
             return true;
         }
@@ -790,44 +790,44 @@ bool FlatSplitterPanel::get_config_item(
     unsigned index, const GUID& p_type, stream_writer* p_out, abort_callback& p_abort) const
 {
     if (is_index_valid(index)) {
-        if (p_type == uie::splitter_window::bool_show_caption) {
+        if (p_type == bool_show_caption) {
             p_out->write_object_t(m_panels[index]->m_show_caption, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::bool_hidden) {
+        if (p_type == bool_hidden) {
             p_out->write_object_t(m_panels[index]->m_hidden, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::bool_autohide) {
+        if (p_type == bool_autohide) {
             p_out->write_object_t(m_panels[index]->m_autohide, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::bool_locked) {
+        if (p_type == bool_locked) {
             p_out->write_object_t(m_panels[index]->m_locked, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::uint32_orientation) {
+        if (p_type == uint32_orientation) {
             p_out->write_object_t(m_panels[index]->m_caption_orientation, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::uint32_size) {
+        if (p_type == uint32_size) {
             p_out->write_object_t(m_panels[index]->m_size.get_scaled_value(), p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::size_and_dpi) {
+        if (p_type == size_and_dpi) {
             p_out->write_object_t(m_panels[index]->m_size.value, p_abort);
             p_out->write_object_t(m_panels[index]->m_size.dpi, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::bool_show_toggle_area && get_orientation() == horizontal) {
+        if (p_type == bool_show_toggle_area && get_orientation() == horizontal) {
             p_out->write_object_t(m_panels[index]->m_show_toggle_area, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::bool_use_custom_title) {
+        if (p_type == bool_use_custom_title) {
             p_out->write_object_t(m_panels[index]->m_use_custom_title, p_abort);
             return true;
         }
-        if (p_type == uie::splitter_window::string_custom_title) {
+        if (p_type == string_custom_title) {
             p_out->write_string(m_panels[index]->m_custom_title, p_abort);
             return true;
         }
@@ -839,13 +839,10 @@ bool FlatSplitterPanel::get_config_item(
 bool FlatSplitterPanel::get_config_item_supported(unsigned index, const GUID& p_type) const
 {
     if (is_index_valid(index)) {
-        if (p_type == uie::splitter_window::bool_show_caption || p_type == uie::splitter_window::bool_locked
-            || p_type == uie::splitter_window::bool_hidden || p_type == uie::splitter_window::uint32_orientation
-            || p_type == uie::splitter_window::bool_autohide
-            || (p_type == uie::splitter_window::bool_show_toggle_area && get_orientation() == horizontal)
-            || p_type == uie::splitter_window::uint32_size || p_type == uie::splitter_window::size_and_dpi
-            || p_type == uie::splitter_window::bool_use_custom_title
-            || p_type == uie::splitter_window::string_custom_title)
+        if (p_type == bool_show_caption || p_type == bool_locked || p_type == bool_hidden
+            || p_type == uint32_orientation || p_type == bool_autohide
+            || (p_type == bool_show_toggle_area && get_orientation() == horizontal) || p_type == uint32_size
+            || p_type == size_and_dpi || p_type == bool_use_custom_title || p_type == string_custom_title)
             return true;
     }
     return false;
@@ -1105,7 +1102,7 @@ void FlatSplitterPanel::FlatSplitterPanelHost::on_size_limit_change(HWND wnd, un
     }
 }
 
-void FlatSplitterPanel::FlatSplitterPanelHost::get_children(pfc::list_base_t<uie::window::ptr>& p_out)
+void FlatSplitterPanel::FlatSplitterPanelHost::get_children(pfc::list_base_t<window::ptr>& p_out)
 {
     if (m_this.is_valid()) {
         t_size count = m_this->m_panels.get_count();

--- a/foo_ui_columns/splitter_window.cpp
+++ b/foo_ui_columns/splitter_window.cpp
@@ -20,7 +20,7 @@ void FlatSplitterPanel::insert_panel(unsigned index, const uie::splitter_item_t*
             refresh_children();
         }
     }
-};
+}
 
 void FlatSplitterPanel::replace_panel(unsigned index, const uie::splitter_item_t* p_item)
 {
@@ -34,7 +34,7 @@ void FlatSplitterPanel::replace_panel(unsigned index, const uie::splitter_item_t
         if (get_wnd())
             refresh_children();
     }
-};
+}
 
 void FlatSplitterPanel::destroy_children()
 {
@@ -715,7 +715,7 @@ bool FlatSplitterPanel::is_point_ours(
         }
     }
     return false;
-};
+}
 
 unsigned FlatSplitterPanel::get_panel_divider_size(unsigned index)
 {

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -318,4 +318,4 @@ void create_window()
     }
 }
 
-}; // namespace cui::status_bar
+} // namespace cui::status_bar

--- a/foo_ui_columns/status_bar_callbacks.cpp
+++ b/foo_ui_columns/status_bar_callbacks.cpp
@@ -22,60 +22,60 @@ public:
 
     void on_playback_new_track(metadb_handle_ptr p_track) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             regenerate_text();
         }
     }
 
     void on_playback_stop(play_control::t_stop_reason p_reason) override
     {
-        if (cui::main_window.get_wnd() && p_reason != play_control::stop_reason_shutting_down) {
+        if (main_window.get_wnd() && p_reason != play_control::stop_reason_shutting_down) {
             statusbartext = core_version_info::g_get_version_string();
             update_text(false);
         }
     }
     void on_playback_seek(double p_time) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             regenerate_text();
         }
     }
     void on_playback_pause(bool b_state) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             regenerate_text();
         }
     }
 
     void on_playback_edited(metadb_handle_ptr p_track) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             regenerate_text();
         }
     }
 
     void on_playback_dynamic_info(const file_info& p_info) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             regenerate_text();
         }
     }
     void on_playback_dynamic_info_track(const file_info& p_info) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             regenerate_text();
         }
     }
     void on_playback_time(double p_time) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             regenerate_text();
         }
     }
     void on_volume_change(float p_new_val) override
     {
-        if (cui::main_window.get_wnd() && g_status)
-            set_part_sizes(cui::status_bar::t_part_volume);
+        if (main_window.get_wnd() && g_status)
+            set_part_sizes(t_part_volume);
     }
 };
 
@@ -85,31 +85,28 @@ class StatusBarPlaylistCallback : public playlist_callback_static {
     unsigned get_flags() override { return flag_on_playlist_activate | flag_on_playlist_locked; }
 
     void on_items_added(unsigned p_playlist, unsigned start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const pfc::bit_array& p_selection) override
+        const bit_array& p_selection) override
     {
     }
     void on_items_reordered(unsigned p_playlist, const unsigned* order, unsigned count) override {}
 
     void on_items_removing(
-        unsigned p_playlist, const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override
+        unsigned p_playlist, const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override
     {
     }
     void on_items_removed(
-        unsigned p_playlist, const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override
+        unsigned p_playlist, const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override
     {
     }
 
-    void on_items_selection_change(
-        unsigned p_playlist, const pfc::bit_array& affected, const pfc::bit_array& state) override
-    {
-    }
+    void on_items_selection_change(unsigned p_playlist, const bit_array& affected, const bit_array& state) override {}
     void on_item_focus_change(unsigned p_playlist, unsigned from, unsigned to) override {}
-    void on_items_modified(unsigned p_playlist, const pfc::bit_array& p_mask) override {}
+    void on_items_modified(unsigned p_playlist, const bit_array& p_mask) override {}
     void on_items_modified_fromplayback(
-        unsigned p_playlist, const pfc::bit_array& p_mask, play_control::t_display_level p_level) override
+        unsigned p_playlist, const bit_array& p_mask, play_control::t_display_level p_level) override
     {
     }
-    void on_items_replaced(unsigned p_playlist, const pfc::bit_array& p_mask,
+    void on_items_replaced(unsigned p_playlist, const bit_array& p_mask,
         const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) override
     {
     }
@@ -117,7 +114,7 @@ class StatusBarPlaylistCallback : public playlist_callback_static {
 
     void on_playlist_activate(unsigned p_old, unsigned p_new) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             if (g_status && main_window::config_get_status_show_lock())
                 set_part_sizes(t_part_lock);
         }
@@ -125,15 +122,15 @@ class StatusBarPlaylistCallback : public playlist_callback_static {
 
     void on_playlist_created(unsigned p_index, const char* p_name, unsigned p_name_len) override {}
     void on_playlists_reorder(const unsigned* p_order, unsigned p_count) override {}
-    void on_playlists_removing(const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override {}
-    void on_playlists_removed(const pfc::bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override {}
+    void on_playlists_removing(const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override {}
+    void on_playlists_removed(const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override {}
     void on_playlist_renamed(unsigned p_index, const char* p_new_name, unsigned p_new_name_len) override {}
 
     void on_default_format_changed() override{};
     void on_playback_order_changed(unsigned p_new_index) override {}
     void on_playlist_locked(unsigned p_playlist, bool p_locked) override
     {
-        if (cui::main_window.get_wnd()) {
+        if (main_window.get_wnd()) {
             if (g_status && main_window::config_get_status_show_lock())
                 set_part_sizes(t_part_lock);
         }

--- a/foo_ui_columns/status_bar_callbacks.cpp
+++ b/foo_ui_columns/status_bar_callbacks.cpp
@@ -118,7 +118,7 @@ class StatusBarPlaylistCallback : public playlist_callback_static {
             if (g_status && main_window::config_get_status_show_lock())
                 set_part_sizes(t_part_lock);
         }
-    };
+    }
 
     void on_playlist_created(unsigned p_index, const char* p_name, unsigned p_name_len) override {}
     void on_playlists_reorder(const unsigned* p_order, unsigned p_count) override {}
@@ -126,7 +126,7 @@ class StatusBarPlaylistCallback : public playlist_callback_static {
     void on_playlists_removed(const bit_array& p_mask, unsigned p_old_count, unsigned p_new_count) override {}
     void on_playlist_renamed(unsigned p_index, const char* p_new_name, unsigned p_new_name_len) override {}
 
-    void on_default_format_changed() override{};
+    void on_default_format_changed() override {}
     void on_playback_order_changed(unsigned p_new_index) override {}
     void on_playlist_locked(unsigned p_playlist, bool p_locked) override
     {
@@ -134,7 +134,7 @@ class StatusBarPlaylistCallback : public playlist_callback_static {
             if (g_status && main_window::config_get_status_show_lock())
                 set_part_sizes(t_part_lock);
         }
-    };
+    }
 
     virtual void on_item_replaced(unsigned pls, unsigned item, metadb_handle* from, metadb_handle* to) {}
 };

--- a/foo_ui_columns/status_bar_font_client.cpp
+++ b/foo_ui_columns/status_bar_font_client.cpp
@@ -13,12 +13,12 @@ static const GUID font_client_status_guid
 
 HFONT g_status_font = nullptr;
 
-class StatusBarFontClient : public cui::fonts::client {
+class StatusBarFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return font_client_status_guid; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Status bar"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_labels; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_labels; }
 
     void on_font_changed() const override { on_status_font_change(); }
 };
@@ -35,9 +35,9 @@ void on_status_font_change()
     }
 
     if (g_status) {
-        g_status_font = static_api_ptr_t<cui::fonts::manager>()->get_font(font_client_status_guid);
+        g_status_font = static_api_ptr_t<fonts::manager>()->get_font(font_client_status_guid);
         SendMessage(g_status, WM_SETFONT, (WPARAM)g_status_font, MAKELPARAM(1, 0));
-        set_part_sizes(cui::status_bar::t_parts_all);
+        set_part_sizes(t_parts_all);
         main_window.resize_child_windows();
     }
 }

--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -10,12 +10,12 @@ namespace cui::status_pane {
 // {522E01C6-EA7C-49f2-AE5E-702B8C6B4B24}
 const GUID StatusPane::g_guid_font = {0x522e01c6, 0xea7c, 0x49f2, {0xae, 0x5e, 0x70, 0x2b, 0x8c, 0x6b, 0x4b, 0x24}};
 
-class StatusPaneFontClient : public cui::fonts::client {
+class StatusPaneFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return StatusPane::g_guid_font; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Status pane"; }
 
-    cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_labels; }
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_labels; }
 
     void on_font_changed() const override { g_status_pane.on_font_changed(); }
 };
@@ -24,8 +24,8 @@ StatusPaneFontClient::factory<StatusPaneFontClient> g_font_client_status_pane;
 
 void StatusPane::on_font_changed()
 {
-    m_font.reset(cui::fonts::helper(g_guid_font).get_font());
-    cui::main_window.resize_child_windows();
+    m_font.reset(fonts::helper(g_guid_font).get_font());
+    main_window.resize_child_windows();
 }
 
 void StatusPane::render_background(HDC dc, const RECT& rc)
@@ -86,6 +86,6 @@ void StatusPane::get_length_data(bool& p_selection, t_size& p_count, pfc::string
     p_selection = b_selection;
 }
 
-cui::status_pane::StatusPane g_status_pane;
+StatusPane g_status_pane;
 
 } // namespace cui::status_pane

--- a/foo_ui_columns/status_pane.h
+++ b/foo_ui_columns/status_pane.h
@@ -47,25 +47,25 @@ class StatusPane
     }
 
     /** PLAYLIST CALLBACKS */
-    void on_items_added(t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const pfc::bit_array& p_selection) override
+    void on_items_added(
+        t_size p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override
     {
         on_playlist_change();
     }
     void on_items_reordered(const t_size* p_order, t_size p_count) override {}
-    void on_items_removing(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
-    void on_items_removed(const pfc::bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
+    void on_items_removing(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override {}
+    void on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
     {
         on_playlist_change();
     }
-    void on_items_selection_change(const pfc::bit_array& p_affected, const pfc::bit_array& p_state) override
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override
     {
         on_playlist_change();
     }
     void on_item_focus_change(t_size p_from, t_size p_to) override {}
-    void on_items_modified(const pfc::bit_array& p_mask) override {}
-    void on_items_modified_fromplayback(const pfc::bit_array& p_mask, play_control::t_display_level p_level) override {}
-    void on_items_replaced(const pfc::bit_array& p_mask,
+    void on_items_modified(const bit_array& p_mask) override {}
+    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override {}
+    void on_items_replaced(const bit_array& p_mask,
         const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override
     {
     }

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -30,14 +30,14 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CREATE: {
         ShowWindow(m_volume_control.create(wnd), SW_SHOWNORMAL);
 
-        m_font.reset(cui::fonts::helper(g_guid_font).get_font());
+        m_font.reset(fonts::helper(g_guid_font).get_font());
         m_theme = IsThemeActive() && IsAppThemed() ? OpenThemeData(wnd, L"Window") : nullptr;
 
         update_playlist_data();
         update_playback_status_text();
-        static_api_ptr_t<playlist_manager>()->register_callback(this, playlist_callback_single::flag_all);
+        static_api_ptr_t<playlist_manager>()->register_callback(this, flag_all);
         static_api_ptr_t<play_callback_manager>()->register_callback(
-            this, play_callback::flag_on_playback_all | play_callback::flag_on_volume_change, false);
+            this, flag_on_playback_all | flag_on_volume_change, false);
     } break;
     case WM_DESTROY:
         static_api_ptr_t<playlist_manager>()->unregister_callback(this);
@@ -70,7 +70,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
     } break;
     case WM_LBUTTONDBLCLK:
-        cui::helpers::execute_main_menu_command(cfg_statusdbl);
+        helpers::execute_main_menu_command(cfg_statusdbl);
         return 0;
     case WM_PRINTCLIENT: {
         if (lp & PRF_ERASEBKGND) {
@@ -111,7 +111,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         const char* placeholder = "999999999 items selected";
         const auto default_text_colour = dark::get_system_colour(COLOR_BTNTEXT, dark::is_dark_mode_enabled());
-        int placeholder_len = uih::get_text_width(dc, placeholder, strlen(placeholder)) + uih::scale_dpi_value(20);
+        int placeholder_len = get_text_width(dc, placeholder, strlen(placeholder)) + uih::scale_dpi_value(20);
 
         pfc::string8 items_text;
         items_text << m_item_count << " item";
@@ -120,30 +120,30 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (m_selection)
             items_text << " selected";
 
-        uih::text_out_colours_tab(dc, items_text, -1, uih::scale_dpi_value(1), uih::scale_dpi_value(3), &rc_line_1,
-            false, default_text_colour, false, false, uih::ALIGN_LEFT);
+        text_out_colours_tab(dc, items_text, -1, uih::scale_dpi_value(1), uih::scale_dpi_value(3), &rc_line_1, false,
+            default_text_colour, false, false, uih::ALIGN_LEFT);
         if (m_item_count) {
             pfc::string_formatter formatter;
-            uih::text_out_colours_tab(dc, formatter << "Length: " << m_length_text, -1, uih::scale_dpi_value(1),
+            text_out_colours_tab(dc, formatter << "Length: " << m_length_text, -1, uih::scale_dpi_value(1),
                 uih::scale_dpi_value(3), &rc_line_2, false, default_text_colour, false, false, uih::ALIGN_LEFT);
         }
 
         if (m_menu_active) {
             {
                 RECT rc_item = rc_line_1;
-                uih::text_out_colours_tab(dc, m_menu_text, -1, uih::scale_dpi_value(1) + placeholder_len,
+                text_out_colours_tab(dc, m_menu_text, -1, uih::scale_dpi_value(1) + placeholder_len,
                     uih::scale_dpi_value(3), &rc_item, false, default_text_colour, false, false, uih::ALIGN_LEFT,
                     nullptr, true, true, nullptr);
             }
         } else {
             placeholder = "Playing:  ";
-            t_size placeholder2_len = uih::get_text_width(dc, placeholder, strlen(placeholder));
+            t_size placeholder2_len = get_text_width(dc, placeholder, strlen(placeholder));
 
             t_size now_playing_x_end = uih::scale_dpi_value(4) + placeholder_len + placeholder2_len;
             {
                 RECT rc_item = rc_line_1;
                 // rc_item.right = 4 + placeholder_len + placeholder2_len;
-                uih::text_out_colours_tab(dc, m_track_label, -1, uih::scale_dpi_value(4) + placeholder_len, 0, &rc_item,
+                text_out_colours_tab(dc, m_track_label, -1, uih::scale_dpi_value(4) + placeholder_len, 0, &rc_item,
                     false, default_text_colour, false, false, uih::ALIGN_LEFT, nullptr, true, true, nullptr);
             }
             if (playing1.get_length()) {
@@ -151,11 +151,11 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 g_split_string_by_crlf(playing1.get_ptr(), playingstrings);
                 t_size lines = playingstrings.get_count();
                 if (lines)
-                    uih::text_out_colours_tab(dc, playingstrings[0], pfc_infinite, now_playing_x_end, 0, &rc_line_1,
-                        false, default_text_colour, true, false, uih::ALIGN_LEFT);
+                    text_out_colours_tab(dc, playingstrings[0], pfc_infinite, now_playing_x_end, 0, &rc_line_1, false,
+                        default_text_colour, true, false, uih::ALIGN_LEFT);
                 if (lines > 1)
-                    uih::text_out_colours_tab(dc, playingstrings[1], pfc_infinite, now_playing_x_end, 0, &rc_line_2,
-                        false, default_text_colour, true, false, uih::ALIGN_LEFT);
+                    text_out_colours_tab(dc, playingstrings[1], pfc_infinite, now_playing_x_end, 0, &rc_line_2, false,
+                        default_text_colour, true, false, uih::ALIGN_LEFT);
             }
         }
 

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -4,7 +4,7 @@
 
 #ifdef _DEBUG
 #define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
+#include <cstdlib>
 #include <crtdbg.h>
 #endif
 

--- a/foo_ui_columns/tab_status.cpp
+++ b/foo_ui_columns/tab_status.cpp
@@ -50,7 +50,7 @@ public:
             } break;
             case IDC_VOL: {
                 cfg_show_vol = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);
-                cui::status_bar::set_part_sizes(cui::status_bar::t_part_volume);
+                set_part_sizes(cui::status_bar::t_part_volume);
             } break;
             case IDC_SELTIME: {
                 cfg_show_seltime = SendMessage((HWND)lp, BM_GETCHECK, 0, 0);

--- a/foo_ui_columns/title_formatting.cpp
+++ b/foo_ui_columns/title_formatting.cpp
@@ -5,7 +5,7 @@ namespace cui::tf {
 
 class ValueVisitor {
 public:
-    ValueVisitor(titleformat_text_out* out) : m_out{out} {};
+    ValueVisitor(titleformat_text_out* out) : m_out{out} {}
 
     bool operator()(const internal::ExplicitBool& value) const
     {

--- a/foo_ui_columns/title_formatting.h
+++ b/foo_ui_columns/title_formatting.h
@@ -35,7 +35,7 @@ public:
         std::function<std::string()>>;
     using FieldMap = std::map<std::string_view, FieldValue, internal::CaseInsensitiveUtf8Comparator>;
 
-    FieldProviderTitleformatHook(FieldMap field_map) : m_field_map(std::move(field_map)){};
+    FieldProviderTitleformatHook(FieldMap field_map) : m_field_map(std::move(field_map)) {}
 
     bool process_field(
         titleformat_text_out* p_out, const char* p_name, t_size p_name_length, bool& p_found_flag) override;

--- a/foo_ui_columns/user_interface_impl.cpp
+++ b/foo_ui_columns/user_interface_impl.cpp
@@ -56,7 +56,7 @@ public:
         cui::status_bar::menudesc = p_text;
         cui::status_bar::set_show_menu_item_description(true);
         cui::status_pane::g_status_pane.enter_menu_mode(p_text);
-    };
+    }
     void revert_statusbar_text() override
     {
         cui::status_bar::set_show_menu_item_description(false);

--- a/foo_ui_columns/utf8api.cpp
+++ b/foo_ui_columns/utf8api.cpp
@@ -60,4 +60,4 @@ unsigned status_bar_get_text_width(HWND wnd, HTHEME thm, const char* p_text, boo
         DeleteFont(fnt);
     return rv;
 }
-}; // namespace win32_helpers
+} // namespace win32_helpers

--- a/foo_ui_columns/utf8api.h
+++ b/foo_ui_columns/utf8api.h
@@ -12,6 +12,6 @@
 
 namespace win32_helpers {
 unsigned status_bar_get_text_width(HWND wnd, HTHEME thm, const char* p_text, bool b_customfont = false);
-};
+}
 
 #endif

--- a/foo_ui_columns/vis_gen_host.cpp
+++ b/foo_ui_columns/vis_gen_host.cpp
@@ -13,9 +13,9 @@ public:
         service_ptr_t<VisualisationPanel> m_wnd;
 
     public:
-        HDC get_device_context() const override { return m_dc; };
+        HDC get_device_context() const override { return m_dc; }
 
-        const RECT* get_area() const override { return &m_rect; };
+        const RECT* get_area() const override { return &m_rect; }
 
         Painter(VisualisationPanel* p_wnd) : m_gdiobj(nullptr), m_wnd(p_wnd)
         {
@@ -39,7 +39,7 @@ public:
             SelectObject(m_dc, m_gdiobj);
             DeleteDC(m_dc);
             ReleaseDC(wnd, dc);
-        };
+        }
     };
 
     void create_painter(painter_ptr& p_out) override

--- a/foo_ui_columns/vis_gen_host.cpp
+++ b/foo_ui_columns/vis_gen_host.cpp
@@ -6,7 +6,7 @@ class VisualisationPanelInterface : public ui_extension::visualisation_host {
     service_ptr_t<VisualisationPanel> p_wnd;
 
 public:
-    class Painter : public uie::visualisation_host::painter_t {
+    class Painter : public painter_t {
         HDC m_dc;
         RECT m_rect;
         HGDIOBJ m_gdiobj;

--- a/foo_ui_columns/vis_gen_host.h
+++ b/foo_ui_columns/vis_gen_host.h
@@ -45,7 +45,7 @@ public:
     unsigned get_frame_style() const { return m_frame; }
     void get_vis_ptr(uie::visualisation_ptr& p_out) { p_out = p_vis; }
 
-    unsigned get_type() const override { return ui_extension::type_toolbar | ui_extension::type_panel; };
+    unsigned get_type() const override { return ui_extension::type_toolbar | ui_extension::type_panel; }
 
     void set_vis_data(const void* p_data, unsigned p_size)
     {

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -130,25 +130,25 @@ private:
         }
     }
 
-    void FB2KAPI on_playback_starting(play_control::t_track_command p_command, bool p_paused) override{};
-    void FB2KAPI on_playback_new_track(metadb_handle_ptr p_track) override { g_register_stream(this); };
+    void FB2KAPI on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
+    void FB2KAPI on_playback_new_track(metadb_handle_ptr p_track) override { g_register_stream(this); }
     void FB2KAPI on_playback_stop(play_control::t_stop_reason p_reason) override
     {
         g_deregister_stream(this, p_reason == play_control::stop_reason_shutting_down);
-    };
-    void FB2KAPI on_playback_seek(double p_time) override{};
+    }
+    void FB2KAPI on_playback_seek(double p_time) override {}
     void FB2KAPI on_playback_pause(bool p_state) override
     {
         if (p_state)
             g_deregister_stream(this, true);
         else
             g_register_stream(this);
-    };
-    void FB2KAPI on_playback_edited(metadb_handle_ptr p_track) override{};
-    void FB2KAPI on_playback_dynamic_info(const file_info& p_info) override{};
-    void FB2KAPI on_playback_dynamic_info_track(const file_info& p_info) override{};
-    void FB2KAPI on_playback_time(double p_time) override{};
-    void FB2KAPI on_volume_change(float p_new_val) override{};
+    }
+    void FB2KAPI on_playback_edited(metadb_handle_ptr p_track) override {}
+    void FB2KAPI on_playback_dynamic_info(const file_info& p_info) override {}
+    void FB2KAPI on_playback_dynamic_info_track(const file_info& p_info) override {}
+    void FB2KAPI on_playback_time(double p_time) override {}
+    void FB2KAPI on_volume_change(float p_new_val) override {}
 };
 
 UINT_PTR SpectrumAnalyserVisualisation::g_timer = NULL;
@@ -163,7 +163,9 @@ SpectrumAnalyserVisualisation::SpectrumAnalyserVisualisation()
     , cr_back(cfg_vis)
     , mode(cfg_vis_mode)
     , m_scale(cfg_scale)
-    , m_vertical_scale(cfg_vertical_scale){};
+    , m_vertical_scale(cfg_vertical_scale)
+{
+}
 
 SpectrumAnalyserVisualisation::~SpectrumAnalyserVisualisation() = default;
 
@@ -585,7 +587,7 @@ class SpectrumAnalyserVisualisationPanel : public VisualisationPanel {
     void get_menu_items(ui_extension::menu_hook_t& p_hook) override
     {
         p_hook.add_node(uie::menu_node_ptr(new uie::menu_node_configure(this)));
-    };
+    }
     void set_config(stream_reader* r, t_size p_size, abort_callback& p_abort) override
     {
         if (p_size) {

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -202,10 +202,8 @@ void SpectrumAnalyserVisualisation::enable(const ui_extension::visualisation_hos
             p_stream_v2->set_channel_mode(visualisation_stream_v2::channel_mode_mono);
     }
 
-    static_api_ptr_t<play_callback_manager>()->register_callback(this,
-        play_callback::flag_on_playback_new_track | play_callback::flag_on_playback_stop
-            | play_callback::flag_on_playback_pause,
-        false);
+    static_api_ptr_t<play_callback_manager>()->register_callback(
+        this, flag_on_playback_new_track | flag_on_playback_stop | flag_on_playback_pause, false);
     if (static_api_ptr_t<play_control>()->is_playing())
         g_register_stream(this);
 }
@@ -539,9 +537,9 @@ void SpectrumAnalyserVisualisation::g_refresh_all()
     unsigned fft_size = 4096;
     bool ret = g_stream->get_spectrum_absolute(p_chunk, p_time, fft_size);
 
-    unsigned count = SpectrumAnalyserVisualisation::g_visualisations.get_count();
+    unsigned count = g_visualisations.get_count();
     for (unsigned n = 0; n < count; n++) {
-        SpectrumAnalyserVisualisation* vis_ext = SpectrumAnalyserVisualisation::g_visualisations[n];
+        SpectrumAnalyserVisualisation* vis_ext = g_visualisations[n];
         if (ret)
             vis_ext->refresh(&p_chunk);
     }

--- a/foo_ui_columns/volume.cpp
+++ b/foo_ui_columns/volume.cpp
@@ -14,7 +14,7 @@ class VolumeBarToolbar : public VolumeBar<false, false, VolumeBarToolbarAttribut
         // {B3259290-CB68-4d37-B0F1-8094862A9524}
         static const GUID ret = {0xb3259290, 0xcb68, 0x4d37, {0xb0, 0xf1, 0x80, 0x94, 0x86, 0x2a, 0x95, 0x24}};
         return ret;
-    };
+    }
 
     void get_name(pfc::string_base& out) const override { out = "Volume"; }
     void get_category(pfc::string_base& out) const override { out = "Toolbars"; }

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -92,7 +92,7 @@ class VolumeBar
         VolumeBar<b_vertical, b_popup, t_attributes, t_base>* m_this;
 
     public:
-        VolumeTrackBar(VolumeBar<b_vertical, b_popup, t_attributes, t_base>* p_this) : m_this(p_this){};
+        VolumeTrackBar(VolumeBar<b_vertical, b_popup, t_attributes, t_base>* p_this) : m_this(p_this) {}
     } m_child;
 
     class VolumeTrackBarCallback : public uih::TrackbarCallback {
@@ -120,7 +120,7 @@ class VolumeBar
         VolumeBar<b_vertical, b_popup, t_attributes, t_base>* m_this;
 
     public:
-        VolumeTrackBarCallback(VolumeBar<b_vertical, b_popup, t_attributes, t_base>* p_this) : m_this(p_this){};
+        VolumeTrackBarCallback(VolumeBar<b_vertical, b_popup, t_attributes, t_base>* p_this) : m_this(p_this) {}
     } m_track_bar_host;
 
 public:
@@ -318,15 +318,15 @@ private:
         return uGetTextExtentPoint32(dc.get(), label_text.data(), label_text.size(), &p_out) != 0;
     }
 
-    void FB2KAPI on_playback_starting(play_control::t_track_command p_command, bool p_paused) override{};
-    void FB2KAPI on_playback_new_track(metadb_handle_ptr p_track) override{};
-    void FB2KAPI on_playback_stop(play_control::t_stop_reason p_reason) override{};
-    void FB2KAPI on_playback_seek(double p_time) override{};
-    void FB2KAPI on_playback_pause(bool p_state) override{};
-    void FB2KAPI on_playback_edited(metadb_handle_ptr p_track) override{};
-    void FB2KAPI on_playback_dynamic_info(const file_info& p_info) override{};
-    void FB2KAPI on_playback_dynamic_info_track(const file_info& p_info) override{};
-    void FB2KAPI on_playback_time(double p_time) override{};
+    void FB2KAPI on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
+    void FB2KAPI on_playback_new_track(metadb_handle_ptr p_track) override {}
+    void FB2KAPI on_playback_stop(play_control::t_stop_reason p_reason) override {}
+    void FB2KAPI on_playback_seek(double p_time) override {}
+    void FB2KAPI on_playback_pause(bool p_state) override {}
+    void FB2KAPI on_playback_edited(metadb_handle_ptr p_track) override {}
+    void FB2KAPI on_playback_dynamic_info(const file_info& p_info) override {}
+    void FB2KAPI on_playback_dynamic_info_track(const file_info& p_info) override {}
+    void FB2KAPI on_playback_time(double p_time) override {}
     void FB2KAPI on_volume_change(float p_new_val) override { update_position(p_new_val); }
 
     constexpr static auto label_text = "Volume"sv;

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -10,7 +10,7 @@ class VolumeBar
         void get_channel_rect(RECT* rc) const override
         {
             if (b_popup)
-                uih::Trackbar::get_channel_rect(rc);
+                Trackbar::get_channel_rect(rc);
             else {
                 RECT rc_client;
                 GetClientRect(get_wnd(), &rc_client);
@@ -28,7 +28,7 @@ class VolumeBar
             if (t_attributes::get_background_colour() != -1)
                 FillRect(dc, rc, wil::unique_hbrush(CreateSolidBrush(t_attributes::get_background_colour())).get());
             else
-                uih::Trackbar::draw_background(dc, rc);
+                Trackbar::draw_background(dc, rc);
         }
         /*void draw_thumb (HDC dc, const RECT * rc) const
         {
@@ -44,7 +44,7 @@ class VolumeBar
         void draw_channel(HDC dc, const RECT* rc) const override
         {
             if (b_popup)
-                uih::Trackbar::draw_channel(dc, rc);
+                Trackbar::draw_channel(dc, rc);
             else {
                 const auto is_dark = cui::dark::is_dark_mode_enabled();
                 COLORREF cr_shadow = cui::dark::get_system_colour(COLOR_3DSHADOW, is_dark);
@@ -153,7 +153,7 @@ public:
         case WM_CREATE: {
             if (!b_popup) {
                 Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-                if (Gdiplus::Ok == Gdiplus::GdiplusStartup(&m_Gdiplus_token, &gdiplusStartupInput, nullptr))
+                if (Gdiplus::Ok == GdiplusStartup(&m_Gdiplus_token, &gdiplusStartupInput, nullptr))
                     m_using_gdiplus = true;
             }
             if (t_attributes::get_show_caption())
@@ -177,8 +177,7 @@ public:
             }
             ShowWindow(wnd_trackbar, SW_SHOWNORMAL);
 
-            static_api_ptr_t<play_callback_manager>()->register_callback(
-                this, play_callback::flag_on_volume_change, false);
+            static_api_ptr_t<play_callback_manager>()->register_callback(this, flag_on_volume_change, false);
 
             break;
         }


### PR DESCRIPTION
This tidies up the code base by removing redundant qualifiers and semicolons across the code base, and also correcting two #include directives.
