### PR TITLE
Tweak dark mode background colours

### DIFF
--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -11,6 +11,7 @@ enum class ColourID {
     LayoutBackground,
     PanelCaptionText,
     PanelCaptionBackground,
+    RebarBackground,
     RebarBandBorder,
     StatusBarBackground,
     StatusBarText,

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -133,10 +133,7 @@ private:
      */
     void fix_z_order();
 
-    void reopen_themes();
-
     std::vector<RebarBand> m_bands;
-    wil::unique_htheme m_toolbar_theme;
     std::unique_ptr<cui::colours::dark_mode_notifier> m_dark_mode_notifier;
 
     friend class RebarWindowHost;


### PR DESCRIPTION
This:

- standardises on a single light background colour used in e.g. the toolbars
- adjusts the dark background colour on Windows 11 to be consistent with its File Explorer
- corrects the minimum Windows 10 build check for dark mode