### PR TITLE
Fix crash when no playlist is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 - The built-in playlist view now remembers vertical scroll positions of
   playlists after closing and reopening foobar2000, on foobar2000 2.0 and newer.
-  [[#742](https://github.com/reupen/columns_ui/pull/742)]
+  [[#742](https://github.com/reupen/columns_ui/pull/742),
+  [#743](https://github.com/reupen/columns_ui/pull/743)]
 
 - The behaviour of Ctrl+Backspace and Ctrl+A was made consistent across edit
   controls that are part of Columns UI itself.

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -2,41 +2,43 @@
 #include "ng_playlist.h"
 
 namespace cui::panels::playlist_view {
-void PlaylistView::on_items_added(/*unsigned p_playlist, */ size_t start,
+void PlaylistView::on_items_added(size_t playlist, size_t start,
     const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
 {
-    /*(if (p_playlist == 0)*/
-    {
-        clear_sort_column();
-        InsertItemsContainer items;
-        get_insert_items(start, p_data.get_count(), items);
-        insert_items(start, items.get_count(), items.get_ptr());
-        refresh_all_items_text();
+    if (playlist != m_playlist_api->get_active_playlist())
+        return;
+
+    clear_sort_column();
+    InsertItemsContainer items;
+    get_insert_items(start, p_data.get_count(), items);
+    insert_items(start, items.get_count(), items.get_ptr());
+    refresh_all_items_text();
+}
+
+void PlaylistView::on_items_reordered(size_t playlist, const size_t* p_order, size_t p_count)
+{
+    if (playlist != m_playlist_api->get_active_playlist())
+        return;
+
+    clear_sort_column();
+    for (auto i : std::ranges::views::iota(size_t{}, p_count)) {
+        const size_t start = i;
+        while (i < p_count && p_order[i] != i) {
+            i++;
+        }
+        if (i > start) {
+            InsertItemsContainer items;
+            get_insert_items(start, i - start, items);
+            replace_items(start, items);
+        }
     }
 }
-void PlaylistView::on_items_reordered(/*size_t p_playlist, */ const size_t* p_order, size_t p_count)
-{
-    /*(if (p_playlist ==0)*/
-    {
-        clear_sort_column();
-        for (size_t i = 0; i < p_count; i++) {
-            size_t start = i;
-            while (i < p_count && p_order[i] != i) {
-                i++;
-            }
-            if (i > start) {
-                InsertItemsContainer items;
-                get_insert_items(start, i - start, items);
-                replace_items(start, items);
-            }
-        }
-    } // namespace cui::panels::playlist_view
-}
-// changes selection too; doesnt actually change set of items that are selected or item having focus, just changes
-// their order
 
-void PlaylistView::on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
+void PlaylistView::on_items_removed(size_t playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
 {
+    if (playlist != m_playlist_api->get_active_playlist())
+        return;
+
     clear_sort_column();
 
     if (p_new_count == 0) {
@@ -48,79 +50,88 @@ void PlaylistView::on_items_removed(const bit_array& p_mask, size_t p_old_count,
     refresh_all_items_text();
 }
 
-void PlaylistView::on_items_selection_change(
-    /*size_t p_playlist, */ const bit_array& p_affected, const bit_array& p_state)
+void PlaylistView::on_items_selection_change(size_t playlist, const bit_array& p_affected, const bit_array& p_state)
 {
-    /*(if (p_playlist == 0)*/
-    if (!m_ignore_callback) {
-        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
-    }
+    if (m_ignore_callback || playlist != m_playlist_api->get_active_playlist())
+        return;
+
+    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
-void PlaylistView::on_item_focus_change(/*size_t p_playlist, */ size_t p_from, size_t p_to)
+
+void PlaylistView::on_item_focus_change(size_t playlist, size_t p_from, size_t p_to)
 {
-    // if (p_playlist==0)
-    if (!m_ignore_callback) {
-        on_focus_change(p_from, p_to);
-    }
-} // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
+    if (m_ignore_callback || playlist != m_playlist_api->get_active_playlist())
+        return;
 
-void PlaylistView::on_items_modified(/*size_t p_playlist, */ const bit_array& p_mask)
-{ // if (p_playlist==0)
-    {
-        clear_sort_column();
-        size_t count = m_playlist_api->activeplaylist_get_item_count();
+    on_focus_change(p_from, p_to);
+}
 
-        for (size_t i = 0; i < count; i++) {
-            size_t start = i;
-            while (i < count && p_mask[i]) {
-                i++;
-            }
-            if (i > start) {
-                InsertItemsContainer items;
-                get_insert_items(start, i - start, items);
-                replace_items(start, items);
-            }
+void PlaylistView::on_items_modified(size_t playlist, const bit_array& p_mask)
+{
+    if (playlist != m_playlist_api->get_active_playlist())
+        return;
+
+    clear_sort_column();
+    const size_t count = m_playlist_api->activeplaylist_get_item_count();
+
+    for (auto i : std::ranges::views::iota(size_t{}, count)) {
+        const size_t start = i;
+        while (i < count && p_mask[i]) {
+            i++;
+        }
+        if (i > start) {
+            InsertItemsContainer items;
+            get_insert_items(start, i - start, items);
+            replace_items(start, items);
         }
     }
 }
 
 void PlaylistView::on_items_modified_fromplayback(
-    /*size_t p_playlist, */ const bit_array& p_mask, play_control::t_display_level p_level)
+    size_t playlist, const bit_array& p_mask, play_control::t_display_level p_level)
 {
-    if (!core_api::is_shutting_down()) {
-        size_t count = m_playlist_api->activeplaylist_get_item_count();
+    if (core_api::is_shutting_down() || playlist != m_playlist_api->get_active_playlist())
+        return;
 
-        for (size_t i = 0; i < count; i++) {
-            size_t start = i;
-            while (i < count && p_mask[i]) {
-                i++;
-            }
-            if (i > start) {
-                update_items(start, i - start);
-            }
+    const size_t count = m_playlist_api->activeplaylist_get_item_count();
+
+    for (auto i : std::ranges::views::iota(size_t{}, count)) {
+        const size_t start = i;
+        while (i < count && p_mask[i]) {
+            i++;
+        }
+        if (i > start) {
+            update_items(start, i - start);
         }
     }
 }
 
 void PlaylistView::on_items_replaced(
-    /*size_t p_playlist, */ const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
+    size_t playlist, const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
 {
-    on_items_modified(p_mask);
+    on_items_modified(playlist, p_mask);
 }
 
-void PlaylistView::on_item_ensure_visible(/*size_t p_playlist, */ size_t p_idx)
-{ // if (p_playlist==0)
-    {
-        ensure_visible(p_idx);
+void PlaylistView::on_item_ensure_visible(size_t playlist, size_t p_idx)
+{
+    if (playlist != m_playlist_api->get_active_playlist())
+        return;
+
+    ensure_visible(p_idx);
+}
+
+void PlaylistView::on_playlist_activate(size_t p_old, size_t p_new)
+{
+    if (p_old != std::numeric_limits<size_t>::max()) {
+        m_playlist_cache.set_item(p_old, save_scroll_position());
     }
-}
 
-void PlaylistView::on_playlist_switch()
-{
     clear_sort_column();
     clear_all_items();
-    const auto playlist_index = m_playlist_api->get_active_playlist();
-    const auto scroll_position = m_playlist_cache.get_item(playlist_index).saved_scroll_position;
+
+    const auto scroll_position = p_new != std::numeric_limits<size_t>::max()
+        ? m_playlist_cache.get_item(p_new).saved_scroll_position
+        : std::nullopt;
 
     if (!scroll_position)
         _set_scroll_position(0);
@@ -131,15 +142,20 @@ void PlaylistView::on_playlist_switch()
     refresh_columns();
     populate_list(scroll_position);
 
-    if (!scroll_position && focus != pfc_infinite)
+    if (!scroll_position && focus != std::numeric_limits<size_t>::max())
         ensure_visible(focus);
 }
-void PlaylistView::on_playlist_renamed(const char* p_new_name, size_t p_new_name_len)
+
+void PlaylistView::on_playlist_renamed(size_t playlist, const char* p_new_name, size_t p_new_name_len)
 {
+    if (playlist != m_playlist_api->get_active_playlist())
+        return;
+
     clear_sort_column();
     clear_all_items();
     refresh_groups();
     refresh_columns();
     populate_list();
 }
+
 } // namespace cui::panels::playlist_view

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -9,7 +9,10 @@ constexpr uint16_t STREAM_VERSION = 1;
 void PlaylistView::get_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
     if (get_wnd()) {
-        m_playlist_cache.set_item(m_playlist_api->get_active_playlist(), save_scroll_position());
+        const auto active_playlist = m_playlist_api->get_active_playlist();
+
+        if (active_playlist != std::numeric_limits<size_t>::max())
+            m_playlist_cache.set_item(active_playlist, save_scroll_position());
     }
 
     p_writer->write_lendian_t(STREAM_VERSION, p_abort);
@@ -35,7 +38,7 @@ void PlaylistView::get_config(stream_writer* p_writer, abort_callback& p_abort) 
     p_writer->write(writer_items.m_data.get_ptr(), writer_items.m_data.size(), p_abort);
 }
 
-void PlaylistView::set_config(stream_reader* p_reader, t_size p_size, abort_callback& p_abort)
+void PlaylistView::set_config(stream_reader* p_reader, size_t p_size, abort_callback& p_abort)
 {
     const auto version = p_reader->read_lendian_t<uint16_t>(p_abort);
 


### PR DESCRIPTION
This:

- refactors the playlist view playlist callback code to be a little bit tidier
- fixes regression from #742 causing crashes when no playlist is active (e.g. happens when using the Edit/Undo command)