### PR TITLE
Tidy up definitions of dark mode colours 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
 
 - The spectrum analyser is now integrated with the Colours and fonts preferences
   page, and its foreground colour and background colour are now configured
-  there. [[#466](https://github.com/reupen/columns_ui/pull/466)]
+  there. [[#466](https://github.com/reupen/columns_ui/pull/466),
+  [#470](https://github.com/reupen/columns_ui/pull/470),
+  [#473](https://github.com/reupen/columns_ui/pull/473)]
 
 - The Filter search toolbar is now integrated with the Colours and fonts
   preferences page, and its font, foreground colour and background colour are

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ Stable and pre-release versions can be downloaded from the
 
 ### Development versions
 
-The latest development version can be downloaded by clicking on the GitHub
-Actions badge above, and then clicking on the last successful build and
-scrolling down to the link named 'Component package (release)' at the bottom.
+If you’re logged into GitHub, you can download the latest development version by
+clicking on the GitHub Actions badge above, and then clicking on the last
+successful build and scrolling down to the link named 'Component package
+(release)' at the bottom.
 
 Development versions may be buggier than formal releases; if you encounter a
-problem, please open an issue.
+problem, open an issue.
 
 ## Development
 

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -90,10 +90,22 @@ int get_light_colour_system_id(ColourID colour_id)
     switch (colour_id) {
     case ColourID::LayoutBackground:
         return COLOR_BTNFACE;
+    case ColourID::PanelCaptionText:
+        return COLOR_MENUTEXT;
     case ColourID::PanelCaptionBackground:
         return COLOR_BTNFACE;
     case ColourID::StatusBarText:
         return COLOR_MENUTEXT;
+    case ColourID::StatusPaneBackground:
+        return COLOR_BTNFACE;
+    case ColourID::StatusPaneText:
+        return COLOR_BTNTEXT;
+    case ColourID::StatusPaneTopLine:
+        return COLOR_3DDKSHADOW;
+    case ColourID::VolumeChannelTopEdge:
+        return COLOR_3DSHADOW;
+    case ColourID::VolumeChannelBottomAndRightEdge:
+        return COLOR_3DHILIGHT;
     case ColourID::VolumePopupBackground:
         return COLOR_BTNFACE;
     case ColourID::VolumePopupBorder:
@@ -122,6 +134,8 @@ COLORREF get_dark_colour(ColourID colour_id)
     switch (colour_id) {
     case ColourID::LayoutBackground:
         return WI_EnumValue(DarkColour::DARK_190);
+    case ColourID::PanelCaptionText:
+        return WI_EnumValue(DarkColour::DARK_999);
     case ColourID::PanelCaptionBackground:
         return WI_EnumValue(DarkColour::DARK_300);
     case ColourID::RebarBandBorder:
@@ -130,6 +144,12 @@ COLORREF get_dark_colour(ColourID colour_id)
         return WI_EnumValue(DarkColour::DARK_200);
     case ColourID::StatusBarText:
         return WI_EnumValue(DarkColour::DARK_999);
+    case ColourID::StatusPaneBackground:
+        return WI_EnumValue(DarkColour::DARK_190);
+    case ColourID::StatusPaneText:
+        return WI_EnumValue(DarkColour::DARK_999);
+    case ColourID::StatusPaneTopLine:
+        return WI_EnumValue(DarkColour::DARK_190);
     case ColourID::TabControlBackground:
         return WI_EnumValue(DarkColour::DARK_200);
     case ColourID::TabControlItemBackground:
@@ -158,6 +178,10 @@ COLORREF get_dark_colour(ColourID colour_id)
         return WI_EnumValue(DarkColour::DARK_750);
     case ColourID::TrackbarDisabledThumb:
         return WI_EnumValue(DarkColour::DARK_400);
+    case ColourID::VolumeChannelTopEdge:
+        return WI_EnumValue(DarkColour::DARK_500);
+    case ColourID::VolumeChannelBottomAndRightEdge:
+        return WI_EnumValue(DarkColour::DARK_500);
     case ColourID::VolumePopupBackground:
         return WI_EnumValue(DarkColour::DARK_200);
     case ColourID::VolumePopupBorder:
@@ -191,32 +215,18 @@ COLORREF get_dark_system_colour(int system_colour_id)
     // Unfortunately, these are hard-coded as there doesn't seem to be a simple
     // way to get a similar set of dark mode colours from Windows.
     switch (system_colour_id) {
+    case COLOR_BTNTEXT:
     case COLOR_HIGHLIGHTTEXT:
-    case COLOR_MENUTEXT:
     case COLOR_WINDOWTEXT:
         return RGB(255, 255, 255);
     case COLOR_WINDOW:
         return RGB(32, 32, 32);
     case COLOR_HIGHLIGHT:
         return RGB(98, 98, 98);
-    case COLOR_BTNTEXT:
-        return RGB(255, 255, 255);
     case COLOR_BTNFACE:
         return RGB(51, 51, 51);
     case COLOR_WINDOWFRAME:
         return RGB(119, 119, 119);
-    case COLOR_3DDKSHADOW:
-        // Standard value: RGB(105, 105, 105)
-        return RGB(28, 28, 28);
-    case COLOR_3DHILIGHT:
-        // Standard value: RGB(255, 255, 255)
-        return RGB(100, 100, 100);
-    case COLOR_3DLIGHT:
-        // Standard value: RGB(227, 227, 227)
-        return RGB(42, 42, 42);
-    case COLOR_3DSHADOW:
-        // Standard value: RGB(160, 160, 160)
-        return RGB(100, 100, 100);
     default:
         return RGB(255, 0, 0);
     }

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -9,10 +9,14 @@ namespace cui::dark {
 
 enum class ColourID {
     LayoutBackground,
+    PanelCaptionText,
     PanelCaptionBackground,
     RebarBandBorder,
     StatusBarBackground,
     StatusBarText,
+    StatusPaneTopLine,
+    StatusPaneBackground,
+    StatusPaneText,
     TabControlBackground,
     TabControlItemBackground,
     TabControlItemText,
@@ -24,6 +28,8 @@ enum class ColourID {
     TrackbarThumb,
     TrackbarHotThumb,
     TrackbarDisabledThumb,
+    VolumeChannelTopEdge,
+    VolumeChannelBottomAndRightEdge,
     VolumePopupBackground,
     VolumePopupBorder,
     VolumePopupText,

--- a/foo_ui_columns/helpers.cpp
+++ b/foo_ui_columns/helpers.cpp
@@ -99,7 +99,7 @@ HBITMAP LoadMonoBitmap(INT_PTR uid, COLORREF cr_btntext)
 
 BOOL uDrawPanelTitle(HDC dc, const RECT* rc_clip, const char* text, int len, bool is_font_vertical, bool is_dark)
 {
-    const COLORREF cr_fore = cui::dark::get_system_colour(COLOR_MENUTEXT, is_dark);
+    const COLORREF cr_fore = cui::dark::get_colour(cui::dark::ColourID::PanelCaptionText, is_dark);
 
     SetBkMode(dc, TRANSPARENT);
     SetTextColor(dc, cr_fore);

--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -31,21 +31,20 @@ void StatusPane::on_font_changed()
 void StatusPane::render_background(HDC dc, const RECT& rc)
 {
     const auto is_dark = colours::is_dark_mode_active();
-    const auto fill_brush = dark::get_system_colour_brush(COLOR_BTNFACE, is_dark);
-    COLORREF cr2 = dark::get_system_colour(COLOR_3DDKSHADOW, is_dark);
+    const auto fill_colour = get_colour(dark::ColourID::StatusPaneBackground, is_dark);
+    const auto fill_brush = get_colour_brush(dark::ColourID::StatusPaneBackground, is_dark);
+    const auto top_line_colour = get_colour(dark::ColourID::StatusPaneTopLine, is_dark);
 
     FillRect(dc, &rc, fill_brush.get());
 
-    if (m_theme) {
-        COLORREF cr_back = cr2;
-        Gdiplus::Color cr_end(0, LOBYTE(LOWORD(cr_back)), HIBYTE(LOWORD(cr_back)), LOBYTE(HIWORD(cr_back)));
-        Gdiplus::Color cr_start(33, LOBYTE(LOWORD(cr_back)), HIBYTE(LOWORD(cr_back)), LOBYTE(HIWORD(cr_back)));
-        Gdiplus::Rect rect(rc.left, rc.top, RECT_CX(rc), uih::scale_dpi_value(2));
-        Gdiplus::LinearGradientBrush lgb(rect, cr_start, cr_end, Gdiplus::LinearGradientModeVertical);
+    if (top_line_colour != fill_colour) {
+        const Gdiplus::Color gradient_start(
+            20, GetRValue(top_line_colour), GetGValue(top_line_colour), GetBValue(top_line_colour));
+        const Gdiplus::Color gradient_end(
+            0, GetRValue(top_line_colour), GetGValue(top_line_colour), GetBValue(top_line_colour));
+        const Gdiplus::Rect rect(rc.left, rc.top, RECT_CX(rc), uih::scale_dpi_value(2));
+        Gdiplus::LinearGradientBrush lgb(rect, gradient_start, gradient_end, Gdiplus::LinearGradientModeVertical);
         Gdiplus::Graphics(dc).FillRectangle(&lgb, rect);
-    } else {
-        RECT rcl = {0, 0, rc.right, uih::scale_dpi_value(1)};
-        FillRect(dc, &rcl, dark::get_system_colour_brush(COLOR_3DLIGHT, is_dark).get());
     }
 }
 

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -113,7 +113,7 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         const auto _ = wil::SelectObject(dc.get(), m_font.get());
 
         constexpr auto selected_placeholder = "999999999 items selected"sv;
-        const auto default_text_colour = dark::get_system_colour(COLOR_BTNTEXT, colours::is_dark_mode_active());
+        const auto default_text_colour = get_colour(dark::ColourID::StatusPaneText, colours::is_dark_mode_active());
         const auto placeholder_len
             = uih::get_text_width(dc.get(), selected_placeholder.data(), gsl::narrow<int>(selected_placeholder.size()))
             + uih::scale_dpi_value(20);

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -29,7 +29,7 @@ class SpectrumAnalyserVisualisation
 
 public:
     static void s_flush_brushes();
-    static void s_refresh_all();
+    static void s_refresh_all(bool include_inactive = false);
 
     bool b_active{false};
     unsigned mode;
@@ -443,7 +443,7 @@ void SpectrumAnalyserVisualisation::refresh(const audio_chunk* p_chunk)
     ps.release();
 }
 
-void SpectrumAnalyserVisualisation::s_refresh_all()
+void SpectrumAnalyserVisualisation::s_refresh_all(bool include_inactive)
 {
     bool is_active{};
     audio_chunk_impl p_chunk;
@@ -456,7 +456,9 @@ void SpectrumAnalyserVisualisation::s_refresh_all()
         is_active = g_stream->get_spectrum_absolute(p_chunk, time, fft_size);
     }
 
-    for (const auto instance : s_instances) {
+    const auto& instances = include_inactive ? s_instances : s_active_instances;
+
+    for (const auto instance : instances) {
         instance->refresh(is_active ? &p_chunk : nullptr);
     }
 }
@@ -599,7 +601,7 @@ class ColourClient : public colours::client {
     void on_colour_changed(uint32_t mask) const override
     {
         SpectrumAnalyserVisualisation::s_flush_brushes();
-        SpectrumAnalyserVisualisation::s_refresh_all();
+        SpectrumAnalyserVisualisation::s_refresh_all(true);
     }
 };
 

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -31,8 +31,9 @@ class VolumeBar
                 Trackbar::draw_channel(dc, rc);
             else {
                 const auto is_dark = cui::colours::is_dark_mode_active();
-                COLORREF cr_shadow = cui::dark::get_system_colour(COLOR_3DSHADOW, is_dark);
-                COLORREF cr_hilight = cui::dark::get_system_colour(COLOR_3DHILIGHT, is_dark);
+                const auto top_edge_colour = cui::dark::get_colour(cui::dark::ColourID::VolumeChannelTopEdge, is_dark);
+                const auto bottom_and_right_edge_colour
+                    = cui::dark::get_colour(cui::dark::ColourID::VolumeChannelBottomAndRightEdge, is_dark);
 
                 if (m_this->get_using_gdiplus()) {
                     Gdiplus::Graphics graphics(dc);
@@ -41,8 +42,8 @@ class VolumeBar
                         RECT rcdraw(*rc);
 
                         Gdiplus::Color colour_hilight, colour_shadow;
-                        colour_hilight.SetFromCOLORREF(cr_hilight);
-                        colour_shadow.SetFromCOLORREF(cr_shadow);
+                        colour_hilight.SetFromCOLORREF(bottom_and_right_edge_colour);
+                        colour_shadow.SetFromCOLORREF(top_edge_colour);
 
                         Gdiplus::Pen pen_hilight(colour_hilight);
                         Gdiplus::Pen pen_shadow(colour_shadow);
@@ -55,8 +56,8 @@ class VolumeBar
                             Gdiplus::Point{rcdraw.left - 1, rcdraw.bottom});
                     }
                 } else {
-                    HPEN pn_light = CreatePen(PS_SOLID, 1, cr_hilight);
-                    HPEN pn_shadow = CreatePen(PS_SOLID, 1, cr_shadow);
+                    HPEN pn_light = CreatePen(PS_SOLID, 1, bottom_and_right_edge_colour);
+                    HPEN pn_shadow = CreatePen(PS_SOLID, 1, top_edge_colour);
 
                     HPEN pn_old = SelectPen(dc, pn_shadow);
                     MoveToEx(dc, rc->left, rc->bottom - 1, nullptr);


### PR DESCRIPTION
This tidies up the definition of dark mode colours so that they are defined in a consistent way.

There's also a minor tweak to the spectrum analyser, and an update to the section in the README about downloading development versions.