### PR TITLE
Fix dynamic switching of menus between light and dark modes

### DIFF
--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -109,7 +109,7 @@ public:
         public:
             ButtonStateCallback& operator=(const ButtonStateCallback& p_source);
             void set_wnd(ButtonsToolbar* p_source);
-            void set_id(const unsigned i);
+            void set_id(unsigned i);
             ButtonStateCallback() = default;
         } m_callback;
 

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -185,7 +185,7 @@ const GUID g_guid_cfg_child_appearance = {0xfa25d859, 0xc808, 0x485d, {0x8a, 0xb
 cfg_int cfg_child_appearance(g_guid_cfg_child_appearance, 0);
 
 // {41E6D7ED-A1DC-4d84-9BC9-352DAF7788B0}
-constexpr const GUID g_guid_colour_preferences
+constexpr GUID g_guid_colour_preferences
     = {0x41e6d7ed, 0xa1dc, 0x4d84, {0x9b, 0xc9, 0x35, 0x2d, 0xaf, 0x77, 0x88, 0xb0}};
 
 static service_factory_single_t<PreferencesTabsHost> g_config_tabs("Colours and fonts", g_tabs_appearance,

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -31,7 +31,7 @@ bool are_private_apis_allowed()
     if (osvi.dwMajorVersion != 10 || osvi.dwMinorVersion != 0)
         return false;
 
-    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22000;
+    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22533;
 }
 
 void set_app_mode(PreferredAppMode mode)

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -40,13 +40,18 @@ void set_app_mode(PreferredAppMode mode)
         return;
 
     using SetPreferredAppModeProc = int(__stdcall*)(int);
+    using FlushMenuThemesProc = void(__stdcall*)();
 
     const wil::unique_hmodule uxtheme(THROW_LAST_ERROR_IF_NULL(LoadLibrary(L"uxtheme.dll")));
 
     const auto set_preferred_app_mode
         = reinterpret_cast<SetPreferredAppModeProc>(GetProcAddress(uxtheme.get(), MAKEINTRESOURCEA(135)));
 
+    const auto flush_menu_themes
+        = reinterpret_cast<FlushMenuThemesProc>(GetProcAddress(uxtheme.get(), MAKEINTRESOURCEA(136)));
+
     set_preferred_app_mode(WI_EnumValue(mode));
+    flush_menu_themes();
 }
 
 void set_titlebar_mode(HWND wnd, bool is_dark)

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -106,7 +106,7 @@ public:
     void delete_band(unsigned idx);
 
     void on_themechanged();
-    std::optional<LRESULT> handle_custom_draw(const LPNMCUSTOMDRAW lpnmcd) const;
+    std::optional<LRESULT> handle_custom_draw(LPNMCUSTOMDRAW lpnmcd) const;
 
     bool on_menu_char(unsigned short c);
     void show_accelerators();

--- a/foo_ui_columns/status_bar.h
+++ b/foo_ui_columns/status_bar.h
@@ -35,6 +35,6 @@ void clear_menu_item_description();
 void create_window();
 void destroy_window();
 void on_status_font_change();
-std::optional<LRESULT> handle_draw_item(const LPDRAWITEMSTRUCT lpdis);
+std::optional<LRESULT> handle_draw_item(LPDRAWITEMSTRUCT lpdis);
 
 } // namespace cui::status_bar

--- a/foo_ui_columns/system_appearance_manager.cpp
+++ b/foo_ui_columns/system_appearance_manager.cpp
@@ -53,7 +53,7 @@ void reset_modern_colours()
 
 bool fetch_dark_mode_available()
 {
-    if (!dark::does_os_support_dark_mode() || !IsAppThemed())
+    if (!dark::does_os_support_dark_mode() || !IsThemeActive() || !IsAppThemed())
         return false;
 
     try {


### PR DESCRIPTION
This resolves a problem where menus were stuck in their previous mode after switching between light and dark modes. It also makes a few other minor tweaks.