### PR TITLE
Update GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: VS 2022
 on:
   workflow_dispatch:
   pull_request:
+  schedule:
+    - cron: 0 4 * * WED
   push:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,11 @@ jobs:
       matrix:
         toolset: ["v143", "llvm"]
         configuration: ["release", "debug"]
+        include:
+          - toolset: v143
+            additional-build-args: '"/logger:$Env:Temp\Reupen.MSBuild.GitHubLogger.dll"'
+          - toolset: llvm
+            additional-build-args: '"/p:PlatformToolset=ClangCL;LinkToolExe=link.exe"'
 
     steps:
       - uses: actions/checkout@v2
@@ -42,14 +47,9 @@ jobs:
         run: |
           Invoke-WebRequest -Uri https://github.com/reupen/msbuild-github-logger/releases/download/v1.0.0/Reupen.MSBuild.GitHubLogger.dll -OutFile "$Env:Temp\Reupen.MSBuild.GitHubLogger.dll"
 
-      - name: Build (v143)
-        if: matrix.toolset == 'v143'
+      - name: Build
         run: |
-          msbuild /m '/p:Platform=Win32;Configuration=${{ matrix.configuration }}' "/logger:$Env:Temp\Reupen.MSBuild.GitHubLogger.dll" vc17\columns_ui-public.sln
-
-      - name: Build (LLVM)
-        if: matrix.toolset == 'llvm'
-        run: msbuild /m '/p:Platform=Win32;Configuration=${{ matrix.configuration }};PlatformToolset=ClangCL;LinkToolExe=link.exe' vc17\columns_ui-public.sln
+          msbuild /m '/p:Platform=Win32;Configuration=${{ matrix.configuration }}' ${{ matrix.additional-build-args }} vc17\columns_ui-public.sln
 
       - uses: actions/upload-artifact@v2
         if: matrix.toolset == 'v143' && matrix.configuration == 'release'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,51 +14,51 @@ jobs:
 
     strategy:
       matrix:
-        toolset: ['v143', 'llvm']
-        configuration: ['release', 'debug']
+        toolset: ["v143", "llvm"]
+        configuration: ["release", "debug"]
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        submodules: true
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
 
-    - name: Set up MSBuild
-      uses: microsoft/setup-msbuild@v1.1
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v1.1
 
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
-        key: ${{ runner.os }}-vcpkg-archives-${{ hashFiles('vcpkg.json') }}
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
+          key: ${{ runner.os }}-vcpkg-archives-${{ hashFiles('vcpkg.json') }}
 
-    - name: Set up vcpkg
-      run: |
-        git -C C:\vcpkg fetch
-        vcpkg version
-        vcpkg integrate install
+      - name: Set up vcpkg
+        run: |
+          git -C C:\vcpkg fetch
+          vcpkg version
+          vcpkg integrate install
 
-    - name: Set up MSBuild logger
-      run: |
-        Invoke-WebRequest -Uri https://github.com/reupen/msbuild-github-logger/releases/download/v1.0.0/Reupen.MSBuild.GitHubLogger.dll -OutFile "$Env:Temp\Reupen.MSBuild.GitHubLogger.dll"
+      - name: Set up MSBuild logger
+        run: |
+          Invoke-WebRequest -Uri https://github.com/reupen/msbuild-github-logger/releases/download/v1.0.0/Reupen.MSBuild.GitHubLogger.dll -OutFile "$Env:Temp\Reupen.MSBuild.GitHubLogger.dll"
 
-    - name: Build (v143)
-      if: matrix.toolset == 'v143'
-      run: |
-        msbuild /m '/p:Platform=Win32;Configuration=${{ matrix.configuration }}' "/logger:$Env:Temp\Reupen.MSBuild.GitHubLogger.dll" vc17\columns_ui-public.sln
+      - name: Build (v143)
+        if: matrix.toolset == 'v143'
+        run: |
+          msbuild /m '/p:Platform=Win32;Configuration=${{ matrix.configuration }}' "/logger:$Env:Temp\Reupen.MSBuild.GitHubLogger.dll" vc17\columns_ui-public.sln
 
-    - name: Build (LLVM)
-      if: matrix.toolset == 'llvm'
-      run: msbuild /m '/p:Platform=Win32;Configuration=${{ matrix.configuration }};PlatformToolset=ClangCL;LinkToolExe=link.exe' vc17\columns_ui-public.sln
+      - name: Build (LLVM)
+        if: matrix.toolset == 'llvm'
+        run: msbuild /m '/p:Platform=Win32;Configuration=${{ matrix.configuration }};PlatformToolset=ClangCL;LinkToolExe=link.exe' vc17\columns_ui-public.sln
 
