### PR TITLE
Enable dark menus on Windows 11 builds greater than 22631

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Development version
 
+### Features
+
+- Dark menus were enabled on Windows 11 builds greater than 22631.
+  [[#788](https://github.com/reupen/columns_ui/pull/788), contributed by
+  [@razielanarki](https://github.com/razielanarki)]
+
 ### Bug fixes
 
 - The tab order of controls on the Grouping tab on the playlist view preferences

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -45,15 +45,7 @@ bool is_native_dark_spin_available()
 
 bool are_private_apis_allowed()
 {
-    OSVERSIONINFO osvi{};
-    osvi.dwOSVersionInfoSize = sizeof(osvi);
-#pragma warning(suppress : 4996)
-    GetVersionEx(&osvi);
-
-    if (osvi.dwMajorVersion != 10 || osvi.dwMinorVersion != 0)
-        return false;
-
-    return osvi.dwBuildNumber >= 19041 && osvi.dwBuildNumber <= 22631;
+    return does_os_support_dark_mode();
 }
 
 void set_app_mode(PreferredAppMode mode)
@@ -61,7 +53,7 @@ void set_app_mode(PreferredAppMode mode)
     if (!are_private_apis_allowed())
         return;
 
-    using SetPreferredAppModeProc = int(__stdcall*)(int);
+    using SetPreferredAppModeProc = PreferredAppMode(__stdcall*)(PreferredAppMode);
     using FlushMenuThemesProc = void(__stdcall*)();
 
     const wil::unique_hmodule uxtheme(THROW_LAST_ERROR_IF_NULL(LoadLibrary(L"uxtheme.dll")));
@@ -72,7 +64,7 @@ void set_app_mode(PreferredAppMode mode)
     const auto flush_menu_themes
         = reinterpret_cast<FlushMenuThemesProc>(GetProcAddress(uxtheme.get(), MAKEINTRESOURCEA(136)));
 
-    set_preferred_app_mode(WI_EnumValue(mode));
+    set_preferred_app_mode(mode);
     flush_menu_themes();
 }
 

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -90,7 +90,7 @@ private:
 [[nodiscard]] bool are_private_apis_allowed();
 [[nodiscard]] bool is_native_dark_spin_available();
 
-enum class PreferredAppMode { System = 1, Dark = 2, Light = 3 };
+enum class PreferredAppMode : int { NotSet, System, Dark, Light };
 
 void set_app_mode(PreferredAppMode mode);
 void set_titlebar_mode(HWND wnd, bool is_dark);

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -295,7 +295,7 @@ void cui::MainWindow::set_dark_mode_attributes(bool is_update) const
 
     const auto is_dark = colours::is_dark_mode_active();
     dark::set_titlebar_mode(m_wnd, is_dark);
-    set_app_mode(is_dark ? dark::PreferredAppMode::Dark : dark::PreferredAppMode::Light);
+    dark::set_app_mode(is_dark ? dark::PreferredAppMode::Dark : dark::PreferredAppMode::Light);
 
     if (!is_update)
         return;

--- a/foo_ui_columns/tab_colours.cpp
+++ b/foo_ui_columns/tab_colours.cpp
@@ -191,7 +191,7 @@ void TabColours::update_scheme_combobox()
 
 void TabColours::update_title() const
 {
-    if (cui::dark::are_private_apis_allowed())
+    if (cui::dark::does_os_support_dark_mode())
         uSetDlgItemText(
             m_wnd, IDC_TITLE1, cui::colours::is_dark_mode_active() ? "Dark mode colours" : "Light mode colours");
 }


### PR DESCRIPTION
 - Allow Windows builds greater than 22631 to access "private" APIs. (Tested on Windows 11 Insiders Canary build 25926)
 - Update `PreferredAppMode` enum
 - Call `AllowDarkModeForWindow` (`@133`) from `dark::set_titlebar_mode`. This fixes the menubar / context menus to use dark mode.
 
Tested both the x86 build (with foobar2000 v1.6.16) and the x64 build (with foobar2000 v2.1 preview 2023-08-01).