### PR TITLE
Improve behaviour when dropping tracks on non-active playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
   [[#742](https://github.com/reupen/columns_ui/pull/742),
   [#743](https://github.com/reupen/columns_ui/pull/743)]
 
+- If the focused item in a non-active playlist changes, the built-in playlist
+  view now scrolls to that focused item when the playlist is next activated.
+  [[#745](https://github.com/reupen/columns_ui/pull/745)]
+
+- In the playlist switcher and playlist tabs, when adding items to a playlist
+  using drag and drop, the first new item added to the playlist is now focused.
+  [[#745](https://github.com/reupen/columns_ui/pull/745)]
+
 - The behaviour of Ctrl+Backspace and Ctrl+A was made consistent across edit
   controls that are part of Columns UI itself.
   [[#735](https://github.com/reupen/columns_ui/pull/735),

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -53,9 +53,9 @@ public:
     }
     void deinitialise() { m_callback.reset(); }
 
-    void set_item(size_t index, uih::lv::SavedScrollPosition saved_scroll_position)
+    void set_item(size_t index, std::optional<uih::lv::SavedScrollPosition> saved_scroll_position)
     {
-        m_items[index].saved_scroll_position = saved_scroll_position;
+        m_items[index].saved_scroll_position = std::move(saved_scroll_position);
     }
     const PlaylistCacheItem& get_item(size_t index) const { return m_items[index]; }
     auto size() const { return m_items.get_size(); }

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -60,7 +60,11 @@ void PlaylistView::on_items_selection_change(size_t playlist, const bit_array& p
 
 void PlaylistView::on_item_focus_change(size_t playlist, size_t p_from, size_t p_to)
 {
-    if (m_ignore_callback || playlist != m_playlist_api->get_active_playlist())
+    if (playlist != m_playlist_api->get_active_playlist()) {
+        m_playlist_cache.set_item(playlist, std::nullopt);
+    }
+
+    if (m_ignore_callback)
         return;
 
     on_focus_change(p_from, p_to);

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -427,11 +427,17 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
                                     playlist_api->playlist_clear_selection(m_insertIndexTracker.m_playlist);
                                 }
 
-                                playlist_api->playlist_add_items(
-                                    m_insertIndexTracker.m_playlist, p_items, bit_array_true());
+                                const auto index = fbh::as_optional(playlist_api->playlist_insert_items(
+                                    m_insertIndexTracker.m_playlist, fbh::max_size_t, p_items, bit_array_true()));
 
-                                if (main_window::config_get_activate_target_playlist_on_dropped_items())
+                                if (!index)
+                                    return;
+
+                                playlist_api->playlist_set_focus_item(m_insertIndexTracker.m_playlist, *index);
+
+                                if (main_window::config_get_activate_target_playlist_on_dropped_items()) {
                                     playlist_api->set_active_playlist(m_insertIndexTracker.m_playlist);
+                                }
                             }
                         }
                         void on_aborted() override {}

--- a/foo_ui_columns/playlist_tabs_drop_target.cpp
+++ b/foo_ui_columns/playlist_tabs_drop_target.cpp
@@ -313,12 +313,17 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Drop(
 
             } else {
                 playlist_api->playlist_clear_selection(target_index);
-                playlist_api->playlist_add_items(target_index, data, bit_array_true());
-                if (main_window::config_get_activate_target_playlist_on_dropped_items())
-                    playlist_api->set_active_playlist(target_index);
-            }
 
-            data.remove_all();
+                const auto index = fbh::as_optional(
+                    playlist_api->playlist_insert_items(target_index, fbh::max_size_t, data, bit_array_true()));
+
+                if (index) {
+                    playlist_api->playlist_set_focus_item(target_index, *index);
+
+                    if (main_window::config_get_activate_target_playlist_on_dropped_items())
+                        playlist_api->set_active_playlist(target_index);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #714 

This makes some behaviour changes to improve the behaviour when tracks are added to a non-active playlist using drag and drop:

- when tracks are dropped on an existing playlist in the playlist switcher and playlist tabs panels, the first newly added item is focused
- when the focused item in a non-active playlist changes, the playlist view scrolls to that item the next time the playlist is activated