### PR TITLE
Always search by actual playlist name when typing in playlist switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@
 - A playlist selector toolbar was added.
   [[#729](https://github.com/reupen/columns_ui/pull/729)]
 
-- The Item details panel no longer reads full metadata from non-playing files on
-  foobar2000 2.0 and newer, as full metadata is always available on these
-  versions. [[#734](https://github.com/reupen/columns_ui/pull/734)]
-
 - The behaviour of Ctrl+Backspace and Ctrl+A was made consistent across edit
   controls that are part of Columns UI itself.
   [[#735](https://github.com/reupen/columns_ui/pull/735)]
+
+- When title formatting is used in the playlist switcher panel, typing in the
+  panel now always searches by the actual playlist name and not the displayed
+  title. [[#738](https://github.com/reupen/columns_ui/pull/738)]
+
+- The Item details panel no longer reads full metadata from non-playing files on
+  foobar2000 2.0 and newer, as full metadata is always available on these
+  versions. [[#734](https://github.com/reupen/columns_ui/pull/734)]
 
 ### Bug fixes
 

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -121,6 +121,14 @@ public:
     void notify_on_create() override;
     void notify_on_destroy() override;
 
+    std::unique_ptr<ListViewSearchContextBase> create_search_context() override
+    {
+        if (cfg_playlist_switcher_use_tagz)
+            return std::make_unique<SearchContext>();
+
+        return ListViewPanelBase::create_search_context();
+    }
+
     void move_selection(int delta) override;
 
     bool notify_before_create_inline_edit(
@@ -316,6 +324,18 @@ public:
     }
 
 private:
+    class SearchContext : public ListViewSearchContextBase {
+    public:
+        const char* get_item_text(size_t index) override
+        {
+            playlist_manager::get()->playlist_get_name(index, m_playlist_name);
+            return m_playlist_name.c_str();
+        }
+
+    private:
+        pfc::string8 m_playlist_name;
+    };
+
     contextmenu_manager::ptr m_contextmenu_manager;
     UINT m_contextmenu_manager_base{NULL};
     ui_status_text_override::ptr m_status_text_override;


### PR DESCRIPTION
Resolves #710

This makes the playlist switcher panel search by the real playlist name when typing in the panel if title formatting is used. Previously, it searched by the formatted title that was displayed.