### PR TITLE
Remove pseudo-transparent splitter panel background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 [#433](https://github.com/reupen/columns_ui/pull/433), [#434](https://github.com/reupen/columns_ui/pull/434),
 [#435](https://github.com/reupen/columns_ui/pull/435), [#436](https://github.com/reupen/columns_ui/pull/436),
 [#437](https://github.com/reupen/columns_ui/pull/437), [#438](https://github.com/reupen/columns_ui/pull/438),
-[#439](https://github.com/reupen/columns_ui/pull/439), [#440](https://github.com/reupen/columns_ui/pull/440)]
+[#439](https://github.com/reupen/columns_ui/pull/439), [#440](https://github.com/reupen/columns_ui/pull/440),
+[#442](https://github.com/reupen/columns_ui/pull/442)]
 
 * The Filter search toolbar is now integrated with the Colours and fonts preferences page, and its font, foreground colour and background colour are now configurable. [[#424](https://github.com/reupen/columns_ui/pull/424)]
   

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -93,6 +93,8 @@ wil::unique_hbrush get_dark_colour_brush(ColourID colour_id)
 int get_light_colour_system_id(ColourID colour_id)
 {
     switch (colour_id) {
+    case ColourID::LayoutBackground:
+        return COLOR_BTNFACE;
     case ColourID::PanelCaptionBackground:
         return COLOR_BTNFACE;
     case ColourID::StatusBarText:
@@ -154,6 +156,8 @@ AccentColours get_system_accent_colours()
 COLORREF get_dark_colour(ColourID colour_id)
 {
     switch (colour_id) {
+    case ColourID::LayoutBackground:
+        return WI_EnumValue(DarkColour::DARK_190);
     case ColourID::PanelCaptionBackground:
         return WI_EnumValue(DarkColour::DARK_300);
     case ColourID::RebarBandBorder:
@@ -266,6 +270,15 @@ wil::unique_hbrush get_system_colour_brush(int system_colour_id, bool is_dark)
     // HBRUSHes returned by GetSysColorBrush don't need destroying, but doing so does no harm
     // according to the docs
     return wil::unique_hbrush(GetSysColorBrush(system_colour_id));
+}
+
+void draw_layout_background(HWND wnd, HDC dc)
+{
+    RECT rc{};
+    GetClientRect(wnd, &rc);
+
+    const auto brush = dark::get_colour_brush(ColourID::LayoutBackground, is_dark_mode_enabled());
+    FillRect(dc, &rc, brush.get());
 }
 
 } // namespace cui::dark

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -8,6 +8,7 @@
 namespace cui::dark {
 
 enum class ColourID {
+    LayoutBackground,
     PanelCaptionBackground,
     RebarBandBorder,
     StatusBarBackground,
@@ -77,5 +78,7 @@ void enable_top_level_non_client_dark_mode(HWND wnd);
 [[nodiscard]] AccentColours get_system_accent_colours();
 [[nodiscard]] COLORREF get_system_colour(int system_colour_id, bool is_dark);
 [[nodiscard]] wil::unique_hbrush get_system_colour_brush(int system_colour_id, bool is_dark);
+
+void draw_layout_background(HWND wnd, HDC dc);
 
 } // namespace cui::dark

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "layout.h"
-#include "splitter.h"
+
+#include "dark_mode.h"
 #include "splitter_utils.h"
 #include "main_window.h"
 
@@ -898,6 +899,9 @@ LRESULT LayoutWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         refresh_child();
         create_child();
         break;
+    case WM_ERASEBKGND:
+        cui::dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
+        return TRUE;
     case WM_WINDOWPOSCHANGED: {
         auto lpwp = (LPWINDOWPOS)lp;
         if (!(lpwp->flags & SWP_NOSIZE)) {

--- a/foo_ui_columns/layout.h
+++ b/foo_ui_columns/layout.h
@@ -112,7 +112,7 @@ private:
 
     class_data& get_class_data() const override
     {
-        __implement_get_class_data(_T("{DA9A1375-A411-48a9-AF74-4AC29FF9BE9C}"), true);
+        __implement_get_class_data(_T("{DA9A1375-A411-48a9-AF74-4AC29FF9BE9C}"), false);
     }
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -480,15 +480,9 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         return 0;
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
-    case WM_ERASEBKGND: {
-        RECT rc{};
-        GetClientRect(wnd, &rc);
-
-        const auto brush = dark::get_system_colour_brush(COLOR_BTNFACE, dark::is_dark_mode_enabled());
-        FillRect(reinterpret_cast<HDC>(wp), &rc, brush.get());
-
+    case WM_ERASEBKGND:
+        dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
         return TRUE;
-    }
     case WM_DRAWITEM: {
         auto lpdis = reinterpret_cast<LPDRAWITEMSTRUCT>(lp);
 

--- a/foo_ui_columns/splitter.cpp
+++ b/foo_ui_columns/splitter.cpp
@@ -8,7 +8,7 @@ pfc::ptr_list_t<FlatSplitterPanel> FlatSplitterPanel::g_instances;
 class HorizontalSplitterPanel : public FlatSplitterPanel {
     class_data& get_class_data() const override
     {
-        __implement_get_class_data_ex(_T("{72FACC90-BB7E-4733-8449-D7537232AD26}"), _T(""), true, 0,
+        __implement_get_class_data_ex(_T("{72FACC90-BB7E-4733-8449-D7537232AD26}"), _T(""), false, 0,
             WS_CHILD | WS_CLIPCHILDREN, WS_EX_CONTROLPARENT, CS_DBLCLKS);
     }
     void get_name(pfc::string_base& p_out) const override { p_out = "Horizontal splitter"; }
@@ -24,7 +24,7 @@ class HorizontalSplitterPanel : public FlatSplitterPanel {
 class VerticalSplitterPanel : public FlatSplitterPanel {
     class_data& get_class_data() const override
     {
-        __implement_get_class_data_ex(_T("{77653A44-66D1-49e0-9A7A-1C71898C0441}"), _T(""), true, 0,
+        __implement_get_class_data_ex(_T("{77653A44-66D1-49e0-9A7A-1C71898C0441}"), _T(""), false, 0,
             WS_CHILD | WS_CLIPCHILDREN, WS_EX_CONTROLPARENT, CS_DBLCLKS);
     }
     void get_name(pfc::string_base& p_out) const override { p_out = "Vertical splitter"; }

--- a/foo_ui_columns/splitter_window_wndproc.cpp
+++ b/foo_ui_columns/splitter_window_wndproc.cpp
@@ -1,4 +1,6 @@
 #include "stdafx.h"
+
+#include "dark_mode.h"
 #include "splitter.h"
 
 namespace cui::panels::splitter {
@@ -28,6 +30,9 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         g_instances.remove_item(this);
         m_wnd = nullptr;
         break;
+    case WM_ERASEBKGND:
+        dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
+        return TRUE;
     case WM_SHOWWINDOW:
         if (wp == TRUE && lp == 0) {
             unsigned count = m_panels.get_count();
@@ -293,46 +298,6 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             // SetCursor(LoadCursor(0, IDC_ARROW));
         }
         break;
-#if 0
-    case WM_PAINT:
-    {
-        PAINTSTRUCT ps;
-        BeginPaint(wnd, &ps);
-        COLORREF cr = GetSysColor(COLOR_3DFACE);
-        wil::unique_hbrush br_line(CreateSolidBrush(/*RGB(226, 226, 226)*/cr));
-
-        t_size n, count = m_panels.get_count();
-        for (n = 0; n + 1<count; n++)
-        {
-            std::shared_ptr<Panel> p_item = m_panels.get_item(n);
-
-            if (p_item->m_wnd_child)
-            {
-                RECT rc_area;
-                GetRelativeRect(p_item->m_wnd_child, m_wnd, &rc_area);
-                if (get_orientation() == vertical)
-                {
-                    rc_area.top = rc_area.bottom;
-                    rc_area.bottom += 2;
-                    //FillRect(ps.hdc, &rc_area, GetSysColorBrush(COLOR_WINDOW));
-                    //rc_area.top++;
-                }
-                else
-                {
-                    rc_area.left = rc_area.right;
-                    rc_area.right += 2;
-                    //FillRect(ps.hdc, &rc_area, GetSysColorBrush(COLOR_WINDOW));
-                    //rc_area.right--;
-                }
-                FillRect(ps.hdc, &rc_area, br_line.get());
-            }
-        }
-
-        EndPaint(wnd, &ps);
-
-    }
-    ;
-#endif
 #if 0
     case WM_CONTEXTMENU:
         if ((HWND)wp == wnd)


### PR DESCRIPTION
The pseudo-transparent backgrounds added in #415 to the splitter panels and layout window reduced performance when resizing the main window for various reasons.

This removes the transparent backgrounds in favour of a simpler self-painted background.