### PR TITLE
Fix crash in playlist view columns preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 - The behaviour of Ctrl+Backspace and Ctrl+A was made consistent across edit
   controls that are part of Columns UI itself.
-  [[#735](https://github.com/reupen/columns_ui/pull/735)]
+  [[#735](https://github.com/reupen/columns_ui/pull/735),
+  [#740](https://github.com/reupen/columns_ui/pull/740)]
 
 - When title formatting is used in the playlist switcher panel, typing in the
   panel now always searches by the actual playlist name and not the displayed

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -74,12 +74,6 @@ public:
     {
         initialising = true;
 
-        uih::enhance_edit_control(wnd, IDC_NAME);
-        uih::enhance_edit_control(wnd, IDC_WIDTH);
-        uih::enhance_edit_control(wnd, IDC_PARTS);
-        uih::enhance_edit_control(wnd, IDC_PLAYLIST_FILTER_STRING);
-        uih::enhance_edit_control(wnd, IDC_EDITFIELD);
-
         if (m_column) {
             uSendDlgItemMessageText(wnd, IDC_NAME, WM_SETTEXT, 0, m_column->name);
             uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_STRING, WM_SETTEXT, 0, m_column->filter);
@@ -111,6 +105,12 @@ public:
         switch (msg) {
         case WM_INITDIALOG: {
             m_wnd = wnd;
+
+            uih::enhance_edit_control(wnd, IDC_NAME);
+            uih::enhance_edit_control(wnd, IDC_WIDTH);
+            uih::enhance_edit_control(wnd, IDC_PARTS);
+            uih::enhance_edit_control(wnd, IDC_PLAYLIST_FILTER_STRING);
+            uih::enhance_edit_control(wnd, IDC_EDITFIELD);
 
             uSendDlgItemMessageText(wnd, IDC_ALIGNMENT, CB_ADDSTRING, 0, "Left");
             uSendDlgItemMessageText(wnd, IDC_ALIGNMENT, CB_ADDSTRING, 0, "Centre");

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -9,7 +9,6 @@ static class TabPlaylistViewArtwork : public PreferencesTab {
         SendDlgItemMessage(
             wnd, IDC_ARTWORKREFLECTION, BM_SETCHECK, cui::panels::playlist_view::cfg_artwork_reflection, 0);
 
-        uih::enhance_edit_control(wnd, IDC_ARTWORKWIDTH);
         SendDlgItemMessage(wnd, IDC_ARTWORKWIDTHSPIN, UDM_SETRANGE32, 0, MAXLONG);
 
         SendDlgItemMessage(
@@ -21,6 +20,7 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG:
+            uih::enhance_edit_control(wnd, IDC_ARTWORKWIDTH);
             refresh_me(wnd);
             m_initialised = true;
             break;


### PR DESCRIPTION
Resolves #739

This resolves a regression following #735 where there was a stack overflow in on the playlist view columns preferences page, due to edit controls being subclassed multiple times.