### PR TITLE
Redraw entire playlist view on background colour change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 
 ### Bug fixes
 
+- A bug where the empty area at the bottom of a playlist view with a small
+  number of items did not immediately update after changing the background
+  colour in preferences was fixed.
+  [[#804](https://github.com/reupen/columns_ui/pull/804)]
+
 - The tab order of controls on the Grouping tab on the playlist view preferences
   page was corrected. [[#781](https://github.com/reupen/columns_ui/pull/781)]
 

--- a/foo_ui_columns/fcl_titles.cpp
+++ b/foo_ui_columns/fcl_titles.cpp
@@ -376,7 +376,7 @@ class PlaylistViewMiscDataSet : public fcl::dataset {
         PlaylistView::g_on_autosize_change();
         PlaylistView::g_on_vertical_item_padding_change();
         PlaylistView::g_on_show_header_change();
-        PlaylistView::g_update_all_items();
+        PlaylistView::s_update_all_items();
     }
 };
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -372,7 +372,7 @@ void PlaylistView::on_artwork_width_change()
     set_group_info_area_size();
 }
 
-void PlaylistView::g_flush_artwork(bool b_redraw, const PlaylistView* p_skip)
+void PlaylistView::s_flush_artwork(bool b_redraw, const PlaylistView* p_skip)
 {
     for (auto& window : g_windows) {
         if (window != p_skip) {
@@ -409,7 +409,7 @@ void PlaylistView::g_on_group_header_font_change()
     for (auto& window : g_windows)
         window->set_group_font(&lf);
 }
-void PlaylistView::g_update_all_items()
+void PlaylistView::s_update_all_items()
 {
     for (auto& window : g_windows)
         window->update_all_items();
@@ -1467,8 +1467,10 @@ PlaylistViewGroupFontClient::factory<PlaylistViewGroupFontClient> g_font_group_h
 void ColoursClient::on_colour_changed(uint32_t mask) const
 {
     if (cfg_show_artwork && cfg_artwork_reflection && (mask & (colours::colour_flag_background)))
-        PlaylistView::g_flush_artwork();
-    PlaylistView::g_update_all_items();
+        PlaylistView::s_flush_artwork();
+
+    PlaylistView::s_update_all_items();
+    PlaylistView::s_redraw_all();
 }
 
 void ColoursClient::on_bool_changed(uint32_t mask) const

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -332,12 +332,12 @@ public:
     static void s_on_group_indentation_amount_change();
     static void g_on_columns_change();
     static void g_on_column_widths_change(const PlaylistView* p_skip = nullptr);
-    static void g_update_all_items();
+    static void s_update_all_items();
     static void g_on_autosize_change();
     static void g_on_show_artwork_change();
     static void g_on_alternate_selection_change();
     static void g_on_artwork_width_change(const PlaylistView* p_skip = nullptr);
-    static void g_flush_artwork(bool b_redraw = false, const PlaylistView* p_skip = nullptr);
+    static void s_flush_artwork(bool b_redraw = false, const PlaylistView* p_skip = nullptr);
     static void g_on_vertical_item_padding_change();
     static void g_on_show_header_change();
     static void g_on_playback_follows_cursor_change(bool b_val);

--- a/foo_ui_columns/tab_global.cpp
+++ b/foo_ui_columns/tab_global.cpp
@@ -75,7 +75,7 @@ public:
         case WM_DESTROY: {
             g_editor_font_notify.release();
             save_string(wnd);
-            cui::panels::playlist_view::PlaylistView::g_update_all_items();
+            cui::panels::playlist_view::PlaylistView::s_update_all_items();
         } break;
 
         case WM_COMMAND:
@@ -133,7 +133,7 @@ public:
                     cfg_colour = default_global_style_script;
                     if (g_cur_tab2 == 1)
                         uSendDlgItemMessageText(wnd, IDC_STRING, WM_SETTEXT, 0, cfg_colour);
-                    cui::panels::playlist_view::PlaylistView::g_update_all_items();
+                    cui::panels::playlist_view::PlaylistView::s_update_all_items();
                 }
             }
 
@@ -143,7 +143,7 @@ public:
                 break;
             case IDC_APPLY:
                 save_string(wnd);
-                cui::panels::playlist_view::PlaylistView::g_update_all_items();
+                cui::panels::playlist_view::PlaylistView::s_update_all_items();
                 break;
             case IDC_PICK_COLOUR:
                 colour_code_gen(wnd, IDC_COLOUR, false, false);


### PR DESCRIPTION
This resolves a problem where the empty area at the bottom of the playlist view (when there are only a few items) was not immediately redrawn when the background colour was reconfigured.