### PR TITLE
Fix Filter search colours not updating instantly on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Support for the Windows 10 and 11 dark mode was added.
-  [[multiple pull requests](https://github.com/reupen/columns_ui/pulls?q=is%3Apr+is%3Aclosed+label%3A%22dark+mode%22+merged%3A%3C2022-03-15)]
+  [[multiple pull requests](https://github.com/reupen/columns_ui/pulls?q=is%3Apr+is%3Aclosed+label%3A%22dark+mode%22+merged%3A%3C2022-03-23)]
 
 - The status bar can now show the number of selected tracks.
   [[#450](https://github.com/reupen/columns_ui/pull/450)]
@@ -29,7 +29,8 @@
 
 - The Filter search toolbar is now integrated with the Colours and fonts
   preferences page, and its font, foreground colour and background colour are
-  now configurable. [[#424](https://github.com/reupen/columns_ui/pull/424)]
+  now configurable. [[#424](https://github.com/reupen/columns_ui/pull/424),
+  [#482](https://github.com/reupen/columns_ui/pull/482)]
 
   (Note that selection colours are not supported.)
 

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -572,7 +572,7 @@ void FilterSearchToolbar::s_update_colours()
     for (auto&& window : s_windows) {
         const HWND wnd = window->m_search_editbox;
         if (wnd)
-            RedrawWindow(wnd, nullptr, nullptr, RDW_INVALIDATE);
+            RedrawWindow(wnd, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN);
     }
 }
 


### PR DESCRIPTION
This fixes a small problem where the Filter search would not update itself straight away when its colours were reconfigured.