### PR TITLE
Add confirmation before deleting layout presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
 - The way metadata changes are saved in Item properties and Filter panel was
   improved. [[#863](https://github.com/reupen/columns_ui/pull/863)]
 
+- Deleting layout presets in preferences is now a two-step process to avoid
+  accidental deletions. [[#891](https://github.com/reupen/columns_ui/pull/891)]
+
+  (The confirmation dialogue box can be bypassed by holding down Shift while
+  clicking the button.)
+
 ### Bug fixes
 
 - A bug sometimes causing the playlist view vertical scroll position to show

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -616,6 +616,22 @@ INT_PTR LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             }
         } break;
         case IDC_DELETE_PRESET: {
+            const auto is_shift_down = GetKeyState(VK_SHIFT) & 0x8000;
+
+            if (!is_shift_down) {
+                pfc::string8 preset_name;
+                cfg_layout.get_preset_name(m_active_preset, preset_name);
+
+                const auto confirmation_message
+                    = fmt::format(u8"Are you sure that you want to delete the layout preset ‘{}’?",
+                        reinterpret_cast<const char8_t*>(preset_name.c_str()));
+
+                if (uMessageBox(wnd, reinterpret_cast<const char*>(confirmation_message.c_str()), "Delete preset",
+                        MB_YESNO | MB_ICONWARNING)
+                    != IDYES)
+                    break;
+            }
+
             deinitialise_tree(wnd);
             HWND wnd_combo = GetDlgItem(wnd, IDC_PRESETS);
             size_t count = cfg_layout.delete_preset(m_active_preset);


### PR DESCRIPTION
#880 

This adds a message box to confirm the deletion of a layout preset, when clicking the Delete button on the Layout preferences tab.

This message box can be bypassed (e.g. when deleting a lot of presets) by holding down the Shift button while clicking the button.