### PR TITLE
Fix incorrect spectrum analyser colours on new installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@
   there. [[#466](https://github.com/reupen/columns_ui/pull/466),
   [#470](https://github.com/reupen/columns_ui/pull/470),
   [#473](https://github.com/reupen/columns_ui/pull/473),
-  [#514](https://github.com/reupen/columns_ui/pull/514)]
+  [#514](https://github.com/reupen/columns_ui/pull/514),
+  [#540](https://github.com/reupen/columns_ui/pull/540)]
 
 - The Filter search toolbar is now integrated with the Colours and fonts
   preferences page, and its font, foreground colour and background colour are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Features
 
-- Support for the Windows 10 and 11 dark mode was added on Windows 10 20H1 and
-  newer.
+- Support for the Windows 10 and 11 dark mode was added on Windows 10 version
+  2004 and newer.
   [[multiple pull requests](https://github.com/reupen/columns_ui/pulls?q=is%3Apr+is%3Aclosed+label%3A%22dark+mode%22+merged%3A%3C%3D2022-04-21)]
 
   This can be enabled from the Mode tab on the Colours and fonts preferences
@@ -32,8 +32,8 @@
 - The shading of alternate rows in the playlist view was disabled by default in
   new installations. [[#522](https://github.com/reupen/columns_ui/pull/522)]
 
-  This can be enabled by uncommenting the second line in the default global
-  style script.
+  It can still be enabled (in new installations) by uncommenting the second line
+  in the default global style script.
 
 - Status bar and status pane preferences were fully separated.
   [[#516](https://github.com/reupen/columns_ui/pull/516)]

--- a/foo_ui_columns/tab_dark_mode.cpp
+++ b/foo_ui_columns/tab_dark_mode.cpp
@@ -7,7 +7,7 @@
 
 constexpr auto unknown_windows_build_message
     = "Your version of Windows has not been tested for dark mode compatibility. Some dark mode features have been disabled."sv;
-constexpr auto windows_too_old_message = "Dark mode requires Windows 10 20H1 or newer."sv;
+constexpr auto windows_too_old_message = "Dark mode requires Windows 10 version 2004 or newer."sv;
 constexpr auto dark_mode_unavailable_message = "Dark mode is unavailable due to the current system settings."sv;
 
 bool TabDarkMode::is_active()

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -514,23 +514,28 @@ void SpectrumAnalyserVisualisation::get_name(pfc::string_base& out) const
 
 void SpectrumAnalyserVisualisation::set_config(stream_reader* r, size_t p_size, abort_callback& p_abort)
 {
-    if (p_size) {
-        const auto legacy_foreground = r->read_lendian_t<COLORREF>(p_abort);
-        const auto legacy_background = r->read_lendian_t<COLORREF>(p_abort);
+    if (!p_size) {
+        has_migrated_spectrum_analyser_colours = true;
+        return;
+    }
 
-        migrate_spectrum_analyser_colours(legacy_foreground, legacy_background);
+    const auto legacy_foreground = r->read_lendian_t<COLORREF>(p_abort);
+    const auto legacy_background = r->read_lendian_t<COLORREF>(p_abort);
 
-        r->read_lendian_t(mode, p_abort);
-        try {
-            r->read_lendian_t(m_scale, p_abort);
-            r->read_lendian_t(m_vertical_scale, p_abort);
-        } catch (const exception_io_data_truncation&) {
-        }
+    migrate_spectrum_analyser_colours(legacy_foreground, legacy_background);
+
+    r->read_lendian_t(mode, p_abort);
+    try {
+        r->read_lendian_t(m_scale, p_abort);
+        r->read_lendian_t(m_vertical_scale, p_abort);
+    } catch (const exception_io_data_truncation&) {
     }
 }
 
 void SpectrumAnalyserVisualisation::get_config(stream_writer* data, abort_callback& p_abort) const
 {
+    has_migrated_spectrum_analyser_colours = true;
+
     colours::helper colours(colour_client_id);
 
     data->write_lendian_t(colours.get_colour(colours::colour_text), p_abort);


### PR DESCRIPTION
This fixes a problem with the spectrum analyser legacy colour configuration import logic that was causing colours to be set incorrectly for new installations.

It also changes references to Windows 10 20H1 to Windows 10 version 2004.