### PR TITLE
Disable shading of alternate playlist view rows by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
   The previous mode setting on the Colours tab of Colours and fonts preferences
   has been renamed scheme to disambiguate it from the new mode setting.
 
+- The shading of alternate rows in the playlist view was disabled by default in
+  new installations. [[#522](https://github.com/reupen/columns_ui/pull/522)]
+
+  This can be enabled by uncommenting the second line in the default global
+  style script.
+
 - Status bar and status pane preferences were fully separated.
   [[#516](https://github.com/reupen/columns_ui/pull/516)]
 

--- a/foo_ui_columns/config_vars.cpp
+++ b/foo_ui_columns/config_vars.cpp
@@ -108,8 +108,11 @@ ConfigMenuItem cfg_statusdbl(GUID{0x21440b3f, 0x4c1d, 0xb049, {0x46, 0xe1, 0x37,
 cfg_string cfg_pgenstring(GUID{0x07bee8c2, 0xc6f1, 0x9db3, {0x52, 0x55, 0x43, 0x28, 0x1f, 0xb3, 0xf1, 0xe6}},
     "%album%\\$directory(%_path%,2)");
 
-const char* g_default_colour
-    = "$if(%_themed%,,$if($and(%isplaying%,$not(%_is_group%)),\r\n"
+const char* default_global_style_script
+    = "// Uncomment the next line to enable the shading of alternate rows\r\n"
+      "// $puts(shade-alternate-rows,1)\r\n"
+      "\r\n"
+      "$if($get(shade-alternate-rows),$if($and(%isplaying%,$not(%_is_group%)),\r\n"
       "\r\n"
       "$puts(back,$offset_colour(%_back%,$offset_colour($calculate_blend_target(%_back%),ff0000,20),25))\r\n"
       "$puts(back-selected,$offset_colour(%_selected_back%,$offset_colour($calculate_blend_target(%_selected_back%),"
@@ -133,7 +136,7 @@ const char* g_default_colour
       "$set_style(back,$get(back),$get(back-selected),$get(back-selected-no-focus)))";
 
 cfg_string cfg_colour(
-    GUID{0xa41b3a98, 0x3834, 0x3b7c, {0x58, 0xae, 0x1d, 0x46, 0xb0, 0xf9, 0x4b, 0x0d}}, g_default_colour);
+    GUID{0xa41b3a98, 0x3834, 0x3b7c, {0x58, 0xae, 0x1d, 0x46, 0xb0, 0xf9, 0x4b, 0x0d}}, default_global_style_script);
 
 ConfigMenuItem cfg_playlist_double(GUID{0xffc47d9d, 0xb43d, 0x8fad, {0x8f, 0xb3, 0x42, 0x84, 0xbf, 0x9a, 0x22, 0x2a}});
 cfg_string cfg_playlist_switcher_tagz(

--- a/foo_ui_columns/tab_global.cpp
+++ b/foo_ui_columns/tab_global.cpp
@@ -4,6 +4,8 @@
 #include "help.h"
 #include "prefs_utils.h"
 
+extern const char* default_global_style_script;
+
 static cfg_int g_cur_tab2(GUID{0x5fb6e011, 0x1ead, 0x49fe, {0x45, 0x32, 0x1c, 0x8a, 0x61, 0x01, 0x91, 0x2b}}, 0);
 
 class TabGlobal : public PreferencesTab {
@@ -128,8 +130,7 @@ public:
                         g_editor_font_notify.on_change();
                     }
                 } else if (cmd == IDM_RESETSTYLE) {
-                    extern const char* g_default_colour;
-                    cfg_colour = g_default_colour;
+                    cfg_colour = default_global_style_script;
                     if (g_cur_tab2 == 1)
                         uSendDlgItemMessageText(wnd, IDC_STRING, WM_SETTEXT, 0, cfg_colour);
                     cui::panels::playlist_view::PlaylistView::g_update_all_items();


### PR DESCRIPTION
This disables the shading of alternate rows in the playlist view by default in all colour schemes.

Previously, the global style script automatically enabled it for non-themed colour schemes, but it was illogical that wanting to customise colours should also turn this on.

(It can still be enabled by uncommenting the indicated line in the default global style script, however.)