### PR TITLE
Add dark mode support to spectrum analyser options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Development version
+
+### Features
+
+- Dark mode support was added to the spectrum analyser options dialogue box.
+  [[#673](https://github.com/reupen/columns_ui/pull/673)]
+
 ## 2.0.0-beta.2
 
 ### Features

--- a/foo_ui_columns/core_dark_list_view.cpp
+++ b/foo_ui_columns/core_dark_list_view.cpp
@@ -15,12 +15,13 @@ void CoreDarkListView::notify_on_initialisation()
     set_use_dark_mode(manager->is_dark_mode());
     set_dark_edit_colours(
         cui::dark::get_dark_system_colour(COLOR_WINDOWTEXT), cui::dark::get_dark_system_colour(COLOR_WINDOW));
-    m_ui_config_callback = std::make_unique<UIConfigCallback>(this, manager);
+    m_dark_mode_status_callback
+        = dark::add_status_callback([this] { set_use_dark_mode(dark::is_active_ui_dark(false)); }, false);
 }
 
 void CoreDarkListView::notify_on_destroy()
 {
-    m_ui_config_callback.reset();
+    m_dark_mode_status_callback.reset();
 }
 
 void CoreDarkListView::render_get_colour_data(ColourData& p_out)

--- a/foo_ui_columns/core_dark_list_view.h
+++ b/foo_ui_columns/core_dark_list_view.h
@@ -1,35 +1,16 @@
 #pragma once
+#include "dark_mode_active_ui.h"
 
 namespace cui::helpers {
 
 class CoreDarkListView : public uih::ListView {
-    class UIConfigCallback : public ui_config_callback {
-    public:
-        UIConfigCallback(CoreDarkListView* list_view, ui_config_manager::ptr manager)
-            : m_list_view(list_view)
-            , m_manager(std::move(manager))
-        {
-            m_manager->add_callback(this);
-        }
-
-        ~UIConfigCallback() { m_manager->remove_callback(this); }
-
-        void ui_fonts_changed() override {}
-
-        void ui_colors_changed() override { m_list_view->set_use_dark_mode(m_manager->is_dark_mode()); }
-
-    private:
-        CoreDarkListView* m_list_view{};
-        ui_config_manager::ptr m_manager;
-    };
-
 protected:
     void notify_on_initialisation() override;
     void notify_on_destroy() override;
     void render_get_colour_data(ColourData& p_out) override;
 
 private:
-    std::unique_ptr<UIConfigCallback> m_ui_config_callback;
+    std::unique_ptr<EventToken> m_dark_mode_status_callback;
 };
 
 } // namespace cui::helpers

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -82,6 +82,26 @@ void set_titlebar_mode(HWND wnd, bool is_dark)
     DwmSetWindowAttribute(wnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
 }
 
+void force_titlebar_redraw(HWND wnd)
+{
+    if (!IsWindowVisible(wnd))
+        return;
+
+    // The below is a hack to force the titlebar to redraw (nothing else works).
+    RECT rc{};
+    if (!GetWindowRect(wnd, &rc))
+        return;
+
+    const auto cx = RECT_CX(rc);
+    const auto cy = RECT_CY(rc);
+
+    if (cx <= 0)
+        return;
+
+    SetWindowPos(wnd, nullptr, 0, 0, cx - 1, cy, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+    SetWindowPos(wnd, nullptr, 0, 0, cx, cy, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
 namespace {
 
 consteval COLORREF create_grey(const int value)
@@ -330,6 +350,13 @@ void draw_layout_background(HWND wnd, HDC dc)
 
     const auto brush = get_colour_brush(ColourID::LayoutBackground, colours::is_dark_mode_active());
     FillRect(dc, &rc, brush.get());
+}
+
+void handle_modern_background_paint(HWND wnd, HWND wnd_button, bool is_dark)
+{
+    const auto top_background_brush = get_system_colour_brush(COLOR_WINDOW, is_dark);
+    const auto bottom_background_brush = get_system_colour_brush(COLOR_3DFACE, is_dark);
+    uih::handle_modern_background_paint(wnd, wnd_button, top_background_brush.get(), bottom_background_brush.get());
 }
 
 } // namespace cui::dark

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -82,6 +82,7 @@ enum class PreferredAppMode { System = 1, Dark = 2, Light = 3 };
 
 void set_app_mode(PreferredAppMode mode);
 void set_titlebar_mode(HWND wnd, bool is_dark);
+void force_titlebar_redraw(HWND wnd);
 
 [[nodiscard]] COLORREF get_dark_colour(ColourID colour_id);
 [[nodiscard]] Gdiplus::Color get_dark_gdiplus_colour(ColourID colour_id);
@@ -94,5 +95,6 @@ void set_titlebar_mode(HWND wnd, bool is_dark);
 [[nodiscard]] wil::unique_hbrush get_system_colour_brush(int system_colour_id, bool is_dark);
 
 void draw_layout_background(HWND wnd, HDC dc);
+void handle_modern_background_paint(HWND wnd, HWND wnd_button, bool is_dark);
 
 } // namespace cui::dark

--- a/foo_ui_columns/dark_mode_active_ui.cpp
+++ b/foo_ui_columns/dark_mode_active_ui.cpp
@@ -1,0 +1,71 @@
+#include "pch.h"
+
+#include "dark_mode_active_ui.h"
+
+#include "main_window.h"
+
+namespace cui::dark {
+
+namespace {
+
+class DarkModeStatusChangedToken : public EventToken {
+public:
+    DarkModeStatusChangedToken(std::function<void()> callback, bool allow_cui_fallback);
+    void on_dark_mode_status_change() const { m_callback(); }
+
+private:
+    std::function<void()> m_callback;
+    std::unique_ptr<class UIConfigCallback> m_ui_config_callback;
+    std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
+};
+
+class UIConfigCallback : public ui_config_callback {
+public:
+    explicit UIConfigCallback(DarkModeStatusChangedToken* callback_object) : m_callback_object(callback_object)
+    {
+        if (m_manager.is_valid())
+            m_manager->add_callback(this);
+    }
+
+    ~UIConfigCallback()
+    {
+        if (m_manager.is_valid())
+            m_manager->remove_callback(this);
+    }
+
+    bool is_valid() const { return m_manager.is_valid(); }
+    void ui_fonts_changed() override {}
+    void ui_colors_changed() override { m_callback_object->on_dark_mode_status_change(); }
+
+private:
+    DarkModeStatusChangedToken* m_callback_object{};
+    ui_config_manager::ptr m_manager{ui_config_manager::tryGet()};
+};
+
+DarkModeStatusChangedToken::DarkModeStatusChangedToken(std::function<void()> callback, bool allow_cui_fallback)
+    : m_callback(std::move(callback))
+{
+    m_ui_config_callback = std::make_unique<UIConfigCallback>(this);
+
+    if (!m_ui_config_callback->is_valid() && allow_cui_fallback)
+        m_dark_mode_notifier = std::make_unique<colours::dark_mode_notifier>([this] { m_callback(); });
+}
+
+} // namespace
+
+bool is_active_ui_dark(bool allow_cui_fallback)
+{
+    const auto manager = ui_config_manager::tryGet();
+
+    if (manager.is_valid())
+        return manager->is_dark_mode();
+
+    return allow_cui_fallback && main_window.get_wnd() && colours::is_dark_mode_active();
+}
+
+std::unique_ptr<EventToken> add_status_callback(std::function<void()> callback, bool allow_cui_fallback)
+{
+    return std::make_unique<DarkModeStatusChangedToken>(std::move(callback), allow_cui_fallback);
+}
+
+} // namespace cui::dark

--- a/foo_ui_columns/dark_mode_active_ui.h
+++ b/foo_ui_columns/dark_mode_active_ui.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "event_token.h"
+
+namespace cui::dark {
+
+[[nodiscard]] bool is_active_ui_dark(bool allow_cui_fallback = true);
+[[nodiscard]] std::unique_ptr<EventToken> add_status_callback(
+    std::function<void()> callback, bool allow_cui_fallback = true);
+
+} // namespace cui::dark

--- a/foo_ui_columns/dark_mode_dialog.cpp
+++ b/foo_ui_columns/dark_mode_dialog.cpp
@@ -1,0 +1,124 @@
+#include "pch.h"
+
+#include "dark_mode_dialog.h"
+
+#include "main_window.h"
+
+namespace cui::dark {
+
+void DialogDarkModeHelper::set_window_themes()
+{
+    const auto is_dark = is_active_ui_dark();
+    set_titlebar_mode(m_wnd, is_dark);
+    set_window_theme(m_button_ids, L"DarkMode_Explorer", is_dark);
+    set_window_theme(m_checkbox_ids, L"DarkMode_Explorer", is_dark);
+    set_window_theme(m_combo_box_ids, L"DarkMode_CFD", is_dark);
+}
+
+std::optional<INT_PTR> DialogDarkModeHelper::handle_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    switch (msg) {
+    case WM_INITDIALOG:
+        m_wnd = wnd;
+        m_dark_mode_status_callback = add_status_callback([this] { on_dark_mode_change(); });
+        break;
+    case WM_NCDESTROY:
+        m_dark_mode_status_callback.reset();
+        m_main_background_brush.reset();
+        m_wnd = nullptr;
+        break;
+    case WM_THEMECHANGED:
+        m_button_theme.reset();
+        break;
+    case WM_ERASEBKGND:
+        SetWindowLongPtr(wnd, DWLP_MSGRESULT, TRUE);
+        return TRUE;
+    case WM_PAINT:
+        handle_modern_background_paint(wnd, GetDlgItem(wnd, IDOK), is_active_ui_dark());
+        return TRUE;
+    case WM_NOTIFY:
+        if (const auto result = handle_wm_notify(wnd, reinterpret_cast<LPNMHDR>(lp)))
+            return result;
+        break;
+    case WM_CTLCOLORLISTBOX:
+    case WM_CTLCOLORSTATIC: {
+        const auto is_dark = is_active_ui_dark();
+
+        if (!m_main_background_brush)
+            m_main_background_brush = get_system_colour_brush(COLOR_WINDOW, is_dark);
+
+        const auto dc = reinterpret_cast<HDC>(wp);
+        SetBkColor(dc, get_system_colour(COLOR_WINDOW, is_dark));
+        SetTextColor(dc, get_system_colour(COLOR_WINDOWTEXT, is_dark));
+        return reinterpret_cast<INT_PTR>(m_main_background_brush.get());
+    }
+    }
+
+    return {};
+}
+
+std::optional<INT_PTR> DialogDarkModeHelper::handle_wm_notify(HWND wnd, LPNMHDR lpnm)
+{
+    switch (lpnm->code) {
+    case NM_CUSTOMDRAW: {
+        if (lpnm->idFrom > gsl::narrow_cast<UINT_PTR>(std::numeric_limits<int>::max()))
+            break;
+
+        if (!m_checkbox_ids.contains(gsl::narrow_cast<int>(lpnm->idFrom)) || !is_active_ui_dark())
+            break;
+
+        const auto lpnmcd = reinterpret_cast<LPNMCUSTOMDRAW>(lpnm);
+
+        switch (lpnmcd->dwDrawStage) {
+        case CDDS_PREPAINT:
+            const auto dc = lpnmcd->hdc;
+
+            if (!m_button_theme)
+                m_button_theme.reset(OpenThemeData(wnd, L"Button"));
+
+            SIZE box_size{};
+            if (FAILED(GetThemePartSize(m_button_theme.get(), dc, BP_CHECKBOX, 0, nullptr, TS_DRAW, &box_size)))
+                break;
+
+            const auto text_length = GetWindowTextLength(lpnm->hwndFrom);
+            std::vector<wchar_t> text(text_length + 1);
+            GetWindowText(lpnm->hwndFrom, text.data(), text_length + 1);
+
+            SIZE zero_digit_size{};
+            GetTextExtentPoint32(dc, L"0", 1, &zero_digit_size);
+
+            RECT rect_text = lpnmcd->rc;
+            rect_text.left += box_size.cx + zero_digit_size.cx / 2;
+
+            SetTextColor(dc, get_system_colour(COLOR_WINDOWTEXT, true));
+
+            // Multi-line text not currently handled
+            DrawTextEx(dc, text.data(), gsl::narrow<int>(text.size()), &rect_text,
+                DT_HIDEPREFIX | DT_SINGLELINE | DT_VCENTER, nullptr);
+
+            SetWindowLongPtr(wnd, DWLP_MSGRESULT, CDRF_SKIPDEFAULT);
+            return TRUE;
+        }
+        break;
+    }
+    }
+
+    return {};
+}
+
+void DialogDarkModeHelper::on_dark_mode_change()
+{
+    if (!m_wnd)
+        return;
+
+    m_main_background_brush.reset();
+
+    SetWindowRedraw(m_wnd, FALSE);
+    set_window_themes();
+    SetWindowRedraw(m_wnd, TRUE);
+    RedrawWindow(m_wnd, nullptr, nullptr,
+        RDW_INVALIDATE | RDW_ERASE | RDW_ALLCHILDREN | RDW_FRAME | RDW_UPDATENOW | RDW_ERASENOW);
+
+    force_titlebar_redraw(m_wnd);
+}
+} // namespace cui::dark

--- a/foo_ui_columns/dark_mode_dialog.h
+++ b/foo_ui_columns/dark_mode_dialog.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "dark_mode.h"
+#include "dark_mode_active_ui.h"
+
+namespace cui::dark {
+
+class DialogDarkModeHelper {
+public:
+    void add_buttons(std::initializer_list<int> ids) { m_button_ids = ids; }
+    void add_checkboxes(std::initializer_list<int> ids) { m_checkbox_ids = ids; }
+    void add_combo_boxes(std::initializer_list<int> ids) { m_combo_box_ids = ids; }
+    void set_window_themes();
+    [[nodiscard]] std::optional<INT_PTR> handle_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+
+private:
+    [[nodiscard]] std::optional<INT_PTR> handle_wm_notify(HWND wnd, LPNMHDR lpnm);
+    void on_dark_mode_change();
+    void set_window_theme(auto&& ids, const wchar_t* dark_class, bool is_dark);
+
+    HWND m_wnd{};
+    wil::unique_hbrush m_main_background_brush;
+    wil::unique_htheme m_button_theme;
+    std::unordered_set<int> m_button_ids;
+    std::unordered_set<int> m_checkbox_ids;
+    std::unordered_set<int> m_combo_box_ids;
+    std::unique_ptr<EventToken> m_dark_mode_status_callback;
+};
+
+void DialogDarkModeHelper::set_window_theme(auto&& ids, const wchar_t* dark_class, bool is_dark)
+{
+    if (!m_wnd)
+        return;
+
+    for (const auto id : ids)
+        SetWindowTheme(GetDlgItem(m_wnd, id), is_dark ? dark_class : nullptr, nullptr);
+}
+
+} // namespace cui::dark

--- a/foo_ui_columns/event_token.h
+++ b/foo_ui_columns/event_token.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace cui {
+
+struct EventToken {
+    virtual ~EventToken() = default;
+};
+
+} // namespace cui

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -259,6 +259,8 @@
     <ClCompile Include="columns_v2.cpp" />
     <ClCompile Include="colour_manager.cpp" />
     <ClCompile Include="core_dark_list_view.cpp" />
+    <ClCompile Include="dark_mode_active_ui.cpp" />
+    <ClCompile Include="dark_mode_dialog.cpp" />
     <ClCompile Include="dark_mode_spin.cpp" />
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="gdi.cpp" />
@@ -427,7 +429,10 @@
     <ClInclude Include="config_defaults.h" />
     <ClInclude Include="config_items.h" />
     <ClInclude Include="core_dark_list_view.h" />
+    <ClInclude Include="dark_mode_dialog.h" />
+    <ClInclude Include="dark_mode_active_ui.h" />
     <ClInclude Include="dark_mode_spin.h" />
+    <ClInclude Include="event_token.h" />
     <ClInclude Include="font_manager_data.h" />
     <ClInclude Include="gdi.h" />
     <ClInclude Include="gdiplus.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -590,6 +590,12 @@
     <ClCompile Include="dark_mode_spin.cpp">
       <Filter>Dark mode</Filter>
     </ClCompile>
+    <ClCompile Include="dark_mode_dialog.cpp">
+      <Filter>Dark mode</Filter>
+    </ClCompile>
+    <ClCompile Include="dark_mode_active_ui.cpp">
+      <Filter>Dark mode</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -856,6 +862,15 @@
     </ClInclude>
     <ClInclude Include="dark_mode_spin.h">
       <Filter>Dark mode</Filter>
+    </ClInclude>
+    <ClInclude Include="dark_mode_dialog.h">
+      <Filter>Dark mode</Filter>
+    </ClInclude>
+    <ClInclude Include="dark_mode_active_ui.h">
+      <Filter>Dark mode</Filter>
+    </ClInclude>
+    <ClInclude Include="event_token.h">
+      <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -300,22 +300,7 @@ void cui::MainWindow::set_dark_mode_attributes(bool is_update) const
 
     update_taskbar_button_images();
 
-    if (!IsWindowVisible(m_wnd))
-        return;
-
-    // The below is a hack to force the titlebar to redraw (nothing else works).
-    RECT rc{};
-    if (!GetWindowRect(m_wnd, &rc))
-        return;
-
-    const auto cx = RECT_CX(rc);
-    const auto cy = RECT_CY(rc);
-
-    if (cx <= 0)
-        return;
-
-    SetWindowPos(m_wnd, nullptr, 0, 0, cx - 1, cy, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-    SetWindowPos(m_wnd, nullptr, 0, 0, cx, cy, SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+    dark::force_titlebar_redraw(m_wnd);
 }
 
 void cui::MainWindow::create_child_windows()

--- a/foo_ui_columns/seekbar.h
+++ b/foo_ui_columns/seekbar.h
@@ -44,7 +44,7 @@ private:
     uih::Trackbar m_child;
     SeekBarTrackbarCallback m_track_bar_host;
     std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
-    std::unique_ptr<system_appearance_manager::EventToken> m_modern_colours_changed_token;
+    std::unique_ptr<EventToken> m_modern_colours_changed_token;
 };
 
 } // namespace cui::toolbars::seekbar

