### PR TITLE
Add dark mode support to tab control scroll buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Features
 
+- The left and right scroll buttons in the Tab stack and Playlist tabs panels
+  are now dark themed on all supported operating systems when dark mode is
+  enabled. [[#666](https://github.com/reupen/columns_ui/pull/666)]
+
+  (Previously, they were only dark themed on Windows 11 22H2 and newer.)
+
 - A Play command was added to the playlist view context menu when right-clicking
   on a single track. [[#665](https://github.com/reupen/columns_ui/pull/665)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   fixed. [[#659](https://github.com/reupen/columns_ui/pull/659), contributed by
   [@marc2k3](https://github.com/marc2k3)]
 
+- Minor rendering glitches relating to the scroll buttons in the Tab stack and
+  Playlist tabs panels with dark mode enabled were fixed.
+  [[#666](https://github.com/reupen/columns_ui/pull/666)]
+
 ### Internal changes
 
 - The component is now compiled using foobar2000 SDK 2023-01-18.

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -37,6 +37,12 @@ bool does_os_support_dark_mode()
     return is_19041_or_newer;
 }
 
+bool is_native_dark_mode_spin_available()
+{
+    // Earliest known build number – exact build number unknown.
+    return check_windows_10_build(22579);
+}
+
 bool are_private_apis_allowed()
 {
     OSVERSIONINFO osvi{};
@@ -190,6 +196,18 @@ COLORREF get_dark_colour(ColourID colour_id)
         return get_base_dark_colour(DarkColourID::DARK_200);
     case ColourID::RebarBandBorder:
         return get_base_dark_colour(DarkColourID::DARK_400);
+    case ColourID::SpinBackground:
+        return get_base_dark_colour(DarkColourID::DARK_200);
+    case ColourID::SpinButtonBorder:
+        return get_base_dark_colour(DarkColourID::DARK_400);
+    case ColourID::SpinButtonArrow:
+        return get_base_dark_colour(DarkColourID::DARK_999);
+    case ColourID::SpinButtonBackground:
+        return get_base_dark_colour(DarkColourID::DARK_000);
+    case ColourID::SpinHotButtonBackground:
+        return get_base_dark_colour(DarkColourID::DARK_300);
+    case ColourID::SpinPressedButtonBackground:
+        return get_base_dark_colour(DarkColourID::DARK_500);
     case ColourID::StatusBarBackground:
         return get_base_dark_colour(DarkColourID::DARK_200);
     case ColourID::StatusBarText:
@@ -241,6 +259,13 @@ COLORREF get_dark_colour(ColourID colour_id)
     default:
         uBugCheck();
     }
+}
+
+Gdiplus::Color get_dark_gdiplus_colour(ColourID colour_id)
+{
+    Gdiplus::Color colour;
+    colour.SetFromCOLORREF(get_dark_colour(colour_id));
+    return colour;
 }
 
 COLORREF get_colour(ColourID colour_id, bool is_dark)

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -37,7 +37,7 @@ bool does_os_support_dark_mode()
     return is_19041_or_newer;
 }
 
-bool is_native_dark_mode_spin_available()
+bool is_native_dark_spin_available()
 {
     // Earliest known build number – exact build number unknown.
     return check_windows_10_build(22579);

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -76,7 +76,7 @@ private:
 
 [[nodiscard]] bool does_os_support_dark_mode();
 [[nodiscard]] bool are_private_apis_allowed();
-[[nodiscard]] bool is_native_dark_mode_spin_available();
+[[nodiscard]] bool is_native_dark_spin_available();
 
 enum class PreferredAppMode { System = 1, Dark = 2, Light = 3 };
 

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -13,6 +13,12 @@ enum class ColourID {
     PanelCaptionBackground,
     RebarBackground,
     RebarBandBorder,
+    SpinBackground,
+    SpinButtonArrow,
+    SpinButtonBackground,
+    SpinButtonBorder,
+    SpinHotButtonBackground,
+    SpinPressedButtonBackground,
     StatusBarBackground,
     StatusBarText,
     StatusPaneTopLine,
@@ -70,6 +76,7 @@ private:
 
 [[nodiscard]] bool does_os_support_dark_mode();
 [[nodiscard]] bool are_private_apis_allowed();
+[[nodiscard]] bool is_native_dark_mode_spin_available();
 
 enum class PreferredAppMode { System = 1, Dark = 2, Light = 3 };
 
@@ -77,6 +84,7 @@ void set_app_mode(PreferredAppMode mode);
 void set_titlebar_mode(HWND wnd, bool is_dark);
 
 [[nodiscard]] COLORREF get_dark_colour(ColourID colour_id);
+[[nodiscard]] Gdiplus::Color get_dark_gdiplus_colour(ColourID colour_id);
 [[nodiscard]] COLORREF get_colour(ColourID colour_id, bool is_dark);
 [[nodiscard]] wil::unique_hbrush get_colour_brush(ColourID colour_id, bool is_dark);
 [[nodiscard]] LazyResource<wil::unique_hbrush> get_colour_brush_lazy(ColourID colour_id, bool is_dark);

--- a/foo_ui_columns/dark_mode_spin.cpp
+++ b/foo_ui_columns/dark_mode_spin.cpp
@@ -1,0 +1,280 @@
+#include "pch.h"
+
+#include "dark_mode.h"
+
+namespace cui::dark::spin {
+
+namespace {
+
+enum class Direction {
+    Left,
+    Right,
+};
+
+enum class ButtonState {
+    Default,
+    Hot,
+    Pressed,
+};
+
+struct WindowState {
+    WNDPROC wnd_proc{};
+    bool enabled{true};
+    std::optional<Direction> render_hot_button;
+    std::optional<Direction> actual_hot_button;
+    std::optional<Direction> pressed_button;
+};
+
+namespace state {
+
+std::optional<ULONG_PTR> gdiplus_token;
+std::unordered_map<HWND, WindowState> state_map;
+
+} // namespace state
+
+void render_button_border_and_background(Gdiplus::Graphics& graphics, RECT rect, Direction direction, ButtonState state)
+{
+    graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias8x8);
+
+    const auto background_colour_id = [state]() {
+        if (state == ButtonState::Pressed)
+            return ColourID::SpinPressedButtonBackground;
+
+        if (state == ButtonState::Hot)
+            return ColourID::SpinHotButtonBackground;
+
+        return ColourID::SpinButtonBackground;
+    }();
+
+    const auto path_width = 1_spx;
+
+    const Gdiplus::SolidBrush background_brush(get_dark_gdiplus_colour(background_colour_id));
+    const Gdiplus::Pen border_pen(
+        get_dark_gdiplus_colour(ColourID::SpinButtonBorder), static_cast<Gdiplus::REAL>(path_width));
+
+    const auto half_path = (path_width + 1) / 2;
+    const auto arc_radius = path_width;
+    const auto arc_diameter = arc_radius * 2;
+
+    const auto border_left = gsl::narrow<int>(rect.left);
+    const auto border_top = gsl::narrow<int>(rect.top);
+    const auto border_right = gsl::narrow<int>(rect.right) - half_path;
+    const auto border_bottom = gsl::narrow<int>(rect.bottom) - half_path;
+    const auto arc_ellipse_right = border_right - arc_diameter;
+    const auto arc_ellipse_bottom = border_bottom - arc_diameter;
+
+    Gdiplus::GraphicsPath border;
+
+    if (direction == Direction::Right) {
+        border.AddArc(arc_ellipse_right, border_top, arc_diameter, arc_diameter, 270, 90);
+        border.AddArc(arc_ellipse_right, arc_ellipse_bottom, arc_diameter, arc_diameter, 0, 90);
+        border.AddLine(border_left, border_bottom, border_left, border_top);
+    } else {
+        border.AddArc(border_left, arc_ellipse_bottom, arc_diameter, arc_diameter, 90, 90);
+        border.AddArc(border_left, border_top, arc_diameter, arc_diameter, 180, 90);
+        border.AddLine(border_right, border_top, border_right, border_bottom);
+    }
+
+    border.CloseFigure();
+
+    graphics.FillPath(&background_brush, &border);
+    graphics.DrawPath(&border_pen, &border);
+
+    graphics.SetSmoothingMode(Gdiplus::SmoothingModeDefault);
+}
+
+void render_button_arrow(Gdiplus::Graphics& graphics, RECT rect, Direction direction)
+{
+    const auto button_height_px = static_cast<float>(rect.bottom);
+    const auto button_left_px = static_cast<float>(rect.left);
+    const auto button_width_px = static_cast<float>(rect.right - rect.left);
+
+    constexpr auto triangle_half_width = 0.75f;
+    constexpr auto triangle_half_height = 1.5f;
+    constexpr auto divisor = 10.0f;
+    constexpr auto half_divisor = divisor / 2.0f;
+
+    auto narrow_side_coeff = half_divisor + (direction == Direction::Right ? 1.0f : -1.0f) * triangle_half_width;
+    auto wide_side_coeff = half_divisor + (direction == Direction::Right ? -1.0f : 1.0f) * triangle_half_width;
+
+    const auto triangle_top = (half_divisor - triangle_half_height) * button_height_px / divisor;
+    const auto triangle_bottom = (half_divisor + triangle_half_height) * button_height_px / divisor;
+    const auto triangle_start = button_left_px + wide_side_coeff * button_width_px / divisor;
+    const auto triangle_end = button_left_px + narrow_side_coeff * button_width_px / divisor;
+
+    const Gdiplus::PointF triangle_points[] = {
+        {triangle_end, button_height_px / 2.0f},
+        {triangle_start, triangle_top},
+        {triangle_start, triangle_bottom},
+    };
+
+    const Gdiplus::SolidBrush arrow_brush(get_dark_gdiplus_colour(ColourID::SpinButtonArrow));
+    graphics.FillPolygon(&arrow_brush, triangle_points, 3);
+}
+
+void render_button(Gdiplus::Graphics& graphics, RECT rect, Direction direction, ButtonState state)
+{
+    render_button_border_and_background(graphics, rect, direction, state);
+    render_button_arrow(graphics, rect, direction);
+}
+
+std::tuple<RECT, RECT> get_button_rects(HWND wnd)
+{
+    RECT client_rect{};
+    GetClientRect(wnd, &client_rect);
+
+    const RECT left_rect{0, 0, client_rect.right / 2, client_rect.bottom};
+    const RECT right_rect{left_rect.right, 0, client_rect.right, client_rect.bottom};
+
+    return {left_rect, right_rect};
+}
+
+bool is_near_window(HWND wnd, POINT pt)
+{
+    RECT client_rect{};
+    GetClientRect(wnd, &client_rect);
+
+    InflateRect(&client_rect, (GetSystemMetrics(SM_CXSIZEFRAME) + 1) / 2, (GetSystemMetrics(SM_CYSIZEFRAME) + 1) / 2);
+
+    return PtInRect(&client_rect, pt) != 0;
+}
+
+std::optional<Direction> get_direction_at_point(HWND wnd, POINT pt, bool strict = true)
+{
+    if (strict && !is_near_window(wnd, pt))
+        return {};
+
+    auto [left_rect, right_rect] = get_button_rects(wnd);
+
+    if (pt.x < right_rect.left)
+        return Direction::Left;
+
+    if (pt.x > right_rect.left)
+        return Direction::Right;
+
+    return {};
+}
+
+ButtonState get_button_state(const WindowState& window_state, Direction direction)
+{
+    const auto direction_opt = std::make_optional(direction);
+
+    if (window_state.pressed_button == direction_opt && window_state.actual_hot_button == direction_opt)
+        return ButtonState::Pressed;
+
+    if ((window_state.pressed_button == direction_opt && window_state.render_hot_button == direction_opt)
+        || window_state.actual_hot_button == direction_opt)
+        return ButtonState::Hot;
+
+    return ButtonState::Default;
+}
+
+LRESULT WINAPI on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    auto& window_state = state::state_map.at(wnd);
+    auto call_next_window_proc
+        = [wnd_proc{window_state.wnd_proc}, wnd, msg, wp, lp] { return CallWindowProc(wnd_proc, wnd, msg, wp, lp); };
+
+    if (msg != WM_NCDESTROY && !(state::gdiplus_token && window_state.enabled))
+        return call_next_window_proc();
+
+    switch (msg) {
+    case WM_LBUTTONDOWN: {
+        const POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+        window_state.pressed_button = get_direction_at_point(wnd, pt);
+        window_state.actual_hot_button = get_direction_at_point(wnd, pt);
+        window_state.render_hot_button = window_state.actual_hot_button;
+        break;
+    }
+    case WM_LBUTTONUP: {
+        const POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+        window_state.pressed_button.reset();
+        window_state.actual_hot_button = get_direction_at_point(wnd, pt);
+        window_state.render_hot_button = window_state.actual_hot_button;
+        break;
+    }
+    case WM_MOUSEMOVE: {
+        const POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+        window_state.actual_hot_button = get_direction_at_point(wnd, pt);
+        window_state.render_hot_button = get_direction_at_point(wnd, pt, (wp & MK_LBUTTON) == 0);
+        break;
+    }
+    case WM_MOUSELEAVE:
+        window_state.render_hot_button.reset();
+        window_state.actual_hot_button.reset();
+        break;
+    case WM_ERASEBKGND:
+        return FALSE;
+    case WM_PAINT: {
+        PAINTSTRUCT ps{};
+        const auto paint_dc = wil::BeginPaint(wnd, &ps);
+        const uih::BufferedDC buffered_dc(paint_dc.get(), ps.rcPaint);
+
+        Gdiplus::Graphics graphics(buffered_dc.get());
+
+        POINT pt{};
+        GetMessagePos(&pt);
+        ScreenToClient(wnd, &pt);
+
+        RECT client_rect{};
+        GetClientRect(wnd, &client_rect);
+
+        const Gdiplus::Rect rect_plus(gsl::narrow<int>(client_rect.left), gsl::narrow<int>(client_rect.top),
+            gsl::narrow<int>(client_rect.right - client_rect.left),
+            gsl::narrow<int>(client_rect.bottom - client_rect.top));
+        const Gdiplus::SolidBrush background_brush(get_dark_gdiplus_colour(ColourID::SpinBackground));
+        graphics.FillRectangle(&background_brush, rect_plus);
+
+        auto [left_rect, right_rect] = get_button_rects(wnd);
+        render_button(graphics, right_rect, Direction::Right, get_button_state(window_state, Direction::Right));
+        render_button(graphics, left_rect, Direction::Left, get_button_state(window_state, Direction::Left));
+
+        return 0;
+    }
+    case WM_NCDESTROY:
+        state::state_map.erase(wnd);
+
+        if (state::state_map.empty() && state::gdiplus_token) {
+            Gdiplus::GdiplusShutdown(*state::gdiplus_token);
+            state::gdiplus_token.reset();
+        }
+        break;
+    }
+
+    return call_next_window_proc();
+}
+
+} // namespace
+
+void add_window(HWND wnd)
+{
+    if (is_native_dark_mode_spin_available())
+        return;
+
+    if (state::state_map.contains(wnd)) {
+        state::state_map[wnd].enabled = true;
+        return;
+    }
+
+    if (!state::gdiplus_token) {
+        console::print("GdiplusStartup");
+        const Gdiplus::GdiplusStartupInput input;
+        ULONG_PTR token{};
+
+        if (GdiplusStartup(&token, &input, nullptr) == Gdiplus::Ok)
+            state::gdiplus_token = token;
+    }
+
+    if (const auto wnd_proc = SubclassWindow(wnd, on_message)) {
+        state::state_map.emplace(wnd, WindowState{wnd_proc});
+    }
+}
+
+void remove_window(HWND wnd)
+{
+    if (state::state_map.contains(wnd)) {
+        state::state_map[wnd].enabled = false;
+    }
+}
+
+} // namespace cui::dark::spin

--- a/foo_ui_columns/dark_mode_spin.cpp
+++ b/foo_ui_columns/dark_mode_spin.cpp
@@ -248,7 +248,7 @@ LRESULT WINAPI on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
 void add_window(HWND wnd)
 {
-    if (is_native_dark_mode_spin_available())
+    if (is_native_dark_spin_available())
         return;
 
     if (state::state_map.contains(wnd)) {

--- a/foo_ui_columns/dark_mode_spin.h
+++ b/foo_ui_columns/dark_mode_spin.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace cui::dark::spin {
+/**
+ * \brief Enable dark mode support for a spin (up-down) window.
+ *
+ * Only supports left/right spin windows, as used in the tab control.
+ */
+void add_window(HWND wnd);
+void remove_window(HWND wnd);
+
+} // namespace cui::dark::spin

--- a/foo_ui_columns/dark_mode_tabs.cpp
+++ b/foo_ui_columns/dark_mode_tabs.cpp
@@ -14,8 +14,19 @@ struct Tab {
 
 auto get_tab_hot_item_index(HWND wnd)
 {
+    POINT pt{};
+    GetMessagePos(&pt);
+
+    if (const auto up_down_window = GetFirstChild(wnd)) {
+        RECT rect{};
+        GetWindowRect(up_down_window, &rect);
+
+        if (IsWindowVisible(up_down_window) && pt.x >= rect.left)
+            return -1;
+    }
+
     TCHITTESTINFO tchti{};
-    GetMessagePos(&tchti.pt);
+    tchti.pt = pt;
     MapWindowPoints(HWND_DESKTOP, wnd, &tchti.pt, 1);
 
     return TabCtrl_HitTest(wnd, &tchti);

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -259,6 +259,7 @@
     <ClCompile Include="columns_v2.cpp" />
     <ClCompile Include="colour_manager.cpp" />
     <ClCompile Include="core_dark_list_view.cpp" />
+    <ClCompile Include="dark_mode_spin.cpp" />
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="icons.cpp" />
@@ -426,6 +427,7 @@
     <ClInclude Include="config_defaults.h" />
     <ClInclude Include="config_items.h" />
     <ClInclude Include="core_dark_list_view.h" />
+    <ClInclude Include="dark_mode_spin.h" />
     <ClInclude Include="font_manager_data.h" />
     <ClInclude Include="gdi.h" />
     <ClInclude Include="gdiplus.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -587,6 +587,9 @@
     <ClCompile Include="icons.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="dark_mode_spin.cpp">
+      <Filter>Dark mode</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -850,6 +853,9 @@
     </ClInclude>
     <ClInclude Include="icons.h">
       <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="dark_mode_spin.h">
+      <Filter>Dark mode</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -191,8 +191,9 @@ bool PlaylistTabs::create_tabs()
         int cy = 0;
 
         wnd_tabs = CreateWindowEx(0, WC_TABCONTROL, _T("Playlist switcher"),
-            WS_CHILD | WS_TABSTOP | TCS_HOTTRACK | TCS_TABS | (t > 1 ? TCS_MULTILINE : 0) | (true ? WS_VISIBLE : 0), x,
-            y, cx, cy, m_host_wnd, HMENU(5002), core_api::get_my_instance(), nullptr);
+            WS_CHILD | WS_TABSTOP | TCS_HOTTRACK | TCS_TABS | (t > 1 ? TCS_MULTILINE : 0) | (true ? WS_VISIBLE : 0)
+                | WS_CLIPCHILDREN,
+            x, y, cx, cy, m_host_wnd, HMENU(5002), core_api::get_my_instance(), nullptr);
 
         if (wnd_tabs) {
             SetWindowLongPtr(wnd_tabs, GWLP_USERDATA, (LPARAM)(this));
@@ -707,7 +708,7 @@ void PlaylistTabs::set_styles(bool visible /*= true*/)
         long flags = WS_CHILD | TCS_HOTTRACK | TCS_TABS
             | ((cfg_tabs_multiline && (TabCtrl_GetItemCount(wnd_tabs) > 1)) ? TCS_MULTILINE | TCS_RIGHTJUSTIFY
                                                                             : TCS_SINGLELINE)
-            | (visible ? WS_VISIBLE : 0) | WS_CLIPSIBLINGS | WS_TABSTOP | 0;
+            | (visible ? WS_VISIBLE : 0) | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_TABSTOP;
 
         if (GetWindowLongPtr(wnd_tabs, GWL_STYLE) != flags)
             SetWindowLongPtr(wnd_tabs, GWL_STYLE, flags);

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "playlist_tabs.h"
 
+#include "dark_mode_spin.h"
 #include "dark_mode_tabs.h"
 #include "playlist_manager_utils.h"
 
@@ -444,8 +445,17 @@ void PlaylistTabs::on_child_position_change()
 
 void PlaylistTabs::set_up_down_window_theme() const
 {
-    if (m_up_down_control_wnd)
-        SetWindowTheme(m_up_down_control_wnd, colours::is_dark_mode_active() ? L"DarkMode_Explorer" : nullptr, nullptr);
+    if (!m_up_down_control_wnd)
+        return;
+
+    const auto is_dark = colours::is_dark_mode_active();
+
+    if (is_dark)
+        dark::spin::add_window(m_up_down_control_wnd);
+    else
+        dark::spin::remove_window(m_up_down_control_wnd);
+
+    SetWindowTheme(m_up_down_control_wnd, is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
 }
 
 void PlaylistTabs::refresh_child_data(abort_callback& aborter) const

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -478,7 +478,7 @@ void TabStackPanel::set_styles(bool visible)
 {
     if (m_wnd_tabs) {
         long flags = WS_CHILD | TCS_HOTTRACK | TCS_TABS | (false ? TCS_MULTILINE | TCS_RIGHTJUSTIFY : TCS_SINGLELINE)
-            | (visible ? WS_VISIBLE : 0) | WS_CLIPSIBLINGS | WS_TABSTOP | 0;
+            | (visible ? WS_VISIBLE : 0) | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_TABSTOP;
 
         if (GetWindowLongPtr(m_wnd_tabs, GWL_STYLE) != flags)
             SetWindowLongPtr(m_wnd_tabs, GWL_STYLE, flags);
@@ -868,8 +868,8 @@ void TabStackPanel::create_tabs()
     g_font.reset(fb2k::std_api_get<fonts::manager>()->get_font(g_guid_splitter_tabs));
     RECT rc;
     GetClientRect(get_wnd(), &rc);
-    DWORD flags = WS_CHILD | WS_TABSTOP | TCS_HOTTRACK | TCS_TABS | TCS_MULTILINE
-        | (true ? WS_VISIBLE : 0); // TCS_MULTILINE hack to prevent BS.
+    DWORD flags = WS_CHILD | WS_TABSTOP | TCS_HOTTRACK | TCS_TABS | TCS_MULTILINE | (true ? WS_VISIBLE : 0)
+        | WS_CLIPCHILDREN; // TCS_MULTILINE hack to prevent BS.
     m_wnd_tabs = CreateWindowEx(0, WC_TABCONTROL, _T("Tab stack"), flags, 0, 0, rc.right, rc.bottom, get_wnd(),
         HMENU(2345), core_api::get_my_instance(), nullptr);
     SetWindowLongPtr(m_wnd_tabs, GWLP_USERDATA, (LPARAM)(this));

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -487,8 +487,17 @@ void TabStackPanel::set_styles(bool visible)
 
 void TabStackPanel::set_up_down_window_theme() const
 {
-    if (m_up_down_control_wnd)
-        SetWindowTheme(m_up_down_control_wnd, colours::is_dark_mode_active() ? L"DarkMode_Explorer" : nullptr, nullptr);
+    if (!m_up_down_control_wnd)
+        return;
+
+    const auto is_dark = colours::is_dark_mode_active();
+
+    if (is_dark)
+        dark::spin::add_window(m_up_down_control_wnd);
+    else
+        dark::spin::remove_window(m_up_down_control_wnd);
+
+    SetWindowTheme(m_up_down_control_wnd, is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
 }
 
 LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "dark_mode_spin.h"
+
 namespace cui::panels::tab_stack {
 
 class TabStackPanel : public uie::container_uie_window_v3_t<uie::splitter_window_v2> {


### PR DESCRIPTION
Resolves #544 

This adds dark mode support to the Tab stack and Playlist tabs spin (up-down) control on Windows 10 and Windows 11 21H1.

This is, of course, a hack as the spin control has no native dark mode support.

There should be no change on Windows 11 22H2 where the spin control does have a native dark mode.

This also resolves some minor glitches that occurred when when using the scroll buttons (spin control) in the Tab stack and Playlist tabs panels with dark mode enabled.