### PR TITLE
Fix right-clicking on panel non-client area during live editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   size is now adjusted accordingly when foobar2000 starts.
   [[#732](https://github.com/reupen/columns_ui/pull/732)]
 
+- Live editing no longer misbehaves when right-clicking on scroll bars.
+  [[#741](https://github.com/reupen/columns_ui/pull/741)]
+
 - In the playlist tabs and tab stack panels, a small rendering glitch below the
   left and right scroll buttons when scrolling left and right with dark mode
   enabled was fixed. [[#737](https://github.com/reupen/columns_ui/pull/737)]


### PR DESCRIPTION
Resolves #736 

This resolves misbehaviours when right-clicking on the non-client area (such as on scroll bars) of panels when live editing is active.