### PR TITLE
Enable dark menus on Windows 11 build 22631

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
   foobar2000 2.0 and newer, as full metadata is always available on these
   versions. [[#734](https://github.com/reupen/columns_ui/pull/734)]
 
+- Dark menus were enabled on Windows 11 build 22631.
+  [[#771](https://github.com/reupen/columns_ui/pull/771)]
+
 ### Bug fixes
 
 - In the themed and system colour schemes, if ‘Use custom active item frame’ is

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -53,7 +53,7 @@ bool are_private_apis_allowed()
     if (osvi.dwMajorVersion != 10 || osvi.dwMinorVersion != 0)
         return false;
 
-    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22624;
+    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22631;
 }
 
 void set_app_mode(PreferredAppMode mode)


### PR DESCRIPTION
This increases the maximum allowed build number for private Win32 dark mode APIs to build 226311 (a beta channel version).