### PR TITLE
Add dark mode toggle to preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Features
 
+* Support for the Windows 10 and 11 dark mode was added. 
+[[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413),
+[#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423),
+[#424](https://github.com/reupen/columns_ui/pull/424), [#432](https://github.com/reupen/columns_ui/pull/432),
+[#433](https://github.com/reupen/columns_ui/pull/433), [#434](https://github.com/reupen/columns_ui/pull/434),
+[#435](https://github.com/reupen/columns_ui/pull/435), [#436](https://github.com/reupen/columns_ui/pull/436),
+[#437](https://github.com/reupen/columns_ui/pull/437), [#438](https://github.com/reupen/columns_ui/pull/438),
+[#439](https://github.com/reupen/columns_ui/pull/439), [#440](https://github.com/reupen/columns_ui/pull/440)]
+
 * The Filter search toolbar is now integrated with the Colours and fonts preferences page, and its font, foreground colour and background colour are now configurable. [[#424](https://github.com/reupen/columns_ui/pull/424)]
   
   (Note that selection colours are not supported.)
@@ -29,15 +38,6 @@
 * The status bar pop-up volume bar now correctly scales with the system DPI setting. [[#418](https://github.com/reupen/columns_ui/pull/418)]
 
 ### Internal changes
-
-* Some internal changes were made in advance of support for the Windows 10 dark mode. 
-[[#411](https://github.com/reupen/columns_ui/pull/411), [#413](https://github.com/reupen/columns_ui/pull/413),
-[#415](https://github.com/reupen/columns_ui/pull/415), [#423](https://github.com/reupen/columns_ui/pull/423),
-[#424](https://github.com/reupen/columns_ui/pull/424), [#432](https://github.com/reupen/columns_ui/pull/432),
-[#433](https://github.com/reupen/columns_ui/pull/433), [#434](https://github.com/reupen/columns_ui/pull/434),
-[#435](https://github.com/reupen/columns_ui/pull/435), [#436](https://github.com/reupen/columns_ui/pull/436),
-[#437](https://github.com/reupen/columns_ui/pull/437), [#438](https://github.com/reupen/columns_ui/pull/438),
-[#439](https://github.com/reupen/columns_ui/pull/439)]
 
 * The component is now compiled using Visual Studio 2022 17.0 and the /std:c++20 compiler option. [[#408](https://github.com/reupen/columns_ui/pull/408), [#409](https://github.com/reupen/columns_ui/pull/409)]
 

--- a/foo_ui_columns/config_appearance.h
+++ b/foo_ui_columns/config_appearance.h
@@ -67,3 +67,15 @@ public:
 
 extern ColoursManagerData g_colours_manager_data;
 extern FontsManagerData g_fonts_manager_data;
+
+namespace cui::colours {
+
+enum class DarkModeStatus {
+    Disabled,
+    Enabled,
+    UseSystemSetting,
+};
+
+extern fbh::ConfigInt32 dark_mode_status;
+
+} // namespace cui::colours

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -62,10 +62,9 @@ private:
     mutable LazyObject<Resource> m_resource;
 };
 
-/**
- * Temporary compile-time flag controlling whether dark mode is enabled.
- */
 [[nodiscard]] bool is_dark_mode_enabled();
+[[nodiscard]] bool does_os_support_dark_mode();
+[[nodiscard]] bool are_private_apis_allowed();
 
 void enable_dark_mode_for_app();
 void enable_top_level_non_client_dark_mode(HWND wnd);

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -684,6 +684,18 @@ BEGIN
     EDITTEXT        IDC_PLAYLIST_TF,7,131,313,133,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL
 END
 
+IDD_PREFS_DARK_MODE DIALOGEX 0, 0, 327, 268
+STYLE DS_SETFONT | DS_3DLOOK | DS_FIXEDSYS | DS_CONTROL | WS_CHILD
+EXSTYLE WS_EX_CONTROLPARENT
+FONT 8, "MS Shell Dlg", 400, 0, 0x0
+BEGIN
+    LTEXT           "Mode (requires restart)",IDC_TITLE1,7,4,313,16
+    CONTROL         "Light",IDC_DARK_MODE_DISABLED,"Button",BS_AUTORADIOBUTTON | WS_GROUP,7,29,32,10
+    CONTROL         "Dark",IDC_DARK_MODE_ENABLED,"Button",BS_AUTORADIOBUTTON,7,44,32,10
+    LTEXT           "Your version of Windows has not been tested for dark mode compatibility. Some dark mode features have been disabled.",IDC_UNKNOWN_WINDOWS_BUILD,7,71,313,20,NOT WS_VISIBLE
+    LTEXT           "Dark mode requires Windows 10 20H1 or newer.",IDC_WINDOWS_VERSION_TOO_OLD,7,71,165,8,NOT WS_VISIBLE
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -976,6 +988,14 @@ BEGIN
         RIGHTMARGIN, 320
         TOPMARGIN, 4
         BOTTOMMARGIN, 264
+    END
+
+    IDD_PREFS_DARK_MODE, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 320
+        TOPMARGIN, 4
+        BOTTOMMARGIN, 261
     END
 END
 #endif    // APSTUDIO_INVOKED

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -312,6 +312,7 @@
     <ClCompile Include="seekbar_callbacks.cpp" />
     <ClCompile Include="status_bar_callbacks.cpp" />
     <ClCompile Include="status_bar_font_client.cpp" />
+    <ClCompile Include="tab_dark_mode.cpp" />
     <ClCompile Include="tab_playlist_swticher.cpp" />
     <ClCompile Include="title_formatting.cpp" />
     <ClCompile Include="version.cpp" />
@@ -569,6 +570,7 @@
     <ClInclude Include="rebar_band.h" />
     <ClInclude Include="rename_dialog.h" />
     <ClInclude Include="splitter_utils.h" />
+    <ClInclude Include="tab_dark_mode.h" />
     <ClInclude Include="tab_layout.h" />
     <ClInclude Include="tab_layout_misc.h" />
     <ClInclude Include="title_formatting.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -536,6 +536,9 @@
     <ClCompile Include="dark_mode_trackbar.cpp">
       <Filter>Dark mode</Filter>
     </ClCompile>
+    <ClCompile Include="tab_dark_mode.cpp">
+      <Filter>Config UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include=".\resource.h">
@@ -769,6 +772,9 @@
     </ClInclude>
     <ClInclude Include="dark_mode_trackbar.h">
       <Filter>Dark mode</Filter>
+    </ClInclude>
+    <ClInclude Include="tab_dark_mode.h">
+      <Filter>Config UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -64,6 +64,7 @@
 #define IDD_COLUMN_SORTING_SCRIPT       232
 #define IDD_COLUMN_STYLE_SCRIPT         233
 #define IDD_PREFS_PLAYLIST_SWITCHER     234
+#define IDD_PREFS_DARK_MODE             235
 #define IDC_LIST                        1003
 #define IDC_COLUMNS                     1003
 #define IDC_INFOSECTIONS                1003
@@ -219,6 +220,7 @@
 #define IDC_COLOURS_MODE                1131
 #define IDC_COLOURS_ELEMENT             1132
 #define IDC_PATCH_FORE                  1133
+#define IDC_DARK_MODE                   1133
 #define IDC_THEMING                     1134
 #define IDC_DEST                        1135
 #define IDC_SORT_STRING                 1143
@@ -251,6 +253,10 @@
 #define IDC_VIEW_OLD_ARTWORK_SOURCES    1177
 #define IDC_VIEW_OLD_ARTWORK_SOURCES_TEXT 1178
 #define IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES 1179
+#define IDC_DARK_MODE_DISABLED          1179
+#define IDC_DARK_MODE_ENABLED           1180
+#define IDC_UNKNOWN_WINDOWS_BUILD       1181
+#define IDC_WINDOWS_VERSION_TOO_OLD     1182
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -260,7 +266,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        169
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1179
+#define _APS_NEXT_CONTROL_VALUE         1183
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/foo_ui_columns/tab_colours.cpp
+++ b/foo_ui_columns/tab_colours.cpp
@@ -45,7 +45,7 @@ BOOL TabColours::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         g_fill_selection_text_inactive.create(
             wnd, uih::WindowPosition{x_col_1, y_start + y_spacing * 2, 18, 14}, nullptr, true);
 
-        g_fill_active_item_frame.create(wnd, uih::WindowPosition{x_col_1, 186, 18, 14}, nullptr, true);
+        g_fill_active_item_frame.create(wnd, uih::WindowPosition{x_col_1, y_start + 92, 18, 14}, nullptr, true);
 
         g_fill_background.create(wnd, uih::WindowPosition{x_col_2, y_start, 18, 14}, nullptr, true);
         g_fill_selection_background.create(
@@ -94,16 +94,16 @@ BOOL TabColours::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             update_fills();
             update_buttons();
             update_mode_combobox();
-        }
             return 0;
+        }
         case IDC_COLOURS_MODE | (CBN_SELCHANGE << 16): {
             int idx = ComboBox_GetCurSel((HWND)lp);
             m_element_ptr->colour_mode = (cui::colours::colour_mode_t)ComboBox_GetItemData((HWND)lp, idx);
             update_fills();
             update_buttons();
             on_colour_changed();
-        }
             return 0;
+        }
         case IDC_CHANGE_TEXT_BACK:
         case IDC_CHANGE_FRAME:
         case IDC_CHANGE_TEXT_FORE:

--- a/foo_ui_columns/tab_dark_mode.cpp
+++ b/foo_ui_columns/tab_dark_mode.cpp
@@ -1,0 +1,76 @@
+#include "stdafx.h"
+#include "tab_dark_mode.h"
+
+#include "config_appearance.h"
+#include "dark_mode.h"
+
+bool TabDarkMode::is_active()
+{
+    return m_wnd != nullptr;
+}
+
+bool TabDarkMode::get_help_url(pfc::string_base& p_out)
+{
+    return false;
+}
+
+const char* TabDarkMode::get_name()
+{
+    return "Mode";
+}
+
+HWND TabDarkMode::create(HWND wnd)
+{
+    return m_helper.create(
+        wnd, IDD_PREFS_DARK_MODE, [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
+}
+
+BOOL TabDarkMode::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    switch (msg) {
+    case WM_INITDIALOG: {
+        m_wnd = wnd;
+
+        const auto disabled_wnd = GetDlgItem(wnd, IDC_DARK_MODE_DISABLED);
+        const auto enabled_wnd = GetDlgItem(wnd, IDC_DARK_MODE_ENABLED);
+        const auto windows_too_old_wnd = GetDlgItem(wnd, IDC_WINDOWS_VERSION_TOO_OLD);
+        const auto unknown_windows_build_wnd = GetDlgItem(wnd, IDC_UNKNOWN_WINDOWS_BUILD);
+
+        if (!cui::dark::does_os_support_dark_mode()) {
+            ShowWindow(windows_too_old_wnd, SW_SHOWNORMAL);
+            EnableWindow(disabled_wnd, FALSE);
+            EnableWindow(enabled_wnd, FALSE);
+            Button_SetCheck(disabled_wnd, BST_CHECKED);
+            break;
+        }
+
+        if (!cui::dark::are_private_apis_allowed()) {
+            ShowWindow(unknown_windows_build_wnd, SW_SHOWNORMAL);
+        }
+
+        switch (static_cast<cui::colours::DarkModeStatus>(cui::colours::dark_mode_status.get())) {
+        case cui::colours::DarkModeStatus::Disabled:
+            Button_SetCheck(disabled_wnd, BST_CHECKED);
+            break;
+        case cui::colours::DarkModeStatus::Enabled:
+            Button_SetCheck(enabled_wnd, BST_CHECKED);
+            break;
+        }
+        break;
+    }
+    case WM_DESTROY:
+        m_wnd = nullptr;
+        break;
+    case WM_COMMAND:
+        switch (wp) {
+        case IDC_DARK_MODE_ENABLED:
+            cui::colours::dark_mode_status.set(WI_EnumValue(cui::colours::DarkModeStatus::Enabled));
+            return 0;
+        case IDC_DARK_MODE_DISABLED:
+            cui::colours::dark_mode_status.set(WI_EnumValue(cui::colours::DarkModeStatus::Disabled));
+            return 0;
+        }
+        break;
+    }
+    return 0;
+}

--- a/foo_ui_columns/tab_dark_mode.h
+++ b/foo_ui_columns/tab_dark_mode.h
@@ -1,0 +1,18 @@
+#pragma once
+#pragma once
+
+#include "config.h"
+
+class TabDarkMode : public PreferencesTab {
+public:
+    BOOL on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    void apply() {}
+    HWND create(HWND wnd) override;
+    const char* get_name() override;
+    bool get_help_url(pfc::string_base& p_out) override;
+    bool is_active();
+
+private:
+    HWND m_wnd{nullptr};
+    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+};


### PR DESCRIPTION
This adds a toggle for dark mode to preferences.

Currently, the options are 'Light' or 'Dark'. A 'Use system setting' option will be added separately.

Changing the option requires restarting foobar2000. Live toggling will also be added separately.

This change also includes various OS version checks for dark mode.