### PR TITLE
Include current values in inline editing edit box when values are inconsistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
   This makes the behaviour consistent with what happens when there are Filter
   panels in the layout.
 
+- When using inline editing on multiple tracks in the playlist view and Item
+  properties, existing values are now included in the edit box after the text
+  `«mixed values»` when the current values of the field differ between the
+  tracks. [[#871](https://github.com/reupen/columns_ui/pull/871)]
+
 - The way metadata changes are saved in Item properties and Filter panel was
   improved. [[#863](https://github.com/reupen/columns_ui/pull/863)]
 
@@ -54,7 +59,7 @@
 
 ### Internal changes
 
-- The component is now compiled with Visual Studio 2022 17.8.
+- The component is now compiled with Visual Studio 2022 17.9.
 
 ## v2.1.0
 

--- a/foo_ui_columns/file_info_utils.h
+++ b/foo_ui_columns/file_info_utils.h
@@ -20,4 +20,19 @@ public:
     std::vector<std::string> m_new_values;
 };
 
+class EditMetadataFieldValueAggregator {
+public:
+    bool process_file_info(const char* field, const file_info* info);
+
+    std::vector<std::string> m_values;
+    bool m_truncated{false};
+    bool m_mixed_values{};
+
+private:
+    void add_value(const std::string_view& value);
+
+    static constexpr size_t max_values = 32;
+    std::optional<std::vector<std::string>> m_first_track_values;
+};
+
 } // namespace cui::helpers


### PR DESCRIPTION
Resolves #414

This updates inline editing in the playlist view and in Item properties so that, when multiple tracks are being edited, if the current values of the field differ between the tracks those current values are included in the edit box after the text `«mixed values»`.