### PR TITLE
Make tab control update hover item when using the mouse wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   playlist switcher, status bar and status pane on foobar2000 2.0.
   [[#721](https://github.com/reupen/columns_ui/pull/721)]
 
+- Incorrect rendering of the hover item when using the mouse wheel in the
+  playlist tabs and tab stack panels was fixed.
+  [[#723](https://github.com/reupen/columns_ui/pull/723)]
+
 - Some buttons toolbar console messages were updated to refer to hover icons
   instead of hot images. [[#708](https://github.com/reupen/columns_ui/pull/708)]
 

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -383,54 +383,48 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             playlist_api->set_active_playlist(new_idx);
         }
     } break;
-    case WM_MOUSEWHEEL:
-        if ((GetWindowLongPtr(wnd, GWL_STYLE) & TCS_MULTILINE) == NULL) {
-            // unsigned scroll_lines = GetNumScrollLines();
+    case WM_MOUSEWHEEL: {
+        if ((GetWindowLongPtr(wnd, GWL_STYLE) & TCS_MULTILINE) != 0)
+            return 0;
 
-            HWND wnd_child = GetWindow(wnd, GW_CHILD);
-            WCHAR str_class[129]{};
-            if (wnd_child && RealGetWindowClass(wnd_child, str_class, gsl::narrow_cast<UINT>(std::size(str_class)) - 1)
-                && !wcscmp(str_class, UPDOWN_CLASS) && IsWindowVisible(wnd_child)) {
-                INT min = NULL;
-                INT max = NULL;
-                INT index = NULL;
-                BOOL err = FALSE;
-                SendMessage(wnd_child, UDM_GETRANGE32, (WPARAM)&min, (LPARAM)&max);
-                index = gsl::narrow<int>(SendMessage(wnd_child, UDM_GETPOS32, (WPARAM)NULL, (LPARAM)&err));
+        if (!m_up_down_control_wnd || !IsWindowVisible(m_up_down_control_wnd))
+            return 0;
 
-                // if (!err)
-                {
-                    if (max) {
-                        int zDelta = short(HIWORD(wp));
+        int min{};
+        int max{};
+        SendMessage(
+            m_up_down_control_wnd, UDM_GETRANGE32, reinterpret_cast<WPARAM>(&min), reinterpret_cast<LPARAM>(&max));
 
-                        // int delta = MulDiv(zDelta, scroll_lines, 120);
-                        m_mousewheel_delta += zDelta;
-                        int scroll_lines = 1; // GetNumScrollLines();
-                        // if (scroll_lines == -1)
-                        // scroll_lines = count;
+        const auto index = gsl::narrow<int>(SendMessage(m_up_down_control_wnd, UDM_GETPOS32, NULL, NULL));
 
-                        if (m_mousewheel_delta * scroll_lines >= WHEEL_DELTA) {
-                            if (index > min) {
-                                SendMessage(wnd, WM_HSCROLL, MAKEWPARAM(SB_THUMBPOSITION, index - 1), NULL);
-                                SendMessage(wnd, WM_HSCROLL, MAKEWPARAM(SB_ENDSCROLL, 0), NULL);
-                                SendMessage(wnd_child, UDM_SETPOS32, NULL, index - 1);
-                            }
-                            m_mousewheel_delta = 0;
-                        } else if (m_mousewheel_delta * scroll_lines <= -WHEEL_DELTA) {
-                            if (index + 1 <= max) {
-                                SendMessage(wnd, WM_HSCROLL, MAKEWPARAM(SB_THUMBPOSITION, index + 1), NULL);
-                                SendMessage(wnd, WM_HSCROLL, MAKEWPARAM(SB_ENDSCROLL, 0), NULL);
-                                SendMessage(wnd_child, UDM_SETPOS32, NULL, index + 1);
-                            }
-                            m_mousewheel_delta = 0;
-                        }
-                    }
-                }
+        if (max == 0)
+            return 0;
 
-                return 0;
-            }
+        const int wheel_delta = GET_WHEEL_DELTA_WPARAM(wp);
+
+        m_mousewheel_delta += wheel_delta;
+
+        POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+        ScreenToClient(wnd, &pt);
+
+        if (abs(m_mousewheel_delta) < WHEEL_DELTA)
+            return 0;
+
+        if (m_mousewheel_delta > 0 && index > min) {
+            SendMessage(wnd, WM_HSCROLL, MAKEWPARAM(SB_THUMBPOSITION, index - 1), NULL);
+            SendMessage(wnd, WM_HSCROLL, MAKEWPARAM(SB_ENDSCROLL, 0), NULL);
+            SendMessage(m_up_down_control_wnd, UDM_SETPOS32, NULL, index - 1);
+            SendMessage(wnd, WM_MOUSEMOVE, GET_KEYSTATE_WPARAM(wp), POINTTOPOINTS(pt));
+        } else if (m_mousewheel_delta < 0 && index + 1 <= max) {
+            SendMessage(wnd, WM_HSCROLL, MAKEWPARAM(SB_THUMBPOSITION, index + 1), NULL);
+            SendMessage(wnd, WM_HSCROLL, MAKEWPARAM(SB_ENDSCROLL, 0), NULL);
+            SendMessage(m_up_down_control_wnd, UDM_SETPOS32, NULL, index + 1);
+            SendMessage(wnd, WM_MOUSEMOVE, GET_KEYSTATE_WPARAM(wp), POINTTOPOINTS(pt));
         }
-        break;
+
+        m_mousewheel_delta = 0;
+        return 0;
+    }
     }
     return CallWindowProc(tabproc, wnd, msg, wp, lp);
 }


### PR DESCRIPTION
This updates the mouse wheel logic in the tab stack and playlist tabs panels so that it makes the tab control update its internal hover item state after scrolling. This is done by sending it a WM_MOUSEMOVE message. This resolves some rendering glitches in both light and dark modes.

(There is some scope to refactor things so that more logic is shared between the two panels, though that is out of scope here.)