### PR TITLE
Eliminate flickering of toolbar sizing grips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
 - Flickering of panel captions when resizing a panel was eliminated.
   [[#496](https://github.com/reupen/columns_ui/pull/496)]
 
+- Various glitches with the rendering of toolbar sizing grips were fixed.
+  [[#495](https://github.com/reupen/columns_ui/pull/495),
+  [#497](https://github.com/reupen/columns_ui/pull/497)]
+
 - Various bugs with the positioning and sizing of panel captions were fixed.
   [[#418](https://github.com/reupen/columns_ui/pull/418)]
 
@@ -74,10 +78,6 @@
 - The position of seekbar and volume bar tooltips relative to the pointer
   position was corrected so that it's based on the actual pointer size, rather
   than a fixed offset. [[#494](https://github.com/reupen/columns_ui/pull/494)]
-
-- A problem where toolbar sizing grips didn’t render correctly when resizing the
-  main window vertically was fixed.
-  [[#495](https://github.com/reupen/columns_ui/pull/495)]
 
 - Various truncated labels in Playlist view preferences were corrected.
   [[#469](https://github.com/reupen/columns_ui/pull/469)]

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -70,9 +70,6 @@ public:
 };
 
 class RebarWindow {
-private:
-    void destroy_bands();
-
 public:
     HWND wnd_rebar{nullptr};
     BandCache cache;
@@ -123,16 +120,22 @@ public:
 
     auto find_band_by_hwnd(HWND wnd)
     {
-        return std::find_if(std::begin(m_bands), std::end(m_bands), [&wnd](auto&& item) { return item.m_wnd == wnd; });
+        return std::ranges::find_if(m_bands, [&wnd](auto&& item) { return item.m_wnd == wnd; });
     }
 
 private:
+    static LRESULT WINAPI s_handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+
+    LRESULT WINAPI handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    void destroy_bands();
+
     /**
      * For some reason, the z-order gets messed up after adding bands to the rebar control.
      * This makes sure that the z-order for bands goes from top to bottom.
      */
     void fix_z_order();
 
+    WNDPROC m_rebar_wnd_proc{nullptr};
     std::vector<RebarBand> m_bands;
     std::unique_ptr<cui::colours::dark_mode_notifier> m_dark_mode_notifier;
 


### PR DESCRIPTION
This subclasses the rebar control to eliminate flickering of toolbar sizing grips when e.g. rearranging toolbars or switching between dark and light modes.