### PR TITLE
Fix console warning when adding playlist view to layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - The tab order of controls on the Grouping tab on the playlist view preferences
   page was corrected. [[#781](https://github.com/reupen/columns_ui/pull/781)]
 
+- A problem where messages containing 'Unsupported format or corrupted file'
+  were logged to the console when adding a new playlist view panel to the layout
+  was fixed. [[#806](https://github.com/reupen/columns_ui/pull/806)]
+
 - A problem where 'UnregisterClass failed: Class does not exist.' was logged to
   the console when quitting foobar2000 was fixed.
   [[#802](https://github.com/reupen/columns_ui/pull/802)]

--- a/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_config.cpp
@@ -40,6 +40,9 @@ void PlaylistView::get_config(stream_writer* p_writer, abort_callback& p_abort) 
 
 void PlaylistView::set_config(stream_reader* p_reader, size_t p_size, abort_callback& p_abort)
 {
+    if (p_size == 0)
+        return;
+
     const auto version = p_reader->read_lendian_t<uint16_t>(p_abort);
 
     if (version > STREAM_VERSION)


### PR DESCRIPTION
This fixes a problem causing console warnings when adding a playlist view to the layout. The problem was due to the panel not handling an empty configuration correctly.