### PR TITLE
Make light and dark mode colour settings independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,20 @@
 
 ### Features
 
-- Support for the Windows 10 and 11 dark mode was added.
-  [[multiple pull requests](https://github.com/reupen/columns_ui/pulls?q=is%3Apr+is%3Aclosed+label%3A%22dark+mode%22+merged%3A%3C2022-03-31)]
+- Support for the Windows 10 and 11 dark mode was added on Windows 10 20H1 and
+  newer.
+  [[multiple pull requests](https://github.com/reupen/columns_ui/pulls?q=is%3Apr+is%3Aclosed+label%3A%22dark+mode%22+merged%3A%3C2022-04-09)]
+
+  This can be enabled from the Mode tab on the Colours and fonts preferences
+  page.
+
+  Light and dark modes have independent colour settings. However, any custom
+  colours that are currently active will be copied to dark mode settings on
+  upgrade.
+
+  The default value for a custom colour can be reselected by clicking on the
+  Change... button for that colour, and selecting the first colour from the
+  'Custom colours:' section of the colour picker dialogue box.
 
 - The status bar can now show the number of selected tracks.
   [[#450](https://github.com/reupen/columns_ui/pull/450)]

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -314,7 +314,7 @@ void ButtonsToolbar::destroy_toolbar()
 
 void ButtonsToolbar::set_window_theme() const
 {
-    SetWindowTheme(wnd_toolbar, cui::colours::is_dark_mode_active() ? L"DarkMode" : nullptr, nullptr);
+    SetWindowTheme(wnd_toolbar, colours::is_dark_mode_active() ? L"DarkMode" : nullptr, nullptr);
 }
 
 LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)

--- a/foo_ui_columns/colour_manager.cpp
+++ b/foo_ui_columns/colour_manager.cpp
@@ -12,8 +12,8 @@ namespace {
 class ColourManagerInstance : public colours::manager_instance {
 public:
     explicit ColourManagerInstance(const GUID& p_client_guid)
-        : m_light_entry(g_colour_manager_data.get_entry_by_guid(p_client_guid, false))
-        , m_dark_entry(g_colour_manager_data.get_entry_by_guid(p_client_guid, true))
+        : m_light_entry(g_colour_manager_data.get_entry(p_client_guid, false))
+        , m_dark_entry(g_colour_manager_data.get_entry(p_client_guid, true))
         , m_global_light_entry(g_colour_manager_data.get_global_entry(false))
         , m_global_dark_entry(g_colour_manager_data.get_global_entry(true))
     {
@@ -22,7 +22,7 @@ public:
     COLORREF get_colour(const colours::colour_identifier_t& p_identifier) const override
     {
         system_appearance_manager::initialise();
-        auto entry = active_entry();
+        const auto entry = active_entry();
         if (entry->colour_set.colour_mode == colours::colour_mode_system
             || entry->colour_set.colour_mode == colours::colour_mode_themed) {
             const auto system_colour_id = get_system_colour_id(p_identifier);

--- a/foo_ui_columns/colour_manager.cpp
+++ b/foo_ui_columns/colour_manager.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 
+#include "colour_utils.h"
 #include "config_appearance.h"
 #include "dark_mode.h"
 #include "system_appearance_manager.h"
@@ -8,60 +9,40 @@ namespace cui {
 
 namespace {
 
-int get_system_colour_id(const colours::colour_identifier_t colour_id)
-{
-    switch (colour_id) {
-    case colours::colour_text:
-        return COLOR_WINDOWTEXT;
-    case colours::colour_selection_text:
-        return COLOR_HIGHLIGHTTEXT;
-    case colours::colour_background:
-        return COLOR_WINDOW;
-    case colours::colour_selection_background:
-        return COLOR_HIGHLIGHT;
-    case colours::colour_inactive_selection_text:
-        return COLOR_BTNTEXT;
-    case colours::colour_inactive_selection_background:
-        return COLOR_BTNFACE;
-    case colours::colour_active_item_frame:
-        return COLOR_WINDOWFRAME;
-    default:
-        uBugCheck();
-    }
-}
-
 class ColourManagerInstance : public colours::manager_instance {
 public:
     explicit ColourManagerInstance(const GUID& p_client_guid)
+        : m_light_entry(g_colour_manager_data.get_entry_by_guid(p_client_guid, false))
+        , m_dark_entry(g_colour_manager_data.get_entry_by_guid(p_client_guid, true))
+        , m_global_light_entry(g_colour_manager_data.get_global_entry(false))
+        , m_global_dark_entry(g_colour_manager_data.get_global_entry(true))
     {
-        g_colour_manager_data.find_by_guid(p_client_guid, m_entry);
-        g_colour_manager_data.find_by_guid(pfc::guid_null, m_global_entry);
     }
+
     COLORREF get_colour(const colours::colour_identifier_t& p_identifier) const override
     {
         system_appearance_manager::initialise();
-        ColourManagerData::entry_ptr_t p_entry
-            = m_entry->colour_mode == colours::colour_mode_global ? m_global_entry : m_entry;
-        if (p_entry->colour_mode == colours::colour_mode_system
-            || p_entry->colour_mode == colours::colour_mode_themed) {
+        auto entry = active_entry();
+        if (entry->colour_set.colour_mode == colours::colour_mode_system
+            || entry->colour_set.colour_mode == colours::colour_mode_themed) {
             const auto system_colour_id = get_system_colour_id(p_identifier);
             return dark::get_system_colour(system_colour_id, colours::is_dark_mode_active());
         }
         switch (p_identifier) {
         case colours::colour_text:
-            return p_entry->text;
+            return entry->colour_set.text;
         case colours::colour_selection_text:
-            return p_entry->selection_text;
+            return entry->colour_set.selection_text;
         case colours::colour_background:
-            return p_entry->background;
+            return entry->colour_set.background;
         case colours::colour_selection_background:
-            return p_entry->selection_background;
+            return entry->colour_set.selection_background;
         case colours::colour_inactive_selection_text:
-            return p_entry->inactive_selection_text;
+            return entry->colour_set.inactive_selection_text;
         case colours::colour_inactive_selection_background:
-            return p_entry->inactive_selection_background;
+            return entry->colour_set.inactive_selection_background;
         case colours::colour_active_item_frame:
-            return p_entry->active_item_frame;
+            return entry->colour_set.active_item_frame;
         default:
             return 0;
         }
@@ -69,11 +50,10 @@ public:
 
     bool get_bool(const colours::bool_identifier_t& p_identifier) const override
     {
-        ColourManagerData::entry_ptr_t p_entry
-            = m_entry->colour_mode == colours::colour_mode_global ? m_global_entry : m_entry;
         switch (p_identifier) {
-        case colours::bool_use_custom_active_item_frame:
-            return p_entry->use_custom_active_item_frame;
+        case colours::bool_use_custom_active_item_frame: {
+            return active_entry()->colour_set.use_custom_active_item_frame;
+        }
         case colours::bool_dark_mode_enabled:
             if (!system_appearance_manager::is_dark_mode_available())
                 return false;
@@ -90,16 +70,20 @@ public:
         }
     }
 
-    bool get_themed() const override
-    {
-        return m_entry->colour_mode == colours::colour_mode_themed
-            || (m_entry->colour_mode == colours::colour_mode_global
-                && m_global_entry->colour_mode == colours::colour_mode_themed);
-    }
+    bool get_themed() const override { return active_entry()->colour_set.colour_mode == colours::colour_mode_themed; }
 
 private:
-    ColourManagerData::entry_ptr_t m_entry;
-    ColourManagerData::entry_ptr_t m_global_entry;
+    [[nodiscard]] colours::Entry::Ptr active_entry() const
+    {
+        auto& global_entry = colours::is_dark_mode_active() ? m_global_dark_entry : m_global_light_entry;
+        auto& entry = colours::is_dark_mode_active() ? m_dark_entry : m_light_entry;
+        return entry->colour_set.colour_mode == colours::colour_mode_global ? global_entry : entry;
+    }
+
+    colours::Entry::Ptr m_light_entry;
+    colours::Entry::Ptr m_dark_entry;
+    colours::Entry::Ptr m_global_light_entry;
+    colours::Entry::Ptr m_global_dark_entry;
 };
 
 class ColourManager : public colours::manager {
@@ -110,11 +94,11 @@ public:
     }
     void register_common_callback(colours::common_callback* p_callback) override
     {
-        g_colour_manager_data.register_common_callback(p_callback);
+        colours::common_colour_callback_manager.register_common_callback(p_callback);
     }
     void deregister_common_callback(colours::common_callback* p_callback) override
     {
-        g_colour_manager_data.deregister_common_callback(p_callback);
+        colours::common_colour_callback_manager.deregister_common_callback(p_callback);
     }
 };
 

--- a/foo_ui_columns/colour_manager_data.h
+++ b/foo_ui_columns/colour_manager_data.h
@@ -1,63 +1,83 @@
 #pragma once
 
+namespace cui::colours {
+
+struct ColourSet {
+    colour_mode_t colour_mode{};
+    COLORREF text{};
+    COLORREF selection_text{};
+    COLORREF inactive_selection_text{};
+    COLORREF background{};
+    COLORREF selection_background{};
+    COLORREF inactive_selection_background{};
+    COLORREF active_item_frame{};
+    bool use_custom_active_item_frame{};
+
+    bool operator==(const ColourSet&) const = default;
+
+    void read(uint32_t version, stream_reader* stream, abort_callback& aborter);
+    void write(stream_writer* stream, abort_callback& aborter) const;
+};
+
+ColourSet create_default_colour_set(bool is_dark, colour_mode_t mode = colour_mode_global);
+
+class Entry {
+public:
+    using Ptr = std::shared_ptr<Entry>;
+
+    enum ExportItemID {
+        identifier_id,
+        identifier_mode,
+        identifier_background,
+        identifier_selection_background,
+        identifier_inactive_selection_background,
+        identifier_text,
+        identifier_selection_text,
+        identifier_inactive_selection_text,
+        identifier_custom_active_item_frame,
+        identifier_use_custom_active_item_frame,
+    };
+    GUID id{};
+    ColourSet colour_set{};
+
+    void write(stream_writer* stream, abort_callback& aborter);
+    void _export(stream_writer* p_stream, abort_callback& p_abort);
+    virtual void import(stream_reader* p_reader, size_t stream_size, uint32_t type, abort_callback& p_abort);
+    void read(uint32_t version, stream_reader* stream, abort_callback& aborter);
+    explicit Entry(bool is_dark, bool b_global = false);
+};
+
 class ColourManagerData : public cfg_var {
 public:
     static const GUID g_cfg_guid;
     enum { cfg_version = 0 };
     void get_data_raw(stream_writer* p_stream, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* p_stream, size_t p_sizehint, abort_callback& p_abort) override;
-    class Entry {
-    public:
-        enum ExportItemID {
-            identifier_guid,
-            identifier_mode,
-            identifier_background,
-            identifier_selection_background,
-            identifier_inactive_selection_background,
-            identifier_text,
-            identifier_selection_text,
-            identifier_inactive_selection_text,
-            identifier_custom_active_item_frame,
-            identifier_use_custom_active_item_frame,
-        };
-        GUID guid{};
-        COLORREF text{};
-        COLORREF selection_text{};
-        COLORREF inactive_selection_text{};
-        COLORREF background{};
-        COLORREF selection_background{};
-        COLORREF inactive_selection_background{};
-        COLORREF active_item_frame{};
-        COLORREF group_foreground{};
-        COLORREF group_background{};
 
-        bool use_custom_active_item_frame{};
-        /*LOGFONT
-        font_content,
-        font_content_group,
-        font_header;*/
-        cui::colours::colour_mode_t colour_mode;
-        void write(stream_writer* p_stream, abort_callback& p_abort);
-        void _export(stream_writer* p_stream, abort_callback& p_abort);
-        virtual void import(stream_reader* p_reader, size_t stream_size, uint32_t type, abort_callback& p_abort);
-        void read(uint32_t version, stream_reader* p_stream, abort_callback& p_abort);
-        void reset_colors();
-        explicit Entry(bool b_global = false);
-    };
-    using entry_ptr_t = std::shared_ptr<Entry>;
-    pfc::list_t<entry_ptr_t> m_entries;
-    entry_ptr_t m_global_entry;
+    Entry::Ptr m_global_light_entry;
+    Entry::Ptr m_global_dark_entry;
+    std::vector<Entry::Ptr> m_light_entries;
+    std::vector<Entry::Ptr> m_dark_entries;
 
-    void find_by_guid(const GUID& p_guid, entry_ptr_t& p_out);
+    Entry::Ptr get_entry(GUID id, bool is_dark = is_dark_mode_active());
+    Entry::Ptr get_global_entry(bool is_dark = is_dark_mode_active()) const;
 
     ColourManagerData();
-
-    void register_common_callback(cui::colours::common_callback* p_callback);
-    void deregister_common_callback(cui::colours::common_callback* p_callback);
-
-    void g_on_common_colour_changed(uint32_t mask);
-
-    void g_on_common_bool_changed(uint32_t mask);
-
-    std::set<cui::colours::common_callback*> m_callbacks;
 };
+
+class CommonColourCallbackManager {
+public:
+    void register_common_callback(common_callback* p_callback);
+    void deregister_common_callback(common_callback* p_callback);
+
+    void s_on_common_colour_changed(uint32_t mask);
+
+    void s_on_common_bool_changed(uint32_t mask);
+
+private:
+    std::set<common_callback*> m_callbacks;
+};
+
+extern CommonColourCallbackManager common_colour_callback_manager;
+
+} // namespace cui::colours

--- a/foo_ui_columns/colour_utils.cpp
+++ b/foo_ui_columns/colour_utils.cpp
@@ -1,0 +1,27 @@
+#include "pch.h"
+
+namespace cui::colours {
+
+int get_system_colour_id(const colour_identifier_t colour_id)
+{
+    switch (colour_id) {
+    case colour_text:
+        return COLOR_WINDOWTEXT;
+    case colour_selection_text:
+        return COLOR_HIGHLIGHTTEXT;
+    case colour_background:
+        return COLOR_WINDOW;
+    case colour_selection_background:
+        return COLOR_HIGHLIGHT;
+    case colour_inactive_selection_text:
+        return COLOR_BTNTEXT;
+    case colour_inactive_selection_background:
+        return COLOR_BTNFACE;
+    case colour_active_item_frame:
+        return COLOR_WINDOWFRAME;
+    default:
+        uBugCheck();
+    }
+}
+
+} // namespace cui::colours

--- a/foo_ui_columns/colour_utils.h
+++ b/foo_ui_columns/colour_utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace cui::colours {
+
+int get_system_colour_id(const colour_identifier_t colour_id);
+
+}

--- a/foo_ui_columns/config.h
+++ b/foo_ui_columns/config.h
@@ -100,8 +100,8 @@ extern const GUID g_guid_columns_ui_preferences_page;
 
 void on_global_colours_change();
 
-cui::colours::colour_mode_t g_get_global_colour_mode();
-void g_set_global_colour_mode(cui::colours::colour_mode_t p_mode);
+cui::colours::colour_mode_t g_get_global_colour_mode(bool is_dark = cui::colours::is_dark_mode_active());
+void g_set_global_colour_mode(cui::colours::colour_mode_t p_mode, bool is_dark = cui::colours::is_dark_mode_active());
 
 namespace cui {
 namespace prefs {

--- a/foo_ui_columns/config_appearance.h
+++ b/foo_ui_columns/config_appearance.h
@@ -65,7 +65,7 @@ public:
     }
 };
 
-extern ColourManagerData g_colour_manager_data;
+extern cui::colours::ColourManagerData g_colour_manager_data;
 extern FontManagerData g_font_manager_data;
 
 namespace cui::colours {

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -307,7 +307,7 @@ void draw_layout_background(HWND wnd, HDC dc)
     RECT rc{};
     GetClientRect(wnd, &rc);
 
-    const auto brush = dark::get_colour_brush(ColourID::LayoutBackground, colours::is_dark_mode_active());
+    const auto brush = get_colour_brush(ColourID::LayoutBackground, colours::is_dark_mode_active());
     FillRect(dc, &rc, brush.get());
 }
 

--- a/foo_ui_columns/fcl_playlist_view.cpp
+++ b/foo_ui_columns/fcl_playlist_view.cpp
@@ -44,8 +44,7 @@ class PlaylistViewAppearanceDataSet : public fcl::dataset {
         abort_callback& p_abort) override
     {
         const auto api = fb2k::std_api_get<fonts::manager>();
-        ColourManagerData::entry_ptr_t colour_manager_entry;
-        g_colour_manager_data.find_by_guid(pfc::guid_null, colour_manager_entry);
+        const auto colour_manager_entry = g_colour_manager_data.get_global_entry(false);
 
         fbh::fcl::Reader reader(p_reader, stream_size, p_abort);
         uint32_t element_id;
@@ -73,37 +72,37 @@ class PlaylistViewAppearanceDataSet : public fcl::dataset {
                 int use_custom_colours{};
                 reader.read_item(use_custom_colours);
                 if (use_custom_colours == 2)
-                    colour_manager_entry->colour_mode = colours::colour_mode_themed;
+                    colour_manager_entry->colour_set.colour_mode = colours::colour_mode_themed;
                 else if (use_custom_colours == 1)
-                    colour_manager_entry->colour_mode = colours::colour_mode_custom;
+                    colour_manager_entry->colour_set.colour_mode = colours::colour_mode_custom;
                 else
-                    colour_manager_entry->colour_mode = colours::colour_mode_system;
+                    colour_manager_entry->colour_set.colour_mode = colours::colour_mode_system;
                 break;
             }
             case colours_pview_use_system_focus_frame: {
                 int use_system_frame{};
                 reader.read_item(use_system_frame);
-                colour_manager_entry->use_custom_active_item_frame = !use_system_frame;
+                colour_manager_entry->colour_set.use_custom_active_item_frame = !use_system_frame;
                 break;
             }
             case colours_pview_background:
                 b_colour_read = true;
-                reader.read_item(colour_manager_entry->background);
+                reader.read_item(colour_manager_entry->colour_set.background);
                 break;
             case colours_pview_selection_background:
-                reader.read_item(colour_manager_entry->selection_background);
+                reader.read_item(colour_manager_entry->colour_set.selection_background);
                 break;
             case colours_pview_inactive_selection_background:
-                reader.read_item(colour_manager_entry->inactive_selection_background);
+                reader.read_item(colour_manager_entry->colour_set.inactive_selection_background);
                 break;
             case colours_pview_text:
-                reader.read_item(colour_manager_entry->text);
+                reader.read_item(colour_manager_entry->colour_set.text);
                 break;
             case colours_pview_selection_text:
-                reader.read_item(colour_manager_entry->selection_text);
+                reader.read_item(colour_manager_entry->colour_set.selection_text);
                 break;
             case colours_pview_inactive_selection_text:
-                reader.read_item(colour_manager_entry->inactive_selection_text);
+                reader.read_item(colour_manager_entry->colour_set.inactive_selection_text);
                 break;
             case colours_pview_header_font: {
                 LOGFONT lf{};
@@ -129,10 +128,6 @@ class PlaylistViewAppearanceDataSet : public fcl::dataset {
             }
         }
 
-        // on_header_font_change();
-        // on_playlist_font_change();
-        // pvt::ng_playlist_view_t::g_on_font_change();
-        // pvt::ng_playlist_view_t::g_on_header_font_change();
         if (b_colour_read)
             on_global_colours_change();
 

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -393,7 +393,7 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
 
 void FilterSearchToolbar::set_window_themes() const
 {
-    const auto is_dark = cui::colours::is_dark_mode_active();
+    const auto is_dark = colours::is_dark_mode_active();
 
     if (m_search_editbox)
         SetWindowTheme(m_search_editbox, is_dark ? L"DarkMode_CFD" : nullptr, nullptr);
@@ -404,7 +404,7 @@ void FilterSearchToolbar::set_window_themes() const
 
 void FilterSearchToolbar::update_toolbar_icons() const
 {
-    const auto is_dark = cui::colours::is_dark_mode_active();
+    const auto is_dark = colours::is_dark_mode_active();
     const int cx = GetSystemMetrics(SM_CXSMICON);
     const int cy = GetSystemMetrics(SM_CYSMICON);
 
@@ -544,7 +544,7 @@ void FilterSearchToolbar::recalculate_dimensions()
 void FilterSearchToolbar::ColourClient::on_bool_changed(uint32_t mask) const
 {
     if (mask & colours::bool_flag_dark_mode_enabled)
-        FilterSearchToolbar::s_on_dark_mode_status_change();
+        s_on_dark_mode_status_change();
 }
 
 LRESULT WINAPI FilterSearchToolbar::g_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -272,6 +272,7 @@
     <ClCompile Include="buttons_config_listview.cpp" />
     <ClCompile Include="buttons_custom_image.cpp" />
     <ClCompile Include="colour_manager_data.cpp" />
+    <ClCompile Include="colour_utils.cpp" />
     <ClCompile Include="columns_v2.cpp" />
     <ClCompile Include="colour_manager.cpp" />
     <ClCompile Include="font_manager.cpp" />
@@ -431,6 +432,7 @@
     <ClInclude Include="artwork_helpers.h" />
     <ClInclude Include="buttons.h" />
     <ClInclude Include="colour_manager_data.h" />
+    <ClInclude Include="colour_utils.h" />
     <ClInclude Include="columns_v2.h" />
     <ClInclude Include="config_appearance.h" />
     <ClInclude Include="config_defaults.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -563,6 +563,9 @@
     <ClCompile Include="font_manager.cpp">
       <Filter>Colours and fonts</Filter>
     </ClCompile>
+    <ClCompile Include="colour_utils.cpp">
+      <Filter>Colours and fonts</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -805,6 +808,9 @@
     </ClInclude>
     <ClInclude Include="vis_spectrum.h">
       <Filter>Spectrum analyser</Filter>
+    </ClInclude>
+    <ClInclude Include="colour_utils.h">
+      <Filter>Colours and fonts</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/helpers.cpp
+++ b/foo_ui_columns/helpers.cpp
@@ -99,7 +99,7 @@ HBITMAP LoadMonoBitmap(INT_PTR uid, COLORREF cr_btntext)
 
 BOOL uDrawPanelTitle(HDC dc, const RECT* rc_clip, const char* text, int len, bool is_font_vertical, bool is_dark)
 {
-    const COLORREF cr_fore = cui::dark::get_colour(cui::dark::ColourID::PanelCaptionText, is_dark);
+    const COLORREF cr_fore = get_colour(cui::dark::ColourID::PanelCaptionText, is_dark);
 
     SetBkMode(dc, TRANSPARENT);
     SetTextColor(dc, cr_fore);

--- a/foo_ui_columns/layout.h
+++ b/foo_ui_columns/layout.h
@@ -83,7 +83,7 @@ public:
     bool get_layout_editing_active();
 
     LayoutWindow()
-        : uie::container_window_v3(uie::container_window_v3_config(L"{DA9A1375-A411-48a9-AF74-4AC29FF9BE9C}"),
+        : container_window_v3(uie::container_window_v3_config(L"{DA9A1375-A411-48a9-AF74-4AC29FF9BE9C}"),
             [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); })
     {
     }

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -353,7 +353,7 @@ HWND RebarWindow::init()
         m_rebar_wnd_proc = reinterpret_cast<WNDPROC>(
             SetWindowLongPtr(wnd_rebar, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(s_handle_hooked_message)));
 
-        m_dark_mode_notifier = std::make_unique<cui::colours::dark_mode_notifier>([this] { on_themechanged(); });
+        m_dark_mode_notifier = std::make_unique<colours::dark_mode_notifier>([this] { on_themechanged(); });
     }
 
     refresh_bands();

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -137,7 +137,7 @@ private:
 
     WNDPROC m_rebar_wnd_proc{nullptr};
     std::vector<RebarBand> m_bands;
-    std::unique_ptr<cui::colours::dark_mode_notifier> m_dark_mode_notifier;
+    std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
 
     friend class RebarWindowHost;
 };

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -60,12 +60,14 @@ INT_PTR QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM 
         }
         ComboBox_InsertString(wnd_theming, 0, L"No");
         ComboBox_InsertString(wnd_theming, 1, L"Yes");
-        m_previous_colour_mode = g_get_global_colour_mode();
+        m_previous_light_colour_mode = g_get_global_colour_mode(false);
+        m_previous_dark_colour_mode = g_get_global_colour_mode(true);
+        const auto active_colour_mode = g_get_global_colour_mode();
 
         size_t select = -1;
-        if (m_previous_colour_mode == cui::colours::colour_mode_themed)
+        if (active_colour_mode == cui::colours::colour_mode_themed)
             select = 1;
-        else if (m_previous_colour_mode == cui::colours::colour_mode_system)
+        else if (active_colour_mode == cui::colours::colour_mode_system)
             select = 0;
 
         ComboBox_SetCurSel(wnd_theming, select);
@@ -96,7 +98,8 @@ INT_PTR QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM 
         switch (wp) {
         case IDCANCEL: {
             cfg_layout.set_preset(cfg_layout.get_active(), m_previous_layout.get_ptr());
-            g_set_global_colour_mode(m_previous_colour_mode);
+            g_set_global_colour_mode(m_previous_light_colour_mode, false);
+            g_set_global_colour_mode(m_previous_dark_colour_mode, true);
             cui::panels::playlist_view::cfg_show_artwork = m_previous_show_artwork;
             cui::panels::playlist_view::cfg_grouping = m_previous_show_grouping;
             cui::panels::playlist_view::PlaylistView::g_on_show_artwork_change();

--- a/foo_ui_columns/setup_dialog.h
+++ b/foo_ui_columns/setup_dialog.h
@@ -5,7 +5,8 @@
 class QuickSetupDialog {
     pfc::list_t<ConfigLayout::Preset> m_presets;
     uie::splitter_item_ptr m_previous_layout;
-    cui::colours::colour_mode_t m_previous_colour_mode{columns_ui::colours::colour_mode_themed};
+    cui::colours::colour_mode_t m_previous_light_colour_mode{columns_ui::colours::colour_mode_themed};
+    cui::colours::colour_mode_t m_previous_dark_colour_mode{columns_ui::colours::colour_mode_themed};
     bool m_previous_show_artwork{};
     bool m_previous_show_grouping{};
     INT_PTR SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -44,7 +44,7 @@ LRESULT WINAPI g_status_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         auto bm_old = (HBITMAP)SelectObject(dc_mem, bm_mem);
 
         if (colours::is_dark_mode_active())
-            FillRect(dc_mem, &rc, dark::get_colour_brush(dark::ColourID::StatusBarBackground, true).get());
+            FillRect(dc_mem, &rc, get_colour_brush(dark::ColourID::StatusBarBackground, true).get());
         else
             CallWindowProc(state->status_proc, wnd, WM_ERASEBKGND, (WPARAM)dc_mem, NULL);
 
@@ -359,7 +359,7 @@ void draw_item_content(const HDC dc, const StatusBarPartID part_id, const std::s
     if (text.empty())
         return;
 
-    const auto text_colour = dark::get_colour(dark::ColourID::StatusBarText, colours::is_dark_mode_active());
+    const auto text_colour = get_colour(dark::ColourID::StatusBarText, colours::is_dark_mode_active());
 
     if (part_id == StatusBarPartID::PlaybackInformation) {
         text_out_colours_tab(dc, text.data(), gsl::narrow<int>(text.size()), 0, 0, &rc, FALSE, text_colour, true, false,

--- a/foo_ui_columns/system_appearance_manager.cpp
+++ b/foo_ui_columns/system_appearance_manager.cpp
@@ -143,18 +143,21 @@ private:
             }
             break;
         case WM_SYSCOLORCHANGE: {
+            if (colours::is_dark_mode_active())
+                break;
+
             ColoursClientList m_colours_client_list;
             ColoursClientList::g_get_list(m_colours_client_list);
             size_t count = m_colours_client_list.get_count();
-            bool b_global_custom = g_colour_manager_data.m_global_entry->colour_mode == colours::colour_mode_custom;
+            bool b_global_custom
+                = g_colour_manager_data.get_global_entry()->colour_set.colour_mode == colours::colour_mode_custom;
             if (!b_global_custom)
-                g_colour_manager_data.g_on_common_colour_changed(colours::colour_flag_all);
+                colours::common_colour_callback_manager.s_on_common_colour_changed(colours::colour_flag_all);
             for (size_t i = 0; i < count; i++) {
-                ColourManagerData::entry_ptr_t p_data;
-                g_colour_manager_data.find_by_guid(m_colours_client_list[i].m_guid, p_data);
-                if (p_data->colour_mode == colours::colour_mode_system
-                    || p_data->colour_mode == colours::colour_mode_themed
-                    || (p_data->colour_mode == colours::colour_mode_global && !b_global_custom)) {
+                const auto p_data = g_colour_manager_data.get_entry(m_colours_client_list[i].m_guid);
+                if (p_data->colour_set.colour_mode == colours::colour_mode_system
+                    || p_data->colour_set.colour_mode == colours::colour_mode_themed
+                    || (p_data->colour_set.colour_mode == colours::colour_mode_global && !b_global_custom)) {
                     m_colours_client_list[i].m_ptr->on_colour_changed(colours::colour_flag_all);
                 }
             }

--- a/foo_ui_columns/tab_colours.h
+++ b/foo_ui_columns/tab_colours.h
@@ -15,20 +15,12 @@ class TabColours : public PreferencesTab {
     uih::FillWindow g_fill_selection_background_inactive;
     uih::FillWindow g_fill_active_item_frame;
     GUID m_element_guid{};
-    ColourManagerData::entry_ptr_t m_element_ptr;
+    cui::colours::Entry::Ptr m_element_ptr;
     cui::colours::client::ptr m_element_api;
     ColoursClientList m_colours_client_list;
 
 public:
-    void refresh_me(HWND wnd);
-
-    void update_fills();
-    bool get_change_colour_enabled(cui::colours::colour_identifier_t p_identifier);
-    bool get_colour_patch_enabled(cui::colours::colour_identifier_t p_identifier);
-    void update_buttons();
-    void update_mode_combobox();
-
-    void on_colour_changed();
+    void handle_external_configuration_change();
 
     INT_PTR on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     void apply();
@@ -38,7 +30,16 @@ public:
     bool is_active();
 
 private:
-    bool initialising{false};
+    bool get_change_colour_enabled(cui::colours::colour_identifier_t p_identifier);
+    bool get_colour_patch_enabled(cui::colours::colour_identifier_t p_identifier);
+
+    void update_fills();
+    void update_buttons();
+    void update_mode_combobox();
+    void update_title() const;
+
+    void on_colour_changed();
+
     cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
 };
 

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -160,7 +160,7 @@ void SpectrumAnalyserVisualisation::paint_background(HDC dc, const RECT* rc_clie
     colours::helper colours(colour_client_id);
 
     if (!s_background_brush)
-        s_background_brush.reset(CreateSolidBrush(colours.get_colour(cui::colours::colour_background)));
+        s_background_brush.reset(CreateSolidBrush(colours.get_colour(colours::colour_background)));
 
     FillRect(dc, rc_client, s_background_brush.get());
 }
@@ -484,7 +484,7 @@ void SpectrumAnalyserVisualisation::set_config(stream_reader* r, size_t p_size, 
 
 void SpectrumAnalyserVisualisation::get_config(stream_writer* data, abort_callback& p_abort) const
 {
-    cui::colours::helper colours(colour_client_id);
+    colours::helper colours(colour_client_id);
 
     data->write_lendian_t(colours.get_colour(colours::colour_text), p_abort);
     data->write_lendian_t(colours.get_colour(colours::colour_background), p_abort);

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -29,9 +29,9 @@ class VolumeBar : play_callback {
                 Trackbar::draw_channel(dc, rc);
             else {
                 const auto is_dark = cui::colours::is_dark_mode_active();
-                const auto top_edge_colour = cui::dark::get_colour(cui::dark::ColourID::VolumeChannelTopEdge, is_dark);
+                const auto top_edge_colour = get_colour(cui::dark::ColourID::VolumeChannelTopEdge, is_dark);
                 const auto bottom_and_right_edge_colour
-                    = cui::dark::get_colour(cui::dark::ColourID::VolumeChannelBottomAndRightEdge, is_dark);
+                    = get_colour(cui::dark::ColourID::VolumeChannelBottomAndRightEdge, is_dark);
 
                 if (m_this->get_using_gdiplus()) {
                     Gdiplus::Graphics graphics(dc);
@@ -223,8 +223,8 @@ public:
             // Note: In non-pop-up mode, this is handled by uie::container_window
             RECT rect{};
             GetClientRect(wnd, &rect);
-            const auto brush = cui::dark::get_colour_brush(
-                cui::dark::ColourID::VolumePopupBackground, cui::colours::is_dark_mode_active());
+            const auto brush
+                = get_colour_brush(cui::dark::ColourID::VolumePopupBackground, cui::colours::is_dark_mode_active());
             FillRect(reinterpret_cast<HDC>(wp), &rect, brush.get());
             return TRUE;
         }
@@ -238,7 +238,7 @@ public:
                 RECT rect{};
                 GetClientRect(wnd, &rect);
 
-                const auto border_colour = cui::dark::get_colour(cui::dark::ColourID::VolumePopupBorder, is_dark);
+                const auto border_colour = get_colour(cui::dark::ColourID::VolumePopupBorder, is_dark);
                 const auto pen = wil::unique_hpen(CreatePen(PS_INSIDEFRAME, 1_spx, border_colour));
                 const auto _select_pen = wil::SelectObject(ps.hdc, pen.get());
                 const auto _select_brush = wil::SelectObject(ps.hdc, GetStockObject(NULL_BRUSH));


### PR DESCRIPTION
This makes the colours configured on the Colours tab of Colours and fonts preferences specific to the active mode (light or dark).

This is so one person can switch between light and dark modes at their will, and have relevant colours configured for each.

On upgrade, any custom colours that are currently active are copied to the dark mode colour settings. This is in case someone already has dark colours configured (which would be otherwise difficult to copy across).

In the colour picker dialogue box shown when changing a custom colour, the custom colour available for selection at the bottom of the dialogue box was also corrected to be the default colour for the currently active mode.

Finally, the Colours tab is now refreshed if the colour mode is set to 'Use system setting' and the system mode changes.