### PR TITLE
Fix stop after current icon intermittently not loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
   [#740](https://github.com/reupen/columns_ui/pull/740)]
 
 - A built-in icon for the stop after current command was added to the Buttons
-  toolbar. [[#757](https://github.com/reupen/columns_ui/pull/757)]
+  toolbar. [[#757](https://github.com/reupen/columns_ui/pull/757),
+  [#762](https://github.com/reupen/columns_ui/pull/762)]
 
 - When title formatting is used in the playlist switcher panel, typing in the
   panel now always searches by the actual playlist name and not the displayed


### PR DESCRIPTION
This fixes a problem where the default stop after current icon sometimes did not show. This was due to there being two different`uie::button` implementations for the command.