### PR TITLE
Fix 64-bit Tab stack crash when no tab is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+- A crash in 64-bit builds after adding a Tab stack to the layout was fixed.
+  [[#606](https://github.com/reupen/columns_ui/pull/606)]
+
 ## 2.0.0-alpha.2
 
 ### Features

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -126,8 +126,8 @@ public:
     static void g_on_font_change();
     void on_size_changed(unsigned width, unsigned height);
     void on_size_changed();
-    void on_active_tab_changing(size_t index_from);
-    void on_active_tab_changed(size_t index_to);
+    void on_active_tab_changing(int index_from);
+    void on_active_tab_changed(int index_to);
 
     TabStackPanel() = default;
 
@@ -136,7 +136,7 @@ private:
     PanelList m_active_panels;
     HWND m_wnd_tabs{nullptr};
     HWND m_up_down_control_wnd{};
-    size_t m_active_tab{(std::numeric_limits<size_t>::max)()};
+    std::optional<size_t> m_active_tab;
     static std::vector<service_ptr_t<t_self>> g_windows;
     uie::size_limit_t m_size_limits;
     int32_t m_mousewheel_delta{NULL};


### PR DESCRIPTION
This resolves a crash (due to an unhandled exception) in 64-bit builds that occurred when a Tab stack doesn't have an active tab (e.g. contains no tabs).