### PR TITLE
Add playlist selector toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Development version
+
+### Features
+
+- A playlist selector toolbar was added.
+  [[#729](https://github.com/reupen/columns_ui/pull/729)]
+
 ## 2.0.0
 
 ### Bug fixes

--- a/foo_ui_columns/audio_track_toolbar.cpp
+++ b/foo_ui_columns/audio_track_toolbar.cpp
@@ -1,110 +1,15 @@
 #include "pch.h"
 
+#include "core_drop_down_list_toolbar.h"
 #include "drop_down_list_toolbar.h"
 
 namespace cui {
 
 namespace {
 
-constexpr GUID stream_selector_api_id{0x6A6FF0B0, 0x3FB8, 0x4413, {0xBB, 0x76, 0xFF, 0x48, 0xC8, 0x8F, 0xF0, 0x57}};
-
-fb2k::toolbarDropDown::ptr get_stream_selector_api()
-{
-    for (auto api : fb2k::toolbarDropDown::enumerate()) {
-        if (api->getGuid() == stream_selector_api_id)
-            return api;
-    }
-
-    return {};
-}
-
-struct AudioTrackToolbarArgs {
-    using ID = size_t;
-    using ItemList = std::vector<std::tuple<ID, std::string>>;
-
-    class AudioTrackCallback : public fb2k::toolbarDropDownNotify {
-    public:
-        void contentChanged() override { DropDownListToolbar<AudioTrackToolbarArgs>::s_refresh_all_items_safe(); }
-        void selectionChanged() override { DropDownListToolbar<AudioTrackToolbarArgs>::s_update_active_item_safe(); }
-    };
-
-    static auto get_items()
-    {
-        ItemList items;
-
-        const auto api = get_stream_selector_api();
-
-        if (api.is_empty())
-            return items;
-
-        for (const auto index : std::ranges::views::iota(size_t{0}, api->getNumValues())) {
-            pfc::string8 value;
-            api->getValue(index, value);
-
-            if (stricmp_utf8(value, "not playing") != 0)
-                items.emplace_back(index, value);
-        }
-
-        return items;
-    }
-
-    static ID get_active_item()
-    {
-        const auto api = get_stream_selector_api();
-
-        if (api.is_empty())
-            return ID{};
-
-        return api->getSelectedIndex();
-    }
-
-    static void set_active_item(ID id)
-    {
-        const auto api = get_stream_selector_api();
-
-        if (api.is_empty())
-            return;
-
-        api->setSelectedIndex(id);
-    }
-
-    static void on_click()
-    {
-        const auto api = get_stream_selector_api();
-
-        if (api.is_empty())
-            return;
-
-        api->onDropDown();
-    }
-
-    static void get_menu_items(uie::menu_hook_t& p_hook) {}
-
-    static void on_first_window_created()
-    {
-        const auto api = get_stream_selector_api();
-
-        if (api.is_empty())
-            return;
-
-        s_callback = std::make_unique<AudioTrackCallback>();
-        api->addNotify(s_callback.get());
-    }
-
-    static void on_last_window_destroyed()
-    {
-        const auto api = get_stream_selector_api();
-
-        if (api.is_empty())
-            return;
-
-        api->removeNotify(s_callback.get());
-        s_callback.reset();
-    }
-
-    static bool is_available() { return get_stream_selector_api().is_valid(); }
-    inline static std::unique_ptr<AudioTrackCallback> s_callback;
-    static constexpr bool refresh_on_click = false;
+struct AudioTrackCoreToolbarArgs {
+    static constexpr GUID core_toolbar_id{0x6A6FF0B0, 0x3FB8, 0x4413, {0xBB, 0x76, 0xFF, 0x48, 0xC8, 0x8F, 0xF0, 0x57}};
+    static constexpr const char* ignored_value{"not playing"};
     static constexpr auto no_items_text = "(not playing)"sv;
     static constexpr const wchar_t* class_name{L"columns_ui_audio_track_toolbar_xvkMz8coqQY"};
     static constexpr const char* name{"Audio track"};
@@ -113,7 +18,7 @@ struct AudioTrackToolbarArgs {
     static constexpr GUID font_client_id{0xe547f854, 0x1efe, 0x4fca, {0x8d, 0x42, 0xe4, 0x24, 0x99, 0x12, 0xbc, 0x9a}};
 };
 
-ui_extension::window_factory<DropDownListToolbar<AudioTrackToolbarArgs>> _;
+ui_extension::window_factory<DropDownListToolbar<CoreDropDownToolbarArgs<AudioTrackCoreToolbarArgs>>> _;
 
 } // namespace
 

--- a/foo_ui_columns/core_drop_down_list_toolbar.h
+++ b/foo_ui_columns/core_drop_down_list_toolbar.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "drop_down_list_toolbar.h"
+
+template <typename BaseArgs>
+struct CoreDropDownToolbarArgs : BaseArgs {
+    using ID = size_t;
+    using ItemList = std::vector<std::tuple<ID, std::string>>;
+
+    class CoreDropDownToolbarCallback : public fb2k::toolbarDropDownNotify {
+    public:
+        void contentChanged() override { DropDownListToolbar<CoreDropDownToolbarArgs>::s_refresh_all_items_safe(); }
+        void selectionChanged() override { DropDownListToolbar<CoreDropDownToolbarArgs>::s_update_active_item_safe(); }
+    };
+
+    static fb2k::toolbarDropDown::ptr get_api()
+    {
+        for (auto api : fb2k::toolbarDropDown::enumerate()) {
+            if (api->getGuid() == BaseArgs::core_toolbar_id)
+                return api;
+        }
+
+        return {};
+    }
+
+    static auto get_items()
+    {
+        ItemList items;
+
+        const auto api = get_api();
+
+        if (api.is_empty())
+            return items;
+
+        for (const auto index : std::ranges::views::iota(size_t{0}, api->getNumValues())) {
+            pfc::string8 value;
+            api->getValue(index, value);
+
+            auto should_include_value{true};
+
+            if constexpr (requires() { BaseArgs::ignored_value; })
+                should_include_value = stricmp_utf8(value, BaseArgs::ignored_value) != 0;
+
+            if (should_include_value)
+                items.emplace_back(index, value);
+        }
+
+        return items;
+    }
+
+    static ID get_active_item()
+    {
+        const auto api = get_api();
+
+        if (api.is_empty())
+            return ID{};
+
+        return api->getSelectedIndex();
+    }
+
+    static void set_active_item(ID id)
+    {
+        const auto api = get_api();
+
+        if (api.is_empty())
+            return;
+
+        api->setSelectedIndex(id);
+    }
+
+    static void on_click()
+    {
+        const auto api = get_api();
+
+        if (api.is_empty())
+            return;
+
+        api->onDropDown();
+    }
+
+    static void on_first_window_created()
+    {
+        const auto api = get_api();
+
+        if (api.is_empty())
+            return;
+
+        s_callback = std::make_unique<CoreDropDownToolbarCallback>();
+        api->addNotify(s_callback.get());
+    }
+
+    static void on_last_window_destroyed()
+    {
+        const auto api = get_api();
+
+        if (api.is_empty())
+            return;
+
+        api->removeNotify(s_callback.get());
+        s_callback.reset();
+    }
+
+    static bool is_available() { return get_api().is_valid(); }
+    inline static std::unique_ptr<CoreDropDownToolbarCallback> s_callback;
+    static constexpr bool refresh_on_click = false;
+};

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -60,7 +60,11 @@ public:
     void get_name(pfc::string_base& out) const override { out = ToolbarArgs::name; }
     void get_category(pfc::string_base& out) const override { out.set_string("Toolbars"); }
     bool is_available(const uie::window_host_ptr& p_host) const override { return ToolbarArgs::is_available(); }
-    void get_menu_items(uie::menu_hook_t& p_hook) override { ToolbarArgs::get_menu_items(p_hook); }
+    void get_menu_items(uie::menu_hook_t& p_hook) override
+    {
+        if constexpr (requires { ToolbarArgs::get_menu_items; })
+            ToolbarArgs::get_menu_items(p_hook);
+    }
     uie::container_window_v3_config get_window_config() override { return {ToolbarArgs::class_name}; }
 
 private:

--- a/foo_ui_columns/dsp_preset.cpp
+++ b/foo_ui_columns/dsp_preset.cpp
@@ -3,9 +3,6 @@
 #include "drop_down_list_toolbar.h"
 #include "panel_menu_item.h"
 
-// Not exposed in the foobar2000 SDK
-constexpr GUID dsp_manager_page_id{0xEB1878C9, 0x4B31, 0x46E3, {0x95, 0x2B, 0x6F, 0x7E, 0x1F, 0xD3, 0x63, 0xDD}};
-
 struct DspPresetToolbarArgs {
     using ID = size_t;
     using ItemList = std::vector<std::tuple<ID, std::string>>;
@@ -44,7 +41,7 @@ struct DspPresetToolbarArgs {
     static void get_menu_items(uie::menu_hook_t& p_hook)
     {
         p_hook.add_node(new cui::panel_helpers::CommandMenuNode{
-            "DSP Manager", [] { ui_control::get()->show_preferences(dsp_manager_page_id); }});
+            "DSP Manager", [] { ui_control::get()->show_preferences(preferences_page::guid_dsp); }});
     }
     static constexpr void on_first_window_created() {}
     static constexpr void on_last_window_destroyed() {}

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -429,6 +429,7 @@
     <ClInclude Include="config_defaults.h" />
     <ClInclude Include="config_items.h" />
     <ClInclude Include="core_dark_list_view.h" />
+    <ClInclude Include="core_drop_down_list_toolbar.h" />
     <ClInclude Include="dark_mode_dialog.h" />
     <ClInclude Include="dark_mode_active_ui.h" />
     <ClInclude Include="dark_mode_spin.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -265,6 +265,7 @@
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="icons.cpp" />
+    <ClCompile Include="playlist_selector.cpp" />
     <ClCompile Include="resource_utils.cpp" />
     <ClCompile Include="svg.cpp" />
     <ClCompile Include="system_appearance_manager.cpp" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -878,6 +878,9 @@
     <ClInclude Include="event_token.h">
       <Filter>Utilities</Filter>
     </ClInclude>
+    <ClInclude Include="core_drop_down_list_toolbar.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".clang-format" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -121,6 +121,9 @@
     <Filter Include="Resources\svg">
       <UniqueIdentifier>{c0bc6330-d052-4fa8-951d-a3e70400bf6f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Playlist selector toolbar">
+      <UniqueIdentifier>{0eaa631f-d75d-4656-a064-8a6201707260}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="config.cpp">
@@ -601,6 +604,9 @@
     </ClCompile>
     <ClCompile Include="dark_mode_active_ui.cpp">
       <Filter>Dark mode</Filter>
+    </ClCompile>
+    <ClCompile Include="playlist_selector.cpp">
+      <Filter>Playlist selector toolbar</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/order_dropdown.cpp
+++ b/foo_ui_columns/order_dropdown.cpp
@@ -35,7 +35,6 @@ struct PlaybackOrderToolbarArgs {
             api->playback_order_set_active(iter - items.begin());
     }
 
-    static void get_menu_items(uie::menu_hook_t& p_hook) {}
     static constexpr void on_first_window_created() {}
     static constexpr void on_last_window_destroyed() {}
     static constexpr bool is_available() { return true; }

--- a/foo_ui_columns/output_format.cpp
+++ b/foo_ui_columns/output_format.cpp
@@ -37,7 +37,6 @@ struct OutputFormatToolbarArgs {
         config.m_bitDepth = bitDepth;
         api->setCoreConfig(config);
     }
-    static void get_menu_items(uie::menu_hook_t& p_hook) {}
     static void on_first_window_created()
     {
         auto api = output_manager_v2::get();

--- a/foo_ui_columns/playlist_selector.cpp
+++ b/foo_ui_columns/playlist_selector.cpp
@@ -1,0 +1,25 @@
+#include "pch.h"
+
+#include "core_drop_down_list_toolbar.h"
+#include "drop_down_list_toolbar.h"
+
+namespace cui {
+
+namespace {
+
+struct PlaylistSelectorCoreToolbarArgs {
+    static constexpr GUID core_toolbar_id{0x6A38E690, 0x83DF, 0x45F1, {0x9C, 0x62, 0x2D, 0x6B, 0x0E, 0x62, 0x2A, 0x96}};
+    static constexpr auto no_items_text = "(no playlists)"sv;
+    static constexpr const wchar_t* class_name{L"columns_ui_playlist_selector_8o6ohpmHCGI"};
+    static constexpr const char* name{"Playlist selector"};
+    static constexpr GUID extension_guid{0xba030af9, 0xd806, 0x499b, {0x8a, 0x9c, 0x4b, 0x26, 0xb0, 0x54, 0x48, 0x22}};
+    static constexpr GUID colour_client_id{
+        0x427c33e1, 0x9568, 0x4a05, {0x9b, 0x4e, 0x6b, 0xde, 0xee, 0x3d, 0xf1, 0x57}};
+    static constexpr GUID font_client_id{0xd42967bb, 0xd672, 0x41f3, {0x91, 0x1f, 0x45, 0x99, 0x8a, 0x46, 0x48, 0x84}};
+};
+
+ui_extension::window_factory<DropDownListToolbar<CoreDropDownToolbarArgs<PlaylistSelectorCoreToolbarArgs>>> _;
+
+} // namespace
+
+} // namespace cui


### PR DESCRIPTION
Resolves #691

This adds a drop-down toolbar for switching between playlists, based on the core `fb2k::toolbarDropDown` interface.

The toolbar name 'Playlist' would be more consistent with other built-in toolbars, but I've made an exception to the usual naming scheme here and added the word 'selector', as 'playlist' on its own could refer to the contents of the playlist.