### PR TITLE
Don't read full file info in Item details on foobar2000 2.0 and newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - A playlist selector toolbar was added.
   [[#729](https://github.com/reupen/columns_ui/pull/729)]
 
+- The Item details panel no longer reads full metadata from non-playing files on
+  foobar2000 2.0 and newer, as full metadata is always available on these
+  versions. [[#734](https://github.com/reupen/columns_ui/pull/734)]
+
 ### Bug fixes
 
 - If the system DPI setting changes between foobar2000 sessions, the main window

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -270,6 +270,9 @@ void ItemDetails::set_handles(const metadb_handle_list& handles)
 
 void ItemDetails::request_full_file_info()
 {
+    if (static_api_test_t<metadb_v2>())
+        return;
+
     if (m_full_file_info_requested)
         return;
 


### PR DESCRIPTION
Resolves #705 

This stops Item details from reading full file info on foobar2000 2.0 and up, as  it isn’t needed (foobar2000 2.0 always loads large fields like lyrics).