### PR TITLE
Reduce background show-through when switching tabs in Tab stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@
 ### Features
 
 - The performance of the Filter panel when handling dynamic media library
-  changes was improved. [[#608](https://github.com/reupen/columns_ui/pull/608)]
+  changes was improved. [[#609](https://github.com/reupen/columns_ui/pull/609)]
 
   This includes reducing Filter panel initialisation time in foobar2000 2.0
   during foobar2000 start-up.
+
+### Bug fixes
+
+- Flickering or flashing when switching tabs in the Tab stack panel was reduced.
+  [[#610](https://github.com/reupen/columns_ui/pull/610)]
 
 ## 2.0.0-alpha.3
 

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -115,6 +115,8 @@ public:
 
     void create_tabs();
     void destroy_tabs();
+    void show_tab_window(HWND wnd);
+    void hide_tab_window();
     void refresh_children();
     void destroy_children();
     void adjust_rect(bool b_larger, RECT* rc);
@@ -126,7 +128,6 @@ public:
     static void g_on_font_change();
     void on_size_changed(unsigned width, unsigned height);
     void on_size_changed();
-    void on_active_tab_changing(int index_from);
     void on_active_tab_changed(int index_to);
 
     TabStackPanel() = default;
@@ -136,6 +137,7 @@ private:
     PanelList m_active_panels;
     HWND m_wnd_tabs{nullptr};
     HWND m_up_down_control_wnd{};
+    HWND m_active_child_wnd{};
     std::optional<size_t> m_active_tab;
     static std::vector<service_ptr_t<t_self>> g_windows;
     uie::size_limit_t m_size_limits;


### PR DESCRIPTION
This eliminates or reduces the probability of the background of the tab control showing when switching tabs in the Tab stack panel.

(Other approaches could be taken if the problem remains, but I could no longer reproduce it with these changes.)