### PR TITLE
Add dark mode for tab control spin buttons on recent Windows 11

### DIFF
--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -47,7 +47,7 @@ bool are_private_apis_allowed()
     if (osvi.dwMajorVersion != 10 || osvi.dwMinorVersion != 0)
         return false;
 
-    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22533;
+    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22581;
 }
 
 void set_app_mode(PreferredAppMode mode)

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -43,27 +43,6 @@ public:
         service_ptr_t<PlaylistTabs> m_this;
     };
 
-private:
-    service_ptr_t<ui_status_text_override> m_status_override;
-
-    WNDPROC tabproc{nullptr};
-
-    bool m_dragging{false};
-    size_t m_dragging_idx{0};
-    RECT m_dragging_rect{};
-
-    bool m_playlist_switched{false};
-    bool m_switch_timer{false};
-    unsigned m_switch_playlist{0};
-    bool initialised{false};
-
-    int32_t m_mousewheel_delta{0};
-    UINT ID_CUSTOM_BASE{NULL};
-
-    service_ptr_t<contextmenu_manager> p_manager;
-
-    uie::container_window_v3_config get_window_config() override { return {L"{ABB72D0D-DBF0-4bba-8C68-3357EBE07A4D}"}; }
-
 public:
     static pfc::ptr_list_t<PlaylistTabs> list_wnd;
 
@@ -173,7 +152,28 @@ public:
     void on_child_position_change();
 
 private:
+    uie::container_window_v3_config get_window_config() override { return {L"{ABB72D0D-DBF0-4bba-8C68-3357EBE07A4D}"}; }
+    void set_up_down_window_theme() const;
+
     static HFONT g_font;
+
+    service_ptr_t<ui_status_text_override> m_status_override;
+
+    WNDPROC tabproc{nullptr};
+
+    bool m_dragging{false};
+    size_t m_dragging_idx{0};
+    RECT m_dragging_rect{};
+
+    bool m_playlist_switched{false};
+    bool m_switch_timer{false};
+    unsigned m_switch_playlist{0};
+    bool initialised{false};
+
+    int32_t m_mousewheel_delta{0};
+    UINT ID_CUSTOM_BASE{NULL};
+
+    service_ptr_t<contextmenu_manager> p_manager;
 
     GUID m_child_guid{};
     mutable pfc::array_t<uint8_t> m_child_data;
@@ -181,6 +181,7 @@ private:
     ui_extension::window_ptr m_child;
     HWND m_child_wnd{nullptr};
     HWND m_host_wnd{nullptr};
+    HWND m_up_down_control_wnd{};
 
     unsigned m_child_top{0};
 

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -51,10 +51,12 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             create_child();
         }
         playlist_manager::get()->register_callback(this, flag_all);
-        m_dark_mode_notifier = std::make_unique<colours::dark_mode_notifier>([wnd, wnd_tabs = wnd_tabs] {
-            RedrawWindow(wnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
-            RedrawWindow(wnd_tabs, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
-        });
+        m_dark_mode_notifier
+            = std::make_unique<colours::dark_mode_notifier>([this, self = ptr{this}, wnd, wnd_tabs = wnd_tabs] {
+                  set_up_down_window_theme();
+                  RedrawWindow(wnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
+                  RedrawWindow(wnd_tabs, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
+              });
         break;
     }
     case WM_SHOWWINDOW: {

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -119,6 +119,7 @@ public:
     void destroy_children();
     void adjust_rect(bool b_larger, RECT* rc);
     void set_styles(bool visible = true);
+    void set_up_down_window_theme() const;
 
     void update_size_limits();
     void on_font_change();
@@ -134,6 +135,7 @@ private:
     PanelList m_panels;
     PanelList m_active_panels;
     HWND m_wnd_tabs{nullptr};
+    HWND m_up_down_control_wnd{};
     size_t m_active_tab{(std::numeric_limits<size_t>::max)()};
     static std::vector<service_ptr_t<t_self>> g_windows;
     uie::size_limit_t m_size_limits;


### PR DESCRIPTION
Recent Windows 11 builds have dark mode support for up-down (spin) controls, so this makes use of that when it's available.

It also bumps the maximum Windows 11 build for using private dark mode APIs (i.e. for dark menus).