### PR TITLE
Improve metadata saving logic in Item properties and Filter panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   This makes the behaviour consistent with what happens when there are Filter
   panels in the layout.
 
+- The way metadata changes are saved in Item properties and Filter panel was
+  improved. [[#863](https://github.com/reupen/columns_ui/pull/863)]
+
 ### Bug fixes
 
 - Various rendering glitches in Playlist tabs and Tab stack when dark mode is

--- a/foo_ui_columns/file_info_utils.cpp
+++ b/foo_ui_columns/file_info_utils.cpp
@@ -1,0 +1,71 @@
+#include "pch.h"
+
+#include "file_info_utils.h"
+
+namespace cui::helpers {
+
+namespace {
+
+std::string_view trim_string(std::string_view value)
+{
+    const auto start = value.find_first_not_of(' ');
+    const auto end = value.find_last_not_of(' ');
+
+    if (start > end || start == std::string_view::npos)
+        return ""sv;
+
+    return value.substr(start, end - start + 1);
+}
+
+} // namespace
+
+std::vector<std::string> split_meta_value(std::string_view value)
+{
+    std::vector<std::string> values;
+
+    for (size_t offset{};;) {
+        const size_t index = value.find(";"sv, offset);
+        const auto substr = value.substr(offset, index - offset);
+        const auto trimmed_substr = trim_string(substr);
+
+        if (trimmed_substr.length() > 0)
+            values.emplace_back(trimmed_substr);
+
+        if (index == std::string_view::npos)
+            break;
+
+        offset = index + 1;
+    }
+
+    return values;
+}
+
+std::vector<std::string_view> get_meta_field_values(const file_info& info, std::string_view field)
+{
+    std::vector<std::string_view> values;
+
+    for (const auto index : ranges::views::iota(size_t{}, info.meta_get_count_by_name(field.data()))) {
+        values.emplace_back(info.meta_get(field.data(), index));
+    }
+
+    return values;
+}
+
+bool SingleFieldFileInfoFilter::apply_filter(metadb_handle_ptr p_location, t_filestats p_stats, file_info& p_info)
+{
+    auto old_values = get_meta_field_values(p_info, m_field);
+    std::vector<std::string_view> new_values;
+    ranges::push_back(new_values, m_new_values);
+
+    if (old_values == new_values)
+        return false;
+
+    p_info.meta_remove_field(m_field.data());
+
+    for (auto&& value : m_new_values)
+        p_info.meta_add_ex(m_field.data(), m_field.length(), value.data(), value.length());
+
+    return true;
+}
+
+} // namespace cui::helpers

--- a/foo_ui_columns/file_info_utils.h
+++ b/foo_ui_columns/file_info_utils.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace cui::helpers {
+
+std::vector<std::string> split_meta_value(std::string_view value);
+
+std::vector<std::string_view> get_meta_field_values(const file_info& info, std::string_view field);
+
+class SingleFieldFileInfoFilter : public file_info_filter {
+public:
+    SingleFieldFileInfoFilter(std::string field, std::vector<std::string> new_values)
+        : m_field(std::move(field))
+        , m_new_values(std::move(new_values))
+    {
+    }
+
+    bool apply_filter(metadb_handle_ptr p_location, t_filestats p_stats, file_info& p_info) override;
+
+    std::string m_field;
+    std::vector<std::string> m_new_values;
+};
+
+} // namespace cui::helpers

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -913,9 +913,6 @@ pfc::list_t<FieldData> FilterPanel::g_field_data;
 
 pfc::list_t<FilterStream::ptr> FilterPanel::g_streams;
 
-// {4D6774AF-C292-44ac-8A8F-3B0855DCBDF4}
-const GUID AppearanceClient::g_guid = {0x4d6774af, 0xc292, 0x44ac, {0x8a, 0x8f, 0x3b, 0x8, 0x55, 0xdc, 0xbd, 0xf4}};
-
 namespace {
 colours::client::factory<AppearanceClient> g_appearance_client_impl;
 }

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -6,9 +6,9 @@ namespace cui::panels::filter {
 
 class AppearanceClient : public colours::client {
 public:
-    static const GUID g_guid;
+    static constexpr GUID id{0x4d6774af, 0xc292, 0x44ac, {0x8a, 0x8f, 0x3b, 0x8, 0x55, 0xdc, 0xbd, 0xf4}};
 
-    const GUID& get_client_guid() const override { return g_guid; }
+    const GUID& get_client_guid() const override { return id; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel"; }
     uint32_t get_supported_colours() const override { return colours::colour_flag_all; }
     uint32_t get_supported_bools() const override

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -266,6 +266,7 @@
     <ClCompile Include="dark_mode_active_ui.cpp" />
     <ClCompile Include="dark_mode_dialog.cpp" />
     <ClCompile Include="dark_mode_spin.cpp" />
+    <ClCompile Include="file_info_utils.cpp" />
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="icons.cpp" />
@@ -440,6 +441,7 @@
     <ClInclude Include="dark_mode_active_ui.h" />
     <ClInclude Include="dark_mode_spin.h" />
     <ClInclude Include="event_token.h" />
+    <ClInclude Include="file_info_utils.h" />
     <ClInclude Include="font_manager_data.h" />
     <ClInclude Include="gdi.h" />
     <ClInclude Include="gdiplus.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -611,6 +611,9 @@
     <ClCompile Include="ng_playlist\ng_playlist_config.cpp">
       <Filter>Playlist view</Filter>
     </ClCompile>
+    <ClCompile Include="file_info_utils.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -888,6 +891,9 @@
       <Filter>Utilities</Filter>
     </ClInclude>
     <ClInclude Include="core_drop_down_list_toolbar.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="file_info_utils.h">
       <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -45,9 +45,9 @@ size_t g_get_info_section_id_by_name(const char* p_name);
 
 class ItemPropertiesColoursClient : public colours::client {
 public:
-    static const GUID g_guid;
+    static constexpr GUID id{0x862f8a37, 0x16e0, 0x4a74, {0xb2, 0x7e, 0x2b, 0x73, 0xdb, 0x56, 0x7d, 0xf}};
 
-    const GUID& get_client_guid() const override { return g_guid; }
+    const GUID& get_client_guid() const override { return id; }
 
     void get_name(pfc::string_base& p_out) const override { p_out = "Item properties"; }
 
@@ -157,7 +157,7 @@ public:
     void notify_on_column_size_change(size_t index, int new_width) override;
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<size_t>& indices, size_t column, bool b_source_mouse) override;
-    static void g_print_field(const char* field, const file_info& p_info, pfc::string_base& p_out);
+    static void s_print_field(const char* field, const file_info& p_info, pfc::string_base& p_out);
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
         pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override;
     void notify_save_inline_edit(const char* value) override;
@@ -179,12 +179,12 @@ public:
 
     void on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) override;
 
-    static void g_on_app_activate(bool b_activated);
-    static void g_redraw_all();
+    static void s_on_app_activate(bool b_activated);
+    static void s_redraw_all();
     static void s_on_dark_mode_status_change();
-    static void g_on_font_items_change();
-    static void g_on_font_header_change();
-    static void g_on_font_groups_change();
+    static void s_on_font_items_change();
+    static void s_on_font_header_change();
+    static void s_on_font_groups_change();
 
     ItemProperties();
 
@@ -199,7 +199,7 @@ private:
     void on_tracking_mode_change();
     bool check_process_on_selection_changed();
 
-    static std::vector<ItemProperties*> g_windows;
+    static std::vector<ItemProperties*> s_windows;
 
     ui_selection_holder::ptr m_selection_holder;
     metadb_handle_list m_handles;

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -50,7 +50,7 @@ protected:
     bool should_show_drag_text(size_t selection_count) override { return true; }
     void render_get_colour_data(ColourData& p_out) override
     {
-        cui::colours::helper p_helper(t_appearance_client::g_guid);
+        cui::colours::helper p_helper(t_appearance_client::id);
         p_out.m_themed = p_helper.get_themed();
         p_out.m_use_custom_active_item_frame = p_helper.get_bool(cui::colours::bool_use_custom_active_item_frame);
         p_out.m_text = p_helper.get_colour(cui::colours::colour_text);

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -1418,8 +1418,6 @@ const GUID PlaylistView::g_extension_guid
 
 uie::window_factory<PlaylistView> g_pvt;
 
-// {C882D3AC-C014-44df-9C7E-2DADF37645A0}
-const GUID ColoursClient::g_guid = {0xc882d3ac, 0xc014, 0x44df, {0x9c, 0x7e, 0x2d, 0xad, 0xf3, 0x76, 0x45, 0xa0}};
 ColoursClient::factory<ColoursClient> g_appearance_client_ngpv_impl;
 
 // {19F8E0B3-E822-4f07-B200-D4A67E4872F9}

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -280,9 +280,9 @@ private:
 
 class ColoursClient : public colours::client {
 public:
-    static const GUID g_guid;
+    static constexpr GUID id{0xc882d3ac, 0xc014, 0x44df, {0x9c, 0x7e, 0x2d, 0xad, 0xf3, 0x76, 0x45, 0xa0}};
 
-    const GUID& get_client_guid() const override { return g_guid; }
+    const GUID& get_client_guid() const override { return id; }
 
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view"; }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -310,7 +310,7 @@ wil::shared_hbitmap PlaylistView::request_group_artwork(size_t index_item)
         m_playlist_api->activeplaylist_get_item_handle(handle, index_item);
         std::shared_ptr<ArtworkReader> p_reader;
         m_artwork_manager->request(handle, p_reader, cx, cy,
-            colours::helper(ColoursClient::g_guid).get_colour(colours::colour_background), cfg_artwork_reflection,
+            colours::helper(ColoursClient::id).get_colour(colours::colour_background), cfg_artwork_reflection,
             std::move(ptr));
         group->m_artwork_load_attempted = true;
         return nullptr;

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -34,7 +34,7 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, size_t 
     std::vector<uih::lv::RendererSubItem> sub_items, int indentation, bool b_selected, bool b_window_focused,
     bool b_highlight, bool should_hide_focus, bool b_focused, RECT rc)
 {
-    colours::helper p_helper(ColoursClient::g_guid);
+    colours::helper p_helper(ColoursClient::id);
 
     const auto calculated_use_highlight = b_highlight && !context.m_is_high_contrast_active;
 
@@ -144,7 +144,7 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, size_t 
 void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t item_index, size_t group_index,
     std::string_view text, int indentation, size_t level, RECT rc)
 {
-    colours::helper p_helper(ColoursClient::g_guid);
+    colours::helper p_helper(ColoursClient::id);
     bool b_theme_enabled = p_helper.get_themed();
 
     int text_width = NULL;

--- a/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
@@ -32,7 +32,7 @@ SharedCellStyleData::~SharedCellStyleData()
 
 CellStyleData CellStyleData::g_create_default()
 {
-    colours::helper p_helper(ColoursClient::g_guid);
+    colours::helper p_helper(ColoursClient::id);
     return CellStyleData(p_helper.get_colour(colours::colour_text), p_helper.get_colour(colours::colour_selection_text),
         p_helper.get_colour(colours::colour_background), p_helper.get_colour(colours::colour_selection_background),
         p_helper.get_colour(colours::colour_inactive_selection_text),
@@ -112,7 +112,7 @@ bool StyleTitleformatHook::process_field(
                 return true;
             }
             if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "themed", pfc_infinite)) {
-                colours::helper p_helper(ColoursClient::g_guid);
+                colours::helper p_helper(ColoursClient::id);
                 if (p_helper.get_themed()) {
                     p_out->write(titleformat_inputtypes::unknown, "1", 1);
                     p_found_flag = true;

--- a/foo_ui_columns/playlist_switcher.cpp
+++ b/foo_ui_columns/playlist_switcher.cpp
@@ -23,10 +23,6 @@ public:
 
 PlaylistSwitcherFontClient::factory<PlaylistSwitcherFontClient> g_font_client_switcher;
 
-// {EB38A997-3B5F-4126-8746-262AA9C1F94B}
-const GUID PlaylistSwitcherColoursClient::g_guid
-    = {0xeb38a997, 0x3b5f, 0x4126, {0x87, 0x46, 0x26, 0x2a, 0xa9, 0xc1, 0xf9, 0x4b}};
-
 PlaylistSwitcherColoursClient::factory<PlaylistSwitcherColoursClient> g_appearance_client_ps_impl;
 
 void PlaylistSwitcherColoursClient::on_colour_changed(uint32_t mask) const

--- a/foo_ui_columns/playlist_switcher.h
+++ b/foo_ui_columns/playlist_switcher.h
@@ -4,9 +4,9 @@ namespace cui::panels::playlist_switcher {
 
 class PlaylistSwitcherColoursClient : public colours::client {
 public:
-    static const GUID g_guid;
+    static constexpr GUID id{0xeb38a997, 0x3b5f, 0x4126, {0x87, 0x46, 0x26, 0x2a, 0xa9, 0xc1, 0xf9, 0x4b}};
 
-    const GUID& get_client_guid() const override { return g_guid; }
+    const GUID& get_client_guid() const override { return id; }
 
     void get_name(pfc::string_base& p_out) const override { p_out = "Playlist switcher"; }
 


### PR DESCRIPTION
This makes the way Item properties and Filter panel write metadata changes when using inline editing more consistent with the playlist view.

In particular, more logic is pushed to the `file_info_filter` class. This should also improve safety, as it causes changes to be applied to freshly read metadata, rather than the cached copy.

Some code was cleaned up at the same time.