### PR TITLE
Add support for Ctrl-Tab to Playlist tabs and Tab stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,23 @@
 
 ### Features
 
+- Ctrl+Tab and Shift+Ctrl+Tab can now be used in Tab stack and Playlist tabs to
+  switch to the next and previous tab respectively.
+  [[#817](https://github.com/reupen/columns_ui/pull/817)]
+
+### Bug fixes
+
+- When switching tabs, the Tab stack panel now updates the keyboard focus to the
+  first focusable element in the new tab.
+  [[#817](https://github.com/reupen/columns_ui/pull/817)]
+
+## v2.1.0
+
+### Features
+
 - Dark menus were enabled on Windows 11 builds greater than 22631.
   [[#788](https://github.com/reupen/columns_ui/pull/788), contributed by
   [@razielanarki](https://github.com/razielanarki)]
-
-### Internal changes
-
-- The component is now compiled using foobar2000 SDK 2023-05-10.
-  [[#799](https://github.com/reupen/columns_ui/pull/799)]
 
 ### Bug fixes
 
@@ -33,6 +42,13 @@
 
 - The copyright year was updated.
   [[#803](https://github.com/reupen/columns_ui/pull/803)]
+
+### Internal changes
+
+- The component is now compiled using foobar2000 SDK 2023-05-10.
+  [[#799](https://github.com/reupen/columns_ui/pull/799)]
+
+- The component is now compiled with Visual Studio 2022 17.7.
 
 ## 2.1.0-beta.3
 

--- a/foo_ui_columns/get_msg_hook.cpp
+++ b/foo_ui_columns/get_msg_hook.cpp
@@ -34,7 +34,10 @@ bool GetMsgHook::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM
                 g_layout_window.hide_menu_access_keys();
             }
         } else if (lpmsg->wParam == VK_TAB) {
-            const auto flags = SendMessage(lpmsg->hwnd, WM_GETDLGCODE, 0, (LPARAM)lpmsg);
+            if (GetKeyState(VK_CONTROL) & 0x8000)
+                return false;
+
+            const auto flags = SendMessage(lpmsg->hwnd, WM_GETDLGCODE, 0, reinterpret_cast<LPARAM>(lpmsg));
             if (!((flags & DLGC_WANTTAB) || (flags & DLGC_WANTMESSAGE))) {
                 ui_extension::window::g_on_tab(lpmsg->hwnd);
                 lpmsg->message = WM_NULL;

--- a/foo_ui_columns/helpers.h
+++ b/foo_ui_columns/helpers.h
@@ -31,4 +31,6 @@ std::vector<HWND> get_child_windows(HWND wnd, std::function<bool(HWND)> filter =
 pfc::string8 get_last_win32_error_message();
 bool open_web_page(HWND wnd, const wchar_t* url);
 void clip_minmaxinfo(MINMAXINFO& mmi);
+void handle_tabs_ctrl_tab(MSG* msg, HWND wnd_container, HWND wnd_tabs);
+
 } // namespace cui::helpers

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -189,6 +189,7 @@ private:
 
     MINMAXINFO mmi{};
     std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
+    std::unique_ptr<uih::EventToken> m_get_message_hook_token;
 };
 
 extern ui_extension::window_host_factory<PlaylistTabs::WindowHost> g_tab_host;

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -57,6 +57,12 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                   RedrawWindow(wnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
                   RedrawWindow(wnd_tabs, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
               });
+
+        m_get_message_hook_token = uih::register_message_hook(
+            uih::MessageHookType::type_get_message, [wnd, this](int code, WPARAM wp, LPARAM lp) -> bool {
+                helpers::handle_tabs_ctrl_tab(reinterpret_cast<LPMSG>(lp), wnd, wnd_tabs);
+                return false;
+            });
         break;
     }
     case WM_SHOWWINDOW: {
@@ -80,6 +86,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     }
         return 0;
     case WM_DESTROY: {
+        m_get_message_hook_token.reset();
         m_dark_mode_notifier.reset();
         playlist_manager::get()->unregister_callback(this);
         destroy_child();

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -132,7 +132,7 @@ public:
     static void g_on_font_change();
     void on_size_changed(unsigned width, unsigned height);
     void on_size_changed();
-    void on_active_tab_changed(int index_to);
+    void on_active_tab_changed(int index_to, bool from_interaction = false);
 
     TabStackPanel() = default;
 
@@ -148,6 +148,7 @@ private:
     int32_t m_mousewheel_delta{NULL};
     wil::unique_hfont g_font;
     std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
+    std::unique_ptr<uih::EventToken> m_get_message_hook_token;
 };
 
 } // namespace cui::panels::tab_stack


### PR DESCRIPTION
Resolves #146

This adds support for using Ctrl-Tab and Shift-Ctrl-Tab to switch tabs in the Playlist tabs and Tab stack panels.

This wasn't straightforward to implement; both component have little control over the contents of children, and  can also contain nested tabs. Nonetheless, this solution should handle most scenarios well.

Additionally, the existing code to update the keyboard focus when switching tabs in the Tab stack wasn't working correctly. This has been fixed as part of this, and the focus is now set to the first focusable element in the new tab (unless the tabs themselves were previously focused, or the new tab doesn't have any focusable children).