### PR TITLE
Add dark mode to trackbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,14 @@
 
 ### Internal changes
 
-* Some internal changes were made in advance of support for the Windows 10 dark mode. [[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413), [#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423), [#424](https://github.com/reupen/columns_ui/pull/424), [#432](https://github.com/reupen/columns_ui/pull/432), [#433](https://github.com/reupen/columns_ui/pull/433), [#434](https://github.com/reupen/columns_ui/pull/434), [#435](https://github.com/reupen/columns_ui/pull/435), [#436](https://github.com/reupen/columns_ui/pull/436), [#437](https://github.com/reupen/columns_ui/pull/437), [#438](https://github.com/reupen/columns_ui/pull/438)]
+* Some internal changes were made in advance of support for the Windows 10 dark mode. 
+[[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413),
+[#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423),
+[#424](https://github.com/reupen/columns_ui/pull/424), [#432](https://github.com/reupen/columns_ui/pull/432),
+[#433](https://github.com/reupen/columns_ui/pull/433), [#434](https://github.com/reupen/columns_ui/pull/434),
+[#435](https://github.com/reupen/columns_ui/pull/435), [#436](https://github.com/reupen/columns_ui/pull/436),
+[#437](https://github.com/reupen/columns_ui/pull/437), [#438](https://github.com/reupen/columns_ui/pull/438),
+[#439](https://github.com/reupen/columns_ui/pull/439)]
 
 * The component is now compiled using Visual Studio 2022 17.0 and the /std:c++20 compiler option. [[#408](https://github.com/reupen/columns_ui/pull/408), [#409](https://github.com/reupen/columns_ui/pull/409)]
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ This repo makes use of Git submodules. If you're not familiar with them, [check 
 
 ### Build instructions
 
-Visual Studio 2022 is required to build Columns UI. You can use the [free community edition](https://www.visualstudio.com/downloads/) (select the Desktop development with C++ workload during installation).
+Visual Studio 2022 and the Windows 11 SDK are required to build Columns UI.
+
+You can use the [free community edition of Visual Studio](https://www.visualstudio.com/downloads/).
+During installation, select the Desktop development with C++ workload and the Windows 11 SDK from the right-hand side.
 
 #### Installing vcpkg
 

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -47,44 +47,9 @@ enum class DarkColour : COLORREF {
     DARK_400 = create_grey(88),
     DARK_500 = create_grey(98),
     DARK_600 = create_grey(119),
-    DARK_900 = create_grey(255),
+    DARK_750 = create_grey(166),
+    DARK_999 = create_grey(255),
 };
-
-COLORREF get_dark_colour(ColourID colour_id)
-{
-    switch (colour_id) {
-    case ColourID::PanelCaptionBackground:
-        return WI_EnumValue(DarkColour::DARK_300);
-    case ColourID::RebarBandBorder:
-        return WI_EnumValue(DarkColour::DARK_400);
-    case ColourID::StatusBarBackground:
-        return WI_EnumValue(DarkColour::DARK_200);
-    case ColourID::StatusBarText:
-        return WI_EnumValue(DarkColour::DARK_900);
-    case ColourID::TabControlBackground:
-        return WI_EnumValue(DarkColour::DARK_200);
-    case ColourID::TabControlItemBackground:
-        return WI_EnumValue(DarkColour::DARK_200);
-    case ColourID::TabControlItemText:
-        return WI_EnumValue(DarkColour::DARK_900);
-    case ColourID::TabControlItemBorder:
-        return WI_EnumValue(DarkColour::DARK_000);
-    case ColourID::TabControlActiveItemBackground:
-        return WI_EnumValue(DarkColour::DARK_500);
-    case ColourID::TabControlHotItemBackground:
-        return WI_EnumValue(DarkColour::DARK_300);
-    case ColourID::TabControlHotActiveItemBackground:
-        return WI_EnumValue(DarkColour::DARK_600);
-    case ColourID::VolumePopupBackground:
-        return WI_EnumValue(DarkColour::DARK_200);
-    case ColourID::VolumePopupBorder:
-        return WI_EnumValue(DarkColour::DARK_300);
-    case ColourID::VolumePopupText:
-        return WI_EnumValue(DarkColour::DARK_900);
-    default:
-        uBugCheck();
-    }
-}
 
 wil::unique_hbrush get_dark_colour_brush(ColourID colour_id)
 {
@@ -119,7 +84,82 @@ wil::unique_hbrush get_light_colour_brush(ColourID colour_id)
     return wil::unique_hbrush(GetSysColorBrush(get_light_colour_system_id(colour_id)));
 }
 
+COLORREF winrt_color_to_colorref(const winrt::Windows::UI::Color& colour)
+{
+    return RGB(colour.R, colour.G, colour.B);
+}
+
+AccentColours fetch_system_accent_colours()
+{
+    try {
+        const winrt::Windows::UI::ViewManagement::UISettings settings;
+        const winrt::Windows::UI::Color accent
+            = settings.GetColorValue(winrt::Windows::UI::ViewManagement::UIColorType::Accent);
+        const winrt::Windows::UI::Color light_accent
+            = settings.GetColorValue(winrt::Windows::UI::ViewManagement::UIColorType::AccentLight1);
+
+        return {winrt_color_to_colorref(accent), winrt_color_to_colorref(light_accent)};
+    } catch (winrt::hresult_error&) {
+        return {WI_EnumValue(DarkColour::DARK_600), WI_EnumValue(DarkColour::DARK_750)};
+    };
+}
+
+std::optional<AccentColours> accent_colours;
+
 } // namespace
+
+AccentColours get_system_accent_colours()
+{
+    // TODO: Flush these on change
+    if (!accent_colours)
+        accent_colours = fetch_system_accent_colours();
+
+    return *accent_colours;
+}
+
+COLORREF get_dark_colour(ColourID colour_id)
+{
+    switch (colour_id) {
+    case ColourID::PanelCaptionBackground:
+        return WI_EnumValue(DarkColour::DARK_300);
+    case ColourID::RebarBandBorder:
+        return WI_EnumValue(DarkColour::DARK_400);
+    case ColourID::StatusBarBackground:
+        return WI_EnumValue(DarkColour::DARK_200);
+    case ColourID::StatusBarText:
+        return WI_EnumValue(DarkColour::DARK_999);
+    case ColourID::TabControlBackground:
+        return WI_EnumValue(DarkColour::DARK_200);
+    case ColourID::TabControlItemBackground:
+        return WI_EnumValue(DarkColour::DARK_200);
+    case ColourID::TabControlItemText:
+        return WI_EnumValue(DarkColour::DARK_999);
+    case ColourID::TabControlItemBorder:
+        return WI_EnumValue(DarkColour::DARK_000);
+    case ColourID::TabControlActiveItemBackground:
+        return WI_EnumValue(DarkColour::DARK_500);
+    case ColourID::TabControlHotItemBackground:
+        return WI_EnumValue(DarkColour::DARK_300);
+    case ColourID::TabControlHotActiveItemBackground:
+        return WI_EnumValue(DarkColour::DARK_600);
+    case ColourID::TrackbarChannel:
+        return WI_EnumValue(DarkColour::DARK_400);
+    case ColourID::TrackbarThumb:
+        return get_system_accent_colours().standard;
+    case ColourID::TrackbarHotThumb:
+        return get_system_accent_colours().light_1;
+    case ColourID::TrackbarDisabledThumb:
+        return WI_EnumValue(DarkColour::DARK_400);
+    case ColourID::VolumePopupBackground:
+        return WI_EnumValue(DarkColour::DARK_200);
+    case ColourID::VolumePopupBorder:
+        return WI_EnumValue(DarkColour::DARK_300);
+    case ColourID::VolumePopupText:
+        return WI_EnumValue(DarkColour::DARK_999);
+    default:
+        uBugCheck();
+    }
+}
 
 COLORREF get_colour(ColourID colour_id, bool is_dark)
 {

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -19,9 +19,18 @@ enum class ColourID {
     TabControlActiveItemBackground,
     TabControlHotItemBackground,
     TabControlHotActiveItemBackground,
+    TrackbarChannel,
+    TrackbarThumb,
+    TrackbarHotThumb,
+    TrackbarDisabledThumb,
     VolumePopupBackground,
     VolumePopupBorder,
     VolumePopupText,
+};
+
+struct AccentColours {
+    COLORREF standard{};
+    COLORREF light_1{};
 };
 
 template <class Object>
@@ -61,10 +70,12 @@ private:
 void enable_dark_mode_for_app();
 void enable_top_level_non_client_dark_mode(HWND wnd);
 
+[[nodiscard]] COLORREF get_dark_colour(ColourID colour_id);
 [[nodiscard]] COLORREF get_colour(ColourID colour_id, bool is_dark);
 [[nodiscard]] wil::unique_hbrush get_colour_brush(ColourID colour_id, bool is_dark);
 [[nodiscard]] LazyResource<wil::unique_hbrush> get_colour_brush_lazy(ColourID colour_id, bool is_dark);
 
+[[nodiscard]] AccentColours get_system_accent_colours();
 [[nodiscard]] COLORREF get_system_colour(int system_colour_id, bool is_dark);
 [[nodiscard]] wil::unique_hbrush get_system_colour_brush(int system_colour_id, bool is_dark);
 

--- a/foo_ui_columns/dark_mode_trackbar.cpp
+++ b/foo_ui_columns/dark_mode_trackbar.cpp
@@ -1,0 +1,14 @@
+#include "stdafx.h"
+#include "dark_mode_trackbar.h"
+
+#include "dark_mode.h"
+
+namespace cui::dark {
+
+uih::TrackbarCustomColours get_dark_trackbar_colours()
+{
+    return {get_dark_colour(ColourID::TrackbarChannel), get_dark_colour(ColourID::TrackbarThumb),
+        get_dark_colour(ColourID::TrackbarHotThumb), get_dark_colour(ColourID::TrackbarDisabledThumb)};
+}
+
+} // namespace cui::dark

--- a/foo_ui_columns/dark_mode_trackbar.h
+++ b/foo_ui_columns/dark_mode_trackbar.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace cui::dark {
+
+uih::TrackbarCustomColours get_dark_trackbar_colours();
+
+}

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -301,6 +301,7 @@
     <ClCompile Include=".\columns_v2.cpp" />
     <ClCompile Include="dark_mode.cpp" />
     <ClCompile Include="dark_mode_tabs.cpp" />
+    <ClCompile Include="dark_mode_trackbar.cpp" />
     <ClCompile Include="filter_fcl.cpp" />
     <ClCompile Include="legacy_artwork_config.cpp" />
     <ClCompile Include="ng_playlist\config_object_callbacks.cpp" />
@@ -512,6 +513,7 @@
     <ClInclude Include="button_items.h" />
     <ClInclude Include="dark_mode.h" />
     <ClInclude Include="dark_mode_tabs.h" />
+    <ClInclude Include="dark_mode_trackbar.h" />
     <ClInclude Include="filter_config_var.h" />
     <ClInclude Include="filter_utils.h" />
     <ClInclude Include="font_utils.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -533,6 +533,9 @@
     <ClCompile Include="dark_mode_tabs.cpp">
       <Filter>Dark mode</Filter>
     </ClCompile>
+    <ClCompile Include="dark_mode_trackbar.cpp">
+      <Filter>Dark mode</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include=".\resource.h">
@@ -762,6 +765,9 @@
       <Filter>Dark mode</Filter>
     </ClInclude>
     <ClInclude Include="dark_mode_tabs.h">
+      <Filter>Dark mode</Filter>
+    </ClInclude>
+    <ClInclude Include="dark_mode_trackbar.h">
       <Filter>Dark mode</Filter>
     </ClInclude>
   </ItemGroup>

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -6,11 +6,10 @@
 
 #include "stdafx.h"
 
-#include "status_pane.h"
-#include "layout.h"
-
 #include "main_window.h"
 
+#include "status_pane.h"
+#include "layout.h"
 #include "dark_mode.h"
 #include "notification_area.h"
 #include "status_bar.h"
@@ -52,6 +51,14 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook)
     }
 
     warn_if_ui_hacks_installed();
+
+    try {
+        THROW_IF_FAILED(OleInitialize(nullptr));
+    } catch (const wil::ResultException&) {
+        MessageBox(
+            nullptr, unsupported_os_message, L"Columns UI - Failed to initialise COM", MB_OK | MB_ICONEXCLAMATION);
+        return nullptr;
+    }
 
     migrate::v100::migrate();
 
@@ -139,6 +146,8 @@ void cui::MainWindow::shutdown()
     if (g_icon)
         DestroyIcon(g_icon);
     g_icon = nullptr;
+
+    OleUninitialize();
 }
 
 void cui::MainWindow::on_query_capability()

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -164,7 +164,6 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (cfg_show_systray)
             create_systray_icon();
 
-        HRESULT hr = OleInitialize(nullptr);
         wil::com_ptr_t<MainWindowDropTarget> drop_handler = new MainWindowDropTarget;
         RegisterDragDrop(m_wnd, drop_handler.get());
 
@@ -189,7 +188,6 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         RevokeDragDrop(m_wnd);
         destroy_systray_icon();
         on_destroy();
-        OleUninitialize();
     } break;
     case WM_NCDESTROY:
         if (g_imagelist_taskbar)

--- a/foo_ui_columns/seekbar.cpp
+++ b/foo_ui_columns/seekbar.cpp
@@ -1,7 +1,8 @@
 #include "stdafx.h"
 #include "seekbar.h"
 
-//#define _WIN32_WINNT 0x500
+#include "dark_mode.h"
+#include "dark_mode_trackbar.h"
 
 #define ID_SEEK 2005
 
@@ -138,6 +139,9 @@ LRESULT SeekBarToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_child.set_callback(&m_track_bar_host);
         m_child.set_show_tooltips(true);
         m_child.set_scroll_step(3);
+
+        if (dark::is_dark_mode_enabled())
+            m_child.set_custom_colours(dark::get_dark_trackbar_colours());
 
         wnd_seekbar = m_child.create(wnd);
 

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -50,8 +50,11 @@
 #include <wincodec.h>
 #include <strsafe.h>
 
+#include <wil/cppwinrt.h>
 #include <wil/com.h>
 #include <wil/resource.h>
+
+#include <winrt/Windows.UI.ViewManagement.h>
 
 #include "../foobar2000/SDK/foobar2000.h"
 #include "../foobar2000/SDK/core_api.h"

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dark_mode.h"
+#include "dark_mode_trackbar.h"
 
 template <bool b_vertical, bool b_popup, typename t_attributes, class t_base = ui_helpers::container_window>
 class VolumeBar
@@ -14,7 +15,7 @@ class VolumeBar
             else {
                 RECT rc_client;
                 GetClientRect(get_wnd(), &rc_client);
-                unsigned cx = calculate_thumb_size();
+                const auto cx = calculate_thumb_size();
 
                 rc->left = get_orientation() ? rc_client.left + 5 : rc_client.left + cx / 2;
                 rc->right = get_orientation() ? rc_client.right - 5 : rc_client.right - cx + cx / 2;
@@ -143,6 +144,9 @@ public:
 
             m_child.set_callback(&m_track_bar_host);
             m_child.set_show_tooltips(true);
+
+            if (cui::dark::is_dark_mode_enabled())
+                m_child.set_custom_colours(cui::dark::get_dark_trackbar_colours());
 
             wnd_trackbar = m_child.create(wnd);
 


### PR DESCRIPTION
This adds dark mode support to the trackbar controls in the seekbar and the various volume controls.

The Windows 11 SDK is now required (it can be installed using the Visual Studio 2022 installer).