### PR TITLE
Improve development build download instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Stable and pre-release versions can be downloaded from the
 ### Development versions
 
 If you’re logged into GitHub, you can download the latest development version by
-clicking on the GitHub Actions badge above, and then clicking on the last
-successful build and scrolling down to the link named 'Component package
-(release)' at the bottom.
+visiting the
+[list of recent GitHub Actions builds](https://github.com/reupen/columns_ui/actions/workflows/build.yml?query=branch%3Amaster),
+clicking on the most recent entry with a green tick, and then scrolling down to
+the links named ‘Component package (release, win32)’ and ‘Component package
+(release, x64)’ at the bottom.
 
 Development versions may be buggier than formal releases; if you encounter a
 problem, open an issue.


### PR DESCRIPTION
This makes the development build download instructions in README a bit clearer.