### PR TITLE
Improve buttons toolbar dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@
 - A problem where the playlist tabs panel had an incorrect maximum width or
   height was fixed. [[#449](https://github.com/reupen/columns_ui/pull/449)]
 
+- The hover colour of text in a buttons toolbar in flat mode was corrected so
+  that it is typically white in light mode.
+  [[#479](https://github.com/reupen/columns_ui/pull/479)]
+
+  (This change has the side effect of an uglier hover animation on some versions
+  of Windows.)
+
 - Various bugs with the positioning and sizing of panel captions were fixed.
   [[#418](https://github.com/reupen/columns_ui/pull/418)]
 

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -424,10 +424,10 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             case CDDS_PREPAINT:
                 return CDRF_NOTIFYITEMDRAW;
             case CDDS_ITEMPREPAINT: {
+                const auto is_dark = colours::is_dark_mode_active();
                 const auto index = lptbcd->nmcd.dwItemSpec;
 
-                if (colours::is_dark_mode_active() && index < m_buttons.size()
-                    && m_buttons[index].m_type == TYPE_SEPARATOR) {
+                if (is_dark && index < m_buttons.size() && m_buttons[index].m_type == TYPE_SEPARATOR) {
                     const auto divider_brush = get_colour_brush(dark::ColourID::ToolbarDivider, true);
                     const auto divider_width = uih::scale_dpi_value(1, USER_DEFAULT_SCREEN_DPI * 2);
                     const auto& item_rect = lptbcd->nmcd.rc;
@@ -446,12 +446,15 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 }
 
                 if (m_appearance == APPEARANCE_FLAT) {
+                    LRESULT ret = TBCDRF_NOEDGES | TBCDRF_NOOFFSET | TBCDRF_HILITEHOTTRACK;
+
                     if (lptbcd->nmcd.uItemState & CDIS_HOT) {
-                        lptbcd->clrText = GetSysColor(COLOR_HIGHLIGHTTEXT);
+                        lptbcd->clrText = get_colour(dark::ColourID::ToolbarFlatHotText, is_dark);
+                        ret |= TBCDRF_USECDCOLORS;
                     }
 
-                    lptbcd->clrHighlightHotTrack = GetSysColor(COLOR_HIGHLIGHT);
-                    return TBCDRF_NOEDGES | TBCDRF_NOOFFSET | TBCDRF_HILITEHOTTRACK;
+                    lptbcd->clrHighlightHotTrack = get_colour(dark::ColourID::ToolbarFlatHotBackground, is_dark);
+                    return ret;
                 }
 
                 if (m_appearance == APPEARANCE_NOEDGE) {

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -103,6 +103,8 @@ const TCHAR* ButtonsToolbar::class_name = _T("{D75D4E2D-603B-4699-9C49-64DDFFE56
 
 void ButtonsToolbar::create_toolbar()
 {
+    const auto is_dark = colours::is_dark_mode_active();
+
     std::vector<TBBUTTON> tbbuttons(m_buttons.size());
     std::vector<ButtonImage> images(m_buttons.size());
     std::vector<ButtonImage> images_hot(m_buttons.size());
@@ -188,15 +190,13 @@ void ButtonsToolbar::create_toolbar()
             m_hot_images.reset(
                 ImageList_Create(width, height, ILC_COLOR32 | ILC_MASK, gsl::narrow<int>(image_count), 0));
 
-        // SendMessage(wnd_toolbar, TB_ADDSTRING,  NULL, (LPARAM)_T("\0")); //Add a empty string at index 0
-
         for (auto&& [n, tbbutton] : ranges::views::enumerate(tbbuttons)) {
             tbbutton.iString = -1; //"It works"
 
             if (m_buttons[n].m_type == TYPE_SEPARATOR) {
                 tbbutton.idCommand = gsl::narrow<int>(n);
-                tbbutton.fsState = TBSTATE_ENABLED;
-                tbbutton.fsStyle = BTNS_SEP;
+                tbbutton.fsStyle = is_dark ? BTNS_BUTTON | BTNS_SHOWTEXT : BTNS_SEP;
+                tbbutton.iBitmap = I_IMAGENONE;
             } else {
                 m_buttons[n].m_callback.set_wnd(this);
                 m_buttons[n].m_callback.set_id(gsl::narrow<int>(n));
@@ -225,7 +225,8 @@ void ButtonsToolbar::create_toolbar()
                     name.append_fromptr(str_conv.get_ptr(), str_conv.length());
                     name.append_single(0);
                     name.append_single(0);
-                    tbbutton.iString = SendMessage(wnd_toolbar, TB_ADDSTRING, NULL, (LPARAM)name.get_ptr());
+                    tbbutton.iString
+                        = SendMessage(wnd_toolbar, TB_ADDSTRING, NULL, reinterpret_cast<LPARAM>(name.get_ptr()));
                 }
 
                 if (m_buttons[n].m_interface.is_valid()) {
@@ -247,44 +248,52 @@ void ButtonsToolbar::create_toolbar()
         SendMessage(wnd_toolbar, TB_SETEXTENDEDSTYLE, 0,
             ex_style | TBSTYLE_EX_DRAWDDARROWS | (!m_text_below ? TBSTYLE_EX_MIXEDBUTTONS : 0));
 
-        SendMessage(wnd_toolbar, TB_SETBITMAPSIZE, (WPARAM)0, MAKELONG(width, height));
+        SendMessage(wnd_toolbar, TB_SETBITMAPSIZE, 0, MAKELONG(width, height));
         // SendMessage(wnd_toolbar, TB_SETBUTTONSIZE, (WPARAM) 0, MAKELONG(width,height));
 
         // todo: custom padding
-        const auto padding = SendMessage(wnd_toolbar, TB_GETPADDING, (WPARAM)0, 0);
+        const auto padding = SendMessage(wnd_toolbar, TB_GETPADDING, 0, 0);
+
         if (m_appearance == APPEARANCE_NOEDGE) {
-            SendMessage(wnd_toolbar, TB_SETPADDING, (WPARAM)0, MAKELPARAM(0, 0));
-            DLLVERSIONINFO2 dvi;
-            HRESULT hr = uih::get_comctl32_version(dvi);
-            if (SUCCEEDED(hr) && dvi.info1.dwMajorVersion >= 6) {
-                /*
-                HTHEME thm;
-                uxtheme_api_ptr p_uxtheme;
-                uxtheme_handle::g_create(p_uxtheme);
-                thm = p_uxtheme->OpenThemeData(wnd_toolbar, L"Toolbar");
-                MARGINS mg;
-                p_uxtheme->GetThemeMargins(thm, NULL, 1, 1, 3602, NULL, &mg);
-                p_uxtheme->CloseThemeData(thm);
-                TBMETRICS temp;
-                memset(&temp, 0, sizeof(temp));
-                temp.cbSize = sizeof(temp);
-                temp.dwMask = TBMF_BUTTONSPACING;
-                temp.cxButtonSpacing =-4;
-                temp.cyButtonSpacing=0;
-                //SendMessage(wnd_toolbar, TB_SETMETRICS, 0, (LPARAM)&temp);
-                temp.dwMask = TBMF_BUTTONSPACING|TBMF_BARPAD|TBMF_PAD;*/
-            }
+            SendMessage(wnd_toolbar, TB_SETPADDING, 0, MAKELPARAM(0, 0));
+            /*
+            HTHEME thm;
+            thm = p_uxtheme->OpenThemeData(wnd_toolbar, L"Toolbar");
+            MARGINS mg;
+            p_uxtheme->GetThemeMargins(thm, NULL, 1, 1, 3602, NULL, &mg);
+            p_uxtheme->CloseThemeData(thm);
+            TBMETRICS temp;
+            memset(&temp, 0, sizeof(temp));
+            temp.cbSize = sizeof(temp);
+            temp.dwMask = TBMF_BUTTONSPACING;
+            temp.cxButtonSpacing =-4;
+            temp.cyButtonSpacing=0;
+            //SendMessage(wnd_toolbar, TB_SETMETRICS, 0, (LPARAM)&temp);
+            temp.dwMask = TBMF_BUTTONSPACING|TBMF_BARPAD|TBMF_PAD;*/
         } else if (m_appearance == APPEARANCE_FLAT)
-            SendMessage(wnd_toolbar, TB_SETPADDING, (WPARAM)0, MAKELPARAM(5, HIWORD(padding)));
+            SendMessage(wnd_toolbar, TB_SETPADDING, 0, MAKELPARAM(5, HIWORD(padding)));
 
         if (m_standard_images)
-            SendMessage(wnd_toolbar, TB_SETIMAGELIST, (WPARAM)0, (LPARAM)m_standard_images.get());
+            SendMessage(wnd_toolbar, TB_SETIMAGELIST, 0, reinterpret_cast<LPARAM>(m_standard_images.get()));
         if (m_hot_images)
-            SendMessage(wnd_toolbar, TB_SETHOTIMAGELIST, (WPARAM)0, (LPARAM)m_hot_images.get());
+            SendMessage(wnd_toolbar, TB_SETHOTIMAGELIST, 0, reinterpret_cast<LPARAM>(m_hot_images.get()));
 
-        SendMessage(wnd_toolbar, TB_BUTTONSTRUCTSIZE, (WPARAM)sizeof(TBBUTTON), 0);
+        SendMessage(wnd_toolbar, TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
 
-        SendMessage(wnd_toolbar, TB_ADDBUTTONS, (WPARAM)tbbuttons.size(), (LPARAM)tbbuttons.data());
+        SendMessage(wnd_toolbar, TB_ADDBUTTONS, tbbuttons.size(), reinterpret_cast<LPARAM>(tbbuttons.data()));
+
+        if (is_dark) {
+            for (auto&& [n, button] : ranges::views::enumerate(m_buttons)) {
+                if (button.m_type != TYPE_SEPARATOR)
+                    continue;
+
+                TBBUTTONINFO tbbi{};
+                tbbi.cbSize = sizeof(tbbi);
+                tbbi.cx = 5_spx;
+                tbbi.dwMask = TBIF_BYINDEX | TBIF_SIZE;
+                SendMessage(wnd_toolbar, TB_SETBUTTONINFO, n, reinterpret_cast<LPARAM>(&tbbi));
+            }
+        }
 
         for (auto&& button : m_buttons) {
             if (button.m_interface.is_valid())
@@ -410,30 +419,41 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             return TBDDRET_DEFAULT;
         }
         case NM_CUSTOMDRAW: {
-            auto lptbcd = (LPNMTBCUSTOMDRAW)lp;
+            const auto lptbcd = reinterpret_cast<LPNMTBCUSTOMDRAW>(lp);
             switch ((lptbcd)->nmcd.dwDrawStage) {
             case CDDS_PREPAINT:
-                return (CDRF_NOTIFYITEMDRAW);
+                return CDRF_NOTIFYITEMDRAW;
             case CDDS_ITEMPREPAINT: {
-                if (m_appearance != APPEARANCE_NOEDGE && !m_text_below && lptbcd->nmcd.dwItemSpec >= 0
-                    && lptbcd->nmcd.dwItemSpec < m_buttons.size()
-                    && m_buttons[lptbcd->nmcd.dwItemSpec].m_show == SHOW_TEXT) {
-                    DLLVERSIONINFO2 dvi;
-                    HRESULT hr = uih::get_comctl32_version(dvi);
-                    if (SUCCEEDED(hr) && dvi.info1.dwMajorVersion >= 6)
-                        lptbcd->rcText.left
-                            -= LOWORD(SendMessage(wnd_toolbar, TB_GETPADDING, (WPARAM)0, 0)) + 2; // Hack for commctrl6
+                const auto index = lptbcd->nmcd.dwItemSpec;
+
+                if (colours::is_dark_mode_active() && index < m_buttons.size()
+                    && m_buttons[index].m_type == TYPE_SEPARATOR) {
+                    const auto divider_brush = get_colour_brush(dark::ColourID::ToolbarDivider, true);
+                    const auto divider_width = uih::scale_dpi_value(1, USER_DEFAULT_SCREEN_DPI * 2);
+                    const auto& item_rect = lptbcd->nmcd.rc;
+                    RECT line_rect{};
+                    line_rect.top = item_rect.top + 1_spx;
+                    line_rect.bottom = item_rect.bottom - 1_spx;
+                    line_rect.left = item_rect.left + (RECT_CX(item_rect) - divider_width) / 2;
+                    line_rect.right = line_rect.left + divider_width;
+                    FillRect(lptbcd->nmcd.hdc, &line_rect, divider_brush.get());
                 }
+
+                if (m_appearance != APPEARANCE_NOEDGE && !m_text_below && index < m_buttons.size()
+                    && m_buttons[index].m_show == SHOW_TEXT) {
+                    // Workaround for commctrl6
+                    lptbcd->rcText.left -= LOWORD(SendMessage(wnd_toolbar, TB_GETPADDING, 0, 0)) + 2;
+                }
+
                 if (m_appearance == APPEARANCE_FLAT) {
-                    LRESULT rv = TBCDRF_NOEDGES | TBCDRF_NOOFFSET;
                     if (lptbcd->nmcd.uItemState & CDIS_HOT) {
                         lptbcd->clrText = GetSysColor(COLOR_HIGHLIGHTTEXT);
-                    } else {
                     }
+
                     lptbcd->clrHighlightHotTrack = GetSysColor(COLOR_HIGHLIGHT);
-                    rv |= TBCDRF_HILITEHOTTRACK;
-                    return rv;
+                    return TBCDRF_NOEDGES | TBCDRF_NOOFFSET | TBCDRF_HILITEHOTTRACK;
                 }
+
                 if (m_appearance == APPEARANCE_NOEDGE) {
                     return TBCDRF_NOEDGES | TBCDRF_NOBACKGROUND;
                 }

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -128,7 +128,7 @@ std::string ButtonsToolbar::Button::get_name(bool short_form) const
         return temp.c_str();
     }
     case TYPE_SEPARATOR:
-        return "-";
+        return "";
     case TYPE_MENU_ITEM_CONTEXT:
         return menu_helpers::contextpath_from_guid(m_guid, m_subcommand, short_form);
     case TYPE_MENU_ITEM_MAIN:

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -138,6 +138,8 @@ COLORREF get_dark_colour(ColourID colour_id)
         return WI_EnumValue(DarkColour::DARK_999);
     case ColourID::PanelCaptionBackground:
         return WI_EnumValue(DarkColour::DARK_300);
+    case ColourID::ToolbarDivider:
+        return WI_EnumValue(DarkColour::DARK_400);
     case ColourID::RebarBandBorder:
         return WI_EnumValue(DarkColour::DARK_400);
     case ColourID::StatusBarBackground:

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -102,6 +102,10 @@ int get_light_colour_system_id(ColourID colour_id)
         return COLOR_BTNTEXT;
     case ColourID::StatusPaneTopLine:
         return COLOR_3DDKSHADOW;
+    case ColourID::ToolbarFlatHotBackground:
+        return COLOR_HIGHLIGHT;
+    case ColourID::ToolbarFlatHotText:
+        return COLOR_HIGHLIGHTTEXT;
     case ColourID::VolumeChannelTopEdge:
         return COLOR_3DSHADOW;
     case ColourID::VolumeChannelBottomAndRightEdge:
@@ -140,6 +144,10 @@ COLORREF get_dark_colour(ColourID colour_id)
         return WI_EnumValue(DarkColour::DARK_300);
     case ColourID::ToolbarDivider:
         return WI_EnumValue(DarkColour::DARK_400);
+    case ColourID::ToolbarFlatHotBackground:
+        return WI_EnumValue(DarkColour::DARK_500);
+    case ColourID::ToolbarFlatHotText:
+        return WI_EnumValue(DarkColour::DARK_999);
     case ColourID::RebarBandBorder:
         return WI_EnumValue(DarkColour::DARK_400);
     case ColourID::StatusBarBackground:

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -24,6 +24,7 @@ enum class ColourID {
     TabControlActiveItemBackground,
     TabControlHotItemBackground,
     TabControlHotActiveItemBackground,
+    ToolbarDivider,
     TrackbarChannel,
     TrackbarThumb,
     TrackbarHotThumb,

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -25,6 +25,8 @@ enum class ColourID {
     TabControlHotItemBackground,
     TabControlHotActiveItemBackground,
     ToolbarDivider,
+    ToolbarFlatHotBackground,
+    ToolbarFlatHotText,
     TrackbarChannel,
     TrackbarThumb,
     TrackbarHotThumb,


### PR DESCRIPTION
This updates the buttons toolbar to:

- work around a problem where separators did not render correctly in dark mode
- correct the flat mode hover colours in dark mode
- correct the text flat mode hover text colour in non-ancient versions of Windows in light mode