### PR TITLE
Add Play command to playlist view context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Development version
 
+### Features
+
+- A Play command was added to the playlist view context menu when right-clicking
+  on a single track. [[#665](https://github.com/reupen/columns_ui/pull/665)]
+
 ### Bug fixes
 
 - A bug where panel captions rendered in the background of some panels was
@@ -11,7 +16,7 @@
 ### Internal changes
 
 - The component is now compiled using foobar2000 SDK 2023-01-18.
-  [[#625](https://github.com/reupen/columns_ui/pull/660)]
+  [[#660](https://github.com/reupen/columns_ui/pull/660)]
 
 ## 2.0.0-beta.1
 


### PR DESCRIPTION
Resolves #662 

This adds a Play command to the playlist view context menu when a single track is selected.

This should be there as it has been the usual convention on Windows (at least to Windows 7) to show the default command in the context menu (in bold).