### PR TITLE
Add open in pop-up viewer context-menu command to Artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   switch to the next and previous tab respectively.
   [[#817](https://github.com/reupen/columns_ui/pull/817)]
 
+- A command was added to the Artwork view context menu to open the displayed
+  image in the foobar2000 picture viewer (requires foobar2000 1.6.2 or newer).
+  [[#849](https://github.com/reupen/columns_ui/pull/849)]
+
 ### Bug fixes
 
 - When switching tabs, the Tab stack panel now updates the keyboard focus to the

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -77,6 +77,8 @@ public:
     static void s_on_dark_mode_status_change();
 
     void force_reload_artwork();
+    bool is_core_image_viewer_available() const;
+    void open_core_image_viewer() const;
 
     ArtworkPanel();
 


### PR DESCRIPTION
Relates to #717

This adds a context menu command to the Artwork view panel that opens the currently displayed image in the foobar2000 picture viewer.