### PR TITLE
Correctly show streaming artwork after changing 'Displayed track'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 - Support for high contrast themes on recent versions of Windows was improved.
   [[#847](https://github.com/reupen/columns_ui/pull/847)]
 
+- A bug where dynamic internet radio artwork may not have been immediately shown
+  after changing the ‘Displayed track’ in the Artwork view panel was fixed.
+  [[#854](https://github.com/reupen/columns_ui/pull/854)]
+
 ### Internal changes
 
 - The component is now compiled with Visual Studio 2022 17.8.

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -317,6 +317,7 @@ void ArtworkPanel::force_reload_artwork()
     if (g_track_mode_includes_now_playing(m_track_mode) && play_control::get()->is_playing()) {
         play_control::get()->get_now_playing(handle);
         is_from_playback = true;
+        m_dynamic_artwork_pending = now_playing_album_art_notify_manager::get()->current().is_valid();
     } else if (g_track_mode_includes_playlist(m_track_mode)) {
         metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
         playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);


### PR DESCRIPTION
This fixes a small bug in the Artwork view panel where, when a stream with dynamic artwork is playing and the playing track is selected, changing the 'Displayed track' from one that doesn't include the playing item to one that does would not immediately show the streaming artwork as expected.