### PR TITLE
Improve consistency of Ctrl+Backspace and Ctrl+A in edit controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   foobar2000 2.0 and newer, as full metadata is always available on these
   versions. [[#734](https://github.com/reupen/columns_ui/pull/734)]
 
+- The behaviour of Ctrl+Backspace and Ctrl+A was made consistent across edit
+  controls that are part of Columns UI itself.
+  [[#735](https://github.com/reupen/columns_ui/pull/735)]
+
 ### Bug fixes
 
 - If the system DPI setting changes between foobar2000 sessions, the main window

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -250,13 +250,17 @@ INT_PTR ButtonsToolbar::ConfigParam::on_dialog_message(HWND wnd, UINT msg, WPARA
         SetWindowFont(GetDlgItem(m_wnd, IDC_BUTTON_OPTIONS_H2), m_h2_font.get(), FALSE);
         SetWindowFont(GetDlgItem(m_wnd, IDC_TOOLBAR_OPTIONS_H1), m_h1_font.get(), FALSE);
 
+        uih::enhance_edit_control(wnd, IDC_TEXT);
+
         HWND icon_size_wnd = GetDlgItem(wnd, IDC_ICON_SIZE);
         ComboBox_AddString(icon_size_wnd, L"Automatic");
         ComboBox_AddString(icon_size_wnd, L"Custom:");
 
+        uih::enhance_edit_control(wnd, IDC_WIDTH);
         HWND width_spin_wnd = GetDlgItem(wnd, IDC_WIDTH_SPIN);
         SendMessage(width_spin_wnd, UDM_SETRANGE32, 1, 999);
 
+        uih::enhance_edit_control(wnd, IDC_HEIGHT);
         HWND height_spin_wnd = GetDlgItem(wnd, IDC_HEIGHT_SPIN);
         SendMessage(height_spin_wnd, UDM_SETRANGE32, 1, 999);
 
@@ -283,7 +287,10 @@ INT_PTR ButtonsToolbar::ConfigParam::on_dialog_message(HWND wnd, UINT msg, WPARA
         update_size_field_status();
 
         SHAutoComplete(GetDlgItem(wnd, IDC_ICON_PATH), SHACF_FILESYSTEM);
+        uih::enhance_edit_control(wnd, IDC_ICON_PATH);
+
         SHAutoComplete(GetDlgItem(wnd, IDC_HOVER_ICON_PATH), SHACF_FILESYSTEM);
+        uih::enhance_edit_control(wnd, IDC_HOVER_ICON_PATH);
 
         HWND wnd_button_list = m_button_list.create(wnd, uih::WindowPosition(14, 24, 310, 106), true);
         populate_buttons_list();

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -59,7 +59,6 @@ public:
             SendDlgItemMessage(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_SETCURSEL, 0, 0);
         }
 
-        EnableWindow(GetDlgItem(wnd, IDC_STRING), show);
         EnableWindow(GetDlgItem(wnd, IDC_NAME), show);
         EnableWindow(GetDlgItem(wnd, IDC_WIDTH), show);
         EnableWindow(GetDlgItem(wnd, IDC_PARTS), show);
@@ -74,6 +73,12 @@ public:
     void refresh_me(HWND wnd, bool init = false)
     {
         initialising = true;
+
+        uih::enhance_edit_control(wnd, IDC_NAME);
+        uih::enhance_edit_control(wnd, IDC_WIDTH);
+        uih::enhance_edit_control(wnd, IDC_PARTS);
+        uih::enhance_edit_control(wnd, IDC_PLAYLIST_FILTER_STRING);
+        uih::enhance_edit_control(wnd, IDC_EDITFIELD);
 
         if (m_column) {
             uSendDlgItemMessageText(wnd, IDC_NAME, WM_SETTEXT, 0, m_column->name);
@@ -114,8 +119,6 @@ public:
             uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Show on all playlists");
             uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Show only on playlists:");
             uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Hide on playlists:");
-
-            SendDlgItemMessage(wnd, IDC_STRING, EM_LIMITTEXT, 0, 0);
 
             refresh_me(wnd, true);
         }
@@ -271,7 +274,7 @@ private:
         case WM_INITDIALOG:
             m_wnd = wnd;
             Edit_LimitText(edit_control(), 0);
-            m_edit_control_hook.attach(edit_control());
+            uih::enhance_edit_control(edit_control());
             g_editor_font_notify.set(edit_control());
             colour_code_gen(wnd, IDC_COLOUR, true, true);
             update_controls();
@@ -299,7 +302,6 @@ private:
 
     HWND edit_control() const { return GetDlgItem(m_wnd, IDC_DISPLAY_SCRIPT); }
 
-    cui::prefs::EditControlSelectAllHook m_edit_control_hook;
     HWND m_wnd;
     bool initialising;
     PlaylistViewColumn::ptr m_column;
@@ -355,7 +357,7 @@ private:
             m_wnd = wnd;
             colour_code_gen(wnd, IDC_COLOUR, true, true);
             Edit_LimitText(edit_control(), 0);
-            m_edit_control_hook.attach(edit_control());
+            uih::enhance_edit_control(edit_control());
             g_editor_font_notify.set(edit_control());
             update_controls();
             break;
@@ -388,7 +390,6 @@ private:
     HWND edit_control() const { return GetDlgItem(m_wnd, IDC_STYLE_SCRIPT); }
     HWND custom_colour_control() const { return GetDlgItem(m_wnd, IDC_CUSTOM_COLOUR); }
 
-    cui::prefs::EditControlSelectAllHook m_edit_control_hook;
     HWND m_wnd;
     bool initialising;
     PlaylistViewColumn::ptr m_column;
@@ -446,7 +447,7 @@ private:
         case WM_INITDIALOG:
             m_wnd = wnd;
             Edit_LimitText(edit_control(), 0);
-            m_edit_control_hook.attach(edit_control());
+            uih::enhance_edit_control(edit_control());
             g_editor_font_notify.set(edit_control());
             update_controls();
             break;
@@ -477,7 +478,6 @@ private:
     HWND edit_control() const { return GetDlgItem(m_wnd, IDC_SORTING_SCRIPT); }
     HWND custom_sorting_control() const { return GetDlgItem(m_wnd, IDC_CUSTOM_SORT); }
 
-    cui::prefs::EditControlSelectAllHook m_edit_control_hook;
     HWND m_wnd;
     bool initialising;
     PlaylistViewColumn::ptr m_column;

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -238,6 +238,7 @@ public:
 
         ComboBox_SetCurSel(wnd_edge_style, cui::panels::filter::cfg_edgestyle);
 
+        uih::enhance_edit_control(wnd, IDC_PADDING);
         SendDlgItemMessage(wnd, IDC_SPINPADDING, UDM_SETRANGE32, -100, 100);
         SendDlgItemMessage(wnd, IDC_SPINPADDING, UDM_SETPOS32, 0, cui::panels::filter::cfg_vertical_item_padding);
 
@@ -333,6 +334,7 @@ public:
         Button_SetCheck(wnd_sort, cui::panels::filter::cfg_sort ? BST_CHECKED : BST_UNCHECKED);
 
         const auto wnd_sort_string = GetDlgItem(wnd, IDC_SORT_STRING);
+        uih::enhance_edit_control(wnd_sort_string);
         uSetWindowText(wnd_sort_string, cui::panels::filter::cfg_sort_string);
 
         const auto wnd_autosend_reverse_sort = GetDlgItem(wnd, IDC_REVERSE_SORT_TRACKS);

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -35,6 +35,7 @@ INT_PTR CALLBACK ItemDetailsConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
             SetWindowText(GetDlgItem(wnd, IDCANCEL), L"Close");
         }
 
+        uih::enhance_edit_control(wnd, IDC_SCRIPT);
         uSetWindowText(GetDlgItem(wnd, IDC_SCRIPT), m_script);
         HWND wnd_combo = GetDlgItem(wnd, IDC_EDGESTYLE);
         ComboBox_AddString(wnd_combo, L"None");
@@ -54,9 +55,11 @@ INT_PTR CALLBACK ItemDetailsConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
         ComboBox_AddString(wnd_combo, L"Bottom");
         ComboBox_SetCurSel(wnd_combo, m_vertical_alignment);
 
+        uih::enhance_edit_control(wnd, IDC_FONT_CODE);
         fb2k::std_api_get<fonts::manager>()->get_font(g_guid_item_details_font_client, m_code_generator_selected_font);
         uSetDlgItemText(wnd, IDC_FONT_CODE, format_font_code(m_code_generator_selected_font).c_str());
 
+        uih::enhance_edit_control(wnd, IDC_COLOUR_CODE);
         colour_code_gen(wnd, IDC_COLOUR_CODE, false, true);
 
         if (!m_modal) {

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -26,8 +26,10 @@ static INT_PTR CALLBACK EditViewProc(edit_view_param& state, HWND wnd, UINT msg,
         EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), state.value.filter_type != FILTER_NONE);
 
         SendDlgItemMessage(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_SETCURSEL, (size_t)state.value.filter_type, 0);
+        uih::enhance_edit_control(wnd, IDC_PLAYLIST_FILTER_STRING);
         uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_STRING, WM_SETTEXT, 0, state.value.filter_playlists);
 
+        uih::enhance_edit_control(wnd, IDC_VALUE);
         uSetDlgItemText(wnd, IDC_VALUE, state.value.string);
     } break;
     case WM_COMMAND:

--- a/foo_ui_columns/prefs_utils.h
+++ b/foo_ui_columns/prefs_utils.h
@@ -7,38 +7,6 @@ void on_menu_combo_change(HWND wnd, LPARAM lp, class ConfigMenuItem& cfg_menu_st
 
 namespace cui::prefs {
 
-class EditControlSelectAllHook {
-public:
-    void attach(HWND wnd)
-    {
-        m_edit_proc = reinterpret_cast<WNDPROC>(
-            SetWindowLongPtr(wnd, GWLP_WNDPROC, reinterpret_cast<LPARAM>(s_on_hooked_message)));
-        SetWindowLongPtr(wnd, GWLP_USERDATA, reinterpret_cast<LPARAM>(this));
-    }
-
-private:
-    static LRESULT WINAPI s_on_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
-    {
-        auto p_data = reinterpret_cast<EditControlSelectAllHook*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
-        return p_data ? p_data->on_hooked_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
-    }
-
-    LRESULT WINAPI on_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
-    {
-        switch (msg) {
-        case WM_CHAR:
-            if (!(HIWORD(lp) & KF_REPEAT) && wp == 1 && (GetKeyState(VK_CONTROL) & KF_UP)) {
-                Edit_SetSel(wnd, 0, -1);
-                return 0;
-            }
-            break;
-        }
-        return CallWindowProc(m_edit_proc, wnd, msg, wp, lp);
-    }
-
-    WNDPROC m_edit_proc{};
-};
-
 HFONT create_default_ui_font(unsigned point_size);
 HFONT create_default_title_font();
 

--- a/foo_ui_columns/rename_dialog.cpp
+++ b/foo_ui_columns/rename_dialog.cpp
@@ -19,6 +19,7 @@ static INT_PTR CALLBACK show_rename_dialog_box_proc(
     case WM_INITDIALOG:
         state.m_scope.initialize(FindOwningPopup(wnd));
         uSetWindowText(wnd, state.m_title);
+        uih::enhance_edit_control(wnd, IDC_EDIT);
         uSetDlgItemText(wnd, IDC_EDIT, state.m_text);
         return TRUE;
     case WM_COMMAND:

--- a/foo_ui_columns/tab_display2.cpp
+++ b/foo_ui_columns/tab_display2.cpp
@@ -36,6 +36,9 @@ public:
         switch (msg) {
         case WM_INITDIALOG: {
             m_menu_cache = cui::helpers::get_main_menu_items();
+
+            uih::enhance_edit_control(wnd, IDC_HEIGHT);
+
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "None");
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "Sunken");
             uSendDlgItemMessageText(wnd, IDC_PLEDGE, CB_ADDSTRING, 0, "Grey");

--- a/foo_ui_columns/tab_global.cpp
+++ b/foo_ui_columns/tab_global.cpp
@@ -50,7 +50,7 @@ public:
 
             refresh_me(wnd);
 
-            m_edit_control_hook.attach(GetDlgItem(wnd, IDC_STRING));
+            uih::enhance_edit_control(wnd, IDC_STRING);
             g_editor_font_notify.set(GetDlgItem(wnd, IDC_STRING));
         }
 
@@ -165,7 +165,6 @@ public:
     }
 
 private:
-    cui::prefs::EditControlSelectAllHook m_edit_control_hook;
     cui::prefs::PreferencesTabHelper m_helper{IDC_TITLE1};
 } g_tab_global;
 

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -535,9 +535,12 @@ INT_PTR LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_INITDIALOG:
+        uih::enhance_edit_control(wnd, IDC_CUSTOM_TITLE);
+
         m_wnd_tree = GetDlgItem(wnd, IDC_TREE);
         TreeView_SetIndent(m_wnd_tree, 0);
         uih::tree_view_set_explorer_theme(m_wnd_tree);
+
         cfg_layout.save_active_preset();
         if (!cfg_layout.get_presets().get_count())
             cfg_layout.reset_presets();
@@ -547,6 +550,7 @@ INT_PTR LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             m_active_preset = 0;
             m_changed = true;
         }
+
         initialise_presets(wnd);
         initialise_tree(wnd);
 

--- a/foo_ui_columns/tab_layout_misc.cpp
+++ b/foo_ui_columns/tab_layout_misc.cpp
@@ -33,11 +33,15 @@ INT_PTR LayoutMiscTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         SendDlgItemMessage(wnd, IDC_USE_CUSTOM_SHOW_DELAY, BM_SETCHECK, cfg_sidebar_use_custom_show_delay, 0);
         SendDlgItemMessage(wnd, IDC_ALLOW_LOCKED_PANEL_RESIZING, BM_SETCHECK, settings::allow_locked_panel_resizing, 0);
 
+        uih::enhance_edit_control(wnd, IDC_SHOW_DELAY);
         SendDlgItemMessage(wnd, IDC_SHOW_DELAY_SPIN, UDM_SETRANGE32, 0, 10000);
+
+        uih::enhance_edit_control(wnd, IDC_HIDE_DELAY);
         SendDlgItemMessage(wnd, IDC_HIDE_DELAY_SPIN, UDM_SETRANGE32, 0, 10000);
 
         const HWND wnd_custom_divider_width_spin = GetDlgItem(wnd, IDC_CUSTOM_DIVIDER_WIDTH_SPIN);
 
+        uih::enhance_edit_control(wnd, IDC_CUSTOM_DIVIDER_WIDTH);
         SetDlgItemInt(wnd, IDC_CUSTOM_DIVIDER_WIDTH, settings::custom_splitter_divider_width, FALSE);
         SendMessage(wnd_custom_divider_width_spin, UDM_SETRANGE32, 0, 20);
 

--- a/foo_ui_columns/tab_main.cpp
+++ b/foo_ui_columns/tab_main.cpp
@@ -26,6 +26,7 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG: {
+            uih::enhance_edit_control(wnd, IDC_STRING);
             SendDlgItemMessage(wnd, IDC_TRANSPARENCY_SPIN, UDM_SETRANGE32, 0, 255);
             refresh_me(wnd);
             m_initialised = true;

--- a/foo_ui_columns/tab_notification_area.cpp
+++ b/foo_ui_columns/tab_notification_area.cpp
@@ -26,6 +26,7 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG: {
+            uih::enhance_edit_control(wnd, IDC_STRING);
             refresh_me(wnd);
             m_initialised = true;
         }

--- a/foo_ui_columns/tab_playlist_dd.cpp
+++ b/foo_ui_columns/tab_playlist_dd.cpp
@@ -24,6 +24,8 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG: {
+            uih::enhance_edit_control(wnd, IDC_DROP_STRING);
+            uih::enhance_edit_control(wnd, IDC_SWITCH_DELAY);
             SendDlgItemMessage(wnd, IDC_SWITCH_SPIN, UDM_SETRANGE32, 0, 10000);
 
             refresh_me(wnd);

--- a/foo_ui_columns/tab_playlist_swticher.cpp
+++ b/foo_ui_columns/tab_playlist_swticher.cpp
@@ -16,8 +16,11 @@ public:
 
             SendDlgItemMessage(wnd, IDC_MCLICK, BM_SETCHECK, cfg_mclick, 0);
             SendDlgItemMessage(wnd, IDC_PLISTEDGE, CB_SETCURSEL, cfg_plistframe, 0);
+            uih::enhance_edit_control(wnd, IDC_PLHEIGHT);
             SendDlgItemMessage(wnd, IDC_SPINPL, UDM_SETPOS32, 0, settings::playlist_switcher_item_padding);
             SendDlgItemMessage(wnd, IDC_USE_PLAYLIST_TF, BM_SETCHECK, cfg_playlist_switcher_use_tagz, 0);
+
+            uih::enhance_edit_control(wnd, IDC_PLAYLIST_TF);
             uSendDlgItemMessageText(wnd, IDC_PLAYLIST_TF, WM_SETTEXT, 0, cfg_playlist_switcher_tagz);
 
             m_initialised = true;

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -8,7 +8,10 @@ static class TabPlaylistViewArtwork : public PreferencesTab {
         SendDlgItemMessage(wnd, IDC_SHOWARTWORK, BM_SETCHECK, cui::panels::playlist_view::cfg_show_artwork, 0);
         SendDlgItemMessage(
             wnd, IDC_ARTWORKREFLECTION, BM_SETCHECK, cui::panels::playlist_view::cfg_artwork_reflection, 0);
+
+        uih::enhance_edit_control(wnd, IDC_ARTWORKWIDTH);
         SendDlgItemMessage(wnd, IDC_ARTWORKWIDTHSPIN, UDM_SETRANGE32, 0, MAXLONG);
+
         SendDlgItemMessage(
             wnd, IDC_ARTWORKWIDTHSPIN, UDM_SETPOS32, NULL, cui::panels::playlist_view::cfg_artwork_width);
     }

--- a/foo_ui_columns/tab_status_bar.cpp
+++ b/foo_ui_columns/tab_status_bar.cpp
@@ -22,6 +22,7 @@ public:
             SendDlgItemMessage(wnd, IDC_SHOW_STATUS, BM_SETCHECK, cfg_status, 0);
             SendDlgItemMessage(wnd, IDC_SHOW_LOCK, BM_SETCHECK, main_window::config_get_status_show_lock(), 0);
 
+            uih::enhance_edit_control(wnd, IDC_STRING);
             uSendDlgItemMessageText(wnd, IDC_STRING, WM_SETTEXT, NULL, main_window::config_status_bar_script.get());
             break;
         case WM_DESTROY:

--- a/foo_ui_columns/tab_status_pane.cpp
+++ b/foo_ui_columns/tab_status_pane.cpp
@@ -18,6 +18,8 @@ public:
                 wnd, IDC_MENU_DBLCLK, IDC_MENU_DESC, cui::status_pane::double_click_action, m_cache, false);
 
             SendDlgItemMessage(wnd, IDC_SHOW_STATUSPANE, BM_SETCHECK, settings::show_status_pane, 0);
+
+            uih::enhance_edit_control(wnd, IDC_STRING);
             uSendDlgItemMessageText(wnd, IDC_STRING, WM_SETTEXT, NULL, cui::status_pane::status_pane_script);
             break;
         case WM_DESTROY:


### PR DESCRIPTION
Resolves #572 

This adds standardised handling of Ctrl+Backspace and Ctrl+A in all edit controls that are created by Columns UI.