### PR TITLE
Work around lag when starting playback of a track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@
   frame may change after upgrading due to the saved custom colour now correctly
   being used.
 
+- A problem causing a slight delay when starting playback of a track was worked
+  around. [[#765](https://github.com/reupen/columns_ui/pull/765)]
+
 - Tooltips in the buttons toolbar, seekbar and volume bar are now dark themed
   when dark mode is active.
   [[#760](https://github.com/reupen/columns_ui/pull/760),

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -251,7 +251,7 @@ void cui::MainWindow::update_taskbar_buttons(bool update) const
 
 void cui::MainWindow::queue_taskbar_button_update(bool update)
 {
-    fb2k::inMainThread([update, this] { update_taskbar_buttons(update); });
+    PostMessage(m_wnd, update ? MSG_UPDATE_TASKBAR_BUTTONS : MSG_CREATE_TASKBAR_BUTTONS, 0, 0);
 }
 
 void cui::MainWindow::warn_if_ui_hacks_installed()

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -22,7 +22,14 @@ COLORREF get_default_colour(colours::ColourID index, bool themed = false);
 #define ID_PLAYLIST_TOOLTIP 50
 
 /** Main window custom message numbers */
-enum { MSG_SET_AOT = WM_USER + 3, MSG_UPDATE_TITLE, MSG_RUN_INITIAL_SETUP, MSG_NOTIFICATION_ICON };
+enum {
+    MSG_SET_AOT = WM_USER + 3,
+    MSG_UPDATE_TITLE,
+    MSG_RUN_INITIAL_SETUP,
+    MSG_NOTIFICATION_ICON,
+    MSG_CREATE_TASKBAR_BUTTONS,
+    MSG_UPDATE_TASKBAR_BUTTONS
+};
 
 bool remember_window_pos();
 

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -457,6 +457,12 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case MSG_RUN_INITIAL_SETUP:
         QuickSetupDialog::s_run();
         return 0;
+    case MSG_CREATE_TASKBAR_BUTTONS:
+        update_taskbar_buttons(false);
+        return 0;
+    case MSG_UPDATE_TASKBAR_BUTTONS:
+        update_taskbar_buttons(true);
+        return 0;
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
     case WM_ERASEBKGND:


### PR DESCRIPTION
Resolves #713 

This adjusts the updating of taskbar buttons to use `PostMessage()` rather than a `main_thread_callback`. Why this makes a difference is unclear: the lag is neither when `fb2k::inMainThread()` is called nor when the callback function is called. The reason may be related to `ITaskbarList3::ThumbBarUpdateButtons()` calling `SendMessageTimeout()` (without `SMTO_BLOCK`) which was previously noted as being the cause of unexpected problems.

(Doing the taskbar button updates off the main thread is an option, but I don't believe that should be needed with this change.)