### PR TITLE
Allow private Win32 dark mode APIs on Windows 11 build 22623

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   foobar2000 API on foobar2000 1.6.1 and newer.
   [[#647](https://github.com/reupen/columns_ui/pull/647)]
 
+- Dark menus were enabled on Windows 11 build 22623.
+  [[#649](https://github.com/reupen/columns_ui/pull/649)]
+
 ### Bug fixes
 
 - A bug where ampersands didn’t render correctly in tab names in the Playlist

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -47,7 +47,7 @@ bool are_private_apis_allowed()
     if (osvi.dwMajorVersion != 10 || osvi.dwMinorVersion != 0)
         return false;
 
-    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22622;
+    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22623;
 }
 
 void set_app_mode(PreferredAppMode mode)


### PR DESCRIPTION
This increases the maximum allowed build number for private Win32 dark mode APIs to build 22623 (a beta channel version).