### PR TITLE
Fix crash when clicking Move down in playlist view preferences groups list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Development version
+## 2.0.0-alpha.4
 
 ### Features
 
@@ -17,7 +17,11 @@
 
 ### Bug fixes
 
-- Flickering or flashing when switching tabs in the Tab stack panel was reduced.
+- A crash, when clicking Move down on the Grouping tab in playlist view
+  preferences without a group selected, was fixed.
+  [[#613](https://github.com/reupen/columns_ui/pull/613)]
+
+- Flickering when switching tabs in the Tab stack panel was reduced.
   [[#610](https://github.com/reupen/columns_ui/pull/610)]
 
 ## 2.0.0-alpha.3

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -114,7 +114,7 @@ BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             const auto index = m_groups_list_view.get_selected_item_single();
             auto& groups = g_groups.get_groups();
 
-            if (index + 1 >= groups.size())
+            if (index == std::numeric_limits<size_t>::max() || index + 1 >= groups.size())
                 break;
 
             g_groups.swap(index, index + 1);


### PR DESCRIPTION
This fixes a crash when clicking Move down on the Grouping tab in playlist view preferences, when there wasn't a group selected.

This regressed in #595.