### PR TITLE
Stop active tabs changing colour on hover in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   A message is also printed to the console when mixed size custom images are
   detected.
 
+- Active tabs in the Tab stack and Playlist tabs panels no longer change colour
+  on hover when dark mode is active.
+  [[#549](https://github.com/reupen/columns_ui/pull/549)]
+
 ### Bug fixes
 
 - A bug which stopped ICO files from working as custom hot images in the buttons

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -213,7 +213,7 @@ COLORREF get_dark_colour(ColourID colour_id)
     case ColourID::TabControlHotItemBackground:
         return get_base_dark_colour(DarkColourID::DARK_300);
     case ColourID::TabControlHotActiveItemBackground:
-        return get_base_dark_colour(DarkColourID::DARK_600);
+        return get_base_dark_colour(DarkColourID::DARK_500);
     case ColourID::TrackbarChannel:
         return get_base_dark_colour(DarkColourID::DARK_400);
     case ColourID::TrackbarThumb:


### PR DESCRIPTION
This stops active tabs in the Tab stack and Playlist tabs panels changing colour on hover when dark mode is active.

This is being changed as the previous behaviour was different from light mode, and generally unusual.