### PR TITLE
Optimise typing in playlist view to jump to items in foobar2000 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
   This requires the SVG services component. Text is not supported.
 
+- Performance when typing into the playlist view to jump to an item was improved
+  in foobar2000 2.0. [[#629](https://github.com/reupen/columns_ui/pull/629)]
+
 ### Bug fixes
 
 - A bug where ampersands didn’t render correctly in tab names in the Playlist


### PR DESCRIPTION
Resolves #602 

This changes how typing in the playlist view to jump to items works in foobar2000 2.0 to improve performance.

Previously, it formatted tracks and columns individually, including style scripts, where this information wasn't already cached.

Now, it formats tracks in large batches, and only formats the display script for the first column. This performs better in foobar2000 2.0. There is also no longer any long-term caching involved.