### PR TITLE
Fix UnregisterClass failed console message at exit

### DIFF
--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -149,7 +149,6 @@ void cui::MainWindow::shutdown()
 {
     DestroyWindow(m_wnd);
     UnregisterClass(main_window_class_name, core_api::get_my_instance());
-    status_bar::volume_popup_window.deregister_class();
     m_wnd = nullptr;
     if (g_icon)
         DestroyIcon(g_icon);

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -147,10 +147,14 @@ void regenerate_text()
 
 void destroy_window()
 {
+    if (volume_popup_window.get_wnd())
+        volume_popup_window.destroy();
+
     if (g_status) {
         DestroyWindow(g_status);
         g_status = nullptr;
     }
+
     state.reset();
 }
 

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -272,7 +272,7 @@ public:
             }
         } break;
         case WM_CLOSE:
-            DestroyWindow(wnd);
+            destroy();
             return 0;
         case WM_ACTIVATE: {
             if (b_popup) {


### PR DESCRIPTION
This resolves a problem where a console message stating 'UnregisterClass failed: Class does not exist' was logged at exit.