### PR TITLE
Remove top and bottom button padding in buttons toolbar no edges mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 - A crash when a third-party spiltter incorrectly destroys a built-in panel was
   resolved. [[#624](https://github.com/reupen/columns_ui/pull/624)]
 
+- Excess top and bottom button padding in a buttons toolbar in ‘no edges’ mode
+  was removed. [[#638](https://github.com/reupen/columns_ui/pull/638)]
+
 ### Internal changes
 
 - The component is now compiled with Visual Studio 2022 17.4.

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -267,7 +267,6 @@ void ButtonsToolbar::create_toolbar()
             ex_style | TBSTYLE_EX_DRAWDDARROWS | (!m_text_below ? TBSTYLE_EX_MIXEDBUTTONS : 0));
 
         SendMessage(wnd_toolbar, TB_SETBITMAPSIZE, 0, MAKELONG(button_width, button_height));
-        // SendMessage(wnd_toolbar, TB_SETBUTTONSIZE, (WPARAM) 0, MAKELONG(width,height));
 
         // todo: custom padding
         const auto padding = SendMessage(wnd_toolbar, TB_GETPADDING, 0, 0);
@@ -319,6 +318,14 @@ void ButtonsToolbar::create_toolbar()
         }
 
         ShowWindow(wnd_toolbar, SW_SHOWNORMAL);
+
+        const auto all_buttons_without_text
+            = ranges::all_of(m_buttons, [](auto&& button) { return button.m_show == SHOW_IMAGE; });
+
+        if (all_buttons_without_text && m_appearance == APPEARANCE_NOEDGE) {
+            SendMessage(wnd_toolbar, TB_SETBUTTONSIZE, 0, MAKELONG(button_width, button_height));
+        }
+
         SendMessage(wnd_toolbar, TB_AUTOSIZE, 0, 0);
     }
 }


### PR DESCRIPTION
This removes some excess top and bottom padding in the buttons toolbar when both:

- ‘no edges’ mode is enabled; and
- no buttons are set to display with text