### PR TITLE
Fix Clang build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
             enable-annotations: true
             publish-artefacts: true
           - toolset: clang
-            additional-build-args: '"/p:PlatformToolset=ClangCL;LinkToolExe=link.exe"'
+            additional-build-args: '"/p:PlatformToolset=ClangCL;LinkToolExe=link.exe;VcpkgAutoLink=true"'
             allowed-failure: true
         exclude:
           - toolset: v143

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ With these installed, open a Developer Command Prompt for VS 2022 from the start
 menu, switch to the Columns UI source directory and run:
 
 ```powershell
-msbuild /m "/p:PlatformToolset=ClangCL;LinkToolExe=link.exe;Platform=Win32;Configuration=Release" vc17\columns_ui-public.sln
+msbuild /m "/p:PlatformToolset=ClangCL;LinkToolExe=link.exe;VcpkgAutoLink=true;Platform=Win32;Configuration=Release" vc17\columns_ui-public.sln
 ```
 
 (Note: Currently `lld-link.exe` can't be used due to


### PR DESCRIPTION
This fixes the Clang build following the change made to vcpkg in https://github.com/microsoft/vcpkg/pull/31239.