### PR TITLE
Optimise Filter panel handling of media library changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+## Development version
+
+### Features
+
+- The performance of the Filter panel when handling dynamic media library
+  changes was improved. [[#608](https://github.com/reupen/columns_ui/pull/608)]
+
+  This includes reducing Filter panel initialisation time in foobar2000 2.0
+  during foobar2000 start-up.
+
 ## 2.0.0-alpha.3
 
 ### Bug fixes

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -381,7 +381,7 @@ void FilterPanel::g_update_subsequent_filters(const pfc::list_base_const_t<Filte
         handles.remove_all();
         windows[i]->get_initial_handles(handles);
         if (b_check_needs_update) {
-            metadb_handle_list items1(windows[i]->m_nodes[0].m_handles);
+            metadb_handle_list items1(windows[i]->m_nodes[0]->m_handles);
             handles.sort_by_pointer();
             items1.sort_by_pointer();
             if (!pfc::comparator_array<>::compare(items1, handles)) {
@@ -455,7 +455,7 @@ void FilterPanel::notify_update_item_data(size_t index)
     auto& subitems = get_item_subitems(index);
     subitems.resize(1);
 
-    subitems[0] = pfc::stringcvt::string_utf8_from_wide(m_nodes[index].m_value.c_str());
+    subitems[0] = pfc::stringcvt::string_utf8_from_wide(m_nodes[index]->m_value.c_str());
 }
 
 size_t FilterPanel::get_highlight_item()
@@ -505,15 +505,15 @@ void FilterPanel::get_selection_handles(
         if (get_item_selected(i)) {
             b_found = true;
             if (b_sort)
-                m_nodes[i].ensure_handles_sorted();
-            p_out.add_items(m_nodes[i].m_handles);
+                m_nodes[i]->ensure_handles_sorted();
+            p_out.add_items(m_nodes[i]->m_handles);
         }
     }
     if (!b_found) {
         if (fallback) {
             if (b_sort)
-                m_nodes[0].ensure_handles_sorted();
-            p_out.add_items(m_nodes[0].m_handles);
+                m_nodes[0]->ensure_handles_sorted();
+            p_out.add_items(m_nodes[0]->m_handles);
         }
     } else {
         fbh::metadb_handle_list_remove_duplicates(p_out);
@@ -535,7 +535,7 @@ void FilterPanel::do_items_action(const bit_array& p_nodes, Action action)
     size_t count = m_nodes.get_count();
     for (i = 0; i < count; i++)
         if (p_nodes[i])
-            handles.add_items(m_nodes[i].m_handles);
+            handles.add_items(m_nodes[i]->m_handles);
 
     if (!handles.get_count())
         return;
@@ -571,7 +571,7 @@ void FilterPanel::do_items_action(const bit_array& p_nodes, Action action)
                 if (p_nodes[i]) {
                     if (playlist_name.get_length())
                         playlist_name << ", ";
-                    playlist_name << pfc::stringcvt::string_utf8_from_wide(m_nodes[i].m_value.c_str());
+                    playlist_name << pfc::stringcvt::string_utf8_from_wide(m_nodes[i]->m_value.c_str());
                 }
             }
         }
@@ -683,7 +683,7 @@ void FilterPanel::update_first_node_text(bool b_update)
                 temp << "s";
             temp << ")";
         }
-        m_nodes[0].m_value = pfc::stringcvt::string_wide_from_utf8(temp).get_ptr();
+        m_nodes[0]->m_value = pfc::stringcvt::string_wide_from_utf8(temp).get_ptr();
         if (b_update)
             update_items(0, 1);
     }
@@ -727,14 +727,14 @@ void Node::remove_handles(metadb_handle_list_cref to_remove)
     m_handles.remove_mask(remove_mask.get_ptr());
 }
 
-int Node::g_compare(const Node& i1, const WCHAR* i2)
+int Node::g_compare(const Node::Ptr& i1, const WCHAR* i2)
 {
-    return StrCmpLogicalW(i1.m_value.c_str(), i2);
+    return StrCmpLogicalW(i1->m_value.c_str(), i2);
 }
 
