### PR TITLE
Update copyright notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   the console when quitting foobar2000 was fixed.
   [[#802](https://github.com/reupen/columns_ui/pull/802)]
 
+- The copyright year was updated.
+  [[#803](https://github.com/reupen/columns_ui/pull/803)]
+
 ## 2.1.0-beta.3
 
 ### Bug fixes

--- a/foo_ui_columns/version.cpp
+++ b/foo_ui_columns/version.cpp
@@ -14,7 +14,7 @@ DECLARE_COMPONENT_VERSION("Columns UI",
     "Columns UI\n"
     "Alternative user interface\n"
     "\n"
-    "Copyright (C) 2003-2019 musicmusic and contributors\n"
+    u8"© musicmusic and contributors "_pcc CUI_COMPILATION_YEAR "\n"
     "Current version at yuo.be\n"
     "\n"
     "Built on " CUI_COMPILATION_DATE "\n"

--- a/foo_ui_columns/version.h.template
+++ b/foo_ui_columns/version.h.template
@@ -1,9 +1,10 @@
 #pragma once
 
 // Note that version.h is automatically generated from version.h.template
-// by the pre-build script scripts\pre-build.ps1
+// by the pre-build script scripts\pre-build.py
 
 #define CUI_COMPILATION_DATE "${{ Date }}"
+#define CUI_COMPILATION_YEAR "${{ Year }}"
 
 namespace cui {
 


### PR DESCRIPTION
Resolves #778 

This simplifies the copyright notice, including using the year of compilation as the copyright date.