### PR TITLE
Update Windows 11 build number for dark mode support

### DIFF
--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -47,7 +47,7 @@ bool are_private_apis_allowed()
     if (osvi.dwMajorVersion != 10 || osvi.dwMinorVersion != 0)
         return false;
 
-    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22598;
+    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22622;
 }
 
 void set_app_mode(PreferredAppMode mode)


### PR DESCRIPTION
As 22H2 is now generally available and dark mode menus don't work, the supported build version needs a bump.

https://blogs.windows.com/windowsexperience/2022/09/20/available-today-the-windows-11-2022-update/

edit: urgh, please excuse the typo in the commit message. 