-int Node::g_compare_ptr_with_node(const Node& i1, const Node& i2)
+int Node::g_compare_ptr_with_node(const Node::Ptr& i1, const Node::Ptr& i2)
 {
-    return StrCmpLogicalW(i1.m_value.c_str(), i2.m_value.c_str());
+    return StrCmpLogicalW(i1->m_value.c_str(), i2->m_value.c_str());
 }
 
 void FilterPanel::refresh_stream()

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -29,6 +29,8 @@ public:
 
 class Node {
 public:
+    using Ptr = std::shared_ptr<Node>;
+
     metadb_handle_list_t<pfc::alloc_fast_aggressive> m_handles;
     std::wstring m_value;
     bool m_handles_sorted{false};
@@ -36,8 +38,8 @@ public:
     void ensure_handles_sorted();
     void remove_handles(metadb_handle_list_cref to_remove);
 
-    static int g_compare(const Node& i1, const WCHAR* i2);
-    static int g_compare_ptr_with_node(const Node& i1, const Node& i2);
+    static int g_compare(const Node::Ptr& i1, const WCHAR* i2);
+    static int g_compare_ptr_with_node(const Node::Ptr& i1, const Node::Ptr& i2);
 };
 
 class FieldData {
@@ -224,7 +226,7 @@ private:
     pfc::string8 m_edit_previous_value;
     std::vector<pfc::string8> m_edit_fields;
     metadb_handle_list m_edit_handles;
-    pfc::list_t<Node> m_nodes;
+    pfc::list_t<Node::Ptr> m_nodes;
     bool m_show_search{false};
     bool m_pending_sort_direction{false};
     contextmenu_manager::ptr m_contextmenu_manager;

--- a/foo_ui_columns/filter_inline_edit.cpp
+++ b/foo_ui_columns/filter_inline_edit.cpp
@@ -15,11 +15,11 @@ bool FilterPanel::notify_create_inline_edit(const pfc::list_base_const_t<size_t>
     size_t indices_count = indices.get_count();
     if (!m_field_data.m_use_script && !m_field_data.m_fields.empty() && indices_count == 1
         && indices[0] < m_nodes.get_count()) {
-        m_edit_handles = m_nodes[indices[0]].m_handles;
+        m_edit_handles = m_nodes[indices[0]]->m_handles;
 
         m_edit_fields = m_field_data.m_fields;
 
-        p_text = (m_edit_previous_value = pfc::stringcvt::string_utf8_from_wide(m_nodes[indices[0]].m_value.c_str()));
+        p_text = (m_edit_previous_value = pfc::stringcvt::string_utf8_from_wide(m_nodes[indices[0]]->m_value.c_str()));
 
         return true;
     }

--- a/foo_ui_columns/filter_items.cpp
+++ b/foo_ui_columns/filter_items.cpp
@@ -17,7 +17,7 @@ void FilterPanel::populate_list_from_chain(const metadb_handle_list_t<pfc::alloc
         b_all_was_selected = selection[0];
         for (size_t i = 1; i < count; i++)
             if (selection[i])
-                previous_nodes.emplace_back(m_nodes[i].m_value);
+                previous_nodes.emplace_back(m_nodes[i]->m_value);
     }
 
     populate_list(handles);
@@ -61,7 +61,7 @@ void FilterPanel::add_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>& ad
     metadb_handle_list_t<pfc::alloc_fast_aggressive> tracks_for_next_window;
     tracks_for_next_window.prealloc(added_tracks.get_count());
 
-    m_nodes[0].m_handles.add_items(added_tracks);
+    m_nodes[0]->m_handles.add_items(added_tracks);
 
     std::vector<DataEntry> data_entries;
     make_data_entries(added_tracks, data_entries, g_showemptyitems);
@@ -82,24 +82,24 @@ void FilterPanel::add_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>& ad
             p_data[start].m_text.get_ptr(), 1, index_item, get_sort_direction());
 
         if (exact_match) {
-            const size_t current_count = m_nodes[index_item].m_handles.get_count();
+            const size_t current_count = m_nodes[index_item]->m_handles.get_count();
             const bool selected = !nothing_or_all_node_selected && get_item_selected(index_item);
 
-            m_nodes[index_item].m_handles.set_count(current_count + handles_count);
+            m_nodes[index_item]->m_handles.set_count(current_count + handles_count);
 
             for (size_t k{0}; k < handles_count; k++)
-                m_nodes[index_item].m_handles[current_count + k] = p_data[start + k].m_handle;
+                m_nodes[index_item]->m_handles[current_count + k] = p_data[start + k].m_handle;
 
             if (selected && handles_count)
                 tracks_for_next_window.add_items_fromptr(
-                    m_nodes[index_item].m_handles.get_ptr() + current_count, handles_count);
+                    m_nodes[index_item]->m_handles.get_ptr() + current_count, handles_count);
         } else {
-            Node node;
-            node.m_value = p_data[start].m_text.get_ptr();
-            node.m_handles.set_count(handles_count);
+            auto node = std::make_shared<Node>();
+            node->m_value = p_data[start].m_text.get_ptr();
+            node->m_handles.set_count(handles_count);
 
             for (size_t k{0}; k < handles_count; k++)
-                node.m_handles[k] = p_data[start + k].m_handle;
+                node->m_handles[k] = p_data[start + k].m_handle;
 
             m_nodes.insert_item(node, index_item);
             InsertItem item;
@@ -130,7 +130,7 @@ void FilterPanel::remove_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
     tracks_for_next_window.prealloc(removed_tracks.get_count());
 
     const auto nothing_or_all_node_selected = get_nothing_or_all_node_selected();
-    m_nodes[0].remove_handles(removed_tracks);
+    m_nodes[0]->remove_handles(removed_tracks);
 
     std::vector<DataEntry> data_entries;
     make_data_entries(removed_tracks, data_entries, g_showemptyitems);
@@ -155,12 +155,12 @@ void FilterPanel::remove_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
             const auto selected = !nothing_or_all_node_selected && get_item_selected(index_item);
 
             for (size_t k{0}; k < group_size; k++) {
-                m_nodes[index_item].m_handles.remove_item(p_data[start + k].m_handle);
+                m_nodes[index_item]->m_handles.remove_item(p_data[start + k].m_handle);
                 if (selected)
                     tracks_for_next_window.add_item(p_data[start + k].m_handle);
             }
 
-            if (m_nodes[index_item].m_handles.get_count() == 0) {
+            if (m_nodes[index_item]->m_handles.get_count() == 0) {
                 mask_nodes[index_item] = true;
             }
         }
@@ -220,7 +220,7 @@ void FilterPanel::update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
 
     auto node_count = m_nodes.get_count();
     for (size_t node_index{1}; node_index < node_count; node_index++) {
-        m_nodes[node_index].remove_handles(modified_tracks);
+        m_nodes[node_index]->remove_handles(modified_tracks);
     }
 
     const DataEntry* p_data = data_entries.data();
@@ -239,25 +239,25 @@ void FilterPanel::update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
             p_data[start].m_text.get_ptr(), 1, index_item, get_sort_direction());
 
         if (exact_match) {
-            const auto current_count = m_nodes[index_item].m_handles.get_count();
-            m_nodes[index_item].m_handles.set_count(current_count + handles_count);
+            const auto current_count = m_nodes[index_item]->m_handles.get_count();
+            m_nodes[index_item]->m_handles.set_count(current_count + handles_count);
 
             const auto selected = !nothing_or_all_node_selected && get_item_selected(index_item);
 
             for (size_t k{0}; k < handles_count; k++) {
-                m_nodes[index_item].m_handles[current_count + k] = p_data[start + k].m_handle;
+                m_nodes[index_item]->m_handles[current_count + k] = p_data[start + k].m_handle;
             }
 
             if (selected && handles_count)
                 tracks_for_next_window.add_items_fromptr(
-                    m_nodes[index_item].m_handles.get_ptr() + current_count, handles_count);
+                    m_nodes[index_item]->m_handles.get_ptr() + current_count, handles_count);
         } else {
-            Node node;
-            node.m_value = p_data[start].m_text.get_ptr();
-            node.m_handles.set_count(handles_count);
+            auto node = std::make_shared<Node>();
+            node->m_value = p_data[start].m_text.get_ptr();
+            node->m_handles.set_count(handles_count);
 
             for (size_t k{0}; k < handles_count; k++)
-                node.m_handles[k] = p_data[start + k].m_handle;
+                node->m_handles[k] = p_data[start + k].m_handle;
 
             m_nodes.insert_item(node, index_item);
             InsertItem item;
@@ -271,7 +271,7 @@ void FilterPanel::update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
     mask_nodes.set_count(node_count);
     mask_nodes[0] = false;
     for (size_t node_index{1}; node_index < node_count; ++node_index) {
-        mask_nodes[node_index] = m_nodes[node_index].m_handles.get_count() == 0;
+        mask_nodes[node_index] = m_nodes[node_index]->m_handles.get_count() == 0;
     }
     m_nodes.remove_mask(mask_nodes.get_ptr());
     transaction.remove_items(pfc::bit_array_table(mask_nodes.get_ptr(), mask_nodes.get_size()));
@@ -516,9 +516,11 @@ void FilterPanel::populate_list(const metadb_handle_list_t<pfc::alloc_fast>& han
     const size_t data_entries_count{data_entries.size()};
 
     m_nodes.set_count(node_count + 1);
-    Node* p_nodes = m_nodes.get_ptr();
-    p_nodes[0].m_handles.add_items(handles);
-    p_nodes[0].m_value = L"All";
+    std::ranges::transform(m_nodes, m_nodes.begin(), [](auto&&) { return std::make_shared<Node>(); });
+
+    const auto* p_nodes = m_nodes.get_ptr();
+    p_nodes[0]->m_handles.add_items(handles);
+    p_nodes[0]->m_value = L"All";
 
     for (size_t i{0}, j{1}; i < data_entries_count; i++) {
         const size_t start{i};
@@ -528,10 +530,10 @@ void FilterPanel::populate_list(const metadb_handle_list_t<pfc::alloc_fast>& han
 
         PFC_ASSERT(j < m_nodes.get_count());
 
-        p_nodes[j].m_handles.set_count(handles_count);
+        p_nodes[j]->m_handles.set_count(handles_count);
         for (size_t k{0}; k < handles_count; k++)
-            p_nodes[j].m_handles[k] = p_data[start + k].m_handle;
-        p_nodes[j].m_value = p_data[start].m_text.get_ptr();
+            p_nodes[j]->m_handles[k] = p_data[start + k].m_handle;
+        p_nodes[j]->m_value = p_data[start].m_text.get_ptr();
         j++;
     }
     update_first_node_text();

--- a/foo_ui_columns/filter_items.cpp
+++ b/foo_ui_columns/filter_items.cpp
@@ -69,6 +69,8 @@ void FilterPanel::add_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>& ad
     const DataEntry* p_data = data_entries.data();
     const auto count{data_entries.size()};
 
+    auto transaction = start_transaction();
+
     for (size_t i{0}; i < count; i++) {
         const auto start = i;
         while (p_data[i].m_same_as_next && i + 1 < count)
@@ -101,7 +103,7 @@ void FilterPanel::add_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>& ad
 
             m_nodes.insert_item(node, index_item);
             InsertItem item;
-            insert_items(index_item, 1, &item);
+            transaction.insert_items(index_item, 1, &item);
         }
     }
 
@@ -224,6 +226,8 @@ void FilterPanel::update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
     const DataEntry* p_data = data_entries.data();
     const auto data_entries_count = data_entries.size();
 
+    auto transaction = start_transaction();
+
     for (size_t i{0}; i < data_entries_count; i++) {
         const auto start = i;
         while (p_data[i].m_same_as_next && i + 1 < data_entries_count)
@@ -257,7 +261,7 @@ void FilterPanel::update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
 
             m_nodes.insert_item(node, index_item);
             InsertItem item;
-            insert_items(index_item, 1, &item);
+            transaction.insert_items(index_item, 1, &item);
         }
     }
 
@@ -270,7 +274,7 @@ void FilterPanel::update_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>&
         mask_nodes[node_index] = m_nodes[node_index].m_handles.get_count() == 0;
     }
     m_nodes.remove_mask(mask_nodes.get_ptr());
-    remove_items(pfc::bit_array_table(mask_nodes.get_ptr(), mask_nodes.get_size()));
+    transaction.remove_items(pfc::bit_array_table(mask_nodes.get_ptr(), mask_nodes.get_size()));
     update_first_node_text(true);
 
     if (next_window) {


### PR DESCRIPTION
This optimises the handling of media library additions and modifications. This is mainly by updating the list view in a more efficient manner. A smaller optimisation was also made related to how Filter nodes are stored in memory.

Optimising handling of media library additions and modifications is particularly important in foobar2000 2.0 where the media library initialises gradually.