### PR TITLE
Add option to open picture viewer on Artwork view click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@
   switch to the next and previous tab respectively.
   [[#817](https://github.com/reupen/columns_ui/pull/817)]
 
+- An option to make clicking on the Artwork view panel open the displayed image
+  in the foobar2000 picture viewer was added on foobar2000 1.6.2 or newer.
+  [[#853](https://github.com/reupen/columns_ui/pull/853)]
+
+  This is now the default for new installations.
+
 - A command was added to the Artwork view context menu to open the displayed
-  image in the foobar2000 picture viewer (requires foobar2000 1.6.2 or newer).
+  image in the foobar2000 picture viewer on foobar2000 1.6.2 or newer.
   [[#849](https://github.com/reupen/columns_ui/pull/849)]
 
 ### Bug fixes

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -4,6 +4,13 @@
 
 namespace cui::artwork_panel {
 
+enum class ClickAction : int32_t {
+    open_image_viewer,
+    show_next_artwork_type,
+};
+
+extern fbh::ConfigInt32 click_action;
+
 class ArtworkPanel
     : public uie::container_uie_window_v3
     , public now_playing_album_art_notify
@@ -79,6 +86,7 @@ public:
     void force_reload_artwork();
     bool is_core_image_viewer_available() const;
     void open_core_image_viewer() const;
+    void show_next_artwork_type();
 
     ArtworkPanel();
 

--- a/foo_ui_columns/config_artwork.cpp
+++ b/foo_ui_columns/config_artwork.cpp
@@ -30,11 +30,30 @@ public:
     void refresh_me(HWND wnd)
     {
         m_initialising = true;
-        const HWND wnd_combo = GetDlgItem(wnd, IDC_EDGESTYLE);
-        ComboBox_AddString(wnd_combo, L"None");
-        ComboBox_AddString(wnd_combo, L"Sunken");
-        ComboBox_AddString(wnd_combo, L"Grey");
-        ComboBox_SetCurSel(wnd_combo, cui::artwork_panel::cfg_edge_style);
+
+        const HWND edge_style_wnd = GetDlgItem(wnd, IDC_EDGESTYLE);
+        ComboBox_AddString(edge_style_wnd, L"None");
+        ComboBox_AddString(edge_style_wnd, L"Sunken");
+        ComboBox_AddString(edge_style_wnd, L"Grey");
+        ComboBox_SetCurSel(edge_style_wnd, cui::artwork_panel::cfg_edge_style);
+
+        const HWND click_action_wnd = GetDlgItem(wnd, IDC_CLICK_ACTION);
+
+        if (fb2k::imageViewer::ptr api; fb2k::imageViewer::tryGet(api)) {
+            uih::combo_box_add_string_data(click_action_wnd, L"Open foobar2000 picture viewer",
+                WI_EnumValue(cui::artwork_panel::ClickAction::open_image_viewer));
+        }
+
+        uih::combo_box_add_string_data(click_action_wnd, L"Show next available artwork type",
+            WI_EnumValue(cui::artwork_panel::ClickAction::show_next_artwork_type));
+
+        const auto click_action_index
+            = uih::combo_box_find_item_by_data(click_action_wnd, cui::artwork_panel::click_action);
+
+        if (click_action_index != CB_ERR) {
+            ComboBox_SetCurSel(click_action_wnd, click_action_index);
+        }
+
         m_initialising = false;
     }
 
@@ -65,6 +84,16 @@ public:
                 cui::artwork_panel::cfg_edge_style = ComboBox_GetCurSel((HWND)lp);
                 cui::artwork_panel::ArtworkPanel::g_on_edge_style_change();
                 break;
+            case IDC_CLICK_ACTION | (CBN_SELCHANGE << 16): {
+                auto index = ComboBox_GetCurSel(reinterpret_cast<HWND>(lp));
+
+                if (index == CB_ERR)
+                    break;
+
+                cui::artwork_panel::click_action
+                    = gsl::narrow<int32_t>(ComboBox_GetItemData(reinterpret_cast<HWND>(lp), index));
+                break;
+            }
             }
         }
         return 0;

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -500,14 +500,16 @@ EXSTYLE WS_EX_CONTROLPARENT
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     LTEXT           "Artwork view panel",IDC_TITLE2,7,4,252,16
-    LTEXT           "Panel edge style",IDC_STATIC,7,30,55,8
-    COMBOBOX        IDC_EDGESTYLE,7,41,40,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Artwork sources",IDC_TITLE1,7,77,252,16
-    LTEXT           "Artwork sources are now configured on the Display preferences page. Columns UI no longer has separate artwork source settings.",IDC_STATIC,7,102,312,23
-    PUSHBUTTON      "Go to Display preferences",IDC_OPEN_DISPLAY_PREFERENCES,7,133,148,14
-    LTEXT           "You previously had artwork sources configured in Columns UI. If artwork is no longer displaying correctly, manually copy your previous configuration to Display preferences.",IDC_VIEW_OLD_ARTWORK_SOURCES_TEXT,7,129,312,22
-    PUSHBUTTON      "View previously configured artwork sources",IDC_VIEW_OLD_ARTWORK_SOURCES,7,158,178,14
-    PUSHBUTTON      "Go to Display preferences",IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES,7,181,179,14
+    LTEXT           "Action to perform on click",IDC_STATIC,7,28,87,8
+    COMBOBOX        IDC_CLICK_ACTION,7,39,140,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Panel edge style",IDC_STATIC,7,63,55,8
+    COMBOBOX        IDC_EDGESTYLE,7,74,40,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Artwork sources",IDC_TITLE1,7,115,252,16
+    LTEXT           "Artwork sources are now configured on the Display preferences page. Columns UI no longer has separate artwork source settings.",IDC_STATIC,7,140,312,23
+    PUSHBUTTON      "Go to Display preferences",IDC_OPEN_DISPLAY_PREFERENCES,7,171,148,14
+    LTEXT           "You previously had artwork sources configured in Columns UI. If artwork is no longer displaying correctly, manually copy your previous configuration to Display preferences.",IDC_VIEW_OLD_ARTWORK_SOURCES_TEXT,7,167,312,22
+    PUSHBUTTON      "View previously configured artwork sources",IDC_VIEW_OLD_ARTWORK_SOURCES,7,196,178,14
+    PUSHBUTTON      "Go to Display preferences",IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES,7,219,179,14
 END
 
 IDD_ITEM_PROPS_OPTIONS DIALOGEX 0, 0, 268, 385

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -64,14 +64,8 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook)
         return nullptr;
     }
 
+    migrate::apply_first_run_defaults();
     migrate::migrate_all();
-
-    if (main_window::config_get_is_first_run()) {
-        colours::dark_mode_status.set(WI_EnumValue(colours::DarkModeStatus::UseSystemSetting));
-
-        if (!cfg_layout.get_presets().get_count())
-            cfg_layout.reset_presets();
-    }
 
     m_hook_proc = hook;
 

--- a/foo_ui_columns/migrate.cpp
+++ b/foo_ui_columns/migrate.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 
 #include "migrate.h"
+
+#include "artwork.h"
 #include "config_appearance.h"
 #include "layout.h"
 #include "status_pane.h"
@@ -141,6 +143,21 @@ void migrate_all()
     v100::migrate();
     v200::migrate_status_pane();
     v200::migrate_custom_colours();
+}
+
+void apply_first_run_defaults()
+{
+    if (!main_window::config_get_is_first_run())
+        return;
+
+    colours::dark_mode_status.set(WI_EnumValue(colours::DarkModeStatus::UseSystemSetting));
+
+    if (!cfg_layout.get_presets().get_count())
+        cfg_layout.reset_presets();
+
+    if (fb2k::imageViewer::ptr api; fb2k::imageViewer::tryGet(api)) {
+        artwork_panel::click_action = WI_EnumValue(artwork_panel::ClickAction::open_image_viewer);
+    }
 }
 
 } // namespace cui::migrate

--- a/foo_ui_columns/migrate.h
+++ b/foo_ui_columns/migrate.h
@@ -4,4 +4,6 @@ namespace cui::migrate {
 
 void migrate_all();
 
+void apply_first_run_defaults();
+
 } // namespace cui::migrate

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -250,6 +250,7 @@
 #define IDC_EDGESTYLE                   1155
 #define IDC_PRECEDENCE                  1156
 #define IDC_HALIGN                      1156
+#define IDC_CLICK_ACTION                1156
 #define IDC_VALIGN                      1157
 #define IDC_ARTWORKWIDTH                1158
 #define IDC_QUICKSETUP                  1159


### PR DESCRIPTION
Resolves #717

This makes action performed when clicking on the Artwork view panel configurable in preferences.

There are two options:

- open in foobar2000 picture viewer (available on foobar2000 1.6.2 and newer only)
- show next available artwork type (the previous standard behaviour)

On new installations of Columns UI, 'Open in foobar2000 picture viewer' is now the default (if using foobar2000 1.6.2 or newer).