### PR TITLE
Add dark mode to list view inline editing edit box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
 
   (Other pages and dialogue boxes will follow in a future release.)
 
+- The edit box that appears during inline editing in Columns UI list views now
+  has a dark appearance when dark mode is on.
+  [[#593](https://github.com/reupen/columns_ui/pull/593)]
+
 - When mixed size images are used in the buttons toolbar, they are now all
   resized to the same size.
   [[#548](https://github.com/reupen/columns_ui/pull/548)]
@@ -89,6 +93,10 @@
 - The initial widths of the list view columns in the Buttons and Item properties
   options dialogue boxes were updated to scale with the system DPI setting.
   [[#550](https://github.com/reupen/columns_ui/pull/550)]
+
+- Rendering glitches in the edit box that appears during inline editing in
+  Columns UI list views were fixed.
+  [[#593](https://github.com/reupen/columns_ui/pull/593)]
 
 - A truncated label in the Item properties options dialogue box was corrected.
   [[#550](https://github.com/reupen/columns_ui/pull/550)]

--- a/foo_ui_columns/core_dark_list_view.cpp
+++ b/foo_ui_columns/core_dark_list_view.cpp
@@ -13,6 +13,8 @@ void CoreDarkListView::notify_on_initialisation()
         return;
 
     set_use_dark_mode(manager->is_dark_mode());
+    set_dark_edit_colours(
+        cui::dark::get_dark_system_colour(COLOR_WINDOWTEXT), cui::dark::get_dark_system_colour(COLOR_WINDOW));
     m_ui_config_callback = std::make_unique<UIConfigCallback>(this, manager);
 }
 

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "dark_mode.h"
+
 template <typename t_appearance_client, typename t_window = uie::window>
 class ListViewPanelBase
     : public uih::ListView
@@ -9,6 +11,8 @@ public:
         std::unique_ptr<uih::lv::RendererBase> renderer = std::make_unique<uih::lv::DefaultRenderer>())
         : ListView(std::move(renderer))
     {
+        set_dark_edit_colours(
+            cui::dark::get_dark_system_colour(COLOR_WINDOWTEXT), cui::dark::get_dark_system_colour(COLOR_WINDOW));
     }
 
     HWND create_or_transfer_window(


### PR DESCRIPTION
This makes the edit box used for inline editing in the various Columns UI list views (playlist view, playlist switcher, filters, item properties, filter preferences) have a dark appearance when dark mode is on.

It also fixes a glitch with the right border of the edit box at high DPIs, and prevents glitching during the initial render of the edit box.