### PR TITLE
Add audio track toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   foobar2000 2.0 and newer.
   [[#568](https://github.com/reupen/columns_ui/pull/568)]
 
+- An audio track toolbar was added. When a file containing multiple audio tracks
+  (e.g. different languages) is playing, this toolbar allows you to select
+  between those tracks. [[#573](https://github.com/reupen/columns_ui/pull/573)]
+
+  It requires foobar2000 2.0 or newer and is equivalent to the ‘Stream Selector’
+  toolbar in the Default User Interface.
+
 - When mixed size images are used in the buttons toolbar, they are now all
   resized to the same size.
   [[#548](https://github.com/reupen/columns_ui/pull/548)]

--- a/foo_ui_columns/audio_track_toolbar.cpp
+++ b/foo_ui_columns/audio_track_toolbar.cpp
@@ -1,0 +1,120 @@
+#include "pch.h"
+
+#include "drop_down_list_toolbar.h"
+
+namespace cui {
+
+namespace {
+
+constexpr GUID stream_selector_api_id{0x6A6FF0B0, 0x3FB8, 0x4413, {0xBB, 0x76, 0xFF, 0x48, 0xC8, 0x8F, 0xF0, 0x57}};
+
+fb2k::toolbarDropDown::ptr get_stream_selector_api()
+{
+    for (auto api : fb2k::toolbarDropDown::enumerate()) {
+        if (api->getGuid() == stream_selector_api_id)
+            return api;
+    }
+
+    return {};
+}
+
+struct AudioTrackToolbarArgs {
+    using ID = size_t;
+    using ItemList = std::vector<std::tuple<ID, std::string>>;
+
+    class AudioTrackCallback : public fb2k::toolbarDropDownNotify {
+    public:
+        void contentChanged() override { DropDownListToolbar<AudioTrackToolbarArgs>::s_refresh_all_items_safe(); }
+        void selectionChanged() override { DropDownListToolbar<AudioTrackToolbarArgs>::s_update_active_item_safe(); }
+    };
+
+    static auto get_items()
+    {
+        ItemList items;
+
+        const auto api = get_stream_selector_api();
+
+        if (api.is_empty())
+            return items;
+
+        for (const auto index : std::ranges::views::iota(size_t{0}, api->getNumValues())) {
+            pfc::string8 value;
+            api->getValue(index, value);
+
+            if (stricmp_utf8(value, "not playing") != 0)
+                items.emplace_back(index, value);
+        }
+
+        return items;
+    }
+
+    static ID get_active_item()
+    {
+        const auto api = get_stream_selector_api();
+
+        if (api.is_empty())
+            return ID{};
+
+        return api->getSelectedIndex();
+    }
+
+    static void set_active_item(ID id)
+    {
+        const auto api = get_stream_selector_api();
+
+        if (api.is_empty())
+            return;
+
+        api->setSelectedIndex(id);
+    }
+
+    static void on_click()
+    {
+        const auto api = get_stream_selector_api();
+
+        if (api.is_empty())
+            return;
+
+        api->onDropDown();
+    }
+
+    static void get_menu_items(uie::menu_hook_t& p_hook) {}
+
+    static void on_first_window_created()
+    {
+        const auto api = get_stream_selector_api();
+
+        if (api.is_empty())
+            return;
+
+        s_callback = std::make_unique<AudioTrackCallback>();
+        api->addNotify(s_callback.get());
+    }
+
+    static void on_last_window_destroyed()
+    {
+        const auto api = get_stream_selector_api();
+
+        if (api.is_empty())
+            return;
+
+        api->removeNotify(s_callback.get());
+        s_callback.reset();
+    }
+
+    static bool is_available() { return get_stream_selector_api().is_valid(); }
+    inline static std::unique_ptr<AudioTrackCallback> s_callback;
+    static constexpr bool refresh_on_click = false;
+    static constexpr auto no_items_text = "(not playing)"sv;
+    static constexpr const wchar_t* class_name{L"columns_ui_audio_track_toolbar_xvkMz8coqQY"};
+    static constexpr const char* name{"Audio track"};
+    static constexpr GUID extension_guid{0xee6d2fed, 0x158, 0x4fa9, {0xaf, 0x1c, 0x72, 0xf2, 0x34, 0x56, 0xb7, 0x8c}};
+    static constexpr GUID colour_client_id{0x91f80f2e, 0x4e58, 0x4600, {0xba, 0x4f, 0x13, 0xc7, 0xeb, 0x5, 0x7d, 0xf0}};
+    static constexpr GUID font_client_id{0xe547f854, 0x1efe, 0x4fca, {0x8d, 0x42, 0xe4, 0x24, 0x99, 0x12, 0xbc, 0x9a}};
+};
+
+ui_extension::window_factory<DropDownListToolbar<AudioTrackToolbarArgs>> _;
+
+} // namespace
+
+} // namespace cui

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -324,8 +324,13 @@ LRESULT DropDownListToolbar<ToolbarArgs>::on_message(HWND wnd, UINT msg, WPARAM 
             break;
         }
         case ID_COMBOBOX | CBN_DROPDOWN << 16: {
+            if constexpr (requires() { ToolbarArgs::on_click(); }) {
+                ToolbarArgs::on_click();
+            }
+
             if (ToolbarArgs::refresh_on_click)
                 refresh_all_items();
+
             break;
         }
         }

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -246,6 +246,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="artwork_helpers.cpp" />
+    <ClCompile Include="audio_track_toolbar.cpp" />
     <ClCompile Include="buttons_button.cpp" />
     <ClCompile Include="buttons_button_image.cpp" />
     <ClCompile Include="buttons_command_picker.cpp" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -112,6 +112,9 @@
     <Filter Include="Colours and fonts">
       <UniqueIdentifier>{15a560a7-d486-480b-9ce9-1081f9083d13}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Audio track toolbar">
+      <UniqueIdentifier>{4b7b57c0-5b8d-4d71-afec-4ecb83b14bad}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="config.cpp">
@@ -565,6 +568,9 @@
     </ClCompile>
     <ClCompile Include="tab_status_pane.cpp">
       <Filter>Config UI</Filter>
+    </ClCompile>
+    <ClCompile Include="audio_track_toolbar.cpp">
+      <Filter>Audio track toolbar</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <span>
 #include <string_view>


### PR DESCRIPTION
This adds a new toolbar called 'Audio track', which lets you select which audio track should be played if the playing file has multiple audio tracks (e.g. different languages).

This requires foobar2000 2.0 and is equivalent to 'Stream Selector' in the Default User Interface.

~Note: This requires the foobar2000 2.0 SDK which hasn't been merged into my repos yet.~