### PR TITLE
Fix incorrect size limit calculation in playlist tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ### Bug fixes
 
+* A problem where the playlist tabs panel had an incorrect maximum width or height was fixed. [[#449](https://github.com/reupen/columns_ui/pull/449)]
+
 * Various bugs with the positioning and sizing of panel captions were fixed. [[#418](https://github.com/reupen/columns_ui/pull/418)]
 
 * The status bar pop-up volume bar now correctly scales with the system DPI setting. [[#418](https://github.com/reupen/columns_ui/pull/418)]

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -618,17 +618,18 @@ void PlaylistTabs::adjust_rect(bool b_larger, RECT* rc)
 
 void PlaylistTabs::reset_size_limits()
 {
+    constexpr auto max_value = static_cast<long>(USHRT_MAX);
     memset(&mmi, 0, sizeof(mmi));
     if (m_child_wnd) {
         mmi.ptMinTrackSize.x = 0;
         mmi.ptMinTrackSize.y = 0;
-        mmi.ptMaxTrackSize.x = MAXLONG;
-        mmi.ptMaxTrackSize.y = MAXLONG;
+        mmi.ptMaxTrackSize.x = max_value;
+        mmi.ptMaxTrackSize.y = max_value;
         SendMessage(m_child_wnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi);
-        if (mmi.ptMinTrackSize.x != 0 || mmi.ptMinTrackSize.y != 0 || mmi.ptMaxTrackSize.x != MAXLONG
-            || mmi.ptMaxTrackSize.y != MAXLONG) {
+        if (mmi.ptMinTrackSize.x != 0 || mmi.ptMinTrackSize.y != 0 || mmi.ptMaxTrackSize.x < max_value
+            || mmi.ptMaxTrackSize.y < max_value) {
             RECT rc_min = {0, 0, mmi.ptMinTrackSize.x, mmi.ptMinTrackSize.y};
-            RECT rc_max = {0, 0, mmi.ptMaxTrackSize.x, mmi.ptMaxTrackSize.y};
+            RECT rc_max = {0, 0, std::min(mmi.ptMaxTrackSize.x, max_value), std::min(mmi.ptMaxTrackSize.y, max_value)};
             if (wnd_tabs) {
                 adjust_rect(TRUE, &rc_min);
                 adjust_rect(TRUE, &rc_max);


### PR DESCRIPTION
#443

This fixes a problem where the playlist tabs was calculating its maximum width and height incorrectly in some cases due to integer overflow.

Mitigations for the same problem had already been put in place for the tab stack panel.