--- a/foo_ui_columns/system_appearance_manager.h
+++ b/foo_ui_columns/system_appearance_manager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "event_token.h"
 
 namespace cui::system_appearance_manager {
 
@@ -13,10 +14,6 @@ struct ModernColours {
         return (GetRValue(background) + GetGValue(background) + GetBValue(background))
             < (GetRValue(foreground) + GetGValue(foreground) + GetBValue(foreground));
     }
-};
-
-struct EventToken {
-    virtual ~EventToken() {}
 };
 
 using ModernColoursChangedHandler = std::function<void()>;

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -370,7 +370,7 @@ private:
     bool m_using_gdiplus{false};
     std::unique_ptr<uie::container_window_v3> m_window;
     std::unique_ptr<cui::colours::dark_mode_notifier> m_dark_mode_notifier;
-    std::unique_ptr<cui::system_appearance_manager::EventToken> m_modern_colours_changed_token;
+    std::unique_ptr<cui::EventToken> m_modern_colours_changed_token;
 };
 
 class PopupVolumeBarAttributes {


### PR DESCRIPTION
This adds dark mode support to the spectrum analyser options dialogue box.

Styling consistent with the rest of Columns UI is used (i.e. not core dark mode support), and foobar2000 1.5 and 1.6 are still supported.