### PR TITLE
Fix update of maximised title bar when toggling dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   components are used was fixed.
   [[#684](https://github.com/reupen/columns_ui/pull/684)]
 
+- The title bar of a maximised main window now correctly updates when switching
+  between light and dark mode on Windows 10.
+  [[#696](https://github.com/reupen/columns_ui/pull/696)]
+
 ### Internal changes
 
 - Various dependencies were updated.


### PR DESCRIPTION
Resolves #693 

This fixes a problem where the title bar of a maximised main window didn't correctly update when switching between light and dark mode.

This was fixed by switching to a different hack to force the title bar to redraw. A workaround is also no longer used on Windows 11, as it doesn't need one.