### PR TITLE
Scale layout tree view indentation with system DPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@
   position was corrected so that it's based on the actual pointer size, rather
   than a fixed offset. [[#494](https://github.com/reupen/columns_ui/pull/494)]
 
+- The item indentation of the layout tree on the Layout preferences page was
+  corrected to scale with the system DPI setting.
+  [[#517](https://github.com/reupen/columns_ui/pull/517)]
+
 - Various truncated labels in preferences were corrected.
   [[#469](https://github.com/reupen/columns_ui/pull/469),
   [#516](https://github.com/reupen/columns_ui/pull/516)]

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -534,8 +534,9 @@ void LayoutTab::switch_to_preset(HWND wnd, size_t index)
 INT_PTR LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
-    case WM_INITDIALOG: {
+    case WM_INITDIALOG:
         m_wnd_tree = GetDlgItem(wnd, IDC_TREE);
+        TreeView_SetIndent(m_wnd_tree, 0);
         uih::tree_view_set_explorer_theme(m_wnd_tree);
         cfg_layout.save_active_preset();
         if (!cfg_layout.get_presets().get_count())
@@ -553,7 +554,7 @@ INT_PTR LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         uSendDlgItemMessageText(wnd, IDC_CAPTIONSTYLE, CB_ADDSTRING, 0, "Vertical");
 
         m_initialised = true;
-    } break;
+        break;
     case WM_DESTROY:
         m_initialised = false;
         apply();


### PR DESCRIPTION
By default, the Win32 tree view control doesn't scale its indentation with the system DPI setting.

This corrects that on the Layout preferences page by telling the control to use the default indentation value.