### PR TITLE
Save playlist view scroll positions between sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - A playlist selector toolbar was added.
   [[#729](https://github.com/reupen/columns_ui/pull/729)]
 
+- The built-in playlist view now remembers vertical scroll positions of
+  playlists after closing and reopening foobar2000, on foobar2000 2.0 and newer.
+  [[#742](https://github.com/reupen/columns_ui/pull/742)]
+
 - The behaviour of Ctrl+Backspace and Ctrl+A was made consistent across edit
   controls that are part of Columns UI itself.
   [[#735](https://github.com/reupen/columns_ui/pull/735),
@@ -160,7 +164,7 @@
   The list of values is provided by the foobar2000 core and can be configured in
   Advanced preferences, under Display/Autocomplete fields.
 
-- Autcompletion in playlist view inline editing was updated to use the latest
+- Autocompletion in playlist view inline editing was updated to use the latest
   foobar2000 API on foobar2000 1.6.1 and newer.
   [[#647](https://github.com/reupen/columns_ui/pull/647)]
 

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -265,6 +265,7 @@
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="icons.cpp" />
+    <ClCompile Include="ng_playlist\ng_playlist_config.cpp" />
     <ClCompile Include="playlist_selector.cpp" />
     <ClCompile Include="resource_utils.cpp" />
     <ClCompile Include="svg.cpp" />
@@ -325,7 +326,7 @@
     <ClCompile Include="ng_playlist\ng_playlist_artwork.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_callbacks.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_clipboard.cpp" />
-    <ClCompile Include="ng_playlist\ng_playlist_config.cpp" />
+    <ClCompile Include="ng_playlist\ng_playlist_prefs_groups.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_dropsource.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_droptarget.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_inline_edit.cpp" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -268,7 +268,7 @@
     <ClCompile Include="ng_playlist\ng_playlist_clipboard.cpp">
       <Filter>Playlist view</Filter>
     </ClCompile>
-    <ClCompile Include="ng_playlist\ng_playlist_config.cpp">
+    <ClCompile Include="ng_playlist\ng_playlist_prefs_groups.cpp">
       <Filter>Playlist view</Filter>
     </ClCompile>
     <ClCompile Include="ng_playlist\ng_playlist_dropsource.cpp">
@@ -607,6 +607,9 @@
     </ClCompile>
     <ClCompile Include="playlist_selector.cpp">
       <Filter>Playlist selector toolbar</Filter>
+    </ClCompile>
+    <ClCompile Include="ng_playlist\ng_playlist_config.cpp">
+      <Filter>Playlist view</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -119,35 +119,19 @@ void PlaylistView::on_playlist_switch()
 {
     clear_sort_column();
     clear_all_items();
-    size_t playlist_index = m_playlist_api->get_active_playlist();
-    bool b_scrolled = false;
-    if (playlist_index != pfc_infinite && m_playlist_cache[playlist_index].m_initialised) {
-        b_scrolled = true;
-        _set_scroll_position(m_playlist_cache[playlist_index].m_scroll_position);
-    } else
+    const auto playlist_index = m_playlist_api->get_active_playlist();
+    const auto scroll_position = m_playlist_cache.get_item(playlist_index).saved_scroll_position;
+
+    if (!scroll_position)
         _set_scroll_position(0);
-    size_t focus = m_playlist_api->activeplaylist_get_focus_item();
-    /*
-    {
-        int pos = 0;
-        if (focus != pfc_infinite)
-        {
-            RECT rc;
-            get_items_rect(&rc);
-            size_t offset = RECT_CY(rc);
-            if (get_item_height()>offset)
-                offset -= get_item_height();
-            else
-                offset=0;
-            offset /= 2;
-            pos = get_item_position(focus) + offset;
-        }
-        _set_scroll_position(pos);
-    }*/
+
+    const auto focus = m_playlist_api->activeplaylist_get_focus_item();
+
     refresh_groups();
     refresh_columns();
-    populate_list();
-    if (!b_scrolled && focus != pfc_infinite)
+    populate_list(scroll_position);
+
+    if (!scroll_position && focus != pfc_infinite)
         ensure_visible(focus);
 }
 void PlaylistView::on_playlist_renamed(const char* p_new_name, size_t p_new_name_len)

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -1,184 +1,65 @@
 #include "pch.h"
 
-#include "dark_mode_dialog.h"
 #include "ng_playlist.h"
-#include "ng_playlist_groups.h"
 
 namespace cui::panels::playlist_view {
 
-// CONFIG
+constexpr uint16_t STREAM_VERSION = 1;
 
-struct edit_view_param {
-    Group value;
-    bool b_new{};
-};
-
-static INT_PTR CALLBACK EditViewProc(edit_view_param& state, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+void PlaylistView::get_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
-    switch (msg) {
-    case WM_INITDIALOG: {
-        SetWindowText(wnd, state.b_new ? L"Add New Group" : L"Edit Group");
-
-        uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Show on all playlists");
-        uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Show only on playlists:");
-        uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Hide on playlists:");
-
-        EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), state.value.filter_type != FILTER_NONE);
-
-        SendDlgItemMessage(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_SETCURSEL, (size_t)state.value.filter_type, 0);
-        uih::enhance_edit_control(wnd, IDC_PLAYLIST_FILTER_STRING);
-        uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_STRING, WM_SETTEXT, 0, state.value.filter_playlists);
-
-        uih::enhance_edit_control(wnd, IDC_VALUE);
-        uSetDlgItemText(wnd, IDC_VALUE, state.value.string);
-    } break;
-    case WM_COMMAND:
-        switch (wp) {
-        case IDCANCEL:
-            EndDialog(wnd, 0);
-            break;
-        case (CBN_SELCHANGE << 16) | IDC_PLAYLIST_FILTER_TYPE: {
-            if (true) {
-                EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING),
-                    ((PlaylistFilterType)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0)) != FILTER_NONE);
-            }
-        } break;
-        case IDOK: {
-            uGetDlgItemText(wnd, IDC_VALUE, state.value.string);
-            state.value.filter_type
-                = ((PlaylistFilterType)SendDlgItemMessage(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_GETCURSEL, 0, 0));
-            state.value.filter_playlists = (uGetDlgItemText(wnd, IDC_PLAYLIST_FILTER_STRING));
-            EndDialog(wnd, 1);
-
-        } break;
-        }
-        break;
+    if (get_wnd()) {
+        m_playlist_cache.set_item(m_playlist_api->get_active_playlist(), save_scroll_position());
     }
-    return FALSE;
+
+    p_writer->write_lendian_t(STREAM_VERSION, p_abort);
+
+    stream_writer_memblock writer_items;
+    uint32_t count{};
+
+    for (auto [playlist_id, saved_scroll_position] : m_playlist_cache) {
+        if (!(saved_scroll_position && playlist_id))
+            continue;
+
+        stream_writer_memblock writer_item;
+        writer_item.write_lendian_t(*playlist_id, p_abort);
+        writer_item.write_lendian_t(saved_scroll_position->previous_item_index, p_abort);
+        writer_item.write_lendian_t(saved_scroll_position->next_item_index, p_abort);
+        writer_item.write_lendian_t(saved_scroll_position->proportional_position, p_abort);
+        writer_items.write_lendian_t(gsl::narrow<uint32_t>(writer_item.m_data.size()), p_abort);
+        writer_items.write(writer_item.m_data.get_ptr(), writer_item.m_data.size(), p_abort);
+        ++count;
+    }
+
+    p_writer->write_lendian_t(count, p_abort);
+    p_writer->write(writer_items.m_data.get_ptr(), writer_items.m_data.size(), p_abort);
 }
 
-static bool run_edit_view(edit_view_param& param, HWND parent)
+void PlaylistView::set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
 {
-    dark::DialogDarkModeConfig dark_mode_config{.button_ids = {IDOK, IDCANCEL},
-        .combo_box_ids = {IDC_PLAYLIST_FILTER_TYPE},
-        .edit_ids = {IDC_VALUE, IDC_PLAYLIST_FILTER_STRING}};
-    const auto dialog_result = modal_dialog_box(IDD_EDIT_GROUP, dark_mode_config, parent,
-        [&param](auto&&... args) { return EditViewProc(param, std::forward<decltype(args)>(args)...); });
+    const auto version = p_reader->read_lendian_t<uint16_t>(p_abort);
 
-    return dialog_result > 0;
-}
+    if (version > STREAM_VERSION)
+        throw exception_io_unsupported_format("Playlist view configuration format is not supported.");
 
-BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
-{
-    switch (msg) {
-    case WM_INITDIALOG: {
-        m_wnd = wnd;
-        m_groups_list_view.create(wnd, {7, 51, 313, 195}, true);
-
-        LOGFONT font{};
-        GetObject(GetWindowFont(wnd), sizeof(font), &font);
-        m_groups_list_view.set_font(&font);
-
-        std::vector<uih::ListView::InsertItem> insert_items;
-        insert_items.reserve(g_groups.get_groups().get_count());
-
-        auto& groups = g_groups.get_groups();
-        std::transform(groups.begin(), groups.end(), std::back_inserter(insert_items), [](const auto& group) {
-            return uih::ListView::InsertItem{{group.string}, {}};
-        });
-
-        m_groups_list_view.insert_items(0, insert_items.size(), insert_items.data());
-        ShowWindow(m_groups_list_view.get_wnd(), SW_SHOWNORMAL);
-
-        Button_SetCheck(GetDlgItem(wnd, IDC_GROUPING), cfg_grouping ? BST_CHECKED : BST_UNCHECKED);
-
-        break;
+    uint32_t count{};
+    try {
+        count = p_reader->read_lendian_t<uint32_t>(p_abort);
+    } catch (const exception_io_data_truncation&) {
+        return;
     }
-    case WM_COMMAND:
-        switch (wp) {
-        case IDC_GROUPING: {
-            cfg_grouping = Button_GetCheck(HWND(lp)) == BST_CHECKED;
-            PlaylistView::g_on_groups_change();
-        } break;
-        case IDC_GROUP_UP: {
-            const auto index = m_groups_list_view.get_selected_item_single();
-            auto& groups = g_groups.get_groups();
 
-            if (index == 0 || index >= groups.size())
-                break;
+    for (auto _ : std::ranges::views::iota(0u, count)) {
+        const auto item_size = p_reader->read_lendian_t<uint32_t>(p_abort);
+        std::vector<uint8_t> item_data(item_size);
+        p_reader->read(item_data.data(), item_data.size(), p_abort);
 
-            g_groups.swap(index, index - 1);
-
-            const std::vector<uih::ListView::InsertItem> insert_items{
-                {{groups[index - 1].string}, {}}, {{groups[index].string}, {}}};
-            m_groups_list_view.replace_items(index - 1, insert_items.size(), insert_items.data());
-            m_groups_list_view.set_item_selected_single(index - 1);
-            m_groups_list_view.ensure_visible(index - 1);
-            break;
-        }
-        case IDC_GROUP_DOWN: {
-            const auto index = m_groups_list_view.get_selected_item_single();
-            auto& groups = g_groups.get_groups();
-
-            if (index == std::numeric_limits<size_t>::max() || index + 1 >= groups.size())
-                break;
-
-            g_groups.swap(index, index + 1);
-
-            const std::vector<uih::ListView::InsertItem> insert_items{
-                {{groups[index].string}, {}}, {{groups[index + 1].string}, {}}};
-            m_groups_list_view.replace_items(index, insert_items.size(), insert_items.data());
-            m_groups_list_view.set_item_selected_single(index + 1);
-            m_groups_list_view.ensure_visible(index + 1);
-            break;
-        }
-        case IDC_GROUP_DELETE: {
-            const auto index = m_groups_list_view.get_selected_item_single();
-            auto& groups = g_groups.get_groups();
-
-            if (index >= groups.size())
-                break;
-
-            g_groups.remove_group(index);
-            m_groups_list_view.remove_item(index);
-
-            if (index > 0 && index == groups.size()) {
-                m_groups_list_view.set_item_selected_single(index - 1);
-            } else if (groups.size() > 0) {
-                m_groups_list_view.set_item_selected_single(index);
-            }
-            break;
-        }
-        case IDC_GROUP_NEW: {
-            edit_view_param p;
-            p.b_new = true;
-            if (run_edit_view(p, wnd)) {
-                const auto n = g_groups.add_group(Group(p.value));
-                const std::vector<uih::ListView::InsertItem> insert_items{{{p.value.string}, {}}};
-                m_groups_list_view.insert_items(n, 1, insert_items.data());
-                m_groups_list_view.set_item_selected_single(n);
-                m_groups_list_view.ensure_visible(n);
-            }
-        } break;
-        }
-        break;
-    case WM_DESTROY:
-        m_groups_list_view.destroy();
-        m_wnd = nullptr;
-        break;
-    }
-    return 0;
-}
-
-void GroupsPreferencesTab::on_group_default_action(size_t index)
-{
-    edit_view_param p;
-    p.b_new = false;
-    p.value = g_groups.get_groups()[index];
-    if (run_edit_view(p, m_wnd)) {
-        g_groups.replace_group(index, p.value);
-        const std::vector<uih::ListView::InsertItem> insert_items{{{p.value.string}, {}}};
-        m_groups_list_view.replace_items(index, 1, insert_items.data());
+        stream_reader_memblock_ref item_reader(item_data.data(), item_data.size());
+        const auto playlist_id = item_reader.read_lendian_t<GUID>(p_abort);
+        const auto previous_item_index = item_reader.read_lendian_t<int32_t>(p_abort);
+        const auto next_item_index = item_reader.read_lendian_t<int32_t>(p_abort);
+        const auto proportional_position = item_reader.read_lendian_t<double>(p_abort);
+        m_initial_scroll_positions[playlist_id] = {previous_item_index, next_item_index, proportional_position};
     }
 }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
@@ -1,0 +1,183 @@
+#include "pch.h"
+
+#include "dark_mode_dialog.h"
+#include "ng_playlist.h"
+#include "ng_playlist_groups.h"
+
+namespace cui::panels::playlist_view {
+
+struct edit_view_param {
+    Group value;
+    bool b_new{};
+};
+
+static INT_PTR CALLBACK EditViewProc(edit_view_param& state, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    switch (msg) {
+    case WM_INITDIALOG: {
+        SetWindowText(wnd, state.b_new ? L"Add New Group" : L"Edit Group");
+
+        uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Show on all playlists");
+        uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Show only on playlists:");
+        uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_ADDSTRING, 0, "Hide on playlists:");
+
+        EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), state.value.filter_type != FILTER_NONE);
+
+        SendDlgItemMessage(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_SETCURSEL, (size_t)state.value.filter_type, 0);
+        uih::enhance_edit_control(wnd, IDC_PLAYLIST_FILTER_STRING);
+        uSendDlgItemMessageText(wnd, IDC_PLAYLIST_FILTER_STRING, WM_SETTEXT, 0, state.value.filter_playlists);
+
+        uih::enhance_edit_control(wnd, IDC_VALUE);
+        uSetDlgItemText(wnd, IDC_VALUE, state.value.string);
+    } break;
+    case WM_COMMAND:
+        switch (wp) {
+        case IDCANCEL:
+            EndDialog(wnd, 0);
+            break;
+        case (CBN_SELCHANGE << 16) | IDC_PLAYLIST_FILTER_TYPE: {
+            if (true) {
+                EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING),
+                    ((PlaylistFilterType)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0)) != FILTER_NONE);
+            }
+        } break;
+        case IDOK: {
+            uGetDlgItemText(wnd, IDC_VALUE, state.value.string);
+            state.value.filter_type
+                = ((PlaylistFilterType)SendDlgItemMessage(wnd, IDC_PLAYLIST_FILTER_TYPE, CB_GETCURSEL, 0, 0));
+            state.value.filter_playlists = (uGetDlgItemText(wnd, IDC_PLAYLIST_FILTER_STRING));
+            EndDialog(wnd, 1);
+
+        } break;
+        }
+        break;
+    }
+    return FALSE;
+}
+
+static bool run_edit_view(edit_view_param& param, HWND parent)
+{
+    dark::DialogDarkModeConfig dark_mode_config{.button_ids = {IDOK, IDCANCEL},
+        .combo_box_ids = {IDC_PLAYLIST_FILTER_TYPE},
+        .edit_ids = {IDC_VALUE, IDC_PLAYLIST_FILTER_STRING}};
+    const auto dialog_result = modal_dialog_box(IDD_EDIT_GROUP, dark_mode_config, parent,
+        [&param](auto&&... args) { return EditViewProc(param, std::forward<decltype(args)>(args)...); });
+
+    return dialog_result > 0;
+}
+
+BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    switch (msg) {
+    case WM_INITDIALOG: {
+        m_wnd = wnd;
+        m_groups_list_view.create(wnd, {7, 51, 313, 195}, true);
+
+        LOGFONT font{};
+        GetObject(GetWindowFont(wnd), sizeof(font), &font);
+        m_groups_list_view.set_font(&font);
+
+        std::vector<uih::ListView::InsertItem> insert_items;
+        insert_items.reserve(g_groups.get_groups().get_count());
+
+        auto& groups = g_groups.get_groups();
+        std::transform(groups.begin(), groups.end(), std::back_inserter(insert_items), [](const auto& group) {
+            return uih::ListView::InsertItem{{group.string}, {}};
+        });
+
+        m_groups_list_view.insert_items(0, insert_items.size(), insert_items.data());
+        ShowWindow(m_groups_list_view.get_wnd(), SW_SHOWNORMAL);
+
+        Button_SetCheck(GetDlgItem(wnd, IDC_GROUPING), cfg_grouping ? BST_CHECKED : BST_UNCHECKED);
+
+        break;
+    }
+    case WM_COMMAND:
+        switch (wp) {
+        case IDC_GROUPING: {
+            cfg_grouping = Button_GetCheck(HWND(lp)) == BST_CHECKED;
+            PlaylistView::g_on_groups_change();
+        } break;
+        case IDC_GROUP_UP: {
+            const auto index = m_groups_list_view.get_selected_item_single();
+            auto& groups = g_groups.get_groups();
+
+            if (index == 0 || index >= groups.size())
+                break;
+
+            g_groups.swap(index, index - 1);
+
+            const std::vector<uih::ListView::InsertItem> insert_items{
+                {{groups[index - 1].string}, {}}, {{groups[index].string}, {}}};
+            m_groups_list_view.replace_items(index - 1, insert_items.size(), insert_items.data());
+            m_groups_list_view.set_item_selected_single(index - 1);
+            m_groups_list_view.ensure_visible(index - 1);
+            break;
+        }
+        case IDC_GROUP_DOWN: {
+            const auto index = m_groups_list_view.get_selected_item_single();
+            auto& groups = g_groups.get_groups();
+
+            if (index == std::numeric_limits<size_t>::max() || index + 1 >= groups.size())
+                break;
+
+            g_groups.swap(index, index + 1);
+
+            const std::vector<uih::ListView::InsertItem> insert_items{
+                {{groups[index].string}, {}}, {{groups[index + 1].string}, {}}};
+            m_groups_list_view.replace_items(index, insert_items.size(), insert_items.data());
+            m_groups_list_view.set_item_selected_single(index + 1);
+            m_groups_list_view.ensure_visible(index + 1);
+            break;
+        }
+        case IDC_GROUP_DELETE: {
+            const auto index = m_groups_list_view.get_selected_item_single();
+            auto& groups = g_groups.get_groups();
+
+            if (index >= groups.size())
+                break;
+
+            g_groups.remove_group(index);
+            m_groups_list_view.remove_item(index);
+
+            if (index > 0 && index == groups.size()) {
+                m_groups_list_view.set_item_selected_single(index - 1);
+            } else if (groups.size() > 0) {
+                m_groups_list_view.set_item_selected_single(index);
+            }
+            break;
+        }
+        case IDC_GROUP_NEW: {
+            edit_view_param p;
+            p.b_new = true;
+            if (run_edit_view(p, wnd)) {
+                const auto n = g_groups.add_group(Group(p.value));
+                const std::vector<uih::ListView::InsertItem> insert_items{{{p.value.string}, {}}};
+                m_groups_list_view.insert_items(n, 1, insert_items.data());
+                m_groups_list_view.set_item_selected_single(n);
+                m_groups_list_view.ensure_visible(n);
+            }
+        } break;
+        }
+        break;
+    case WM_DESTROY:
+        m_groups_list_view.destroy();
+        m_wnd = nullptr;
+        break;
+    }
+    return 0;
+}
+
+void GroupsPreferencesTab::on_group_default_action(size_t index)
+{
+    edit_view_param p;
+    p.b_new = false;
+    p.value = g_groups.get_groups()[index];
+    if (run_edit_view(p, m_wnd)) {
+        g_groups.replace_group(index, p.value);
+        const std::vector<uih::ListView::InsertItem> insert_items{{{p.value.string}, {}}};
+        m_groups_list_view.replace_items(index, 1, insert_items.data());
+    }
+}
+
+} // namespace cui::panels::playlist_view


### PR DESCRIPTION
Resolves #715

This adds saving and restoring of playlist view vertical scroll positions between foobar2000 sessions for all playlists. Previously, the focused item was scrolled to after closing and reopening foobar2000.