### PR TITLE
Rework buttons toolbar image loading logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Development version
 
+### Features
+
+- When mixed size images are used in the buttons toolbar, they are now all
+  resized to the size of the largest non-hot custom image.
+  [[#548](https://github.com/reupen/columns_ui/pull/548)]
+
+  (Previously, images in the wrong size would display incorrectly or otherwise
+  misbehave.)
+
+  A message is also printed to the console when mixed size custom images are
+  detected.
+
 ### Bug fixes
 
 - A bug which stopped ICO files from working as custom hot images in the buttons

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -77,7 +77,9 @@ public:
             COLORREF m_mask_colour{};
             ui_extension::t_mask m_mask_type{uie::MASK_NONE};
 
-            void get_path(pfc::string8& p_out) const;
+            [[nodiscard]] bool is_ico() const;
+
+            [[nodiscard]] pfc::string8 get_path() const;
             void write(stream_writer* out, abort_callback& p_abort) const;
             void read(ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort);
             void write_to_file(stream_writer& p_file, bool b_paths, abort_callback& p_abort);
@@ -129,23 +131,33 @@ public:
     };
 
     class ButtonImage {
-        wil::unique_hbitmap m_bm;
-        wil::unique_hicon m_icon;
-        ui_extension::t_mask m_mask_type{uie::MASK_NONE};
-        wil::unique_hbitmap m_bm_mask;
-        COLORREF m_mask_colour{0};
-
     public:
         ButtonImage() = default;
         ButtonImage(const ButtonImage&) = delete;
         ButtonImage& operator=(const ButtonImage&) = delete;
         ButtonImage(ButtonImage&&) = delete;
         ButtonImage& operator=(ButtonImage&&) = delete;
+
         bool is_valid() const;
-        void load(const Button::CustomImage& p_image);
-        void load(const service_ptr_t<uie::button>& p_in, COLORREF colour_btnface, unsigned cx, unsigned cy);
+        void preload(const Button::CustomImage& p_image);
+        bool load(std::optional<std::reference_wrapper<Button::CustomImage>> custom_image,
+            const service_ptr_t<uie::button>& button_ptr, COLORREF colour_btnface, int width, int height);
         unsigned add_to_imagelist(HIMAGELIST iml);
-        SIZE get_size() const;
+        [[nodiscard]] std::optional<std::tuple<int, int>> get_size() const { return m_bitmap_source_size; };
+
+    private:
+        bool load_custom_image(const Button::CustomImage& custom_image, int width, int height);
+        void load_default_image(
+            const service_ptr_t<uie::button>& button_ptr, COLORREF colour_btnface, int width, int height);
+
+        wil::com_ptr_t<IWICBitmapSource> m_bitmap_source;
+        std::optional<std::tuple<int, int>> m_bitmap_source_size;
+
+        wil::unique_hbitmap m_bm;
+        wil::unique_hicon m_icon;
+        ui_extension::t_mask m_mask_type{uie::MASK_NONE};
+        wil::unique_hbitmap m_bm_mask;
+        COLORREF m_mask_colour{0};
     };
 
     HWND wnd_toolbar{nullptr};
@@ -278,8 +290,6 @@ private:
     }
 
     static const TCHAR* class_name;
-    int width{0};
-    int height{0};
 
     WNDPROC menuproc{nullptr};
     bool initialised{false}, m_gdiplus_initialised{false};

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -2,6 +2,11 @@
 
 namespace cui::wic {
 
+class wic_error : public std::exception {
+public:
+    using std::exception::exception;
+};
+
 struct BitmapData {
     unsigned width{};
     unsigned height{};
@@ -9,7 +14,13 @@ struct BitmapData {
     std::vector<uint8_t> data;
 };
 
-wil::unique_hbitmap create_hbitmap_from_path(const char* path);
+void check_hresult(HRESULT hr);
+wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_path(const char* path);
+wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr_t<IWICBitmapSource>& source);
+wil::com_ptr_t<IWICBitmapSource> resize_bitmap_source(
+    const wil::com_ptr_t<IWICBitmapSource>& original_bitmap, int width, int height);
+wil::unique_hbitmap resize_hbitmap(HBITMAP original_bitmap, int width, int height);
+
 BitmapData decode_image_data(const void* data, size_t size);
 
 } // namespace cui::wic


### PR DESCRIPTION
Resolves #546

This resolves various odd behaviours when mixed size custom images are used in the buttons toolbar, by making the toolbar resize all images to the same size when mixed size images are detected.