### PR TITLE
Work around visual glitches after running full-screen games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
   first focusable element in the new tab.
   [[#817](https://github.com/reupen/columns_ui/pull/817)]
 
+- A Windows bug causing visual glitches after running a full-screen game with
+  certain monitor configurations was worked around.
+  [[#843](https://github.com/reupen/columns_ui/pull/843)]
+
+### Internal changes
+
+- The component is now compiled with Visual Studio 2022 17.8.
+
 ## v2.1.0
 
 ### Features

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -244,6 +244,9 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             }
         }
     } break;
+    case WM_DISPLAYCHANGE:
+        RedrawWindow(wnd, nullptr, nullptr, RDW_ALLCHILDREN | RDW_ERASE | RDW_INVALIDATE | RDW_FRAME);
+        break;
     case WM_ACTIVATE: {
         if ((LOWORD(wp) == WA_INACTIVE)) {
             if (!uih::are_keyboard_cues_enabled())


### PR DESCRIPTION
This works around a Windows bug that can cause visual glitches after running a full-screen game at a reduced resolution under a multiple-monitor set-up.

The problem is described in more detail at https://hydrogenaud.io/index.php/topic,125030.msg1038153.