### PR TITLE
Disable min() and max() macros

### DIFF
--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -377,7 +377,7 @@ void ArtworkPanel::on_completion(unsigned p_code)
     bool b_found = false;
     t_size count = g_artwork_types.size();
     if (m_lock_type)
-        count = min(1, count);
+        count = std::min(size_t{1}, count);
     for (t_size i = 0; i < count; i++) {
         if (refresh_image()) {
             b_found = true;

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -171,8 +171,8 @@ void ButtonsToolbar::create_toolbar()
 
                         SIZE szt;
                         images[n].get_size(szt);
-                        sz.cx = max(sz.cx, szt.cx);
-                        sz.cy = max(sz.cy, szt.cy);
+                        sz.cx = std::max(sz.cx, szt.cx);
+                        sz.cy = std::max(sz.cy, szt.cy);
                     }
                 }
             }
@@ -345,8 +345,8 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             int cy = lpwp->cy;
             int extra = 0;
             if (count && (BOOL)SendMessage(wnd_toolbar, TB_GETITEMRECT, count - 1, (LPARAM)(&rc))) {
-                cx = min(cx, rc.right);
-                cy = min(cy, rc.bottom);
+                cx = std::min(cx, gsl::narrow_cast<int>(rc.right));
+                cy = std::min(cy, gsl::narrow_cast<int>(rc.bottom));
                 extra = (lpwp->cy - rc.bottom) / 2;
             }
             SetWindowPos(wnd_toolbar, nullptr, 0, extra, cx, cy, SWP_NOZORDER);

--- a/foo_ui_columns/buttons_config_droptarget.cpp
+++ b/foo_ui_columns/buttons_config_droptarget.cpp
@@ -176,8 +176,8 @@ HRESULT STDMETHODCALLTYPE ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListD
             // blaarrgg, designed in the dark ages
             m_button_list_view->m_param.m_selection = &m_button_list_view->m_param.m_buttons[new_index];
 
-            const size_t first_index = (std::min)(old_index, new_index);
-            const size_t last_index = (std::max)(old_index, new_index);
+            const size_t first_index = std::min(old_index, new_index);
+            const size_t last_index = std::max(old_index, new_index);
             m_button_list_view->m_param.refresh_buttons_list_items(first_index, last_index - first_index + 1);
             m_button_list_view->set_item_selected_single(new_index);
         }

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -202,7 +202,7 @@ int DropDownListToolbar<ToolbarArgs>::calculate_max_item_width()
     for (auto index : ranges::views::iota(0, item_count)) {
         uComboBox_GetText(m_wnd_combo, index, text);
         const auto cx = uih::get_text_width(dc.get(), text, text.get_length());
-        max_item_width = max(max_item_width, cx);
+        max_item_width = std::max(max_item_width, cx);
     }
 
     COMBOBOXINFO cbi{};

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -217,7 +217,7 @@ void FilterPanel::g_on_new_field(const Field& field)
 }
 void FilterPanel::g_on_fields_swapped(t_size index_1, t_size index_2)
 {
-    if (max(index_1, index_2) < g_field_data.get_count())
+    if (std::max(index_1, index_2) < g_field_data.get_count())
         g_field_data.swap_items(index_1, index_2);
     if (!cfg_orderedbysplitters) {
         t_size count = g_streams.get_count();
@@ -232,7 +232,7 @@ void FilterPanel::g_on_fields_swapped(t_size index_1, t_size index_2)
                         g_update_subsequent_filters(windows, j, false, false);
                         break;
                     }
-                    if (this_index > max(index_1, index_2))
+                    if (this_index > std::max(index_1, index_2))
                         break;
                 }
             }
@@ -436,7 +436,7 @@ void FilterPanel::set_field(const FieldData& field, bool b_force)
         pfc::ptr_list_t<FilterPanel> windows_after;
         get_windows(windows_after);
         t_size pos_after = windows_after.find_item(this);
