### PR TITLE
Add autocompletion when editing metadata in Item properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 - Performance when typing into the playlist view to jump to an item was improved
   in foobar2000 2.0. [[#629](https://github.com/reupen/columns_ui/pull/629)]
 
+- Autocompletion was added when editing metadata in the Item properties panel
+  [[#647](https://github.com/reupen/columns_ui/pull/647)]
+
+  The list of values is provided by the foobar2000 core and can be configured in
+  Advanced preferences, under Display/Autocomplete fields.
+
 ### Bug fixes
 
 - A bug where ampersands didn’t render correctly in tab names in the Playlist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   The list of values is provided by the foobar2000 core and can be configured in
   Advanced preferences, under Display/Autocomplete fields.
 
+- Autcompletion in playlist view inline editing was updated to use the latest
+  foobar2000 API on foobar2000 1.6.1 and newer.
+  [[#647](https://github.com/reupen/columns_ui/pull/647)]
+
 ### Bug fixes
 
 - A bug where ampersands didn’t render correctly in tab names in the Playlist

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -200,7 +200,8 @@ private:
     static std::vector<ItemProperties*> g_windows;
 
     ui_selection_holder::ptr m_selection_holder;
-    metadb_handle_list m_handles, m_selection_handles;
+    metadb_handle_list m_handles;
+    metadb_handle_list m_selection_handles;
     pfc::list_t<Field> m_fields;
     bool m_callback_registered{false};
     uint32_t m_tracking_mode;
@@ -216,6 +217,9 @@ private:
     size_t m_edit_column, m_edit_index;
     pfc::string8 m_edit_field;
     metadb_handle_list m_edit_handles;
+
+    library_meta_autocomplete::ptr m_library_autocomplete_v1;
+    library_meta_autocomplete_v2::ptr m_library_autocomplete_v2;
 };
 
 } // namespace cui::panels::item_properties

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -743,6 +743,9 @@ void PlaylistView::notify_on_destroy()
     m_playlist_api.release();
     m_column_mask.set_size(0);
 
+    m_library_autocomplete_v1.reset();
+    m_library_autocomplete_v2.reset();
+
     m_artwork_manager->deinitialise();
     m_artwork_manager.reset();
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -682,8 +682,8 @@ private:
     std::shared_ptr<ArtworkReaderManager> m_artwork_manager;
     ui_selection_holder::ptr m_selection_holder;
 
-    // pfc::list_t<group_t> m_groups;
-    // pfc::list_t<style_data_t> m_style_data;
+    library_meta_autocomplete::ptr m_library_autocomplete_v1;
+    library_meta_autocomplete_v2::ptr m_library_autocomplete_v2;
 };
 
 class PlaylistViewDropTarget : public IDropTarget {

--- a/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
@@ -103,14 +103,22 @@ bool PlaylistView::notify_create_inline_edit(const pfc::list_base_const_t<size_t
         p_text = "<multiple values>";
     }
 
-    try {
-        library_meta_autocomplete::ptr p_library_autocomplete = standard_api_create_t<library_meta_autocomplete>();
-        p_flags |= inline_edit_autocomplete;
-        pfc::com_ptr_t<IUnknown> pUnk;
-        p_library_autocomplete->get_value_list(m_edit_field, pUnk);
-        pAutocompleteEntries = pUnk.get_ptr();
-    } catch (exception_service_not_found const&) {
+    if (m_library_autocomplete_v2.is_empty() && m_library_autocomplete_v1.is_empty()) {
+        if (!library_meta_autocomplete_v2::tryGet(m_library_autocomplete_v2)) {
+            m_library_autocomplete_v1 = library_meta_autocomplete::get();
+        }
     }
+
+    p_flags |= inline_edit_autocomplete;
+    pfc::com_ptr_t<IUnknown> autocomplete_entries;
+
+    if (m_library_autocomplete_v2.is_valid())
+        m_library_autocomplete_v2->get_value_list_async(m_edit_field, autocomplete_entries);
+    else
+        m_library_autocomplete_v1->get_value_list(m_edit_field, autocomplete_entries);
+
+    pAutocompleteEntries = autocomplete_entries.get_ptr();
+
     return true;
 }
 


### PR DESCRIPTION
Resolves #304

This adds autocompletion to Item properties when editing metadata fields. The list of values is provided by the foobar2000 core.

The playlist view was also updated to use the latest `library_meta_autocomplete_v2` interface (which is said to include caching and asynchronicity).