### PR TITLE
Add dark mode support to Filter preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@
   toolbar in the Default User Interface.
 
 - Dark mode support was added for certain preference pages in foobar2000 2.0.
-  [[#582](https://github.com/reupen/columns_ui/pull/582)]
+  [[#582](https://github.com/reupen/columns_ui/pull/582),
+  [#592](https://github.com/reupen/columns_ui/pull/592)]
 
   (Other pages and dialogue boxes will follow in a future release.)
 

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -2,8 +2,9 @@
 #include "filter.h"
 #include "filter_config_var.h"
 #include "config.h"
+#include "core_dark_list_view.h"
 
-class FieldList : public uih::ListView {
+class FieldList : public cui::helpers::CoreDarkListView {
 public:
     size_t m_edit_index, m_edit_column;
     FieldList() : m_edit_index(pfc_infinite), m_edit_column(pfc_infinite) {}
@@ -69,8 +70,6 @@ public:
         m_edit_column = pfc_infinite;
         m_edit_index = pfc_infinite;
     }
-
-private:
 };
 
 static class TabFilterFields : public PreferencesTab {
@@ -220,7 +219,7 @@ public:
     }
 
 private:
-    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
+    cui::prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}};
     bool m_initialising{false};
 } g_tab_filter_fields;
 
@@ -297,7 +296,7 @@ public:
     }
 
 private:
-    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
+    cui::prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}};
     bool m_initialising{false};
 } g_tab_filter_appearance;
 
@@ -406,7 +405,7 @@ public:
     }
 
 private:
-    cui::prefs::PreferencesTabHelper m_helper{{{IDC_TITLE1}}, false};
+    cui::prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}};
     bool m_initialising{false};
 } g_tab_filter_behaviour;
 
