### PR TITLE
Add SVG support to buttons toolbar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "scripts"]
 	path = scripts
 	url = https://github.com/reupen/foobar2000-development-scripts.git
+[submodule "svg-services"]
+	path = svg-services
+	url = https://github.com/reupen/svg-services.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Development version
 
+### Features
+
+- Support for static SVG files was added to the Buttons toolbar.
+  [[#628](https://github.com/reupen/columns_ui/pull/628)]
+
+  This requires the SVG services component. Text is not supported.
+
 ### Bug fixes
 
 - A bug where ampersands didn’t render correctly in tab names in the Playlist

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -682,11 +682,19 @@ INT_PTR CALLBACK ButtonsToolbar::ConfigChildProc(HWND wnd, UINT msg, WPARAM wp, 
                     || (uGetFileAttributes(temp) & FILE_ATTRIBUTE_DIRECTORY))
                     temp.reset();
 
-                constexpr auto extension_mask
-                    = "Image Files (*.bmp;*.gif;*.ico;*.png;*.tiff;*.webp)|*.bmp;*.gif;*.ico;*.png;*.tiff;*.webp|All "
-                      "Files (*.*)|*.*";
+                std::vector extensions = {"*.bmp"s, "*.gif"s, "*.ico"s, "*.png"s, "*.tiff"s, "*.webp"s};
 
-                if (uGetOpenFileName(wnd, extension_mask, 0, "png", "Choose image", nullptr, temp, FALSE)) {
+                if (static_api_test_t<svg_services::svg_renderer>()) {
+                    extensions.emplace_back("*.svg"s);
+                    std::ranges::sort(extensions);
+                }
+
+                const auto joined_extensions = mmh::join(extensions, ";");
+
+                const auto extension_mask = fmt::format("Image Files ({extensions})|{extensions}|All Files (*.*)|*.*",
+                    fmt::arg("extensions", joined_extensions.c_str()));
+
+                if (uGetOpenFileName(wnd, extension_mask.c_str(), 0, "png", "Choose image", nullptr, temp, FALSE)) {
                     ptr->m_image->m_path = temp;
                     uSendDlgItemMessageText(
                         wnd, IDC_IMAGE_PATH, WM_SETTEXT, 0, (true) ? ptr->m_image->m_path.get_ptr() : "");

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -77,6 +77,12 @@ public:
 
     enum ImageIdentifier { IMAGE_NAME, IMAGE_DATA, IMAGE_PATH };
 
+    enum class CustomImageContentType {
+        Ico,
+        Svg,
+        Other,
+    };
+
     class Button {
     public:
         class CustomImage {
@@ -86,9 +92,9 @@ public:
             COLORREF m_mask_colour{};
             ui_extension::t_mask m_mask_type{uie::MASK_NONE};
 
-            [[nodiscard]] bool is_ico() const;
-
+            [[nodiscard]] CustomImageContentType content_type() const;
             [[nodiscard]] pfc::string8 get_path() const;
+
             void write(stream_writer* out, abort_callback& p_abort) const;
             void read(ConfigVersion p_version, stream_reader* reader, abort_callback& p_abort);
             void write_to_file(stream_writer& p_file, bool b_paths, abort_callback& p_abort);
@@ -156,6 +162,7 @@ public:
 
     private:
         bool load_custom_image(const Button::CustomImage& custom_image, int width, int height);
+        void load_custom_svg_image(const char* full_path, int width, int height);
         void load_default_image(
             const service_ptr_t<uie::button>& button_ptr, COLORREF colour_btnface, int width, int height);
 

--- a/foo_ui_columns/buttons_custom_image.cpp
+++ b/foo_ui_columns/buttons_custom_image.cpp
@@ -3,9 +3,17 @@
 
 namespace cui::toolbars::buttons {
 
-bool ButtonsToolbar::Button::CustomImage::is_ico() const
+ButtonsToolbar::CustomImageContentType ButtonsToolbar::Button::CustomImage::content_type() const
 {
-    return !_stricmp(pfc::string_extension(m_path), "ico");
+    const auto extension = string_extension(m_path);
+
+    if (!_stricmp(extension, "ico"))
+        return CustomImageContentType::Ico;
+
+    if (!_stricmp(extension, "svg"))
+        return CustomImageContentType::Svg;
+
+    return CustomImageContentType::Other;
 }
 
 pfc::string8 ButtonsToolbar::Button::CustomImage::get_path() const

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -67,6 +67,7 @@
 #include "../foobar2000/SDK/metadb_info_container_impl.h"
 #include "../foobar2000/helpers/playlist_position_reference_tracker.h"
 
+#include "../svg-services/api/api.h"
 #include "../columns_ui-sdk/ui_extension.h"
 #include "../ui_helpers/stdafx.h"
 #include "../mmh/stdafx.h"

--- a/foo_ui_columns/wic.cpp
+++ b/foo_ui_columns/wic.cpp
@@ -112,6 +112,18 @@ wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_path(const char* path
     return get_image_frame(decoder);
 }
 
+wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const BitmapData& bitmap_data)
+{
+    const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
+    wil::com_ptr_t<IWICBitmap> bitmap;
+
+    check_hresult(imaging_factory->CreateBitmapFromMemory(bitmap_data.width, bitmap_data.height,
+        GUID_WICPixelFormat32bppBGRA, bitmap_data.stride, gsl::narrow<UINT>(bitmap_data.data.size()),
+        const_cast<BYTE*>(bitmap_data.data.data()), &bitmap));
+
+    return bitmap;
+}
+
 wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr_t<IWICBitmapSource>& source)
 {
     const auto bitmap_data = decode_image(source);

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -16,6 +16,7 @@ struct BitmapData {
 
 void check_hresult(HRESULT hr);
 wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_path(const char* path);
+wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const BitmapData& bitmap_data);
 wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr_t<IWICBitmapSource>& source);
 wil::com_ptr_t<IWICBitmapSource> resize_bitmap_source(
     const wil::com_ptr_t<IWICBitmapSource>& original_bitmap, int width, int height);


### PR DESCRIPTION
Resolves #553

This adds SVG support for custom images to the Buttons toolbar using the experimental [SVG services](https://github.com/reupen/svg-services) component. The SVG services component must be installed for this to work.

The SVG services repository has been added as a submodule to access the definition of its public API.