### PR TITLE
Fix crashes when changing colours and fonts in foobar2000 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - Various built-in pop-up foobar2000 windows (e.g. Album List, Search, Playlist
   Manager) now use Columns UI mode, colour and font settings when Columns UI is
   active. [[#574](https://github.com/reupen/columns_ui/pull/574),
-  [#579](https://github.com/reupen/columns_ui/pull/579)]
+  [#579](https://github.com/reupen/columns_ui/pull/579),
+  [#590](https://github.com/reupen/columns_ui/pull/590)]
 
   This requires foobar2000 2.0 or newer. For colours, only the text, background
   and selection background colours can be explicitly configured. The equivalent

--- a/foo_ui_columns/user_interface_impl.cpp
+++ b/foo_ui_columns/user_interface_impl.cpp
@@ -108,8 +108,16 @@ public:
     }
     uint32_t get_supported_bools() const override { return 0; };
     bool get_themes_supported() const override { return false; };
-    void on_colour_changed(uint32_t changed_items_mask) const override { ui_config_manager_impl->on_colours_changed(); }
-    void on_bool_changed(uint32_t changed_items_mask) const override { ui_config_manager_impl->on_colours_changed(); }
+    void on_colour_changed(uint32_t changed_items_mask) const override
+    {
+        if (ui_config_manager_impl.is_valid())
+            ui_config_manager_impl->on_colours_changed();
+    }
+    void on_bool_changed(uint32_t changed_items_mask) const override
+    {
+        if (ui_config_manager_impl.is_valid())
+            ui_config_manager_impl->on_colours_changed();
+    }
 };
 
 class CoreConsoleFontClient : public fonts::client {
@@ -117,7 +125,11 @@ public:
     const GUID& get_client_guid() const override { return core_console_font_client_id; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Core: Console"; };
     fonts::font_type_t get_default_font_type() const override { return fonts::font_type_labels; }
-    void on_font_changed() const override { ui_config_manager_impl->on_fonts_changed(); }
+    void on_font_changed() const override
+    {
+        if (ui_config_manager_impl.is_valid())
+            ui_config_manager_impl->on_fonts_changed();
+    }
 };
 
 class CoreDefaultFontClient : public fonts::client {
@@ -125,7 +137,11 @@ public:
     const GUID& get_client_guid() const override { return core_default_font_client_id; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Core: Default"; };
     fonts::font_type_t get_default_font_type() const override { return fonts::font_type_labels; }
-    void on_font_changed() const override { ui_config_manager_impl->on_fonts_changed(); }
+    void on_font_changed() const override
+    {
+        if (ui_config_manager_impl.is_valid())
+            ui_config_manager_impl->on_fonts_changed();
+    }
 };
 
 class CoreListsFontClient : public fonts::client {
@@ -133,7 +149,11 @@ public:
     const GUID& get_client_guid() const override { return core_lists_font_client_id; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Core: List items"; };
     fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
-    void on_font_changed() const override { ui_config_manager_impl->on_fonts_changed(); }
+    void on_font_changed() const override
+    {
+        if (ui_config_manager_impl.is_valid())
+            ui_config_manager_impl->on_fonts_changed();
+    }
 };
 
 class UserInterfaceImpl : public user_interface_v3 {


### PR DESCRIPTION
Resolves #589

This fixes crashes when changing colours and fonts in foobar2000 1.x.

This was caused by #574.