### PR TITLE
Fix drop-down toolbar scroll bar in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+- The scroll bars in the DSP preset and output device toolbars are now dark
+  themed when dark mode is active.
+  [[#703](https://github.com/reupen/columns_ui/pull/703)]
+
 ## 2.0.0-rc.1
 
 ### Features


### PR DESCRIPTION
This corrects the appearance of the scroll bar in all built-in drop-down list toolbars (including DSP manager and output device) when dark mode is enabled.