### PR TITLE
Update buttons console messages about hover icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   older versions of Windows was fixed.
   [[#704](https://github.com/reupen/columns_ui/pull/704)]
 
+- Some buttons toolbar console messages were updated to refer to hover icons
+  instead of hot images. [[#708](https://github.com/reupen/columns_ui/pull/708)]
+
 ### Internal changes
 
 - The component is now compiled using foobar2000 SDK 2023-04-18.

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -191,12 +191,12 @@ void ButtonsToolbar::create_toolbar()
 
         if (any_images_resized)
             console::print(reinterpret_cast<const char*>(fmt::format(
-                u8"Buttons toolbar – resized some custom non-hot images to {} x {}px", button_width, button_height)
+                u8"Buttons toolbar – resized some custom non-hover icons to {} x {}px", button_width, button_height)
                                                              .c_str()));
 
         if (any_hot_images_resized)
             console::print(reinterpret_cast<const char*>(fmt::format(
-                u8"Buttons toolbar – resized some custom hot images to {} x {}px", button_width, button_height)
+                u8"Buttons toolbar – resized some custom hover icons to {} x {}px", button_width, button_height)
                                                              .c_str()));
 
         m_standard_images.reset(


### PR DESCRIPTION
Some buttons toolbar console messages still referred to 'hot images'. These have been updated to refer to 'hover icons', in line with the rest of the UI.