### PR TITLE
Improve support for high contrast mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   certain monitor configurations was worked around.
   [[#843](https://github.com/reupen/columns_ui/pull/843)]
 
+- Support for high contrast themes on recent versions of Windows was improved.
+  [[#847](https://github.com/reupen/columns_ui/pull/847)]
+
 ### Internal changes
 
 - The component is now compiled with Visual Studio 2022 17.8.

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -775,6 +775,7 @@ void PlaylistView::notify_on_initialisation()
     refresh_columns();
     refresh_groups();
 }
+
 void PlaylistView::notify_on_create()
 {
     pfc::hires_timer timer;

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -36,11 +36,16 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, size_t 
 {
     colours::helper p_helper(ColoursClient::g_guid);
 
+    const auto calculated_use_highlight = b_highlight && !context.m_is_high_contrast_active;
+
     int theme_state = NULL;
-    if (b_selected)
-        theme_state = (b_highlight ? LISS_HOTSELECTED : (b_window_focused ? LISS_SELECTED : LISS_SELECTEDNOTFOCUS));
-    else if (b_highlight)
+
+    if (b_selected) {
+        theme_state = (calculated_use_highlight ? LISS_HOTSELECTED
+                                                : (b_window_focused ? LISS_SELECTED : LISS_SELECTEDNOTFOCUS));
+    } else if (calculated_use_highlight) {
         theme_state = LISS_HOT;
+    }
 
     bool b_theme_enabled = p_helper.get_themed();
     // NB Third param of IsThemePartDefined "must be 0". But this works.

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -807,6 +807,9 @@ LRESULT RebarWindow::handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM
         uih::paint_subclassed_window_with_buffering(wnd, m_rebar_wnd_proc);
         return 0;
     }
+    case WM_THEMECHANGED:
+        on_themechanged();
+        break;
     }
     return CallWindowProc(m_rebar_wnd_proc, wnd, msg, wp, lp);
 }

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -69,6 +69,7 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
         break;
     case WM_THEMECHANGED:
         reopen_theme();
+        RedrawWindow(wnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
         break;
     case WM_DESTROY:
         m_dark_mode_notifier.reset();


### PR DESCRIPTION
Resolves #837

This improves support for high contrast mode on recent versions of Windows. It:

- fixes colour-related problems in list views when a high contrast theme is enabled
- fixes various visual glitches immediately after switching to or from a high contrast theme