### PR TITLE
Migrate to uie::container_window_v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - Support for the Windows 10 and 11 dark mode was added.
-  [[multiple pull requests](https://github.com/reupen/columns_ui/pulls?q=is%3Apr+is%3Aclosed+label%3A%22dark+mode%22+merged%3A%3C2022-03-23)]
+  [[multiple pull requests](https://github.com/reupen/columns_ui/pulls?q=is%3Apr+is%3Aclosed+label%3A%22dark+mode%22+merged%3A%3C2022-03-31)]
 
 - The status bar can now show the number of selected tracks.
   [[#450](https://github.com/reupen/columns_ui/pull/450)]

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -79,6 +79,20 @@ void ArtworkPanel::get_menu_items(ui_extension::menu_hook_t& p_hook)
 
 ArtworkPanel::ArtworkPanel() : m_track_mode(cfg_track_mode), m_preserve_aspect_ratio(cfg_preserve_aspect_ratio) {}
 
+uie::container_window_v3_config ArtworkPanel::get_window_config()
+{
+    uie::container_window_v3_config config(L"columns_ui_artwork_view_VaODDnIsit0", false);
+
+    if (cfg_edge_style == 1)
+        config.extended_window_styles |= WS_EX_CLIENTEDGE;
+    else if (cfg_edge_style == 2)
+        config.extended_window_styles |= WS_EX_STATICEDGE;
+
+    config.class_cursor = IDC_HAND;
+
+    return config;
+}
+
 void ArtworkPanel::g_on_edge_style_change()
 {
     for (auto& window : g_windows) {
@@ -587,17 +601,6 @@ ArtworkPanel::CompletionNotifyForwarder::CompletionNotifyForwarder(ArtworkPanel*
 void ArtworkPanel::CompletionNotifyForwarder::on_completion(unsigned p_code)
 {
     m_this->on_completion(p_code);
-}
-
-ArtworkPanel::class_data& ArtworkPanel::get_class_data() const
-{
-    DWORD flags = 0;
-    if (cfg_edge_style == 1)
-        flags |= WS_EX_CLIENTEDGE;
-    if (cfg_edge_style == 2)
-        flags |= WS_EX_STATICEDGE;
-    __implement_get_class_data_ex2(_T("CUI Artwork View"), _T(""), false, true, 0,
-        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, WS_EX_CONTROLPARENT | flags, 0, IDC_HAND);
 }
 
 void ArtworkPanel::set_config(stream_reader* p_reader, size_t size, abort_callback& p_abort)

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -5,7 +5,7 @@
 namespace cui::artwork_panel {
 
 class ArtworkPanel
-    : public uie::container_ui_extension_t<>
+    : public uie::container_uie_window_v3
     , public now_playing_album_art_notify
     , public play_callback
     , public playlist_callback_single
@@ -79,7 +79,7 @@ public:
     ArtworkPanel();
 
 private:
-    class_data& get_class_data() const override;
+    uie::container_window_v3_config get_window_config() override;
 
     class MenuNodeTrackMode : public ui_extension::menu_node_command_t {
         service_ptr_t<ArtworkPanel> p_this;

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -8,11 +8,6 @@
 
 namespace cui::toolbars::buttons {
 
-ButtonsToolbar::class_data& ButtonsToolbar::get_class_data() const
-{
-    __implement_get_class_data_child_ex(class_name, true, false);
-}
-
 const GUID& ButtonsToolbar::get_extension_guid() const
 {
     return extension_guid;

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -4,7 +4,7 @@
 
 namespace cui::toolbars::buttons {
 
-class ButtonsToolbar : public ui_extension::container_ui_extension {
+class ButtonsToolbar : public uie::container_uie_window_v3 {
 public:
     enum ConfigVersion { VERSION_1, VERSION_2, VERSION_CURRENT = VERSION_2 };
 
@@ -271,7 +271,12 @@ public:
     static const GUID g_guid_fcb;
 
 private:
-    class_data& get_class_data() const override;
+    uie::container_window_v3_config get_window_config() override
+    {
+        uie::container_window_v3_config config(class_name);
+        config.invalidate_children_on_move_or_resize = true;
+        return config;
+    }
 
     static const TCHAR* class_name;
     int width{0};

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -1,7 +1,7 @@
 #pragma once
 
 template <class ToolbarArgs>
-class DropDownListToolbar : public ui_extension::container_ui_extension {
+class DropDownListToolbar : public ui_extension::container_uie_window_v3 {
 public:
     static void s_update_active_item_safe()
     {
@@ -61,10 +61,7 @@ public:
     void get_category(pfc::string_base& out) const override { out.set_string("Toolbars"); }
     bool is_available(const uie::window_host_ptr& p_host) const override { return ToolbarArgs::is_available(); }
     void get_menu_items(uie::menu_hook_t& p_hook) override { ToolbarArgs::get_menu_items(p_hook); }
-    class_data& get_class_data() const override
-    {
-        __implement_get_class_data_child_ex(ToolbarArgs::class_name, false, false);
-    }
+    uie::container_window_v3_config get_window_config() override { return {ToolbarArgs::class_name}; }
 
 private:
     class FontClient : public cui::fonts::client {
@@ -290,16 +287,15 @@ LRESULT DropDownListToolbar<ToolbarArgs>::on_message(HWND wnd, UINT msg, WPARAM 
             ToolbarArgs::on_last_window_destroyed();
         }
         std::erase(s_windows, this);
-
         m_initialised = false;
-        const auto count = get_class_data().refcount;
-        DestroyWindow(m_wnd_combo);
-        if (count == 1) {
+        break;
+    }
+    case WM_NCDESTROY:
+        if (s_windows.empty()) {
             s_items_font.reset();
             s_background_brush.reset();
         }
         break;
-    }
     case WM_CTLCOLOREDIT:
     case WM_CTLCOLORLISTBOX: {
         const auto dc = reinterpret_cast<HDC>(wp);

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -164,6 +164,13 @@ void FilterSearchToolbar::on_size(int cx, int cy)
     SetWindowPos(m_wnd_toolbar, nullptr, cx - m_toolbar_cx, 0, m_toolbar_cx, cy, SWP_NOZORDER);
 }
 
+void FilterSearchToolbar::on_size()
+{
+    RECT rc{};
+    GetClientRect(get_wnd(), &rc);
+    on_size(RECT_CX(rc), RECT_CY(rc));
+}
+
 void FilterSearchToolbar::on_search_editbox_change()
 {
     if (m_query_timer_active)
@@ -277,10 +284,12 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
             return 0;
         }
         break;
-    case WM_SETFOCUS:
+    case WM_WINDOWPOSCHANGED: {
+        const auto lpwp = reinterpret_cast<LPWINDOWPOS>(lp);
+        if (!(lpwp->flags & SWP_NOSIZE) || (lpwp->flags & SWP_FRAMECHANGED))
+            on_size(lpwp->cx, lpwp->cy);
         break;
-    case WM_KILLFOCUS:
-        break;
+    }
     case msg_favourite_selected:
         if (m_query_timer_active) {
             KillTimer(get_wnd(), TIMER_QUERY);

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -5,7 +5,7 @@
 
 namespace cui::panels::filter {
 
-class FilterSearchToolbar : public uie::container_uie_window_v2 {
+class FilterSearchToolbar : public uie::container_uie_window_v3 {
 public:
     static bool g_activate();
     static bool g_filter_search_bar_has_stream(
@@ -33,7 +33,12 @@ public:
 
     unsigned get_type() const override { return uie::type_toolbar; }
 
-    uint32_t get_flags() const override { return flag_default_flags_plus_transparent_background; }
+    uie::container_window_v3_config get_window_config() override
+    {
+        uie::container_window_v3_config config(L"columns_ui_filter_search_toolbar_smuVaKiMNUs");
+        config.invalidate_children_on_move_or_resize = true;
+        return config;
+    }
 
 private:
     class FontClient : public fonts::client {
@@ -72,8 +77,6 @@ private:
     static void s_update_colours();
     static void s_update_font();
 
-    const GUID& get_class_guid() override { return toolbars::guid_filter_search_bar; }
-
     void set_config(stream_reader* p_reader, size_t p_size, abort_callback& p_abort) override;
     void get_config(stream_writer* p_writer, abort_callback& p_abort) const override;
     void get_menu_items(uie::menu_hook_t& p_hook) override;
@@ -90,12 +93,11 @@ private:
     void update_toolbar_icons() const;
     void create_edit();
     void recalculate_dimensions();
-    void on_size(int cx, int cy) override;
+    void on_size(int cx, int cy);
+    void on_size();
     void activate();
 
     LRESULT on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-
-    using uie::container_uie_window_v2::on_size;
 
     static constexpr GUID font_client_id
         = {0xfc156d41, 0xcbb, 0x4b98, {0x88, 0x8b, 0x36, 0x4f, 0x38, 0x17, 0x2a, 0x2e}};

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -117,23 +117,18 @@ private:
 };
 
 class ItemDetails
-    : public uie::container_ui_extension
+    : public uie::container_uie_window_v3
     , public ui_selection_callback
     , public play_callback
     , public playlist_callback_single
     , public metadb_io_callback_dynamic {
-    class MessageWindow : public container_window {
-        class_data& get_class_data() const override;
-        LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
-    };
-
-    static MessageWindow g_message_window;
+    inline static std::unique_ptr<uie::container_window_v3> s_message_window;
 
     enum {
         MSG_REFRESH = WM_USER + 2,
     };
 
-    class_data& get_class_data() const override;
+    uie::container_window_v3_config get_window_config() override;
 
 public:
     enum TrackingMode {
@@ -299,6 +294,9 @@ public:
     ItemDetails();
 
 private:
+    static void s_create_message_window();
+    static void s_destroy_message_window();
+
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
 
     void register_callback();

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -88,12 +88,7 @@ class ItemProperties
     , public ui_selection_callback
     , public play_callback
     , public metadb_io_callback_dynamic {
-    class MessageWindow : public ui_helpers::container_window {
-        class_data& get_class_data() const override;
-        LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
-    };
-
-    static MessageWindow g_message_window;
+    inline static std::unique_ptr<uie::container_window_v3> s_message_window;
 
     enum {
         MSG_REFRESH = WM_USER + 2,
@@ -192,6 +187,9 @@ public:
     ItemProperties();
 
 private:
+    static void s_create_message_window();
+    static void s_destroy_message_window();
+
     void register_callback();
     void deregister_callback();
     void on_app_activate(bool b_activated);

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -899,9 +899,6 @@ LRESULT LayoutWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         refresh_child();
         create_child();
         break;
-    case WM_ERASEBKGND:
-        cui::dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
-        return TRUE;
     case WM_WINDOWPOSCHANGED: {
         auto lpwp = (LPWINDOWPOS)lp;
         if (!(lpwp->flags & SWP_NOSIZE)) {

--- a/foo_ui_columns/layout.h
+++ b/foo_ui_columns/layout.h
@@ -52,7 +52,7 @@ private:
 };
 
 class LayoutWindow
-    : public ui_helpers::container_window
+    : public uie::container_window_v3
     , private uih::MessageHook {
 public:
     enum { MSG_LAYOUT_SET_FOCUS = WM_USER + 2, MSG_EDIT_PANEL };
@@ -82,7 +82,11 @@ public:
     void set_layout_editing_active(bool b_val);
     bool get_layout_editing_active();
 
-    LayoutWindow() = default;
+    LayoutWindow()
+        : uie::container_window_v3(uie::container_window_v3_config(L"{DA9A1375-A411-48a9-AF74-4AC29FF9BE9C}"),
+            [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); })
+    {
+    }
 
 private:
     class LiveEditData {
@@ -101,12 +105,7 @@ private:
     void run_live_edit_base(const LiveEditData& p_data);
     bool on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp) override;
 
-    class_data& get_class_data() const override
-    {
-        __implement_get_class_data(_T("{DA9A1375-A411-48a9-AF74-4AC29FF9BE9C}"), false);
-    }
-
-    LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
+    LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
     void create_child();
     void destroy_child();

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -141,7 +141,7 @@ void cui::MainWindow::shutdown()
 {
     DestroyWindow(m_wnd);
     UnregisterClass(main_window_class_name, core_api::get_my_instance());
-    status_bar::volume_popup_window.class_release();
+    status_bar::volume_popup_window.deregister_class();
     m_wnd = nullptr;
     if (g_icon)
         DestroyIcon(g_icon);

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -58,7 +58,7 @@ public:
 };
 
 class MenuToolbar
-    : public ui_extension::container_uie_window_t<uie::menu_window_v2>
+    : public uie::container_uie_window_v3_t<uie::menu_window_v2>
     , uih::MessageHook {
 public:
     //    static pfc::ptr_list_t<playlists_list_window> list_wnd;
@@ -74,7 +74,12 @@ public:
     service_ptr_t<mainmenu_manager> p_manager;
     service_ptr_t<ui_status_text_override> m_status_override;
 
-    class_data& get_class_data() const override { __implement_get_class_data_child_ex(class_name, true, false); }
+    uie::container_window_v3_config get_window_config() override
+    {
+        uie::container_window_v3_config config(class_name);
+        config.invalidate_children_on_move_or_resize = true;
+        return config;
+    }
 
     HWND wnd_menu{nullptr};
     HWND wnd_prev_focus{nullptr};
@@ -113,7 +118,6 @@ public:
     HWND get_previous_focus_window() const override;
 
     MenuToolbar();
-    ~MenuToolbar();
 
 private:
     void set_window_theme();
@@ -129,8 +133,6 @@ private:
 bool MenuToolbar::hooked = false;
 
 MenuToolbar::MenuToolbar() : p_manager(nullptr) {}
-
-MenuToolbar::~MenuToolbar() = default;
 
 const TCHAR* MenuToolbar::class_name = _T("{76E6DB50-0DE3-4f30-A7E4-93FD628B1401}");
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -309,33 +309,12 @@ class PlaylistView
     friend class NgTfThread;
     friend class PlaylistViewRenderer;
 
-    class SharedMesageWindow : public ui_helpers::container_window {
-        class_data& get_class_data() const override
-        {
-            __implement_get_class_data_ex(_T("NGPV_GMW"), _T(""), false, 0, 0, 0, 0);
-        }
-
-        LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override
-        {
-            switch (msg) {
-            case WM_CREATE:
-                break;
-            case WM_TIMECHANGE:
-                g_on_time_change();
-                break;
-            case WM_DESTROY:
-                break;
-            }
-            return DefWindowProc(wnd, msg, wp, lp);
-        }
-    };
-
 public:
     PlaylistView();
     ~PlaylistView();
 
     static std::vector<PlaylistView*> g_windows;
-    static SharedMesageWindow g_global_mesage_window;
+    inline static std::unique_ptr<uie::container_window_v3> s_message_window;
 
     static void g_on_groups_change();
     static void g_on_columns_change();
@@ -403,6 +382,10 @@ private:
         }
         size_t get_group_count() { return m_groups.size(); }
     };
+
+    static void s_create_message_window();
+    static void s_destroy_message_window();
+
     virtual void flush_artwork_images()
     {
         if (m_artwork_manager) {

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -783,12 +783,6 @@ void FB2KAPI PlaylistTabs::on_items_removing(
 {
 }
 
-PlaylistTabs::class_data& PlaylistTabs::get_class_data() const
-{
-    __implement_get_class_data_ex(_T("{ABB72D0D-DBF0-4bba-8C68-3357EBE07A4D}"), _T(""), false, 0,
-        WS_CHILD | WS_CLIPCHILDREN, WS_EX_CONTROLPARENT, CS_DBLCLKS);
-}
-
 void g_on_autohide_tabs_change()
 {
     const auto count = PlaylistTabs::list_wnd.get_count();

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -12,7 +12,7 @@ void remove_playlist_helper(size_t index);
 constexpr unsigned SWITCH_TIMER_ID = 670u;
 
 class PlaylistTabs
-    : public uie::container_ui_extension_t<ui_helpers::container_window, uie::splitter_window_v2>
+    : public uie::container_uie_window_v3_t<uie::splitter_window_v2>
     , public playlist_callback {
 public:
     enum : uint32_t { MSG_RESET_SIZE_LIMITS = WM_USER + 3 };
@@ -62,7 +62,7 @@ private:
 
     service_ptr_t<contextmenu_manager> p_manager;
 
-    class_data& get_class_data() const override;
+    uie::container_window_v3_config get_window_config() override { return {L"{ABB72D0D-DBF0-4bba-8C68-3357EBE07A4D}"}; }
 
 public:
     static pfc::ptr_list_t<PlaylistTabs> list_wnd;

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -57,9 +57,6 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         });
         break;
     }
-    case WM_ERASEBKGND:
-        dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
-        return TRUE;
     case WM_SHOWWINDOW: {
         if (wp == TRUE && lp == NULL && !IsWindowVisible(m_child_wnd)) {
             ShowWindow(m_child_wnd, SW_SHOWNORMAL);

--- a/foo_ui_columns/seekbar.h
+++ b/foo_ui_columns/seekbar.h
@@ -4,7 +4,7 @@
 
 namespace cui::toolbars::seekbar {
 
-class SeekBarToolbar : public ui_extension::container_ui_extension {
+class SeekBarToolbar : public uie::container_uie_window_v3 {
 public:
     static pfc::ptr_list_t<SeekBarToolbar> windows;
     inline static INT_PTR g_seek_timer{};
@@ -19,10 +19,7 @@ public:
     SeekBarToolbar();
     ~SeekBarToolbar();
 
-    class_data& get_class_data() const override
-    {
-        __implement_get_class_data(_T("{89A3759F-348A-4e3f-BF43-3D16BC059186}"), true);
-    }
+    uie::container_window_v3_config get_window_config() override { return {L"{89A3759F-348A-4e3f-BF43-3D16BC059186}"}; }
 
     const GUID& get_extension_guid() const override;
 

--- a/foo_ui_columns/splitter.cpp
+++ b/foo_ui_columns/splitter.cpp
@@ -6,10 +6,9 @@ namespace cui::panels::splitter {
 pfc::ptr_list_t<FlatSplitterPanel> FlatSplitterPanel::g_instances;
 
 class HorizontalSplitterPanel : public FlatSplitterPanel {
-    class_data& get_class_data() const override
+    uie::container_window_v3_config get_window_config() override
     {
-        __implement_get_class_data_ex(_T("{72FACC90-BB7E-4733-8449-D7537232AD26}"), _T(""), false, 0,
-            WS_CHILD | WS_CLIPCHILDREN, WS_EX_CONTROLPARENT, CS_DBLCLKS);
+        return {L"{72FACC90-BB7E-4733-8449-D7537232AD26}", true, CS_DBLCLKS};
     }
     void get_name(pfc::string_base& p_out) const override { p_out = "Horizontal splitter"; }
     const GUID& get_extension_guid() const override
@@ -22,10 +21,9 @@ class HorizontalSplitterPanel : public FlatSplitterPanel {
 };
 
 class VerticalSplitterPanel : public FlatSplitterPanel {
-    class_data& get_class_data() const override
+    uie::container_window_v3_config get_window_config() override
     {
-        __implement_get_class_data_ex(_T("{77653A44-66D1-49e0-9A7A-1C71898C0441}"), _T(""), false, 0,
-            WS_CHILD | WS_CLIPCHILDREN, WS_EX_CONTROLPARENT, CS_DBLCLKS);
+        return {L"{77653A44-66D1-49e0-9A7A-1C71898C0441}", true, CS_DBLCLKS};
     }
     void get_name(pfc::string_base& p_out) const override { p_out = "Vertical splitter"; }
     const GUID& get_extension_guid() const override

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -7,7 +7,7 @@ enum Orientation {
     vertical,
 };
 
-class FlatSplitterPanel : public uie::container_ui_extension_t<ui_helpers::container_window, uie::splitter_window_v2> {
+class FlatSplitterPanel : public uie::container_uie_window_v3_t<uie::splitter_window_v2> {
 public:
     virtual Orientation get_orientation() const = 0;
     static int g_get_caption_size();
@@ -84,20 +84,22 @@ private:
     };
     class Panel : public std::enable_shared_from_this<Panel> {
     public:
-        class PanelContainer
-            : public container_window
-            , private fbh::LowLevelMouseHookManager::HookCallback {
+        class PanelContainer : fbh::LowLevelMouseHookManager::HookCallback {
         public:
             enum { MSG_AUTOHIDE_END = WM_USER + 2 };
 
             explicit PanelContainer(Panel* p_panel);
 
             ~PanelContainer();
+
+            HWND create(HWND parent) const;
+            void destroy() const;
+            HWND get_wnd() const { return m_wnd; }
+
             void set_window_ptr(FlatSplitterPanel* p_ptr);
             void enter_autohide_hook();
             // private:
-            class_data& get_class_data() const override;
-            LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
+            LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
             void on_hooked_message(WPARAM msg, const MSLLHOOKSTRUCT& mllhs) override;
             service_ptr_t<FlatSplitterPanel> m_this;
 
@@ -112,7 +114,10 @@ private:
             void close_theme();
             bool test_autohide_window(HWND wnd);
 
+            inline constexpr static auto class_name = L"foo_ui_columns_splitter_panel_child_container";
+
             HWND m_wnd{};
+            std::unique_ptr<uie::container_window_v3> m_window;
             std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
         } m_container;
 

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -22,7 +22,7 @@ void FlatSplitterPanel::Panel::PanelContainer::close_theme()
 
 bool FlatSplitterPanel::Panel::PanelContainer::test_autohide_window(HWND wnd)
 {
-    return IsChild(get_wnd(), wnd) || wnd == get_wnd() || wnd == m_this->get_wnd();
+    return IsChild(m_wnd, wnd) || wnd == m_wnd || wnd == m_this->get_wnd();
 }
 
 void FlatSplitterPanel::Panel::PanelContainer::on_hooked_message(WPARAM msg, const MSLLHOOKSTRUCT& mllhs)
@@ -45,10 +45,10 @@ void FlatSplitterPanel::Panel::PanelContainer::on_hooked_message(WPARAM msg, con
             if (!(wnd_capture && test_autohide_window(wnd_capture)) && !(wnd_pt && test_autohide_window(wnd_pt))
                 && !m_this->test_divider_pt(pt, index)) {
                 if (!m_timer_active)
-                    PostMessage(get_wnd(), MSG_AUTOHIDE_END, 0, 0);
+                    PostMessage(m_wnd, MSG_AUTOHIDE_END, 0, 0);
             } else {
                 if (m_timer_active) {
-                    KillTimer(get_wnd(), HOST_AUTOHIDE_TIMER_ID);
+                    KillTimer(m_wnd, HOST_AUTOHIDE_TIMER_ID);
                     m_timer_active = false;
                 }
             }
@@ -229,7 +229,7 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
         if (m_this.is_valid() && m_panel->m_autohide) {
             if ((m_panel->m_hidden)) {
                 m_panel->m_hidden = false;
-                m_this->get_host()->on_size_limit_change(get_wnd(), uie::size_limit_all);
+                m_this->get_host()->on_size_limit_change(m_wnd, uie::size_limit_all);
                 m_this->on_size_changed();
                 enter_autohide_hook();
             }
@@ -240,7 +240,7 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
             if (cfg_sidebar_use_custom_show_delay && !cfg_sidebar_show_delay) {
                 if ((m_panel->m_hidden)) {
                     m_panel->m_hidden = false;
-                    m_this->get_host()->on_size_limit_change(get_wnd(), uie::size_limit_all);
+                    m_this->get_host()->on_size_limit_change(m_wnd, uie::size_limit_all);
                     m_this->on_size_changed();
                     enter_autohide_hook();
                 }
@@ -351,12 +351,6 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-FlatSplitterPanel::Panel::PanelContainer::class_data& FlatSplitterPanel::Panel::PanelContainer::get_class_data() const
-{
-    __implement_get_class_data_ex(_T("foo_ui_columns_splitter_panel_child_container"), _T(""), false, NULL,
-        WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS, WS_EX_CONTROLPARENT, CS_DBLCLKS);
-}
-
 void FlatSplitterPanel::Panel::PanelContainer::enter_autohide_hook()
 {
     if (!m_hook_active) {
@@ -372,11 +366,24 @@ void FlatSplitterPanel::Panel::PanelContainer::set_window_ptr(FlatSplitterPanel*
 
 FlatSplitterPanel::Panel::PanelContainer::~PanelContainer() = default;
 
+HWND FlatSplitterPanel::Panel::PanelContainer::create(HWND parent) const
+{
+    return m_window->create(parent);
+}
+
+void FlatSplitterPanel::Panel::PanelContainer::destroy() const
+{
+    m_window->destroy();
+}
+
 FlatSplitterPanel::Panel::PanelContainer::PanelContainer(Panel* p_panel)
     : m_panel(p_panel)
     , m_hook_active(false)
     , m_timer_active(false)
 {
+    uie::container_window_v3_config config{class_name, true, CS_DBLCLKS};
+    m_window = std::make_unique<uie::container_window_v3>(
+        config, [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
 }
 
 } // namespace cui::panels::splitter

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -280,11 +280,6 @@ void TabStackPanel::Panel::import(stream_reader* t, abort_callback& p_abort)
     //    throw pfc::exception_not_implemented();
 }
 
-TabStackPanel::class_data& TabStackPanel::get_class_data() const
-{
-    __implement_get_class_data_ex(_T("{5CB67C98-B77F-4926-A79F-49D9B21B9705}"), _T(""), false, 0,
-        WS_CHILD | WS_CLIPCHILDREN, WS_EX_CONTROLPARENT, CS_DBLCLKS);
-}
 void TabStackPanel::get_name(pfc::string_base& p_out) const
 {
     p_out = "Tab stack";
@@ -512,9 +507,6 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             RedrawWindow(wnd_tabs, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
         });
     } break;
-    case WM_ERASEBKGND:
-        dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
-        return TRUE;
     case WM_KEYDOWN: {
         if (wp != VK_LEFT && wp != VK_RIGHT && get_host()->get_keyboard_shortcuts_enabled()
             && g_process_keydown_keyboard_shortcuts(wp))

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -2,11 +2,12 @@
 
 namespace cui::panels::tab_stack {
 
-class TabStackPanel : public uie::container_ui_extension_t<ui_helpers::container_window, uie::splitter_window_v2> {
+class TabStackPanel : public uie::container_uie_window_v3_t<uie::splitter_window_v2> {
     using t_self = TabStackPanel;
 
 public:
-    class_data& get_class_data() const override;
+    uie::container_window_v3_config get_window_config() override { return {L"{5CB67C98-B77F-4926-A79F-49D9B21B9705}"}; }
+
     void get_name(pfc::string_base& p_out) const override;
     const GUID& get_extension_guid() const override;
     void get_category(pfc::string_base& p_out) const override;

--- a/foo_ui_columns/splitter_window_wndproc.cpp
+++ b/foo_ui_columns/splitter_window_wndproc.cpp
@@ -33,9 +33,6 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         g_instances.remove_item(this);
         m_wnd = nullptr;
         break;
-    case WM_ERASEBKGND:
-        dark::draw_layout_background(wnd, reinterpret_cast<HDC>(wp));
-        return TRUE;
     case WM_SHOWWINDOW:
         if (wp == TRUE && lp == 0) {
             const auto count = m_panels.get_count();

--- a/foo_ui_columns/status_pane.h
+++ b/foo_ui_columns/status_pane.h
@@ -4,8 +4,7 @@
 namespace cui::status_pane {
 
 class StatusPane
-    : public ui_helpers::container_window
-    , private playlist_callback_single
+    : playlist_callback_single
     , play_callback {
     class StatusPaneVolumeBarAttributes {
     public:
@@ -37,14 +36,7 @@ class StatusPane
         }
 
         StatusPaneTitleformatHook() = default;
-
-    private:
     };
-
-    class_data& get_class_data() const override
-    {
-        __implement_get_class_data_child_ex3(L"CUI_STATUS_PAIN", false, true, CS_DBLCLKS, IDC_ARROW);
-    }
 
     /** PLAYLIST CALLBACKS */
     void on_items_added(
@@ -171,7 +163,17 @@ class StatusPane
     void get_length_data(bool& p_selection, size_t& p_count, pfc::string_base& p_out);
 
 public:
-    StatusPane() = default;
+    StatusPane()
+    {
+        m_window = std::make_unique<uie::container_window_v3>(
+            uie::container_window_v3_config(L"columns_ui_status_pane_mN4A3Qy1Spk", false, CS_DBLCLKS),
+            [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
+    }
+
+    HWND create(HWND parent) const { return m_window->create(parent); }
+    void destroy() const { m_window->destroy(); }
+    HWND get_wnd() const { return m_window->get_wnd(); }
+
     int get_ideal_height() const
     {
         return uih::get_font_height(m_font.get()) * 2 + uih::scale_dpi_value(2) + uih::scale_dpi_value(4)
@@ -189,7 +191,7 @@ public:
         m_menu_text.reset();
         invalidate_all();
     }
-    LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
+    LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
     void on_font_changed();
 
@@ -205,6 +207,7 @@ private:
     bool m_menu_active{false};
     wil::unique_hfont m_font;
     HTHEME m_theme{nullptr};
+    std::unique_ptr<uie::container_window_v3> m_window;
     std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
 };
 

--- a/foo_ui_columns/vis_gen_host.h
+++ b/foo_ui_columns/vis_gen_host.h
@@ -1,6 +1,6 @@
 #pragma once
 
-class VisualisationPanel : public ui_extension::container_ui_extension {
+class VisualisationPanel : public uie::container_uie_window_v3 {
     static const wchar_t* class_name;
     bool initialised{false};
     pfc::array_t<uint8_t> m_data;
@@ -18,15 +18,16 @@ public:
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
 
-    class_data& get_class_data() const override
+    uie::container_window_v3_config get_window_config() override
     {
-        DWORD flags = WS_EX_CONTROLPARENT;
-        if (m_frame == 1)
-            flags |= WS_EX_CLIENTEDGE;
-        if (m_frame == 2)
-            flags |= WS_EX_STATICEDGE;
+        uie::container_window_v3_config config(class_name, false);
 
-        __implement_get_class_data_ex(class_name, _T(""), false, 0, WS_CHILD | WS_CLIPCHILDREN, flags, 0);
+        if (m_frame == 1)
+            config.extended_window_styles |= WS_EX_CLIENTEDGE;
+        else if (m_frame == 2)
+            config.extended_window_styles |= WS_EX_STATICEDGE;
+
+        return config;
     }
 
     VisualisationPanel();

--- a/foo_ui_columns/volume.cpp
+++ b/foo_ui_columns/volume.cpp
@@ -7,7 +7,7 @@ public:
     static bool get_show_caption() { return false; }
 };
 
-class VolumeBarToolbar : public VolumeBar<false, false, VolumeBarToolbarAttributes, uie::container_ui_extension_t<>> {
+class VolumeBarToolbar : public uie::window {
     const GUID& get_extension_guid() const override
     {
         // {B3259290-CB68-4d37-B0F1-8094862A9524}
@@ -19,6 +19,37 @@ class VolumeBarToolbar : public VolumeBar<false, false, VolumeBarToolbarAttribut
     void get_category(pfc::string_base& out) const override { out = "Toolbars"; }
 
     unsigned get_type() const override { return uie::type_toolbar; }
+
+    bool is_available(const uie::window_host_ptr& p) const override { return true; }
+
+    HWND get_wnd() const final { return m_volume_bar.get_wnd(); }
+
+    HWND create_or_transfer_window(
+        HWND parent, const uie::window_host_ptr& host, const ui_helpers::window_position_t& position) final
+    {
+        if (get_wnd()) {
+            ShowWindow(get_wnd(), SW_HIDE);
+            SetParent(get_wnd(), parent);
+            m_host->relinquish_ownership(get_wnd());
+            m_host = host;
+
+            SetWindowPos(get_wnd(), nullptr, position.x, position.y, position.cx, position.cy, SWP_NOZORDER);
+        } else {
+            m_host = host;
+            m_volume_bar.create(parent, position.x, position.y, position.cx, position.cy);
+        }
+
+        return get_wnd();
+    }
+
+    void destroy_window() final
+    {
+        m_volume_bar.destroy();
+        m_host.release();
+    }
+
+    VolumeBar<false, false, VolumeBarToolbarAttributes> m_volume_bar;
+    uie::window_host_ptr m_host;
 };
 
 uie::window_factory<VolumeBarToolbar> g_volume_panel;


### PR DESCRIPTION
This migrates to the new `uie::container_window_v3` and `uie::container_uie_window_v3_t` classes added in the Columns UI SDK.

This includes usage of pseudo-transparent backgrounds for layout-related windows such as splitters (this time without the performance deficit) in order to simplify the dark mode implementation.