### PR TITLE
Fix dark mode rendering glitch below tab spin buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   size is now adjusted accordingly when foobar2000 starts.
   [[#732](https://github.com/reupen/columns_ui/pull/732)]
 
+- In the playlist tabs and tab stack panels, a small rendering glitch below the
+  left and right scroll buttons when scrolling left and right with dark mode
+  enabled was fixed. [[#737](https://github.com/reupen/columns_ui/pull/737)]
+
 ## 2.0.0
 
 ### Bug fixes

--- a/foo_ui_columns/dark_mode_tabs.cpp
+++ b/foo_ui_columns/dark_mode_tabs.cpp
@@ -92,6 +92,17 @@ void handle_tab_control_paint(HWND wnd)
     if (ps.fErase)
         FillRect(buffered_dc.get(), &ps.rcPaint, *get_colour_brush_lazy(ColourID::TabControlBackground, is_dark));
 
+    RECT client_rect{};
+    GetClientRect(wnd, &client_rect);
+
+    if (const HWND spin_wnd = GetWindow(wnd, GW_CHILD); IsWindowVisible(spin_wnd)) {
+        RECT spin_rect{};
+        if (GetWindowRect(spin_wnd, &spin_rect)) {
+            MapWindowPoints(HWND_DESKTOP, wnd, reinterpret_cast<LPPOINT>(&spin_rect), 2);
+            ExcludeClipRect(buffered_dc.get(), spin_rect.left, 0, client_rect.right, client_rect.bottom);
+        }
+    }
+
     for (auto&& [index, item] : ranges::views::enumerate(items)) {
         const auto is_new_line = index == 0 || items[index - 1].rc.top != item.rc.top;
 


### PR DESCRIPTION
Resolves #709

This fixes a minor rendering glitch below the playlist tabs and tab stack panels when dark mode is enabled. Previously, a tab would render in this small space, but did not re-render when scrolling. Now, tabs are not rendered in that small space and only the background colour shows through,