### PR TITLE
Update references to default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     - cron: 0 4 * * WED
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Columns UI
 
-[![Build status](https://github.com/reupen/columns_ui/actions/workflows/build.yml/badge.svg)](https://github.com/reupen/columns_ui/actions/workflows/build.yml?query=branch%3Amaster)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/reupen/columns_ui/master.svg)](https://results.pre-commit.ci/latest/github/reupen/columns_ui/master)
-[![Codiga code quality](https://api.codiga.io/project/31411/score/svg)](https://app.codiga.io/project/31411/dashboard)
+[![Build status](https://github.com/reupen/columns_ui/actions/workflows/build.yml/badge.svg)](https://github.com/reupen/columns_ui/actions/workflows/build.yml?query=branch%3Amain)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/reupen/columns_ui/main.svg)](https://results.pre-commit.ci/latest/github/reupen/columns_ui/main)
 [![Codacy code quality](https://app.codacy.com/project/badge/Grade/7a892c27551745ea883810ab7493983d)](https://www.codacy.com/gh/reupen/columns_ui/dashboard)
 
 Columns UI is released under the Lesser GNU Public Licence (see COPYING and
@@ -19,7 +18,7 @@ Stable and pre-release versions can be downloaded from the
 
 If you’re logged into GitHub, you can download the latest development version by
 visiting the
-[list of recent GitHub Actions builds](https://github.com/reupen/columns_ui/actions/workflows/build.yml?query=branch%3Amaster),
+[list of recent GitHub Actions builds](https://github.com/reupen/columns_ui/actions/workflows/build.yml?query=branch%3Amain),
 clicking on the most recent entry with a green tick, and then scrolling down to
 the links named ‘Component package (release, win32)’ and ‘Component package
 (release, x64)’ at the bottom.

--- a/vc17/columns_ui-public.sln
+++ b/vc17/columns_ui-public.sln
@@ -31,7 +31,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.gitattributes = ..\.gitattributes
 		..\.gitignore = ..\.gitignore
 		..\.gitmodules = ..\.gitmodules
-		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
 		..\CHANGELOG.md = ..\CHANGELOG.md
 		..\CONTRIBUTING.md = ..\CONTRIBUTING.md
 		..\COPYING = ..\COPYING


### PR DESCRIPTION
This updates a few references to the default branch following a rename from `master` to `main`.

The Codiga badge was also removed from the README as the service is being shut down.