-        t_size pos_update = min(pos_before, pos_after);
+        t_size pos_update = std::min(pos_before, pos_after);
         if (b_redraw)
             enable_redrawing();
         // update_window();

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -294,7 +294,7 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
     case WM_GETMINMAXINFO: {
         auto mmi = LPMINMAXINFO(lp);
         mmi->ptMinTrackSize.x = m_combo_cx + m_toolbar_cx;
-        mmi->ptMinTrackSize.y = max(m_combo_cy, m_toolbar_cy);
+        mmi->ptMinTrackSize.y = std::max(m_combo_cy, m_toolbar_cy);
         mmi->ptMaxTrackSize.y = mmi->ptMinTrackSize.y;
     }
         return 0;

--- a/foo_ui_columns/helpers.cpp
+++ b/foo_ui_columns/helpers.cpp
@@ -164,10 +164,10 @@ bool open_web_page(HWND wnd, const wchar_t* url)
 
 void clip_minmaxinfo(MINMAXINFO& mmi)
 {
-    mmi.ptMinTrackSize.x = min(mmi.ptMinTrackSize.x, MAXSHORT);
-    mmi.ptMinTrackSize.y = min(mmi.ptMinTrackSize.y, MAXSHORT);
-    mmi.ptMaxTrackSize.y = min(mmi.ptMaxTrackSize.y, MAXSHORT);
-    mmi.ptMaxTrackSize.x = min(mmi.ptMaxTrackSize.x, MAXSHORT);
+    mmi.ptMinTrackSize.x = std::min(mmi.ptMinTrackSize.x, static_cast<long>(MAXSHORT));
+    mmi.ptMinTrackSize.y = std::min(mmi.ptMinTrackSize.y, static_cast<long>(MAXSHORT));
+    mmi.ptMaxTrackSize.y = std::min(mmi.ptMaxTrackSize.y, static_cast<long>(MAXSHORT));
+    mmi.ptMaxTrackSize.x = std::min(mmi.ptMaxTrackSize.x, static_cast<long>(MAXSHORT));
 }
 
 } // namespace cui::helpers

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -247,12 +247,12 @@ void ItemDetails::update_scrollbar(ScrollbarType scrollbar_type, bool reset_posi
     si_new.nMin = 0;
 
     if (scrollbar_type == ScrollbarType::vertical) {
-        si_new.nPage = (std::max)(RECT_CY(rc), 1l);
-        si_new.nMax = (std::max)(m_display_sz.cy - 1, 1l);
+        si_new.nPage = std::max(RECT_CY(rc), 1l);
+        si_new.nMax = std::max(m_display_sz.cy - 1, 1l);
     } else {
         const auto padding_size = 2_spx * 2;
-        si_new.nPage = (std::max)(RECT_CX(rc), 1l);
-        si_new.nMax = m_hscroll ? (std::max)(m_display_sz.cx + padding_size - 1, 1l) : 0l;
+        si_new.nPage = std::max(RECT_CX(rc), 1l);
+        si_new.nMax = m_hscroll ? std::max(m_display_sz.cx + padding_size - 1, 1l) : 0l;
     }
 
     if (si_new.nMax >= gsl::narrow<int>(si_new.nPage)) {
@@ -865,11 +865,11 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         const int padding = uih::scale_dpi_value(2);
         const int width
-            = m_hscroll ? (std::max)(client_width, gsl::narrow<int>(m_display_sz.cx) + padding * 2) : client_width;
+            = m_hscroll ? std::max(client_width, gsl::narrow<int>(m_display_sz.cx) + padding * 2) : client_width;
 
         RECT rc_placement{};
         rc_placement.left = rc_client.left + padding - sih.nPos;
-        rc_placement.right = (std::max)(rc_placement.left + width - padding * 2, rc_placement.left);
+        rc_placement.right = std::max(rc_placement.left + width - padding * 2, rc_placement.left);
         rc_placement.top = rc_client.top - siv.nPos;
 
         if (m_display_sz.cy < client_height) {

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -282,7 +282,7 @@ DisplayInfo g_get_multiline_text_dimensions(HDC dc, std::wstring_view text, cons
                     line_height = font_iter->m_font->m_height;
                     is_line_height_explicitly_set = true;
                 } else {
-                    line_height = (std::max)(line_height, font_iter->m_font->m_height);
+                    line_height = std::max(line_height, font_iter->m_font->m_height);
                     is_line_height_explicitly_set = true;
                 }
                 ++font_iter;
@@ -293,7 +293,7 @@ DisplayInfo g_get_multiline_text_dimensions(HDC dc, std::wstring_view text, cons
                 uih::UniscribeTextRenderer script_string;
 
                 script_string.analyse(dc, fragment.data() + fragment_character_pos,
-                    fragment.length() - fragment_character_pos, (std::max)(max_width - line_width, 0), word_wrapping,
+                    fragment.length() - fragment_character_pos, std::max(max_width - line_width, 0), word_wrapping,
                     true, line_width);
 
                 if (word_wrapping) {
@@ -348,7 +348,7 @@ DisplayInfo g_get_multiline_text_dimensions(HDC dc, std::wstring_view text, cons
     }
 
     display_info.sz.cx = ranges::accumulate(
-        display_info.line_sizes, 0, [](auto&& val, auto&& line_info) { return (std::max)(val, line_info.m_width); });
+        display_info.line_sizes, 0, [](auto&& val, auto&& line_info) { return std::max(val, line_info.m_width); });
 
     display_info.sz.cy = ranges::accumulate(
         display_info.line_sizes, 0, [](auto&& val, auto&& line_info) { return val + line_info.m_height; });

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -546,7 +546,7 @@ void ItemProperties::refresh_contents()
 
     if (new_count && old_count) {
         pfc::list_t<InsertItem> items_replace;
-        items_replace.add_items_fromptr(items.get_ptr(), min(new_count, old_count));
+        items_replace.add_items_fromptr(items.get_ptr(), std::min(new_count, old_count));
         replace_items(0, items_replace);
     }
 

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -757,7 +757,7 @@ void LayoutWindow::run_live_edit_base(const LiveEditData& p_data)
         uie::window_ptr window;
         service_ptr_t<uie::splitter_window> splitter;
         if (uie::window::create_by_guid(panels[panel_index].guid, window) && window->service_query_t(splitter)) {
-            unsigned count = min(p_splitter->get_panel_count(), splitter->get_maximum_panel_count());
+            unsigned count = std::min(p_splitter->get_panel_count(), splitter->get_maximum_panel_count());
             if (count == p_splitter->get_panel_count()
                 || MessageBox(get_wnd(),
                        _T("The number of child items will not fit in the selected splitter type. ")
@@ -794,7 +794,7 @@ void LayoutWindow::run_live_edit_base(const LiveEditData& p_data)
         uie::window_ptr window;
         service_ptr_t<uie::splitter_window> splitter;
         if (uie::window::create_by_guid(panels[panel_index].guid, window) && window->service_query_t(splitter)) {
-            unsigned count = min(p_splitter->get_panel_count(), splitter->get_maximum_panel_count());
+            unsigned count = std::min(p_splitter->get_panel_count(), splitter->get_maximum_panel_count());
             if (index != pfc_infinite
                 && (count == p_splitter->get_panel_count()
                     || MessageBox(p_data.m_wnd,

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -214,8 +214,8 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             int cy = lpwp->cy;
             int extra = 0;
             if (count && (BOOL)SendMessage(wnd_menu, TB_GETITEMRECT, count - 1, (LPARAM)(&rc))) {
-                cx = min(cx, rc.right);
-                cy = min(cy, rc.bottom);
+                cx = std::min(cx, gsl::narrow_cast<int>(rc.right));
+                cy = std::min(cy, gsl::narrow_cast<int>(rc.bottom));
                 extra = (lpwp->cy - rc.bottom) / 2;
             }
             SetWindowPos(wnd_menu, nullptr, 0, extra, cx, cy, SWP_NOZORDER);

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -18,8 +18,8 @@ void PlaylistViewRenderer::render_group_info(uih::lv::RendererContext context, t
     RECT rc_bitmap;
     rc_bitmap.left = rc.left + (RECT_CX(rc) - bminfo.bmWidth) / 2;
     rc_bitmap.top = rc.top;
-    rc_bitmap.right = rc_bitmap.left + min(bminfo.bmWidth, RECT_CX(rc));
-    rc_bitmap.bottom = rc_bitmap.top + min(bminfo.bmHeight, RECT_CY(rc));
+    rc_bitmap.right = rc_bitmap.left + std::min(bminfo.bmWidth, RECT_CX(rc));
+    rc_bitmap.bottom = rc_bitmap.top + std::min(bminfo.bmHeight, RECT_CY(rc));
 
     HBITMAP bm_old = SelectBitmap(dcc, bm.get());
     BitBlt(context.dc, rc_bitmap.left, rc_bitmap.top, RECT_CX(rc_bitmap), RECT_CY(rc_bitmap), dcc, 0, 0, SRCCOPY);
@@ -161,7 +161,7 @@ void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t
         uih::scale_dpi_value(3), &rc, false, cr, true, cfg_ellipsis != 0, uih::ALIGN_LEFT, nullptr, true, true,
         &text_width);
 
-    auto cx = (LONG)min(text_width, MAXLONG);
+    auto cx = static_cast<long>(std::min(text_width, MAXLONG));
 
     RECT rc_line = {cx + uih::scale_dpi_value(7), rc.top + RECT_CY(rc) / 2 - uih::scale_dpi_value(1) / 2,
         rc.right - uih::scale_dpi_value(4),

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -691,7 +691,8 @@ void RebarWindow::update_band(unsigned n, bool size)
         if (mmi.ptMaxTrackSize.y < 0)
             mmi.ptMaxTrackSize.y = 0;
         if (mmi.ptMinTrackSize.y <= 0)
-            mmi.ptMinTrackSize.y = min(uih::scale_dpi_value(default_toolbar_height), mmi.ptMaxTrackSize.y);
+            mmi.ptMinTrackSize.y
+                = std::min(static_cast<long>(uih::scale_dpi_value(default_toolbar_height)), mmi.ptMaxTrackSize.y);
         if (mmi.ptMinTrackSize.x <= 0)
             mmi.ptMinTrackSize.x = uih::scale_dpi_value(default_toolbar_width);
 
@@ -761,7 +762,8 @@ void RebarWindow::refresh_bands(bool force_destroy_bands)
                     if (mmi.ptMaxTrackSize.y < 0)
                         mmi.ptMaxTrackSize.y = 0;
                     if (mmi.ptMinTrackSize.y <= 0)
-                        mmi.ptMinTrackSize.y = min(uih::scale_dpi_value(default_toolbar_height), mmi.ptMaxTrackSize.y);
+                        mmi.ptMinTrackSize.y = std::min(
+                            static_cast<long>(uih::scale_dpi_value(default_toolbar_height)), mmi.ptMaxTrackSize.y);
                     if (mmi.ptMinTrackSize.x <= 0)
                         mmi.ptMinTrackSize.x = uih::scale_dpi_value(default_toolbar_width);
 

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -149,7 +149,7 @@ private:
         void set_hidden(bool val);
 
         void on_size();
-        void on_size(unsigned cx, unsigned cy);
+        void on_size(int cx, int cy);
 
         void destroy();
         Panel();

--- a/foo_ui_columns/splitter_panel.cpp
+++ b/foo_ui_columns/splitter_panel.cpp
@@ -21,9 +21,9 @@ void FlatSplitterPanel::Panel::destroy()
         m_container.destroy();
 }
 
-void FlatSplitterPanel::Panel::on_size(unsigned cx, unsigned cy)
+void FlatSplitterPanel::Panel::on_size(int cx, int cy)
 {
-    unsigned caption_size = m_show_caption ? g_get_caption_size() : 0;
+    const auto caption_size = m_show_caption ? g_get_caption_size() : 0;
 
     // get_orientation()
     unsigned x = m_caption_orientation == vertical ? caption_size : 0;
@@ -36,8 +36,8 @@ void FlatSplitterPanel::Panel::on_size(unsigned cx, unsigned cy)
         SetWindowPos(m_wnd_child, nullptr, x, y, cx - x, cy - y, SWP_NOZORDER);
     if (caption_size /*&& (m_caption_orientation == vertical || (m_container.m_uxtheme.is_valid() && m_container.m_theme))*/)
     {
-        int caption_cx = min(m_caption_orientation == vertical ? caption_size : (cx), MAXLONG);
-        int caption_cy = min(m_caption_orientation == vertical ? cy : caption_size, MAXLONG);
+        int caption_cx = m_caption_orientation == vertical ? caption_size : cx;
+        int caption_cy = m_caption_orientation == vertical ? cy : caption_size;
 
         RECT rc_caption = {0, 0, caption_cx, caption_cy};
         RedrawWindow(m_wnd, &rc_caption, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -35,10 +35,10 @@ public:
             mmi.ptMaxTrackSize.x = MAXLONG;
             mmi.ptMaxTrackSize.y = MAXLONG;
             SendMessage(wnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi);
-            p_ext->m_size_limits.min_width = min(mmi.ptMinTrackSize.x, MAXSHORT);
-            p_ext->m_size_limits.min_height = min(mmi.ptMinTrackSize.y, MAXSHORT);
-            p_ext->m_size_limits.max_height = min(mmi.ptMaxTrackSize.y, MAXSHORT);
-            p_ext->m_size_limits.max_width = min(mmi.ptMaxTrackSize.x, MAXSHORT);
+            p_ext->m_size_limits.min_width = std::min(mmi.ptMinTrackSize.x, static_cast<long>(MAXSHORT));
+            p_ext->m_size_limits.min_height = std::min(mmi.ptMinTrackSize.y, static_cast<long>(MAXSHORT));
+            p_ext->m_size_limits.max_height = std::min(mmi.ptMaxTrackSize.y, static_cast<long>(MAXSHORT));
+            p_ext->m_size_limits.max_width = std::min(mmi.ptMaxTrackSize.x, static_cast<long>(MAXSHORT));
 
             m_this->update_size_limits();
 
@@ -417,10 +417,10 @@ void TabStackPanel::import_config(stream_reader* p_reader, t_size p_size, abort_
 
 void clip_sizelimit(uie::size_limit_t& mmi)
 {
-    mmi.max_height = min(mmi.max_height, MAXSHORT);
-    mmi.min_height = min(mmi.min_height, MAXSHORT);
-    mmi.max_width = min(mmi.max_width, MAXSHORT);
-    mmi.min_width = min(mmi.min_width, MAXSHORT);
+    mmi.max_height = std::min(mmi.max_height, static_cast<unsigned>(MAXSHORT));
+    mmi.min_height = std::min(mmi.min_height, static_cast<unsigned>(MAXSHORT));
+    mmi.max_width = std::min(mmi.max_width, static_cast<unsigned>(MAXSHORT));
+    mmi.min_width = std::min(mmi.min_width, static_cast<unsigned>(MAXSHORT));
 }
 
 void TabStackPanel::update_size_limits()
@@ -438,10 +438,10 @@ void TabStackPanel::update_size_limits()
         if (m_active_panels[n]->m_wnd) {
             SendMessage(m_active_panels[n]->m_wnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi);
 
-            m_size_limits.min_height = max((unsigned)mmi.ptMinTrackSize.y, m_size_limits.min_height);
-            m_size_limits.min_width = max((unsigned)mmi.ptMinTrackSize.x, m_size_limits.min_width);
-            m_size_limits.max_height = min((unsigned)mmi.ptMaxTrackSize.y, m_size_limits.max_height);
-            m_size_limits.max_width = min((unsigned)mmi.ptMaxTrackSize.x, m_size_limits.max_width);
+            m_size_limits.min_height = std::max((unsigned)mmi.ptMinTrackSize.y, m_size_limits.min_height);
+            m_size_limits.min_width = std::max((unsigned)mmi.ptMinTrackSize.x, m_size_limits.min_width);
+            m_size_limits.max_height = std::min((unsigned)mmi.ptMaxTrackSize.y, m_size_limits.max_height);
+            m_size_limits.max_width = std::min((unsigned)mmi.ptMaxTrackSize.x, m_size_limits.max_width);
         }
         if (m_size_limits.max_width < m_size_limits.min_width)
             m_size_limits.max_width = m_size_limits.min_width;

--- a/foo_ui_columns/splitter_window.cpp
+++ b/foo_ui_columns/splitter_window.cpp
@@ -1088,10 +1088,10 @@ void FlatSplitterPanel::FlatSplitterPanelHost::on_size_limit_change(HWND wnd, un
         mmi.ptMaxTrackSize.x = MAXLONG;
         mmi.ptMaxTrackSize.y = MAXLONG;
         SendMessage(wnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi);
-        p_ext->m_size_limits.min_width = min(mmi.ptMinTrackSize.x, MAXSHORT);
-        p_ext->m_size_limits.min_height = min(mmi.ptMinTrackSize.y, MAXSHORT);
-        p_ext->m_size_limits.max_height = min(mmi.ptMaxTrackSize.y, MAXSHORT);
-        p_ext->m_size_limits.max_width = min(mmi.ptMaxTrackSize.x, MAXSHORT);
+        p_ext->m_size_limits.min_width = std::min(mmi.ptMinTrackSize.x, static_cast<long>(MAXSHORT));
+        p_ext->m_size_limits.min_height = std::min(mmi.ptMinTrackSize.y, static_cast<long>(MAXSHORT));
+        p_ext->m_size_limits.max_height = std::min(mmi.ptMaxTrackSize.y, static_cast<long>(MAXSHORT));
+        p_ext->m_size_limits.max_width = std::min(mmi.ptMaxTrackSize.x, static_cast<long>(MAXSHORT));
         pfc::string8 name;
         p_ext->m_child->get_name(name);
         // console::formatter() << "change: name: " << name << " min width: " << (t_int32)mmi.ptMinTrackSize.x;

--- a/foo_ui_columns/splitter_window_wndproc.cpp
+++ b/foo_ui_columns/splitter_window_wndproc.cpp
@@ -109,7 +109,7 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 if (get_orientation() == vertical) {
                     lpmmi->ptMinTrackSize.y += mmi.ptMinTrackSize.y + divider_size;
 
-                    lpmmi->ptMinTrackSize.x = max(mmi.ptMinTrackSize.x, lpmmi->ptMinTrackSize.x);
+                    lpmmi->ptMinTrackSize.x = std::max(mmi.ptMinTrackSize.x, lpmmi->ptMinTrackSize.x);
 
                     if (lpmmi->ptMaxTrackSize.y <= MAXLONG - mmi.ptMaxTrackSize.y
                         && lpmmi->ptMaxTrackSize.y + mmi.ptMaxTrackSize.y <= MAXLONG - (long)divider_size) {
@@ -117,25 +117,25 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     } else {
                         lpmmi->ptMaxTrackSize.y = MAXLONG;
                     }
-                    lpmmi->ptMaxTrackSize.x = min(mmi.ptMaxTrackSize.x, lpmmi->ptMaxTrackSize.x);
+                    lpmmi->ptMaxTrackSize.x = std::min(mmi.ptMaxTrackSize.x, lpmmi->ptMaxTrackSize.x);
                 } else {
                     lpmmi->ptMinTrackSize.x += mmi.ptMinTrackSize.x + divider_size;
-                    lpmmi->ptMinTrackSize.y = max(mmi.ptMinTrackSize.y, lpmmi->ptMinTrackSize.y);
+                    lpmmi->ptMinTrackSize.y = std::max(mmi.ptMinTrackSize.y, lpmmi->ptMinTrackSize.y);
                     if (lpmmi->ptMaxTrackSize.x <= MAXLONG - mmi.ptMaxTrackSize.x
                         && lpmmi->ptMaxTrackSize.x + mmi.ptMaxTrackSize.x <= MAXLONG - (long)divider_size) {
                         lpmmi->ptMaxTrackSize.x += mmi.ptMaxTrackSize.x + divider_size;
                     } else {
                         lpmmi->ptMaxTrackSize.x = MAXLONG;
                     }
-                    lpmmi->ptMaxTrackSize.y = min(mmi.ptMaxTrackSize.y, lpmmi->ptMaxTrackSize.y);
+                    lpmmi->ptMaxTrackSize.y = std::min(mmi.ptMaxTrackSize.y, lpmmi->ptMaxTrackSize.y);
                 }
             }
         }
         if (b_found) {
             if (get_orientation() == vertical)
-                lpmmi->ptMaxTrackSize.x = max(lpmmi->ptMaxTrackSize.x, lpmmi->ptMinTrackSize.x);
+                lpmmi->ptMaxTrackSize.x = std::max(lpmmi->ptMaxTrackSize.x, lpmmi->ptMinTrackSize.x);
             else
-                lpmmi->ptMaxTrackSize.y = max(lpmmi->ptMaxTrackSize.y, lpmmi->ptMinTrackSize.y);
+                lpmmi->ptMaxTrackSize.y = std::max(lpmmi->ptMaxTrackSize.y, lpmmi->ptMinTrackSize.y);
         } else {
             if (get_orientation() == vertical)
                 lpmmi->ptMaxTrackSize.y = MAXLONG;

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -143,7 +143,7 @@ int calculate_volume_size(const char* p_text)
 
 int calculate_selected_length_size(const char* p_text)
 {
-    return max(win32_helpers::status_bar_get_text_width(g_status, p_text),
+    return std::max(win32_helpers::status_bar_get_text_width(g_status, p_text),
         win32_helpers::status_bar_get_text_width(g_status, "0d 00:00:00"));
 }
 

--- a/foo_ui_columns/stdafx.h
+++ b/foo_ui_columns/stdafx.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #define OEMRESOURCE
+#define NOMINMAX
 
 #ifdef _DEBUG
 #define _CRTDBG_MAP_ALLOC

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -351,7 +351,7 @@ void LayoutTab::switch_splitter(HWND wnd, HTREEITEM ti, const GUID& p_guid)
     uie::window_ptr window;
     service_ptr_t<uie::splitter_window> splitter;
     if (uie::window::create_by_guid(p_guid, window) && window->service_query_t(splitter)) {
-        unsigned count = min(old_node->m_children.size(), splitter->get_maximum_panel_count());
+        unsigned count = std::min(old_node->m_children.size(), splitter->get_maximum_panel_count());
         if (count == old_node->m_children.size()
             || MessageBox(wnd, _T("The number of child items will not fit in the selected splitter type. Continue?"),
                    _T("Warning"), MB_YESNO | MB_ICONEXCLAMATION)

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -442,7 +442,7 @@ t_size g_scale_value_single(double val, t_size count, bool b_log)
         val_trans = start;
     }
     t_size ret = pfc::rint32(val_trans);
-    ret = max(min(ret, count), 0);
+    ret = std::clamp(ret, size_t{0}, count);
     return ret;
 }
 
@@ -477,7 +477,7 @@ void SpectrumAnalyserVisualisation::refresh(const audio_chunk* p_chunk)
                                 for (t_size k = 0; k < channel_count; k++)
                                     sample_val += p_data[j * channel_count + k];
                                 sample_val *= 1.0 / channel_count;
-                                val = max(val, sample_val);
+                                val = std::max(val, sample_val);
                             }
                         }
 
@@ -512,7 +512,7 @@ void SpectrumAnalyserVisualisation::refresh(const audio_chunk* p_chunk)
                             for (t_size k = 0; k < channel_count; k++)
                                 sample_val += p_data[j * channel_count + k];
                             sample_val *= 1.0 / channel_count;
-                            val = max(val, sample_val);
+                            val = std::max(val, sample_val);
                         }
                     }
                     RECT r;


### PR DESCRIPTION
This adds a `#define NOMINMAX` to stop the Windows SDK headers defining `min()` and `max()` macros.

Various uses of the macros were updated to use C++ standard library equivalents.