### PR TITLE
Optimise calculation of total length of tracks in foobar2000 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Performance under foobar2000 2.0 was improved.
   [[#585](https://github.com/reupen/columns_ui/pull/585),
   [#587](https://github.com/reupen/columns_ui/pull/587),
-  [#588](https://github.com/reupen/columns_ui/pull/588)]
+  [#588](https://github.com/reupen/columns_ui/pull/588),
+  [#591](https://github.com/reupen/columns_ui/pull/591)]
 
 - Various built-in pop-up foobar2000 windows (e.g. Album List, Search, Playlist
   Manager) now use Columns UI mode, colour and font settings when Columns UI is

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -426,6 +426,7 @@
     <ClInclude Include="item_details.h" />
     <ClInclude Include="item_properties.h" />
     <ClInclude Include="menu_helpers.h" />
+    <ClInclude Include="metadb_helpers.h" />
     <ClInclude Include="mw_drop_target.h" />
     <ClInclude Include="system_appearance_manager.h" />
     <ClInclude Include="button_items.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -818,6 +818,9 @@
     <ClInclude Include="colour_utils.h">
       <Filter>Colours and fonts</Filter>
     </ClInclude>
+    <ClInclude Include="metadb_helpers.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".clang-format" />

--- a/foo_ui_columns/metadb_helpers.h
+++ b/foo_ui_columns/metadb_helpers.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace cui::helpers {
+
+double calculate_tracks_total_length(auto& tracks)
+{
+    const auto metadb_v2_api = metadb_v2::tryGet();
+
+    if (!metadb_v2_api.is_valid())
+        return metadb_handle_list_helper::calc_total_duration(tracks);
+
+    std::vector<double> lengths(tracks.size());
+    metadb_v2_api->queryMultiParallel_(tracks, [&lengths](size_t index, const metadb_v2_rec_t& rec) {
+        if (rec.info.is_valid())
+            lengths[index] = rec.info->info().get_length();
+    });
+    return std::reduce(lengths.begin(), lengths.end());
+}
+
+} // namespace cui::helpers

--- a/foo_ui_columns/playlist_switcher_title_formatting.cpp
+++ b/foo_ui_columns/playlist_switcher_title_formatting.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "playlist_switcher_title_formatting.h"
+
+#include "metadb_helpers.h"
 #include "title_formatting.h"
 
 namespace cui {
@@ -21,7 +23,7 @@ public:
     double total_duration()
     {
         if (!m_total_duration)
-            m_total_duration = tracks().calc_total_duration();
+            m_total_duration = helpers::calculate_tracks_total_length(tracks());
 
         return *m_total_duration;
     }

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -2,6 +2,7 @@
 #include "status_bar.h"
 
 #include "main_window.h"
+#include "metadb_helpers.h"
 
 extern HWND g_status;
 
@@ -199,7 +200,7 @@ std::string get_selected_length_text(unsigned dp = 0)
     sels.prealloc(count);
 
     playlist_api->activeplaylist_get_selected_items(sels);
-    length = sels.calc_total_duration();
+    length = helpers::calculate_tracks_total_length(sels);
 
     return pfc::format_time_ex(length, dp).get_ptr();
 }

--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -5,6 +5,7 @@
 
 #include "dark_mode.h"
 #include "menu_items.h"
+#include "metadb_helpers.h"
 
 namespace cui::status_pane {
 
@@ -114,7 +115,7 @@ void StatusPane::get_length_data(bool& p_selection, size_t& p_count, pfc::string
     else
         playlist_api->activeplaylist_get_all_items(sels);
 
-    length = sels.calc_total_duration();
+    length = helpers::calculate_tracks_total_length(sels);
 
     p_out = pfc::format_time_ex(length, 0);
     p_count = count;


### PR DESCRIPTION
This optimises the calculation of the total length of multiple tracks in the status bar, status pane and playlist switcher, using the method that performed the best (at least for me).