### PR TITLE
Eliminate panel caption flicker when resizing panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,6 @@
 - The default no-cover artwork image was updated.
   [[#437](https://github.com/reupen/columns_ui/pull/437)]
 
-- Flickering when resizing the Playlist tabs and Tab stack panels was
-  eliminated. [[#451](https://github.com/reupen/columns_ui/pull/451)]
-
 - The 'View/Show toolbars' menu item is now only shown if the shift key is held
   down when opening the View menu.
   [[#410](https://github.com/reupen/columns_ui/pull/410)]
@@ -61,6 +58,12 @@
 
   (This change has the side effect of an uglier hover animation on some versions
   of Windows.)
+
+- Flickering when resizing the Playlist tabs and Tab stack panels was
+  eliminated. [[#451](https://github.com/reupen/columns_ui/pull/451)]
+
+- Flickering of panel captions when resizing a panel was eliminated.
+  [[#496](https://github.com/reupen/columns_ui/pull/496)]
 
 - Various bugs with the positioning and sizing of panel captions were fixed.
   [[#418](https://github.com/reupen/columns_ui/pull/418)]

--- a/foo_ui_columns/splitter_panel.cpp
+++ b/foo_ui_columns/splitter_panel.cpp
@@ -34,14 +34,8 @@ void FlatSplitterPanel::Panel::on_size(int cx, int cy)
 
     if (m_wnd_child)
         SetWindowPos(m_wnd_child, nullptr, x, y, cx - x, cy - y, SWP_NOZORDER);
-    if (caption_size /*&& (m_caption_orientation == vertical || (m_container.m_uxtheme.is_valid() && m_container.m_theme))*/)
-    {
-        int caption_cx = m_caption_orientation == vertical ? caption_size : cx;
-        int caption_cy = m_caption_orientation == vertical ? cy : caption_size;
 
-        RECT rc_caption = {0, 0, caption_cx, caption_cy};
-        RedrawWindow(m_wnd, &rc_caption, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
-    }
+    RedrawWindow(m_wnd, nullptr, nullptr, RDW_INVALIDATE | RDW_ERASE);
 }
 
 void FlatSplitterPanel::Panel::on_size()


### PR DESCRIPTION
This updates the rendering logic for splitter panel containers to eliminate flicker of panel captions when resizing panels.