### PR TITLE
Don't report Filter panel initialisation times if library not ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   This includes reducing Filter panel initialisation time in foobar2000 2.0
   during foobar2000 start-up.
 
+- The Filter panel no longer reports initialisation times in foobar2000 2.0 when
+  it loads before the media library has initialised.
+  [[#612](https://github.com/reupen/columns_ui/pull/612)]
+
 ### Bug fixes
 
 - Flickering or flashing when switching tabs in the Tab stack panel was reduced.

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -846,15 +846,20 @@ void FilterPanel::notify_on_create()
     refresh_columns();
     refresh_groups();
 
+    auto library_v4 = library_manager_v4::tryGet();
+    auto is_library_initialised = !library_v4.is_valid() || library_v4->is_initialized();
+
     pfc::hires_timer timer0;
     timer0.start();
     metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
     get_initial_handles(handles);
     populate_list(handles);
     double time = timer0.query();
-    console::formatter formatter;
-    formatter << "Filter Panel - " << m_field_data.m_name << ": initialised in " << pfc::format_float(time, 0, 3)
-              << " s";
+
+    if (is_library_initialised && handles.size() > 0)
+        console::print(fmt::format("Filter panel - {}: initialised in {} s", m_field_data.m_name.c_str(),
+            pfc::format_float(time, 0, 3).c_str())
+                           .c_str());
 
     g_windows.push_back(this);
     fbh::library_callback_manager::register_callback(this);


### PR DESCRIPTION
This stops the Filter panel reporting initialisation times when it initialises before the media library does (on foobar2000 2.0).

This is because it resulted in incorrect times (such as zero seconds) being reported.

No time is now reported in such cases.

(Additionally, it no longer reports times when the media library is empty.)