### PR TITLE
Adjust playlist view grouping layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - A playlist selector toolbar was added.
   [[#729](https://github.com/reupen/columns_ui/pull/729)]
 
+- Grouping in the built-in playlist view was updated
+  [[#770](https://github.com/reupen/columns_ui/pull/770)]:
+
+  - each group level is no longer indented
+  - padding either side of artwork was reduced
+  - artwork reflection is now disabled by default
+
 - The built-in playlist view now remembers vertical scroll positions of
   playlists after closing and reopening foobar2000, on foobar2000 2.0 and newer.
   [[#742](https://github.com/reupen/columns_ui/pull/742),

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -34,7 +34,7 @@ std::vector<PlaylistView*> PlaylistView::g_windows;
 
 ConfigGroups g_groups(g_groups_guid);
 
-cfg_bool cfg_artwork_reflection(g_artwork_reflection, true);
+cfg_bool cfg_artwork_reflection(g_artwork_reflection, false);
 
 fbh::ConfigBool cfg_grouping(g_guid_grouping, true, [](auto&&) { button_items::ShowGroupsButton::s_on_change(); });
 fbh::ConfigBool cfg_show_artwork(
@@ -694,6 +694,7 @@ void PlaylistView::sort_by_column_fb2k_v2(size_t column_index, bool b_descending
 void PlaylistView::notify_on_initialisation()
 {
     set_use_dark_mode(colours::is_dark_mode_active());
+    set_group_level_indentation_enabled(false);
     set_group_info_area_size(
         cfg_artwork_width, cfg_artwork_width + (cfg_artwork_reflection ? (cfg_artwork_width * 3) / 11 : 0));
     set_show_group_info_area(cfg_show_artwork);

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -415,6 +415,7 @@ private:
 
     static void s_create_message_window();
     static void s_destroy_message_window();
+    static auto get_artwork_left_right_padding() { return 5_spx; }
 
     virtual void flush_artwork_images()
     {

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -300,7 +300,7 @@ wil::shared_hbitmap PlaylistView::request_group_artwork(size_t index_item)
     PlaylistViewGroup* group = item->get_group(group_count - 1);
 
     if (!group->m_artwork_load_attempted) {
-        const auto cx = get_group_info_area_width();
+        const auto cx = get_group_info_area_width() - 2 * get_artwork_left_right_padding();
         const auto cy = get_group_info_area_height();
 
         ArtworkCompletionNotify::ptr_t ptr = std::make_shared<ArtworkCompletionNotify>();

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -10,15 +10,18 @@ void PlaylistViewRenderer::render_group_info(uih::lv::RendererContext context, s
     if (!bm)
         return;
 
+    RECT deflated_rect{rc};
+    InflateRect(&deflated_rect, -m_playlist_view->get_artwork_left_right_padding(), 0);
+
     HDC dcc = CreateCompatibleDC(context.dc);
     BITMAP bminfo{};
     GetObject(bm.get(), sizeof(BITMAP), &bminfo);
 
     RECT rc_bitmap;
-    rc_bitmap.left = rc.left + (wil::rect_width(rc) - bminfo.bmWidth) / 2;
-    rc_bitmap.top = rc.top;
-    rc_bitmap.right = rc_bitmap.left + std::min(bminfo.bmWidth, wil::rect_width(rc));
-    rc_bitmap.bottom = rc_bitmap.top + std::min(bminfo.bmHeight, wil::rect_height(rc));
+    rc_bitmap.left = deflated_rect.left + (wil::rect_width(deflated_rect) - bminfo.bmWidth) / 2;
+    rc_bitmap.top = deflated_rect.top;
+    rc_bitmap.right = rc_bitmap.left + std::min(bminfo.bmWidth, wil::rect_width(deflated_rect));
+    rc_bitmap.bottom = rc_bitmap.top + std::min(bminfo.bmHeight, wil::rect_height(deflated_rect));
 
     HBITMAP bm_old = SelectBitmap(dcc, bm.get());
     BitBlt(context.dc, rc_bitmap.left, rc_bitmap.top, wil::rect_width(rc_bitmap), wil::rect_height(rc_bitmap), dcc, 0,


### PR DESCRIPTION
This updates grouping in the playlist view:

- each group level is no longer indented
- padding either side of artwork was reduced
- artwork reflection is now disabled by default