### PR TITLE
Fix incorrect button size when image fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 [#435](https://github.com/reupen/columns_ui/pull/435), [#436](https://github.com/reupen/columns_ui/pull/436),
 [#437](https://github.com/reupen/columns_ui/pull/437), [#438](https://github.com/reupen/columns_ui/pull/438),
 [#439](https://github.com/reupen/columns_ui/pull/439), [#440](https://github.com/reupen/columns_ui/pull/440),
-[#442](https://github.com/reupen/columns_ui/pull/442), [#444](https://github.com/reupen/columns_ui/pull/444)]
+[#442](https://github.com/reupen/columns_ui/pull/442), [#444](https://github.com/reupen/columns_ui/pull/444),
+[#445](https://github.com/reupen/columns_ui/pull/445)]
 
 * The Filter search toolbar is now integrated with the Colours and fonts preferences page, and its font, foreground colour and background colour are now configurable. [[#424](https://github.com/reupen/columns_ui/pull/424)]
   

--- a/foo_ui_columns/buttons_button_image.cpp
+++ b/foo_ui_columns/buttons_button_image.cpp
@@ -82,7 +82,7 @@ void ButtonsToolbar::ButtonImage::load(
 }
 unsigned ButtonsToolbar::ButtonImage::add_to_imagelist(HIMAGELIST iml)
 {
-    unsigned rv = I_IMAGENONE;
+    unsigned rv = I_IMAGECALLBACK;
     if (m_icon) {
         rv = ImageList_ReplaceIcon(iml, -1, m_icon);
     } else if (m_bm) {


### PR DESCRIPTION
This fixes a regression added in #444 which caused a button in the buttons toolbar to have the wrong size if it was using a custom image that failed to load.