### PR TITLE
Improve playlist tabs and tab stack rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         submodules: true
 
     - name: Set up MSBuild
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Cache dependencies
       uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,27 +13,29 @@
 [#437](https://github.com/reupen/columns_ui/pull/437), [#438](https://github.com/reupen/columns_ui/pull/438),
 [#439](https://github.com/reupen/columns_ui/pull/439), [#440](https://github.com/reupen/columns_ui/pull/440),
 [#442](https://github.com/reupen/columns_ui/pull/442), [#444](https://github.com/reupen/columns_ui/pull/444),
-[#445](https://github.com/reupen/columns_ui/pull/445)]
+[#445](https://github.com/reupen/columns_ui/pull/445), [#451](https://github.com/reupen/columns_ui/pull/451)]
+
+* The status bar can now show the number of selected tracks. [[#450](https://github.com/reupen/columns_ui/pull/450)]
+
+* Improvements were made to the status bar layout logic (including better DPI scaling). [[#432](https://github.com/reupen/columns_ui/pull/432)]
+
+* The status bar playlist lock icon was replaced with the 🔒 character. [[#432](https://github.com/reupen/columns_ui/pull/432)]
+
+* The default playback button icons were tweaked. This includes the removal of subtle glow effects. [[#435](https://github.com/reupen/columns_ui/pull/435)]
 
 * The Filter search toolbar is now integrated with the Colours and fonts preferences page, and its font, foreground colour and background colour are now configurable. [[#424](https://github.com/reupen/columns_ui/pull/424)]
   
   (Note that selection colours are not supported.)
 
-* Improvements were made to the status bar layout logic (including better DPI scaling). [[#432](https://github.com/reupen/columns_ui/pull/432)]
-
-* The default playback button icons were tweaked. This includes the removal of subtle glow effects. [[#435](https://github.com/reupen/columns_ui/pull/435)]
-
 * The filter search button icons were updated. [[#438](https://github.com/reupen/columns_ui/pull/438)]
 
 * The default no-cover artwork image was updated. [[#437](https://github.com/reupen/columns_ui/pull/437)]
 
-* The status bar playlist lock icon was replaced with the 🔒 character. [[#432](https://github.com/reupen/columns_ui/pull/432)]
+* Flickering when resizing the Playlist tabs and Tab stack panels was eliminated. [[#451](https://github.com/reupen/columns_ui/pull/451)]
 
 * The 'View/Show toolbars' menu item is now only shown if the shift key is held down when opening the View menu. [[#410](https://github.com/reupen/columns_ui/pull/410)]
 
 * A warning was added under the 'Show toolbars' option in preferences. [[#410](https://github.com/reupen/columns_ui/pull/410)]
-
-* The status bar can now show the number of selected tracks. [[#450](https://github.com/reupen/columns_ui/pull/450)]
 
 ### Bug fixes
 

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -259,17 +259,13 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_ERASEBKGND:
-        if (!colours::is_dark_mode_active())
-            break;
-
         return FALSE;
-    case WM_PAINT: {
-        if (!colours::is_dark_mode_active())
-            break;
-
-        dark::handle_tab_control_paint(wnd);
+    case WM_PAINT:
+        if (colours::is_dark_mode_active())
+            dark::handle_tab_control_paint(wnd);
+        else
+            uih::paint_subclassed_window_with_buffering(wnd, tabproc);
         return 0;
-    }
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
     case WM_KEYDOWN: {

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include "common.h"
+#include "dark_mode.h"
 #include "playlist_tabs.h"
 #include "playlist_manager_utils.h"
 
@@ -52,7 +53,9 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         static_api_ptr_t<playlist_manager>()->register_callback(this, flag_all);
         break;
     }
-
+    case WM_ERASEBKGND:
+        dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
+        return TRUE;
     case WM_SHOWWINDOW: {
         if (wp == TRUE && lp == NULL && !IsWindowVisible(m_child_wnd)) {
             ShowWindow(m_child_wnd, SW_SHOWNORMAL);

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -915,17 +915,13 @@ LRESULT WINAPI TabStackPanel::on_hooked_message(HWND wnd, UINT msg, WPARAM wp, L
 {
     switch (msg) {
     case WM_ERASEBKGND:
-        if (!colours::is_dark_mode_active())
-            break;
-
         return FALSE;
-    case WM_PAINT: {
-        if (!colours::is_dark_mode_active())
-            break;
-
-        dark::handle_tab_control_paint(wnd);
+    case WM_PAINT:
+        if (colours::is_dark_mode_active())
+            dark::handle_tab_control_paint(wnd);
+        else
+            uih::paint_subclassed_window_with_buffering(wnd, m_tab_proc);
         return 0;
-    }
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
     case WM_KEYDOWN: {

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "splitter_tabs.h"
 
+#include "dark_mode.h"
 #include "dark_mode_tabs.h"
 
 namespace cui::panels::tab_stack {
@@ -511,6 +512,9 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_dark_mode_notifier = std::make_unique<colours::dark_mode_notifier>(
             [wnd_tabs = m_wnd_tabs] { RedrawWindow(wnd_tabs, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE); });
     } break;
+    case WM_ERASEBKGND:
+        dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
+        return TRUE;
     case WM_KEYDOWN: {
         if (wp != VK_LEFT && wp != VK_RIGHT && get_host()->get_keyboard_shortcuts_enabled()
             && g_process_keydown_keyboard_shortcuts(wp))

--- a/vc17/columns_ui-public.sln
+++ b/vc17/columns_ui-public.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29215.179
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Components", "Components", "{5CE500DE-1CE0-4222-9433-DCE0A3364124}"
 EndProject
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.gitattributes = ..\.gitattributes
 		..\.gitignore = ..\.gitignore
 		..\.gitmodules = ..\.gitmodules
+		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
 		..\CHANGELOG.md = ..\CHANGELOG.md
 		..\CONTRIBUTING.md = ..\CONTRIBUTING.md
 		..\COPYING = ..\COPYING
@@ -41,10 +42,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fbh", "..\fbh\fbh.vcxproj", "{84D30275-D3D7-4867-82D2-8031A53DCE20}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Azure", "Azure", "{4800C6BC-4666-4EBD-882B-B50A759132F0}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{9697868F-BFF6-40A6-8818-F351DD370422}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{9A1841D3-5B7E-4831-A6B7-8B3899D66EF2}"
 	ProjectSection(SolutionItems) = preProject
-		..\azure\job-build.yml = ..\azure\job-build.yml
-		..\azure\pipeline.yml = ..\azure\pipeline.yml
+		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
 	EndProjectSection
 EndProject
 Global
@@ -147,7 +149,8 @@ Global
 		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C} = {B9D1251F-E5BC-412F-950B-BE588408EA59}
 		{743CBAAD-BE8E-430A-918B-2BB68008A616} = {5CE500DE-1CE0-4222-9433-DCE0A3364124}
 		{93EC0EDE-01CD-4FB0-B8E8-4F2A027E026E} = {3A85ACE2-E7C5-4F1F-A253-9C60B8076BE8}
-		{4800C6BC-4666-4EBD-882B-B50A759132F0} = {0FF158B9-F515-4DCF-B879-3D38EEC6DA2C}
+		{9697868F-BFF6-40A6-8818-F351DD370422} = {0FF158B9-F515-4DCF-B879-3D38EEC6DA2C}
+		{9A1841D3-5B7E-4831-A6B7-8B3899D66EF2} = {9697868F-BFF6-40A6-8818-F351DD370422}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69B91470-DA3C-4CE2-B984-1659F90BD386}


### PR DESCRIPTION
This improves the playlist tabs and tab stack panels by:

- eliminating flickering when resizing panels by using double-buffered painting
- correcting the background colour of their containers in dark mode so that child panels with transparent panels render with a more appropriate background colour