### PR TITLE
Update ui_helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
   incorrectly after switching playlists was fixed.
   [[#866](https://github.com/reupen/columns_ui/pull/866)]
 
+- A bug with inline editing in the playlist view, Item properties and Filter
+  panels where it wasn’t possible to click on autocomplete suggestions was
+  fixed. [[#886](https://github.com/reupen/columns_ui/pull/886)]
+
 - A bug where files copied in File Explorer couldn’t be pasted in the playlist
   view using the context menu was fixed.
   [[#873](https://github.com/reupen/columns_ui/pull/873)]


### PR DESCRIPTION
Resolves #885

This updates ui_helpers to resolve a problem where it wasn't possible to click on an autocomplete suggestion when using inline editing in list views.