### PR TITLE
Add dark mode settings to FCL files

### DIFF
--- a/foo_ui_columns/fcl_playlist_view.cpp
+++ b/foo_ui_columns/fcl_playlist_view.cpp
@@ -3,6 +3,7 @@
 #include "colour_manager_data.h"
 #include "config.h"
 #include "config_appearance.h"
+#include "tab_dark_mode.h"
 
 namespace cui {
 
@@ -128,8 +129,15 @@ class PlaylistViewAppearanceDataSet : public fcl::dataset {
             }
         }
 
-        if (b_colour_read)
-            on_global_colours_change();
+        if (b_colour_read) {
+            const auto old_is_dark = colours::is_dark_mode_active();
+            colours::dark_mode_status.set(WI_EnumValue(cui::colours::DarkModeStatus::Disabled));
+
+            g_tab_dark_mode.refresh();
+
+            if (old_is_dark == colours::is_dark_mode_active())
+                on_global_colours_change();
+        }
 
         if (font_read)
             refresh_appearance_prefs();

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -278,7 +278,7 @@ void cui::MainWindow::on_destroy()
 
 void cui::MainWindow::set_dark_mode_attributes(bool is_update) const
 {
-    if (!dark::does_os_support_dark_mode())
+    if (!m_wnd || !dark::does_os_support_dark_mode())
         return;
 
     const auto is_dark = colours::is_dark_mode_active();

--- a/foo_ui_columns/tab_dark_mode.h
+++ b/foo_ui_columns/tab_dark_mode.h
@@ -17,3 +17,5 @@ private:
     HWND m_wnd{nullptr};
     cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
 };
+
+extern TabDarkMode g_tab_dark_mode;


### PR DESCRIPTION
This adds all dark-mode related settings to configuration exports.

If a configuration without any dark mode settings is imported, light mode is automatically activated.