### PR TITLE
Centre SVGs in buttons in buttons toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Features
 
 - Support for static SVG files was added to the Buttons toolbar.
-  [[#628](https://github.com/reupen/columns_ui/pull/628)]
+  [[#628](https://github.com/reupen/columns_ui/pull/628),
+  [#643](https://github.com/reupen/columns_ui/pull/643)]
 
   This requires the SVG services component. Text is not supported.
 

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -691,7 +691,7 @@ INT_PTR CALLBACK ButtonsToolbar::ConfigChildProc(HWND wnd, UINT msg, WPARAM wp, 
 
                 std::vector extensions = {"*.bmp"s, "*.gif"s, "*.ico"s, "*.png"s, "*.tiff"s, "*.webp"s};
 
-                if (static_api_test_t<svg_services::svg_renderer>()) {
+                if (static_api_test_t<svg_services::svg_services>()) {
                     extensions.emplace_back("*.svg"s);
                     std::ranges::sort(extensions);
                 }

--- a/foo_ui_columns/buttons_button_image.cpp
+++ b/foo_ui_columns/buttons_button_image.cpp
@@ -77,7 +77,7 @@ bool ButtonsToolbar::ButtonImage::load_custom_image(const Button::CustomImage& c
 
 void ButtonsToolbar::ButtonImage::load_custom_svg_image(const char* full_path, int width, int height)
 {
-    svg_services::svg_renderer::ptr svg_api;
+    svg_services::svg_services::ptr svg_api;
 
     if (!fb2k::std_api_try_get(svg_api)) {
         throw exception_service_not_found(
@@ -94,8 +94,9 @@ void ButtonsToolbar::ButtonImage::load_custom_svg_image(const char* full_path, i
         gsl::narrow<unsigned>(render_width) * 4, {}};
     bitmap_data.data.resize(bitmap_data.stride * bitmap_data.height);
 
-    svg_api->render(svg_data->data(), svg_data->size(), render_width, render_height, bitmap_data.data.data(),
-        bitmap_data.data.size());
+    const auto svg_document = svg_api->open(svg_data->data(), svg_data->size());
+    svg_document->render(render_width, render_height, svg_services::Position::Centred, svg_services::ScalingMode::Fit,
+        svg_services::PixelFormat::BGRA, bitmap_data.data.data(), bitmap_data.data.size());
 
     const auto bitmap_source = create_bitmap_source_from_bitmap_data(bitmap_data);
     m_bm = wic::create_hbitmap_from_bitmap_source(bitmap_source);
@@ -137,8 +138,6 @@ void ButtonsToolbar::ButtonImage::load_default_image(
     } catch (const std::exception& ex) {
         fbh::print_to_console(u8"Buttons toolbar – error resizing default image: "_pcc, ex.what());
     }
-
-    return;
 }
 
 bool ButtonsToolbar::ButtonImage::load(std::optional<std::reference_wrapper<Button::CustomImage>> custom_image,


### PR DESCRIPTION
This updates to the latest SVG services API and makes SVGs used in the buttons toolbar centred in the button when the SVG has a different aspect ratio to the button.