### PR TITLE
Add dark mode support to Buttons options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   [#686](https://github.com/reupen/columns_ui/pull/686),
   [#688](https://github.com/reupen/columns_ui/pull/688) (contributed by
   [@marc2k3](https://github.com/marc2k3)),
-  [#689](https://github.com/reupen/columns_ui/pull/689)]
+  [#689](https://github.com/reupen/columns_ui/pull/689),
+  [#692](https://github.com/reupen/columns_ui/pull/692)]
 
 - Dark menus were enabled on Windows 11 build 22624.
   [[#680](https://github.com/reupen/columns_ui/pull/680), contributed by

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -2,8 +2,8 @@
 #include "buttons.h"
 
 #include "dark_mode.h"
+#include "dark_mode_dialog.h"
 #include "menu_items.h"
-#include "svg.h"
 
 #define ID_BUTTONS 2001
 
@@ -635,7 +635,14 @@ bool ButtonsToolbar::show_config_popup(HWND wnd_parent)
     param.m_width = m_width;
     param.m_height = m_height;
 
-    const auto dialog_result = uih::modal_dialog_box(IDD_BUTTONS_OPTIONS, wnd_parent,
+    dark::DialogDarkModeConfig dark_mode_config{.button_ids
+        = {IDC_PICK, IDC_ADD, IDC_REMOVE, IDC_RESET, IDC_BROWSE_ICON, IDC_BROWSE_HOVER_ICON, IDC_TOOLS, IDOK, IDCANCEL},
+        .checkbox_ids = {IDC_USE_CUSTOM_TEXT, IDC_USE_CUSTOM_ICON, IDC_USE_CUSTOM_HOVER_ICON},
+        .combo_box_ids = {IDC_SHOW, IDC_TEXT_LOCATION, IDC_APPEARANCE, IDC_ICON_SIZE},
+        .edit_ids = {IDC_TEXT, IDC_ICON_PATH, IDC_HOVER_ICON_PATH, IDC_WIDTH, IDC_HEIGHT},
+        .spin_ids = {IDC_WIDTH_SPIN, IDC_HEIGHT_SPIN}};
+
+    const auto dialog_result = modal_dialog_box(IDD_BUTTONS_OPTIONS, dark_mode_config, wnd_parent,
         [&param](auto&&... args) { return param.on_dialog_message(std::forward<decltype(args)>(args)...); });
 
     if (dialog_result > 0) {

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -2,6 +2,8 @@
 
 #include "pch.h"
 
+#include "core_dark_list_view.h"
+
 namespace cui::toolbars::buttons {
 
 class ButtonsToolbar : public uie::container_uie_window_v3 {
@@ -195,7 +197,7 @@ public:
     class ConfigParam {
     public:
         // service_ptr_t<toolbar_extension> m_this;
-        class ButtonsList : public uih::ListView {
+        class ButtonsList : public helpers::CoreDarkListView {
             ConfigParam& m_param;
             static CLIPFORMAT g_clipformat();
             struct DDData {
@@ -230,7 +232,7 @@ public:
             bool do_drag_drop(WPARAM wp) override;
 
         public:
-            explicit ButtonsList(ConfigParam& p_param) : m_param(p_param) {}
+            explicit ButtonsList(ConfigParam& p_param) : CoreDarkListView(true), m_param(p_param) {}
         } m_button_list;
 
         void export_to_file(const char* p_path, bool b_paths = false);

--- a/foo_ui_columns/buttons_config_listview.cpp
+++ b/foo_ui_columns/buttons_config_listview.cpp
@@ -11,6 +11,7 @@ CLIPFORMAT ButtonsToolbar::ConfigParam::ButtonsList::g_clipformat()
 
 void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_initialisation()
 {
+    CoreDarkListView::notify_on_initialisation();
     set_selection_mode(SelectionMode::SingleRelaxed);
     set_columns({{"Name", 225_spx}, {"Type", 150_spx}});
 }

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -561,6 +561,9 @@ void ButtonsToolbar::ConfigParam::update_size_field_status()
 
     uSetDlgItemText(m_wnd, IDC_WIDTH, is_custom_size ? std::to_string(m_width.get_scaled_value()).c_str() : "");
     uSetDlgItemText(m_wnd, IDC_HEIGHT, is_custom_size ? std::to_string(m_height.get_scaled_value()).c_str() : "");
+
+    RedrawWindow(GetDlgItem(m_wnd, IDC_WIDTH_SPIN), nullptr, nullptr, RDW_INVALIDATE);
+    RedrawWindow(GetDlgItem(m_wnd, IDC_HEIGHT_SPIN), nullptr, nullptr, RDW_INVALIDATE);
 }
 
 } // namespace cui::toolbars::buttons

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -112,10 +112,13 @@ consteval COLORREF create_grey(const int value)
 enum class DarkColourID : COLORREF {
     DARK_000,
     DARK_200,
+    DARK_250,
     DARK_300,
     DARK_400,
     DARK_500,
     DARK_600,
+    DARK_700,
+    DARK_740,
     DARK_750,
     DARK_999,
 };
@@ -127,6 +130,8 @@ COLORREF get_base_dark_colour(DarkColourID colour_id)
         return is_windows_11_rtm_or_newer() ? create_grey(25) : create_grey(32);
     case DarkColourID::DARK_200:
         return create_grey(51);
+    case DarkColourID::DARK_250:
+        return create_grey(64);
     case DarkColourID::DARK_300:
         return create_grey(77);
     case DarkColourID::DARK_400:
@@ -135,6 +140,10 @@ COLORREF get_base_dark_colour(DarkColourID colour_id)
         return create_grey(98);
     case DarkColourID::DARK_600:
         return create_grey(119);
+    case DarkColourID::DARK_700:
+        return create_grey(131);
+    case DarkColourID::DARK_740:
+        return create_grey(155);
     case DarkColourID::DARK_750:
         return create_grey(166);
     case DarkColourID::DARK_999:
@@ -200,6 +209,10 @@ wil::unique_hbrush get_light_colour_brush(ColourID colour_id)
 COLORREF get_dark_colour(ColourID colour_id)
 {
     switch (colour_id) {
+    case ColourID::CheckboxDisabledText:
+        return get_base_dark_colour(DarkColourID::DARK_700);
+    case ColourID::CheckboxText:
+        return get_base_dark_colour(DarkColourID::DARK_999);
     case ColourID::EditBackground:
         return get_base_dark_colour(DarkColourID::DARK_200);
     case ColourID::LayoutBackground:
@@ -220,14 +233,28 @@ COLORREF get_dark_colour(ColourID colour_id)
         return get_base_dark_colour(DarkColourID::DARK_400);
     case ColourID::SpinBackground:
         return get_base_dark_colour(DarkColourID::DARK_200);
+    case ColourID::SpinBuddyButtonBackground:
+        return get_base_dark_colour(DarkColourID::DARK_200);
+    case ColourID::SpinBuddyButtonBorder:
+        return get_base_dark_colour(DarkColourID::DARK_740);
     case ColourID::SpinButtonBorder:
         return get_base_dark_colour(DarkColourID::DARK_400);
     case ColourID::SpinButtonArrow:
         return get_base_dark_colour(DarkColourID::DARK_999);
     case ColourID::SpinButtonBackground:
         return get_base_dark_colour(DarkColourID::DARK_000);
-    case ColourID::SpinHotButtonBackground:
+    case ColourID::SpinDisabledBuddyButtonBackground:
+        return get_base_dark_colour(DarkColourID::DARK_000);
+    case ColourID::SpinDisabledBuddyButtonBorder:
+        return get_base_dark_colour(DarkColourID::DARK_250);
+    case ColourID::SpinDisabledButtonBackground:
+        return get_base_dark_colour(DarkColourID::DARK_000);
+    case ColourID::SpinHotBuddyButtonBackground:
         return get_base_dark_colour(DarkColourID::DARK_300);
+    case ColourID::SpinHotButtonBackground:
+        return get_base_dark_colour(DarkColourID::DARK_250);
+    case ColourID::SpinPressedBuddyButtonBackground:
+        return get_base_dark_colour(DarkColourID::DARK_500);
     case ColourID::SpinPressedButtonBackground:
         return get_base_dark_colour(DarkColourID::DARK_500);
     case ColourID::StatusBarBackground:

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -8,6 +8,8 @@
 namespace cui::dark {
 
 enum class ColourID {
+    CheckboxDisabledText,
+    CheckboxText,
     EditBackground,
     LayoutBackground,
     PanelCaptionText,
@@ -15,10 +17,17 @@ enum class ColourID {
     RebarBackground,
     RebarBandBorder,
     SpinBackground,
+    SpinBuddyButtonBackground,
+    SpinBuddyButtonBorder,
     SpinButtonArrow,
     SpinButtonBackground,
     SpinButtonBorder,
+    SpinDisabledButtonBackground,
+    SpinDisabledBuddyButtonBackground,
+    SpinDisabledBuddyButtonBorder,
+    SpinHotBuddyButtonBackground,
     SpinHotButtonBackground,
+    SpinPressedBuddyButtonBackground,
     SpinPressedButtonBackground,
     StatusBarBackground,
     StatusBarText,

--- a/foo_ui_columns/dark_mode_dialog.h
+++ b/foo_ui_columns/dark_mode_dialog.h
@@ -11,6 +11,7 @@ struct DialogDarkModeConfig {
     std::unordered_set<int> combo_box_ids;
     std::unordered_set<int> edit_ids;
     std::unordered_set<int> list_box_ids;
+    std::unordered_set<int> spin_ids;
     std::unordered_set<int> tree_view_ids;
 };
 

--- a/foo_ui_columns/dark_mode_spin.cpp
+++ b/foo_ui_columns/dark_mode_spin.cpp
@@ -6,7 +6,14 @@ namespace cui::dark::spin {
 
 namespace {
 
+enum class SpinType {
+    UpDown,
+    LeftRight,
+};
+
 enum class Direction {
+    Up,
+    Down,
     Left,
     Right,
 };
@@ -15,14 +22,23 @@ enum class ButtonState {
     Default,
     Hot,
     Pressed,
+    Disabled,
 };
 
 struct WindowState {
     WNDPROC wnd_proc{};
+    SpinType spin_type{SpinType::UpDown};
     bool enabled{true};
     std::optional<Direction> render_hot_button;
     std::optional<Direction> actual_hot_button;
     std::optional<Direction> pressed_button;
+};
+
+struct RenderContext {
+    RECT button_rect{};
+    Direction direction{};
+    ButtonState button_state{};
+    bool has_buddy{};
 };
 
 namespace state {
@@ -32,47 +48,67 @@ std::unordered_map<HWND, WindowState> state_map;
 
 } // namespace state
 
-void render_button_border_and_background(Gdiplus::Graphics& graphics, RECT rect, Direction direction, ButtonState state)
+void render_button_border_and_background(Gdiplus::Graphics& graphics, const RenderContext& context)
 {
     graphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias8x8);
 
-    const auto background_colour_id = [state]() {
-        if (state == ButtonState::Pressed)
-            return ColourID::SpinPressedButtonBackground;
+    const auto background_colour_id = [button_state{context.button_state}, has_buddy{context.has_buddy}]() {
+        if (button_state == ButtonState::Pressed)
+            return has_buddy ? ColourID::SpinPressedBuddyButtonBackground : ColourID::SpinPressedButtonBackground;
 
-        if (state == ButtonState::Hot)
-            return ColourID::SpinHotButtonBackground;
+        if (button_state == ButtonState::Hot)
+            return has_buddy ? ColourID::SpinHotBuddyButtonBackground : ColourID::SpinHotButtonBackground;
 
-        return ColourID::SpinButtonBackground;
+        if (button_state == ButtonState::Disabled)
+            return has_buddy ? ColourID::SpinDisabledBuddyButtonBackground : ColourID::SpinDisabledButtonBackground;
+
+        return has_buddy ? ColourID::SpinBuddyButtonBackground : ColourID::SpinButtonBackground;
+    }();
+
+    const Gdiplus::SolidBrush background_brush(get_dark_gdiplus_colour(background_colour_id));
+
+    const auto border_colour_id = [&context]() {
+        if (!context.has_buddy)
+            return ColourID::SpinButtonBorder;
+
+        if (context.button_state == ButtonState::Disabled)
+            return ColourID::SpinDisabledBuddyButtonBorder;
+
+        return ColourID::SpinBuddyButtonBorder;
     }();
 
     const auto path_width = 1_spx;
-
-    const Gdiplus::SolidBrush background_brush(get_dark_gdiplus_colour(background_colour_id));
-    const Gdiplus::Pen border_pen(
-        get_dark_gdiplus_colour(ColourID::SpinButtonBorder), static_cast<Gdiplus::REAL>(path_width));
+    const Gdiplus::Pen border_pen(get_dark_gdiplus_colour(border_colour_id), static_cast<Gdiplus::REAL>(path_width));
 
     const auto half_path = (path_width + 1) / 2;
     const auto arc_radius = path_width;
     const auto arc_diameter = arc_radius * 2;
 
-    const auto border_left = gsl::narrow<int>(rect.left);
-    const auto border_top = gsl::narrow<int>(rect.top);
-    const auto border_right = gsl::narrow<int>(rect.right) - half_path;
-    const auto border_bottom = gsl::narrow<int>(rect.bottom) - half_path;
+    const auto border_left = gsl::narrow<int>(context.button_rect.left);
+    const auto border_top = gsl::narrow<int>(context.button_rect.top);
+    const auto border_right = gsl::narrow<int>(context.button_rect.right) - half_path;
+    const auto border_bottom = gsl::narrow<int>(context.button_rect.bottom) - half_path;
     const auto arc_ellipse_right = border_right - arc_diameter;
     const auto arc_ellipse_bottom = border_bottom - arc_diameter;
 
     Gdiplus::GraphicsPath border;
 
-    if (direction == Direction::Right) {
-        border.AddArc(arc_ellipse_right, border_top, arc_diameter, arc_diameter, 270, 90);
-        border.AddArc(arc_ellipse_right, arc_ellipse_bottom, arc_diameter, arc_diameter, 0, 90);
+    switch (context.direction) {
+    case Direction::Up:
+    case Direction::Down:
         border.AddLine(border_left, border_bottom, border_left, border_top);
-    } else {
+        border.AddLine(border_right, border_top, border_right, border_bottom);
+        break;
+    case Direction::Left:
         border.AddArc(border_left, arc_ellipse_bottom, arc_diameter, arc_diameter, 90, 90);
         border.AddArc(border_left, border_top, arc_diameter, arc_diameter, 180, 90);
         border.AddLine(border_right, border_top, border_right, border_bottom);
+        break;
+    case Direction::Right:
+        border.AddArc(arc_ellipse_right, border_top, arc_diameter, arc_diameter, 270, 90);
+        border.AddArc(arc_ellipse_right, arc_ellipse_bottom, arc_diameter, arc_diameter, 0, 90);
+        border.AddLine(border_left, border_bottom, border_left, border_top);
+        break;
     }
 
     border.CloseFigure();
@@ -83,45 +119,90 @@ void render_button_border_and_background(Gdiplus::Graphics& graphics, RECT rect,
     graphics.SetSmoothingMode(Gdiplus::SmoothingModeDefault);
 }
 
-void render_button_arrow(Gdiplus::Graphics& graphics, RECT rect, Direction direction)
+void render_button_arrow(Gdiplus::Graphics& graphics, const RenderContext& context)
 {
-    const auto button_height_px = static_cast<float>(rect.bottom);
-    const auto button_left_px = static_cast<float>(rect.left);
-    const auto button_width_px = static_cast<float>(rect.right - rect.left);
+    const auto direction = context.direction;
+    const auto button_rect = context.button_rect;
+    const auto is_up_down = direction == Direction::Up || direction == Direction::Down;
+    const auto half_button_height = static_cast<float>(button_rect.bottom - button_rect.top) / 2.0f;
+    const auto half_button_width = static_cast<float>(button_rect.right - button_rect.left) / 2.0f;
+    const auto x_midpoint = static_cast<float>(button_rect.left) + half_button_width;
+    const auto y_midpoint = static_cast<float>(button_rect.top) + half_button_height;
 
-    constexpr auto triangle_half_width = 0.75f;
-    constexpr auto triangle_half_height = 1.5f;
-    constexpr auto divisor = 10.0f;
-    constexpr auto half_divisor = divisor / 2.0f;
+    // Internal height (actually horizontal in left and right arrows)
+    const auto half_triangle_height = 0.15f * half_button_width;
+    const auto half_triangle_base_length = 0.3f * (is_up_down ? half_button_width : half_button_height);
 
-    auto narrow_side_coeff = half_divisor + (direction == Direction::Right ? 1.0f : -1.0f) * triangle_half_width;
-    auto wide_side_coeff = half_divisor + (direction == Direction::Right ? -1.0f : 1.0f) * triangle_half_width;
+    const auto triangle_points = [=] {
+        const auto coefficient = direction == Direction::Right || direction == Direction::Down ? 1.0f : -1.0f;
 
-    const auto triangle_top = (half_divisor - triangle_half_height) * button_height_px / divisor;
-    const auto triangle_bottom = (half_divisor + triangle_half_height) * button_height_px / divisor;
-    const auto triangle_start = button_left_px + wide_side_coeff * button_width_px / divisor;
-    const auto triangle_end = button_left_px + narrow_side_coeff * button_width_px / divisor;
+        if (is_up_down) {
+            const auto triangle_left = x_midpoint - half_triangle_base_length;
+            const auto triangle_right = x_midpoint + half_triangle_base_length;
+            const auto triangle_start = y_midpoint - coefficient * half_triangle_height;
+            const auto triangle_end = y_midpoint + coefficient * half_triangle_height;
 
-    const Gdiplus::PointF triangle_points[] = {
-        {triangle_end, button_height_px / 2.0f},
-        {triangle_start, triangle_top},
-        {triangle_start, triangle_bottom},
-    };
+            return std::vector<Gdiplus::PointF>{
+                {half_button_width, triangle_end},
+                {triangle_left, triangle_start},
+                {triangle_right, triangle_start},
+            };
+        }
+
+        const auto triangle_top = y_midpoint - half_triangle_base_length;
+        const auto triangle_bottom = y_midpoint + half_triangle_base_length;
+        const auto triangle_start = x_midpoint - coefficient * half_triangle_height;
+        const auto triangle_end = x_midpoint + coefficient * half_triangle_height;
+
+        return std::vector<Gdiplus::PointF>{
+            {triangle_end, half_button_height},
+            {triangle_start, triangle_top},
+            {triangle_start, triangle_bottom},
+        };
+    }();
 
     const Gdiplus::SolidBrush arrow_brush(get_dark_gdiplus_colour(ColourID::SpinButtonArrow));
-    graphics.FillPolygon(&arrow_brush, triangle_points, 3);
+    graphics.FillPolygon(&arrow_brush, triangle_points.data(), gsl::narrow<INT>(triangle_points.size()));
 }
 
-void render_button(Gdiplus::Graphics& graphics, RECT rect, Direction direction, ButtonState state)
+ButtonState get_button_state(const WindowState& window_state, Direction direction, bool is_disabled)
 {
-    render_button_border_and_background(graphics, rect, direction, state);
-    render_button_arrow(graphics, rect, direction);
+    if (is_disabled)
+        return ButtonState::Disabled;
+
+    const auto direction_opt = std::make_optional(direction);
+
+    if (window_state.pressed_button == direction_opt && window_state.actual_hot_button == direction_opt)
+        return ButtonState::Pressed;
+
+    if ((window_state.pressed_button == direction_opt && window_state.render_hot_button == direction_opt)
+        || window_state.actual_hot_button == direction_opt)
+        return ButtonState::Hot;
+
+    return ButtonState::Default;
 }
 
-std::tuple<RECT, RECT> get_button_rects(HWND wnd)
+void render_button(Gdiplus::Graphics& graphics, RECT button_rect, const WindowState& window_state, Direction direction,
+    bool is_disabled, bool has_buddy)
+{
+    const RenderContext context{
+        button_rect, direction, get_button_state(window_state, direction, is_disabled), has_buddy};
+
+    render_button_border_and_background(graphics, context);
+    render_button_arrow(graphics, context);
+}
+
+std::tuple<RECT, RECT> get_button_rects(HWND wnd, SpinType spin_type)
 {
     RECT client_rect{};
     GetClientRect(wnd, &client_rect);
+
+    if (spin_type == SpinType::UpDown) {
+        const RECT top_rect{0, 0, client_rect.right, client_rect.bottom / 2};
+        const RECT bottom_rect{0, top_rect.bottom, client_rect.right, client_rect.bottom};
+
+        return {top_rect, bottom_rect};
+    }
 
     const RECT left_rect{0, 0, client_rect.right / 2, client_rect.bottom};
     const RECT right_rect{left_rect.right, 0, client_rect.right, client_rect.bottom};
@@ -139,34 +220,28 @@ bool is_near_window(HWND wnd, POINT pt)
     return PtInRect(&client_rect, pt) != 0;
 }
 
-std::optional<Direction> get_direction_at_point(HWND wnd, POINT pt, bool strict = true)
+std::optional<Direction> get_direction_at_point(HWND wnd, SpinType spin_type, POINT pt, bool strict = true)
 {
     if (strict && !is_near_window(wnd, pt))
         return {};
 
-    auto [left_rect, right_rect] = get_button_rects(wnd);
+    auto [first_rect, second_rect] = get_button_rects(wnd, spin_type);
 
-    if (pt.x < right_rect.left)
-        return Direction::Left;
+    if (spin_type == SpinType::UpDown) {
+        if (pt.y < second_rect.top)
+            return Direction::Up;
 
-    if (pt.x > right_rect.left)
-        return Direction::Right;
+        if (pt.y > second_rect.top)
+            return Direction::Down;
+    } else {
+        if (pt.x < second_rect.left)
+            return Direction::Left;
+
+        if (pt.x > second_rect.left)
+            return Direction::Right;
+    }
 
     return {};
-}
-
-ButtonState get_button_state(const WindowState& window_state, Direction direction)
-{
-    const auto direction_opt = std::make_optional(direction);
-
-    if (window_state.pressed_button == direction_opt && window_state.actual_hot_button == direction_opt)
-        return ButtonState::Pressed;
-
-    if ((window_state.pressed_button == direction_opt && window_state.render_hot_button == direction_opt)
-        || window_state.actual_hot_button == direction_opt)
-        return ButtonState::Hot;
-
-    return ButtonState::Default;
 }
 
 LRESULT WINAPI on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -181,22 +256,23 @@ LRESULT WINAPI on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     switch (msg) {
     case WM_LBUTTONDOWN: {
         const POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        window_state.pressed_button = get_direction_at_point(wnd, pt);
-        window_state.actual_hot_button = get_direction_at_point(wnd, pt);
+        window_state.pressed_button = get_direction_at_point(wnd, window_state.spin_type, pt);
+        window_state.actual_hot_button = get_direction_at_point(wnd, window_state.spin_type, pt);
         window_state.render_hot_button = window_state.actual_hot_button;
         break;
     }
     case WM_LBUTTONUP: {
         const POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
         window_state.pressed_button.reset();
-        window_state.actual_hot_button = get_direction_at_point(wnd, pt);
+        window_state.actual_hot_button = get_direction_at_point(wnd, window_state.spin_type, pt);
         window_state.render_hot_button = window_state.actual_hot_button;
         break;
     }
     case WM_MOUSEMOVE: {
         const POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
-        window_state.actual_hot_button = get_direction_at_point(wnd, pt);
-        window_state.render_hot_button = get_direction_at_point(wnd, pt, (wp & MK_LBUTTON) == 0);
+        window_state.actual_hot_button = get_direction_at_point(wnd, window_state.spin_type, pt);
+        window_state.render_hot_button
+            = get_direction_at_point(wnd, window_state.spin_type, pt, (wp & MK_LBUTTON) == 0);
         break;
     }
     case WM_MOUSELEAVE:
@@ -206,6 +282,11 @@ LRESULT WINAPI on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_ERASEBKGND:
         return FALSE;
     case WM_PAINT: {
+        const auto buddy_wnd = reinterpret_cast<HWND>(SendMessage(wnd, UDM_GETBUDDY, 0, 0));
+        const auto has_buddy = buddy_wnd != nullptr;
+        const auto buddy_styles = has_buddy ? GetWindowLongPtr(buddy_wnd, GWL_STYLE) : 0;
+        const auto is_disabled = (buddy_styles & WS_DISABLED) != 0;
+
         PAINTSTRUCT ps{};
         const auto paint_dc = wil::BeginPaint(wnd, &ps);
         const uih::BufferedDC buffered_dc(paint_dc.get(), ps.rcPaint);
@@ -225,9 +306,12 @@ LRESULT WINAPI on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         const Gdiplus::SolidBrush background_brush(get_dark_gdiplus_colour(ColourID::SpinBackground));
         graphics.FillRectangle(&background_brush, rect_plus);
 
-        auto [left_rect, right_rect] = get_button_rects(wnd);
-        render_button(graphics, right_rect, Direction::Right, get_button_state(window_state, Direction::Right));
-        render_button(graphics, left_rect, Direction::Left, get_button_state(window_state, Direction::Left));
+        auto [first_rect, second_rect] = get_button_rects(wnd, window_state.spin_type);
+        const auto first_direction = window_state.spin_type == SpinType::UpDown ? Direction::Up : Direction::Left;
+        const auto second_direction = window_state.spin_type == SpinType::UpDown ? Direction::Down : Direction::Right;
+
+        render_button(graphics, first_rect, window_state, first_direction, is_disabled, has_buddy);
+        render_button(graphics, second_rect, window_state, second_direction, is_disabled, has_buddy);
 
         return 0;
     }
@@ -257,7 +341,6 @@ void add_window(HWND wnd)
     }
 
     if (!state::gdiplus_token) {
-        console::print("GdiplusStartup");
         const Gdiplus::GdiplusStartupInput input;
         ULONG_PTR token{};
 
@@ -266,7 +349,8 @@ void add_window(HWND wnd)
     }
 
     if (const auto wnd_proc = SubclassWindow(wnd, on_message)) {
-        state::state_map.emplace(wnd, WindowState{wnd_proc});
+        const auto spin_type = (GetWindowLongPtr(wnd, GWL_STYLE) & UDS_HORZ) ? SpinType::LeftRight : SpinType::UpDown;
+        state::state_map.emplace(wnd, WindowState{wnd_proc, spin_type});
     }
 }
 

--- a/foo_ui_columns/dark_mode_spin.h
+++ b/foo_ui_columns/dark_mode_spin.h
@@ -1,10 +1,11 @@
 #pragma once
 
 namespace cui::dark::spin {
+
 /**
  * \brief Enable dark mode support for a spin (up-down) window.
  *
- * Only supports left/right spin windows, as used in the tab control.
+ * Supports only left/right standalone and up/down buddy modes.
  */
 void add_window(HWND wnd);
 void remove_window(HWND wnd);


### PR DESCRIPTION
This adds dark mode support to the Buttons options dialogue box.

This includes handling of spin controls adjacent to an edit control, and disabled checkboxes.