### PR TITLE
Fix GDI-object leak in Item properties dialogue box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   themed when dark mode is active.
   [[#703](https://github.com/reupen/columns_ui/pull/703)]
 
+- A leak of GDI objects when closing the Item properties options dialogue box on
+  older versions of Windows was fixed.
+  [[#704](https://github.com/reupen/columns_ui/pull/704)]
+
 ## 2.0.0-rc.1
 
 ### Features

--- a/foo_ui_columns/item_properties_config.cpp
+++ b/foo_ui_columns/item_properties_config.cpp
@@ -45,9 +45,15 @@ INT_PTR CALLBACK ItemPropertiesConfig::on_message(HWND wnd, UINT msg, WPARAM wp,
         Button_SetCheck(GetDlgItem(wnd, IDC_SHOWCOLUMNS), m_show_columns ? BST_CHECKED : BST_UNCHECKED);
         Button_SetCheck(GetDlgItem(wnd, IDC_SHOWGROUPS), m_show_groups ? BST_CHECKED : BST_UNCHECKED);
     } break;
-    case WM_DESTROY:
+    case WM_DESTROY: {
+        const auto wnd_sections_tree = GetDlgItem(wnd, IDC_INFOSECTIONS);
+        HIMAGELIST state_image_list = TreeView_GetImageList(wnd_sections_tree, TVSIL_STATE);
+        TreeView_SetImageList(wnd_sections_tree, nullptr, TVSIL_STATE);
+        ImageList_Destroy(state_image_list);
+
         m_field_list.destroy();
         break;
+    }
     case WM_NOTIFY: {
         const auto lpnm = reinterpret_cast<LPNMHDR>(lp);
 


### PR DESCRIPTION
This fixes a regression caused by #683 on older versions of Windows, where the Item properties options tree view state image list was being leaked every time the dialogue was closed. This is linked to the use of the TVS_CHECKBOXES style.

This change destroys the image list as directed in the documentation. I was only able to reproduce the leak on older versions of Windows (e.g. Windows 7).

(The FCL import and export dialogues already had the logic to destroy the image list, so weren't affected by this problem.)