@@ -417,4 +416,4 @@ cfg_int cfg_child_filters({0xe57a430e, 0x51bb, 0x4fcc, {0xb0, 0xbc, 0x9d, 0x22, 
 constexpr GUID guid_filters_page = {0x71a480e2, 0x9007, 0x4315, {0x8d, 0xf3, 0x81, 0x63, 0x6c, 0x74, 0xa, 0xad}};
 
 service_factory_single_t<PreferencesTabsHost> page_filters(
-    "Filters", g_tabs_filters, guid_filters_page, g_guid_columns_ui_preferences_page, cfg_child_filters, false);
+    "Filters", g_tabs_filters, guid_filters_page, g_guid_columns_ui_preferences_page, cfg_child_filters);

--- a/foo_ui_columns/core_dark_list_view.cpp
+++ b/foo_ui_columns/core_dark_list_view.cpp
@@ -1,0 +1,46 @@
+#include "pch.h"
+
+#include "core_dark_list_view.h"
+#include "dark_mode.h"
+
+namespace cui::helpers {
+
+void CoreDarkListView::notify_on_initialisation()
+{
+    const auto manager = ui_config_manager::tryGet();
+
+    if (!manager.is_valid())
+        return;
+
+    set_use_dark_mode(manager->is_dark_mode());
+    m_ui_config_callback = std::make_unique<UIConfigCallback>(this, manager);
+}
+
+void CoreDarkListView::notify_on_destroy()
+{
+    m_ui_config_callback.reset();
+}
+
+void CoreDarkListView::render_get_colour_data(ColourData& p_out)
+{
+    const auto manager = ui_config_manager::tryGet();
+
+    if (!manager.is_valid() || !manager->is_dark_mode()) {
+        ListView::render_get_colour_data(p_out);
+        return;
+    }
+
+    p_out.m_themed = true;
+    p_out.m_use_custom_active_item_frame = false;
+    p_out.m_text = cui::dark::get_dark_system_colour(COLOR_WINDOWTEXT);
+    p_out.m_selection_text = cui::dark::get_dark_system_colour(COLOR_HIGHLIGHTTEXT);
+    p_out.m_background = cui::dark::get_dark_system_colour(COLOR_WINDOW);
+    p_out.m_selection_background = cui::dark::get_dark_system_colour(COLOR_HIGHLIGHT);
+    p_out.m_inactive_selection_text = cui::dark::get_dark_system_colour(COLOR_BTNTEXT);
+    p_out.m_inactive_selection_background = cui::dark::get_dark_system_colour(COLOR_BTNFACE);
+    p_out.m_active_item_frame = cui::dark::get_dark_system_colour(COLOR_WINDOWFRAME);
+    p_out.m_group_text = get_group_text_colour_default();
+    p_out.m_group_background = p_out.m_background;
+}
+
+} // namespace cui::helpers

--- a/foo_ui_columns/core_dark_list_view.h
+++ b/foo_ui_columns/core_dark_list_view.h
@@ -1,0 +1,33 @@
+#pragma once
+
+namespace cui::helpers {
+
+class CoreDarkListView : public uih::ListView {
+    class UIConfigCallback : public ui_config_callback {
+    public:
+        UIConfigCallback(CoreDarkListView* list_view, ui_config_manager::ptr manager)
+            : m_list_view(list_view)
+            , m_manager(std::move(manager))
+        {
+            m_manager->add_callback(this);
+        }
+
+        ~UIConfigCallback() { m_manager->remove_callback(this); }
+
+        void ui_fonts_changed() override {}
+
+        void ui_colors_changed() override { m_list_view->set_use_dark_mode(m_manager->is_dark_mode()); }
+
+    private:
+        CoreDarkListView* m_list_view{};
+        ui_config_manager::ptr m_manager;
+    };
+
+    void notify_on_initialisation() override;
+    void notify_on_destroy() override;
+    void render_get_colour_data(ColourData& p_out) override;
+
+    std::unique_ptr<UIConfigCallback> m_ui_config_callback;
+};
+
+} // namespace cui::helpers

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -258,8 +258,6 @@ LazyResource<wil::unique_hbrush> get_colour_brush_lazy(ColourID colour_id, bool 
     return LazyResource<wil::unique_hbrush>{[colour_id, is_dark] { return get_colour_brush(colour_id, is_dark); }};
 }
 
-namespace {
-
 COLORREF get_dark_system_colour(int system_colour_id)
 {
     // Unfortunately, these are hard-coded as there doesn't seem to be a simple
@@ -281,8 +279,6 @@ COLORREF get_dark_system_colour(int system_colour_id)
         return RGB(255, 0, 0);
     }
 }
-
-} // namespace
 
 COLORREF get_system_colour(int system_colour_id, bool is_dark)
 {

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -81,6 +81,7 @@ void set_titlebar_mode(HWND wnd, bool is_dark);
 [[nodiscard]] wil::unique_hbrush get_colour_brush(ColourID colour_id, bool is_dark);
 [[nodiscard]] LazyResource<wil::unique_hbrush> get_colour_brush_lazy(ColourID colour_id, bool is_dark);
 
+[[nodiscard]] COLORREF get_dark_system_colour(int system_colour_id);
 [[nodiscard]] COLORREF get_system_colour(int system_colour_id, bool is_dark);
 [[nodiscard]] wil::unique_hbrush get_system_colour_brush(int system_colour_id, bool is_dark);
 

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -258,6 +258,7 @@
     <ClCompile Include="colour_utils.cpp" />
     <ClCompile Include="columns_v2.cpp" />
     <ClCompile Include="colour_manager.cpp" />
+    <ClCompile Include="core_dark_list_view.cpp" />
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="system_appearance_manager.cpp" />
     <ClCompile Include="dark_mode.cpp" />
@@ -420,6 +421,7 @@
     <ClInclude Include="config_appearance.h" />
     <ClInclude Include="config_defaults.h" />
     <ClInclude Include="config_items.h" />
+    <ClInclude Include="core_dark_list_view.h" />
     <ClInclude Include="font_manager_data.h" />
     <ClInclude Include="gdiplus.h" />
     <ClInclude Include="get_msg_hook.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -572,6 +572,9 @@
     <ClCompile Include="audio_track_toolbar.cpp">
       <Filter>Audio track toolbar</Filter>
     </ClCompile>
+    <ClCompile Include="core_dark_list_view.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -819,6 +822,9 @@
       <Filter>Colours and fonts</Filter>
     </ClInclude>
     <ClInclude Include="metadb_helpers.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="core_dark_list_view.h">
       <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This adds support for dark mode to Filter preferences in foobar2000 2.0.