### PR TITLE
Fix ability to paste files copied in File Explorer in the playlist view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
   incorrectly after switching playlists was fixed.
   [[#866](https://github.com/reupen/columns_ui/pull/866)]
 
+- A bug where files copied in File Explorer couldn’t be pasted in the playlist
+  view using the context menu was fixed.
+  [[#873](https://github.com/reupen/columns_ui/pull/873)]
+
 - Various rendering glitches in Playlist tabs and Tab stack when dark mode is
   active were fixed. [[#851](https://github.com/reupen/columns_ui/pull/851)]
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
@@ -6,16 +6,15 @@ namespace playlist_utils {
 bool check_clipboard()
 {
     const auto api = ole_interaction::get();
-    wil::com_ptr_t<IDataObject> pDO;
-    if (FAILED(OleGetClipboard(&pDO)))
+    wil::com_ptr_t<IDataObject> data_object;
+
+    if (FAILED(OleGetClipboard(&data_object)))
         return false;
 
-    bool b_native;
+    bool is_native{};
     DWORD dummy = DROPEFFECT_COPY;
-    if (FAILED(api->check_dataobject(pDO.get(), dummy, b_native)))
-        return false;
 
-    return b_native;
+    return SUCCEEDED(api->check_dataobject(data_object.get(), dummy, is_native));
 }
 
 bool cut()
@@ -64,9 +63,9 @@ bool paste(HWND wnd, size_t index)
 
     dropped_files_data_impl data;
     metadb_handle_list handles;
-    bool b_native;
+    bool is_native;
     DWORD dummy = DROPEFFECT_COPY;
-    HRESULT hr = ole_api->check_dataobject(pDO.get(), dummy, b_native);
+    HRESULT hr = ole_api->check_dataobject(pDO.get(), dummy, is_native);
     if (FAILED(hr))
         return false;
 
@@ -74,7 +73,7 @@ bool paste(HWND wnd, size_t index)
     if (FAILED(hr))
         return false;
 
-    data.to_handles(handles, b_native, GetAncestor(wnd, GA_ROOT));
+    data.to_handles(handles, !is_native, GetAncestor(wnd, GA_ROOT));
     playlist_api->activeplaylist_undo_backup();
     playlist_api->activeplaylist_clear_selection();
     playlist_api->activeplaylist_insert_items(index, handles, bit_array_true());

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -117,7 +117,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::DragEnter(
         m_ole_api->get_clipboard_format(m_ole_api->KClipboardFormatMultiFPL), pDataObj);
 
     m_is_accepted_type = ui_drop_item_callback::g_is_accepted_type(pDataObj, pdwEffect)
-        || S_OK == m_ole_api->check_dataobject(pDataObj, dummy, native);
+        || SUCCEEDED(m_ole_api->check_dataobject(pDataObj, dummy, native));
     if (!m_is_accepted_type) {
         *pdwEffect = DROPEFFECT_NONE;
         uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");


### PR DESCRIPTION
Resolves #864 

This resolves a bug where it wasn’t possible to paste files that had been copied in File Explorer in the playlist view using the context menu.