### PR TITLE
Avoid crash in built-in panels when incorrectly destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   didn’t function correctly was fixed.
   [[#623](https://github.com/reupen/columns_ui/pull/623)]
 
+- A crash when a third-party spiltter incorrectly destroys a built-in panel was
+  resolved. [[#624](https://github.com/reupen/columns_ui/pull/624)]
+
 ## 2.0.0-alpha.5
 
 ### Features


### PR DESCRIPTION
This updates `columns_ui-sdk` to pick up a fix to stop `container_uie_window_v3_t::destroy_window()` crashing if the panel window was already destroyed, or was never created.