### PR TITLE
Fix ICO file bugs in button toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+- A bug which stopped ICO files from working as custom hot images in the buttons
+  toolbar was fixed. [[#547](https://github.com/reupen/columns_ui/pull/547)]
+
 ## 2.0.0-alpha.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - A bug which stopped ICO files from working as custom hot images in the buttons
   toolbar was fixed. [[#547](https://github.com/reupen/columns_ui/pull/547)]
 
+- A GDI object leak when using ICO files as custom button images was fixed.
+  [[#547](https://github.com/reupen/columns_ui/pull/547)]
+
 ## 2.0.0-alpha.1
 
 ### Features

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -159,8 +159,7 @@ void ButtonsToolbar::create_toolbar()
                     } else {
                         images[n].load(button.m_custom_image);
 
-                        SIZE szt;
-                        images[n].get_size(szt);
+                        const auto szt = images[n].get_size();
                         sz.cx = std::max(sz.cx, szt.cx);
                         sz.cy = std::max(sz.cy, szt.cy);
                     }

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -142,7 +142,7 @@ public:
         ButtonImage(ButtonImage&&) = delete;
         ButtonImage& operator=(ButtonImage&&) = delete;
         ~ButtonImage();
-        bool is_valid();
+        bool is_valid() const;
         void load(const Button::CustomImage& p_image);
         void load(const service_ptr_t<uie::button>& p_in, COLORREF colour_btnface, unsigned cx, unsigned cy);
         unsigned add_to_imagelist(HIMAGELIST iml);

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -129,10 +129,10 @@ public:
     };
 
     class ButtonImage {
-        HBITMAP m_bm{nullptr};
-        HICON m_icon{nullptr};
+        wil::unique_hbitmap m_bm;
+        wil::unique_hicon m_icon;
         ui_extension::t_mask m_mask_type{uie::MASK_NONE};
-        HBITMAP m_bm_mask{nullptr};
+        wil::unique_hbitmap m_bm_mask;
         COLORREF m_mask_colour{0};
 
     public:
@@ -141,12 +141,11 @@ public:
         ButtonImage& operator=(const ButtonImage&) = delete;
         ButtonImage(ButtonImage&&) = delete;
         ButtonImage& operator=(ButtonImage&&) = delete;
-        ~ButtonImage();
         bool is_valid() const;
         void load(const Button::CustomImage& p_image);
         void load(const service_ptr_t<uie::button>& p_in, COLORREF colour_btnface, unsigned cx, unsigned cy);
         unsigned add_to_imagelist(HIMAGELIST iml);
-        void get_size(SIZE& p_out);
+        SIZE get_size() const;
     };
 
     HWND wnd_toolbar{nullptr};

--- a/foo_ui_columns/buttons_button_image.cpp
+++ b/foo_ui_columns/buttons_button_image.cpp
@@ -4,19 +4,9 @@
 
 namespace cui::toolbars::buttons {
 
-ButtonsToolbar::ButtonImage::~ButtonImage()
-{
-    if (m_bm)
-        DeleteBitmap(m_bm);
-    if (m_bm_mask)
-        DeleteBitmap(m_bm_mask);
-    if (m_icon)
-        DestroyIcon(m_icon);
-}
-
 bool ButtonsToolbar::ButtonImage::is_valid() const
 {
-    return m_bm != nullptr || m_icon != nullptr;
+    return m_bm || m_icon;
 }
 
 void ButtonsToolbar::ButtonImage::load(const Button::CustomImage& p_image)
@@ -26,46 +16,25 @@ void ButtonsToolbar::ButtonImage::load(const Button::CustomImage& p_image)
     m_mask_type = p_image.m_mask_type;
     m_mask_colour = p_image.m_mask_colour;
 
-    pfc::string8 fullPath;
-    p_image.get_path(fullPath);
+    pfc::string8 full_path;
+    p_image.get_path(full_path);
 
-    if (!_stricmp(string_extension(fullPath), "bmp")) // Gdiplus vs 32bpp
-        m_bm = (HBITMAP)uLoadImage(
-            core_api::get_my_instance(), fullPath, IMAGE_BITMAP, 0, 0, LR_DEFAULTSIZE | LR_LOADFROMFILE);
-    else if (!_stricmp(string_extension(fullPath), "ico"))
-        m_icon = (HICON)uLoadImage(core_api::get_my_instance(), fullPath, IMAGE_ICON, GetSystemMetrics(SM_CXSMICON),
-            GetSystemMetrics(SM_CYSMICON), LR_LOADFROMFILE);
+    if (!_stricmp(string_extension(full_path), "bmp")) // Gdiplus vs 32bpp
+        m_bm.reset(static_cast<HBITMAP>(uLoadImage(
+            wil::GetModuleInstanceHandle(), full_path, IMAGE_BITMAP, 0, 0, LR_DEFAULTSIZE | LR_LOADFROMFILE)));
+    else if (!_stricmp(string_extension(full_path), "ico"))
+        m_icon.reset(static_cast<HICON>(uLoadImage(wil::GetModuleInstanceHandle(), full_path, IMAGE_ICON,
+            GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON), LR_LOADFROMFILE)));
     else {
         try {
-            m_bm = wic::create_hbitmap_from_path(fullPath).release();
+            m_bm.reset(wic::create_hbitmap_from_path(full_path).release());
         } catch (const std::exception& ex) {
             fbh::print_to_console(u8"Buttons toolbar – loading image failed: "_pcc, ex.what());
-            m_bm = nullptr;
         }
     }
-    if (m_bm) {
-        switch (p_image.m_mask_type) {
-        default:
-            break;
-        case ui_extension::MASK_COLOUR:
-            break;
-#if 0
-        case ui_extension::MASK_BITMAP:
-        {
-            if (!_stricmp(pfc::string_extension(p_image.m_mask_path), "png"))
-            {
-                m_bm_mask = read_png(0, p_image.m_mask_path);
-            }
-            else
-                m_bm_mask = (HBITMAP)LoadImage(core_api::get_my_instance(), pfc::stringcvt::string_os_from_utf8(p_image.m_mask_path), IMAGE_BITMAP, 0, 0, LR_DEFAULTSIZE | LR_LOADFROMFILE | LR_MONOCHROME);
-            if (!m_bm_mask)
-                console::printf("failed loading image \"%s\"", p_image.m_mask_path.get_ptr());
-        }
-        break;
-#endif
-        }
-    } else if (!m_icon)
-        console::printf("failed loading image \"%s\"", fullPath.get_ptr());
+
+    if (!m_bm && !m_icon)
+        console::printf("failed loading image \"%s\"", full_path.get_ptr());
 }
 void ButtonsToolbar::ButtonImage::load(
     const service_ptr_t<uie::button>& p_in, COLORREF colour_btnface, unsigned cx, unsigned cy)
@@ -75,47 +44,58 @@ void ButtonsToolbar::ButtonImage::load(
         unsigned handle_type = 0;
         HANDLE image = inv2->get_item_bitmap(0, colour_btnface, cx, cy, handle_type);
         if (handle_type == uie::button_v2::handle_type_bitmap)
-            m_bm = (HBITMAP)image;
+            m_bm.reset(static_cast<HBITMAP>(image));
         else if (handle_type == uie::button_v2::handle_type_icon)
-            m_icon = (HICON)image;
+            m_icon.reset(static_cast<HICON>(image));
     } else
-        m_bm = p_in->get_item_bitmap(0, colour_btnface, m_mask_type, m_mask_colour, m_bm_mask);
+        m_bm.reset(p_in->get_item_bitmap(0, colour_btnface, m_mask_type, m_mask_colour, *m_bm_mask.put()));
 }
 unsigned ButtonsToolbar::ButtonImage::add_to_imagelist(HIMAGELIST iml)
 {
     unsigned rv = I_IMAGECALLBACK;
     if (m_icon) {
-        rv = ImageList_ReplaceIcon(iml, -1, m_icon);
+        rv = ImageList_ReplaceIcon(iml, -1, m_icon.get());
     } else if (m_bm) {
         switch (m_mask_type) {
         default:
-            rv = ImageList_Add(iml, m_bm, nullptr);
+            rv = ImageList_Add(iml, m_bm.get(), nullptr);
             break;
         case ui_extension::MASK_COLOUR:
-            rv = ImageList_AddMasked(iml, m_bm, m_mask_colour);
+            rv = ImageList_AddMasked(iml, m_bm.get(), m_mask_colour);
             break;
         case ui_extension::MASK_BITMAP: {
-            rv = ImageList_Add(iml, m_bm, m_bm_mask);
+            rv = ImageList_Add(iml, m_bm.get(), m_bm_mask.get());
         } break;
         }
     }
     return rv;
 }
-void ButtonsToolbar::ButtonImage::get_size(SIZE& p_out)
+
+SIZE ButtonsToolbar::ButtonImage::get_size() const
 {
-    p_out.cx = 0;
-    p_out.cy = 0;
-    BITMAP bmi{};
     if (m_icon) {
         ICONINFO ii{};
-        if (GetIconInfo(m_icon, &ii)) {
-            GetObject(ii.hbmColor ? ii.hbmColor : ii.hbmMask, sizeof(BITMAP), &bmi);
-        }
-    } else if (m_bm) {
-        GetObject(m_bm, sizeof(BITMAP), &bmi);
+        if (!GetIconInfo(m_icon.get(), &ii))
+            return {};
+
+        const wil::unique_hbitmap colour_bitmap(ii.hbmColor);
+        const wil::unique_hbitmap mask_bitmap(ii.hbmMask);
+
+        BITMAP bmi{};
+        if (!GetObject(ii.hbmColor ? ii.hbmColor : ii.hbmMask, sizeof(BITMAP), &bmi))
+            return {};
+
+        return {bmi.bmWidth, ii.hbmColor ? bmi.bmHeight : bmi.bmHeight / 2};
     }
-    p_out.cx = bmi.bmWidth;
-    p_out.cy = bmi.bmHeight;
+
+    if (!m_bm)
+        return {};
+
+    BITMAP bmi{};
+    if (!GetObject(m_bm.get(), sizeof(BITMAP), &bmi))
+        return {};
+
+    return {bmi.bmWidth, bmi.bmHeight};
 }
 
 } // namespace cui::toolbars::buttons

--- a/foo_ui_columns/buttons_button_image.cpp
+++ b/foo_ui_columns/buttons_button_image.cpp
@@ -13,9 +13,10 @@ ButtonsToolbar::ButtonImage::~ButtonImage()
     if (m_icon)
         DestroyIcon(m_icon);
 }
-bool ButtonsToolbar::ButtonImage::is_valid()
+
+bool ButtonsToolbar::ButtonImage::is_valid() const
 {
-    return m_bm != nullptr;
+    return m_bm != nullptr || m_icon != nullptr;
 }
 
 void ButtonsToolbar::ButtonImage::load(const Button::CustomImage& p_image)


### PR DESCRIPTION
#546 

This updates the buttons toolbar to:

- fix a bug preventing ICO files from working as a custom hot button image
- fix a GDI object leak when using ICO files as custom images
- tidy up some of the button image code