-    - uses: actions/upload-artifact@v2
-      if: matrix.toolset == 'v143' && matrix.configuration == 'release'
-      with:
-        name: Component package (release)
-        path: vc17\Release\foo_ui_columns*.fb2k-component
+      - uses: actions/upload-artifact@v2
+        if: matrix.toolset == 'v143' && matrix.configuration == 'release'
+        with:
+          name: Component package (release)
+          path: vc17\Release\foo_ui_columns*.fb2k-component
 
-    - uses: actions/upload-artifact@v2
-      if: matrix.toolset == 'v143' && matrix.configuration == 'release'
-      with:
-        name: Symbols for debugging
-        path: vc17\Release\foo_ui_columns.pdb
+      - uses: actions/upload-artifact@v2
+        if: matrix.toolset == 'v143' && matrix.configuration == 'release'
+        with:
+          name: Symbols for debugging
+          path: vc17\Release\foo_ui_columns.pdb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,18 +11,32 @@ on:
 
 jobs:
   build:
+    name: build (${{ matrix.run-code-analysis && format('{0}, code analysis', matrix.platform) || format('{0}, {1}, {2}', matrix.platform, matrix.toolset, matrix.configuration) }})
     runs-on: windows-2022
-    continue-on-error: ${{ matrix.toolset == 'llvm' }}
+    continue-on-error: ${{ matrix.allowed-failure == true }}
 
     strategy:
       matrix:
-        toolset: ["v143", "llvm"]
+        toolset: ["v143", "clang"]
+        platform: ["win32"]
         configuration: ["release", "debug"]
+        run-code-analysis: [false]
         include:
           - toolset: v143
-            additional-build-args: '"/logger:$Env:Temp\Reupen.MSBuild.GitHubLogger.dll"'
-          - toolset: llvm
+            configuration: release
+            enable-annotations: true
+            publish-artefacts: true
+          - toolset: clang
             additional-build-args: '"/p:PlatformToolset=ClangCL;LinkToolExe=link.exe"'
+            allowed-failure: true
+          - toolset: v143
+            configuration: release
+            platform: win32
+            run-code-analysis: true
+            allowed-failure: true
+        exclude:
+          - toolset: clang
+            configuration: debug
 
     steps:
       - uses: actions/checkout@v2
@@ -46,21 +60,29 @@ jobs:
           vcpkg integrate install
 
       - name: Set up MSBuild logger
+        if: matrix.enable-annotations
         run: |
           Invoke-WebRequest -Uri https://github.com/reupen/msbuild-github-logger/releases/download/v1.0.0/Reupen.MSBuild.GitHubLogger.dll -OutFile "$Env:Temp\Reupen.MSBuild.GitHubLogger.dll"
 
       - name: Build
         run: |
-          msbuild /m '/p:Platform=Win32;Configuration=${{ matrix.configuration }}' ${{ matrix.additional-build-args }} vc17\columns_ui-public.sln
+          msbuild `
+            /m `
+            '/p:Platform=${{ matrix.platform }}' `
+            '/p:Configuration=${{ matrix.configuration }}' `
+            '/p:RunCodeAnalysis=${{ matrix.run-code-analysis }}' `
+            ${{ matrix.additional-build-args }} `
+            ${{ matrix.enable-annotations && '"/logger:$Env:Temp\Reupen.MSBuild.GitHubLogger.dll"' }} `
+            vc17\columns_ui-public.sln
 
       - uses: actions/upload-artifact@v2
-        if: matrix.toolset == 'v143' && matrix.configuration == 'release'
+        if: matrix.publish-artefacts
         with:
-          name: Component package (release)
+          name: Component package (${{ matrix.configuration }})
           path: vc17\Release\foo_ui_columns*.fb2k-component
 
       - uses: actions/upload-artifact@v2
-        if: matrix.toolset == 'v143' && matrix.configuration == 'release'
+        if: matrix.publish-artefacts
         with:
-          name: Symbols for debugging
+          name: Symbols for debugging (${{ matrix.configuration }})
           path: vc17\Release\foo_ui_columns.pdb


### PR DESCRIPTION
This updates the GitHub Actions workflow to:

- add a weekly scheduled build (to pick up any breakages due to external factors)
- add a code analysis build (currently failing due to an internal compiler error)
- remove the Clang debug build
- refactor the workflow more generally and update the job names