### PR TITLE
Fix buttons toolbar padding change on system setting change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 
 ### Bug fixes
 
+- A bug where the padding of buttons in the buttons toolbar changed when a
+  notification about a system setting change was received was fixed.
+  [[#562](https://github.com/reupen/columns_ui/pull/562)]
+
 - A bug which stopped ICO files from working as custom hot images in the buttons
   toolbar was fixed. [[#547](https://github.com/reupen/columns_ui/pull/547)]
 

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -300,6 +300,7 @@ private:
     uie::container_window_v3_config get_window_config() override
     {
         uie::container_window_v3_config config(class_name);
+        config.forward_wm_settingchange = false;
         config.invalidate_children_on_move_or_resize = true;
         return config;
     }

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -36,6 +36,7 @@ public:
     uie::container_window_v3_config get_window_config() override
     {
         uie::container_window_v3_config config(L"columns_ui_filter_search_toolbar_smuVaKiMNUs");
+        config.forward_wm_settingchange = false;
         config.invalidate_children_on_move_or_resize = true;
         return config;
     }


### PR DESCRIPTION
This resolves a problem where the padding of buttons in the buttons toolbar became incorrect when certain system settings were changed. In particular, this was observed after starting Adobe Photoshop.

The incorrect behaviour was due to buggy WM_SETTINGCHANGE handling in the Win32 toolbar control.