### PR TITLE
Fix playlist view artwork crash in certain error cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
   [[#680](https://github.com/reupen/columns_ui/pull/680), contributed by
   [@marc2k3](https://github.com/marc2k3)]
 
+### Bug fixes
+
+- A crash when artwork is enabled in the playlist view and certain input
+  components are used was fixed.
+  [[#684](https://github.com/reupen/columns_ui/pull/684)]
+
 ### Internal changes
 
 - Various dependencies were updated.

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -130,17 +130,17 @@ DWORD ArtworkReader::on_thread()
 unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
 {
     TRACK_CALL_TEXT("artwork_reader_ng_t::read_artwork");
-    const GUID artwork_type_id = album_art_ids::cover_front;
+    constexpr GUID artwork_type_id = album_art_ids::cover_front;
 
     m_bitmaps.clear();
 
     const auto p_album_art_manager_v2 = album_art_manager_v2::get();
 
     album_art_data_ptr data;
-    auto artwork_api_v2 = p_album_art_manager_v2->open(
-        pfc::list_single_ref_t<metadb_handle_ptr>(m_handle), pfc::list_single_ref_t<GUID>(artwork_type_id), p_abort);
 
     try {
+        const auto artwork_api_v2 = p_album_art_manager_v2->open(pfc::list_single_ref_t<metadb_handle_ptr>(m_handle),
+            pfc::list_single_ref_t<GUID>(artwork_type_id), p_abort);
         data = artwork_api_v2->query(artwork_type_id, p_abort);
     } catch (const exception_aborted&) {
         throw;


### PR DESCRIPTION
This fixes a crash when artwork is enabled in the playlist view and there is an error when creating an album art extractor object for a particular track.

This happened in particular with certain input components.