### PR TITLE
Add toolbar dividers in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Internal changes
 
-* Some internal changes were made in advance of support for the Windows 10 dark mode. [[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413), [#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423), [#424](https://github.com/reupen/columns_ui/pull/424), [#432](https://github.com/reupen/columns_ui/pull/432), [#433](https://github.com/reupen/columns_ui/pull/433), [#434](https://github.com/reupen/columns_ui/pull/434), [#435](https://github.com/reupen/columns_ui/pull/435)]
+* Some internal changes were made in advance of support for the Windows 10 dark mode. [[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413), [#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423), [#424](https://github.com/reupen/columns_ui/pull/424), [#432](https://github.com/reupen/columns_ui/pull/432), [#433](https://github.com/reupen/columns_ui/pull/433), [#434](https://github.com/reupen/columns_ui/pull/434), [#435](https://github.com/reupen/columns_ui/pull/435), [#436](https://github.com/reupen/columns_ui/pull/436)]
 
 * The component is now compiled using Visual Studio 2022 17.0 and the /std:c++20 compiler option. [[#408](https://github.com/reupen/columns_ui/pull/408), [#409](https://github.com/reupen/columns_ui/pull/409)]
 

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -55,6 +55,8 @@ COLORREF get_dark_colour(ColourID colour_id)
     switch (colour_id) {
     case ColourID::PanelCaptionBackground:
         return WI_EnumValue(DarkColour::DARK_300);
+    case ColourID::RebarBandBorder:
+        return WI_EnumValue(DarkColour::DARK_400);
     case ColourID::StatusBarBackground:
         return WI_EnumValue(DarkColour::DARK_200);
     case ColourID::StatusBarText:

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -9,6 +9,7 @@ namespace cui::dark {
 
 enum class ColourID {
     PanelCaptionBackground,
+    RebarBandBorder,
     StatusBarBackground,
     StatusBarText,
     TabControlBackground,


### PR DESCRIPTION
This adds (subtle) dividers between rows and bands in the rebar in dark mode.

These are present in light mode and were previously missing in dark mode.