### PR TITLE
Add dark mode to seekbar and volume bar tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
   frame may change after upgrading due to the saved custom colour now correctly
   being used.
 
+- Tooltips in the seekbar and volume bar are now dark themed when dark mode is
+  active. [[#760](https://github.com/reupen/columns_ui/pull/760)]
+
 - If the system DPI setting changes between foobar2000 sessions, the main window
   size is now adjusted accordingly when foobar2000 starts.
   [[#732](https://github.com/reupen/columns_ui/pull/732)]

--- a/foo_ui_columns/seekbar.cpp
+++ b/foo_ui_columns/seekbar.cpp
@@ -22,10 +22,9 @@ void SeekBarToolbar::SeekBarTrackbarCallback::get_tooltip_text(unsigned pos, uih
 
 void SeekBarToolbar::set_custom_colours()
 {
-    if (colours::is_dark_mode_active())
-        m_child.set_custom_colours(dark::get_dark_trackbar_colours());
-    else
-        m_child.set_custom_colours({});
+    const auto is_dark = colours::is_dark_mode_active();
+    m_child.set_custom_colours(is_dark ? std::make_optional(dark::get_dark_trackbar_colours()) : std::nullopt);
+    m_child.set_are_tooltips_dark(is_dark);
 }
 
 void SeekBarToolbar::update_seekbars(bool positions_only)

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -132,10 +132,9 @@ public:
 
     void set_custom_colours()
     {
-        if (cui::colours::is_dark_mode_active())
-            m_child.set_custom_colours(cui::dark::get_dark_trackbar_colours());
-        else
-            m_child.set_custom_colours({});
+        const auto is_dark = cui::colours::is_dark_mode_active();
+        m_child.set_custom_colours(is_dark ? std::make_optional(cui::dark::get_dark_trackbar_colours()) : std::nullopt);
+        m_child.set_are_tooltips_dark(is_dark);
     }
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)


### PR DESCRIPTION
Resolves #758

This makes the seekbar and volume bar tooltips dark when dark mode is active.