### PR TITLE
Fix toggling of Alternative selection model playlist view setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   tabs and Tab stack panels when dark mode is active was fixed.
   [[#622](https://github.com/reupen/columns_ui/pull/622)]
 
+- A bug where toggling the Alternative selection model playlist view option
+  didn’t function correctly was fixed.
+  [[#623](https://github.com/reupen/columns_ui/pull/623)]
+
 ## 2.0.0-alpha.5
 
 ### Features

--- a/foo_ui_columns/tab_display2.cpp
+++ b/foo_ui_columns/tab_display2.cpp
@@ -89,7 +89,7 @@ public:
                     ComboBox_GetItemData(reinterpret_cast<HWND>(lp), ComboBox_GetCurSel(reinterpret_cast<HWND>(lp))));
             } break;
             case IDC_SELECTION_MODEL:
-                cfg_alternative_sel = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_CHECKED;
+                cfg_alternative_sel = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
                 cui::panels::playlist_view::PlaylistView::g_on_alternate_selection_change();
                 break;
             case IDC_SORT_ARROWS:


### PR DESCRIPTION
Resolves #621 

This resolves a problem where toggling the Alternative selection model option in playlist view preferences set the setting to the wrong value.

This regressed in #467.