### PR TITLE
Make saved main window position DPI aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - A playlist selector toolbar was added.
   [[#729](https://github.com/reupen/columns_ui/pull/729)]
 
+### Bug fixes
+
+- If the system DPI setting changes between foobar2000 sessions, the main window
+  size is now adjusted accordingly when foobar2000 starts.
+  [[#732](https://github.com/reupen/columns_ui/pull/732)]
+
 ## 2.0.0
 
 ### Bug fixes

--- a/foo_ui_columns/config_vars.h
+++ b/foo_ui_columns/config_vars.h
@@ -15,12 +15,16 @@ extern advconfig_checkbox_factory advbool_close_to_notification_icon;
 extern cfg_bool cfg_playlist_tabs_middle_click;
 } // namespace cui::config
 
-class ConfigWindowPlacement : public cfg_struct_t<WINDOWPLACEMENT> {
-    using cfg_struct_t<WINDOWPLACEMENT>::operator=;
-    void get_data_raw(stream_writer* out, abort_callback& p_abort) override;
-
+class ConfigWindowPlacement : public cfg_var {
 public:
     explicit ConfigWindowPlacement(const GUID& p_guid);
+
+    void get_data_raw(stream_writer* out, abort_callback& p_abort) override;
+    void set_data_raw(stream_reader* p_stream, t_size p_sizehint, abort_callback& p_abort) override;
+    WINDOWPLACEMENT get_value() const;
+
+    WINDOWPLACEMENT m_value{};
+    int32_t m_dpi{USER_DEFAULT_SCREEN_DPI};
 };
 
 class ConfigMenuItem : public cfg_struct_t<MenuItemIdentifier> {

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -112,9 +112,11 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook)
     const bool rem_pos = remember_window_pos();
 
     if (rem_pos && !main_window::config_get_is_first_run()) {
-        SetWindowPlacement(m_wnd, &cfg_window_placement_columns.get_value());
+        const auto placement = cfg_window_placement_columns.get_value();
+
+        SetWindowPlacement(m_wnd, &placement);
         resize_child_windows();
-        ShowWindow(m_wnd, cfg_window_placement_columns.get_value().showCmd);
+        ShowWindow(m_wnd, placement.showCmd);
 
         if (g_icon_created && cfg_go_to_tray)
             ShowWindow(m_wnd, SW_HIDE);


### PR DESCRIPTION
Resolves #706

This makes the saving and restoring of the main window position between foobar2000 sessions DPI aware. If the system DPI changes between foobar2000 sessions, the position will be scaled accordingly.

(There may be some scope to further improve things by digging into the monitor configuration, but there is a lot of potential complexity there so it's not done here.)