### PR TITLE
Fix layout selection in Quick setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Change log
 
-## Development version
+## 2.0.0-alpha.3
 
 ### Bug fixes
 
 - A crash in 64-bit builds after adding a Tab stack to the layout was fixed.
   [[#606](https://github.com/reupen/columns_ui/pull/606)]
+
+- A problem in the Quick setup dialogue box where selecting a layout preset had
+  no effect was fixed. [[#607](https://github.com/reupen/columns_ui/pull/607)]
 
 ## 2.0.0-alpha.2
 

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -159,6 +159,33 @@ INT_PTR QuickSetupDialog::SetupDialogProc(HWND wnd, UINT msg, WPARAM wp, LPARAM 
         }
         }
         break;
+    case WM_NOTIFY: {
+        auto lpnm = (LPNMHDR)lp;
+        switch (lpnm->idFrom) {
+        case IDC_LIST: {
+            switch (lpnm->code) {
+            case LVN_ITEMCHANGED: {
+                auto lpnmlv = (LPNMLISTVIEW)lp;
+                if (lpnmlv->iItem != -1 && lpnmlv->iItem >= 0 && (size_t)lpnmlv->iItem < m_presets.get_count()) {
+                    if ((lpnmlv->uNewState & LVIS_SELECTED) && !(lpnmlv->uOldState & LVIS_SELECTED)) {
+                        uie::splitter_item_ptr ptr;
+                        m_presets[lpnmlv->iItem].get(ptr);
+                        cfg_layout.set_preset(cfg_layout.get_active(), ptr.get_ptr());
+                        m_preset_changed = true;
+                    }
+                }
+                return 0;
+            }
+            default:
+                break;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+        break;
+    }
     case WM_CLOSE:
         DestroyWindow(wnd);
         return 0;


### PR DESCRIPTION
This fixes a regression in #595 that made selecting a layout preset in the Quick setup dialogue box have no effect.