### PR TITLE
Add dark mode support to some preference pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   It requires foobar2000 2.0 or newer and is equivalent to the ‘Stream Selector’
   toolbar in the Default User Interface.
 
+- Dark mode support was added for certain preference pages in foobar2000 2.0.
+  [[#582](https://github.com/reupen/columns_ui/pull/582)]
+
+  (Other pages and dialogue boxes will follow in a future release.)
+
 - When mixed size images are used in the buttons toolbar, they are now all
   resized to the same size.
   [[#548](https://github.com/reupen/columns_ui/pull/548)]

--- a/foo_ui_columns/config.cpp
+++ b/foo_ui_columns/config.cpp
@@ -61,12 +61,12 @@ const GUID& config_get_main_guid()
 namespace cui {
 namespace prefs {
 
-service_factory_single_t<PreferencesTabsHost> page_main("Columns UI", g_tabs, std::size(g_tabs),
-    g_guid_columns_ui_preferences_page, preferences_page::guid_display, &cfg_root_page_active_tab);
+service_factory_single_t<PreferencesTabsHost> page_main(
+    "Columns UI", g_tabs, g_guid_columns_ui_preferences_page, preferences_page::guid_display, cfg_root_page_active_tab);
 service_factory_single_t<PreferencesTabsHost> page_playlist_view("Playlist view", g_tabs_playlist_view,
-    std::size(g_tabs_playlist_view), guid_playlist_view_page, g_guid_columns_ui_preferences_page, &cfg_child_playlist);
+    guid_playlist_view_page, g_guid_columns_ui_preferences_page, cfg_child_playlist, false);
 service_factory_single_t<PreferencesTabsHost> page_playlist_switcher("Playlist switcher", g_tabs_panels,
-    std::size(g_tabs_panels), guid_playlist_switcher_page, g_guid_columns_ui_preferences_page, &cfg_child_panels);
+    guid_playlist_switcher_page, g_guid_columns_ui_preferences_page, cfg_child_panels);
 
 } // namespace prefs
 } // namespace cui

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -201,7 +201,7 @@ constexpr GUID g_guid_colour_preferences
     = {0x41e6d7ed, 0xa1dc, 0x4d84, {0x9b, 0xc9, 0x35, 0x2d, 0xaf, 0x77, 0x88, 0xb0}};
 
 static service_factory_single_t<PreferencesTabsHost> g_config_tabs("Colours and fonts", g_tabs_appearance,
-    std::size(g_tabs_appearance), g_guid_colour_preferences, g_guid_columns_ui_preferences_page, &cfg_child_appearance);
+    g_guid_colour_preferences, g_guid_columns_ui_preferences_page, cfg_child_appearance, true);
 
 // {15FD4FF9-0622-4077-BFBB-DF0102B6A068}
 const GUID cui::colours::ColourManagerData::g_cfg_guid

--- a/foo_ui_columns/config_columns_v2.h
+++ b/foo_ui_columns/config_columns_v2.h
@@ -48,7 +48,7 @@ public:
 private:
     TabColumns() = default;
 
-    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
     ColumnList m_columns;
     bool initialising{false};
 };

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -220,7 +220,7 @@ public:
     }
 
 private:
-    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
     bool m_initialising{false};
 } g_tab_filter_fields;
 
@@ -297,7 +297,7 @@ public:
     }
 
 private:
-    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
     bool m_initialising{false};
 } g_tab_filter_appearance;
 
@@ -406,7 +406,7 @@ public:
     }
 
 private:
-    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
     bool m_initialising{false};
 } g_tab_filter_behaviour;
 
@@ -416,5 +416,5 @@ cfg_int cfg_child_filters({0xe57a430e, 0x51bb, 0x4fcc, {0xb0, 0xbc, 0x9d, 0x22, 
 
 constexpr GUID guid_filters_page = {0x71a480e2, 0x9007, 0x4315, {0x8d, 0xf3, 0x81, 0x63, 0x6c, 0x74, 0xa, 0xad}};
 
-service_factory_single_t<PreferencesTabsHost> page_filters("Filters", g_tabs_filters, std::size(g_tabs_filters),
-    guid_filters_page, g_guid_columns_ui_preferences_page, &cfg_child_filters);
+service_factory_single_t<PreferencesTabsHost> page_filters(
+    "Filters", g_tabs_filters, guid_filters_page, g_guid_columns_ui_preferences_page, cfg_child_filters, false);

--- a/foo_ui_columns/config_layout.cpp
+++ b/foo_ui_columns/config_layout.cpp
@@ -14,5 +14,5 @@ PreferencesTab* tabs_layout[] = {&g_tab_layout, &g_tab_layout_misc};
 
 cfg_int cfg_child_layout(GUID{0xe5c3db3c, 0xccd8, 0x4c8e, {0x9f, 0x74, 0xdf, 0xcc, 0x57, 0x6a, 0x41, 0xea}}, 0);
 
-service_factory_single_t<PreferencesTabsHost> page_layout("Layout", tabs_layout, std::size(tabs_layout),
-    cui::prefs::layout_page_guid, g_guid_columns_ui_preferences_page, &cfg_child_layout);
+service_factory_single_t<PreferencesTabsHost> page_layout(
+    "Layout", tabs_layout, cui::prefs::layout_page_guid, g_guid_columns_ui_preferences_page, cfg_child_layout);

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -703,7 +703,7 @@ public:
 
 private:
     BOOL ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
 };
 } // namespace cui::panels::playlist_view
 

--- a/foo_ui_columns/tab_display2.cpp
+++ b/foo_ui_columns/tab_display2.cpp
@@ -145,7 +145,7 @@ public:
 private:
     bool m_initialised{};
     std::vector<MenuItemInfo> m_menu_cache;
-    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
 } g_tab_display2;
 
 PreferencesTab* g_get_tab_display2()

--- a/foo_ui_columns/tab_global.cpp
+++ b/foo_ui_columns/tab_global.cpp
@@ -166,7 +166,7 @@ public:
 
 private:
     cui::prefs::EditControlSelectAllHook m_edit_control_hook;
-    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
 } g_tab_global;
 
 PreferencesTab* g_get_tab_global()

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -61,7 +61,7 @@ public:
 
 private:
     bool m_initialised{};
-    cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
+    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
 } g_tab_pview_artwork;
 
 PreferencesTab* g_get_tab_pview_artwork()


### PR DESCRIPTION
This adds dark mode support to the root, Colours and fonts, Layout and Playlist switcher preference pages using foobar2000 core dark mode support.

Some other pages have been left out for now due to list view complexities. Various dialogue boxes also still need to be updated.