### PR TITLE
Fix incorrect toolbar sizing grip rendering vertical main window resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@
   position was corrected so that it's based on the actual pointer size, rather
   than a fixed offset. [[#494](https://github.com/reupen/columns_ui/pull/494)]
 
+- A problem where toolbar sizing grips didn’t render correctly when resizing the
+  main window vertically was fixed.
+  [[#495](https://github.com/reupen/columns_ui/pull/495)]
+
 - Various truncated labels in Playlist view preferences were corrected.
   [[#469](https://github.com/reupen/columns_ui/pull/469)]
 

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -365,7 +365,7 @@ void cui::MainWindow::resize_child_windows()
                     rc_main_client.right - rc_main_client.left,
                     rc_main_client.bottom - rc_main_client.top - rebar_height - status_height, SWP_NOZORDER);
             if (rebar::g_rebar) {
-                RedrawWindow(rebar::g_rebar, nullptr, nullptr, RDW_INVALIDATE);
+                RedrawWindow(rebar::g_rebar, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE);
                 dwp = DeferWindowPos(dwp, rebar::g_rebar, nullptr, 0, 0, rc_main_client.right - rc_main_client.left,
                     rebar_height, SWP_NOZORDER);
             }


### PR DESCRIPTION
This fixes a small problem where, when resizing the main window vertically, toolbar sizing grips would render incorrectly (when the toolbars aren't locked).