### PR TITLE
Use actual pointer size for seekbar and volume bar tooltip offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@
 - The status bar pop-up volume bar now correctly scales with the system DPI
   setting. [[#418](https://github.com/reupen/columns_ui/pull/418)]
 
+- The position of seekbar and volume bar tooltips relative to the pointer
+  position was corrected so that it's based on the actual pointer size, rather
+  than a fixed offset. [[#494](https://github.com/reupen/columns_ui/pull/494)]
+
 - Various truncated labels in Playlist view preferences were corrected.
   [[#469](https://github.com/reupen/columns_ui/pull/469)]
 


### PR DESCRIPTION
Previously, the seekbar and volume toolbar tooltips used a fixed offset of 21 pixels from the top of the pointer, which was incorrect for larger pointer sizes.

This updates ui_helpers to pick up a fix for this where the offset is now calculated dynamically based on the pointer size.