### PR TITLE
Migrate list views to DirectWrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Features
 
-- Text in the status bar is now rendered using DirectWrite.
-  [[#897](https://github.com/reupen/columns_ui/pull/897)]
+- Text in list views (such as the playlist view, playlist switcther, Filter
+  panel and Item properties) and in the status bar is now rendered using
+  DirectWrite. [[#897](https://github.com/reupen/columns_ui/pull/897),
+  [#904](https://github.com/reupen/columns_ui/pull/904)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -581,7 +581,7 @@ INT_PTR TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         LOGFONT font{};
         GetObject(GetWindowFont(wnd), sizeof(font), &font);
-        m_columns_list_view.set_font(&font);
+        m_columns_list_view.set_font(font);
 
         m_columns.set_entries_copy(g_columns, true);
 

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -196,7 +196,7 @@ void FilterPanel::g_on_font_items_change()
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_filter_items_font_client, lf);
     for (auto& window : g_windows) {
-        window->set_font(&lf);
+        window->set_font(lf);
     }
 }
 
@@ -205,7 +205,7 @@ void FilterPanel::g_on_font_header_change()
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_filter_header_font_client, lf);
     for (auto& window : g_windows) {
-        window->set_header_font(&lf);
+        window->set_header_font(lf);
     }
 }
 void FilterPanel::g_redraw_all()
@@ -794,9 +794,9 @@ void FilterPanel::notify_on_initialisation()
 
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_filter_items_font_client, lf);
-    set_font(&lf);
+    set_font(lf);
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_filter_header_font_client, lf);
-    set_header_font(&lf);
+    set_header_font(lf);
 
     size_t index = g_windows.size();
     if (index == 0) {

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -173,11 +173,11 @@ void ItemProperties::notify_on_initialisation()
     set_autosize(m_autosizing_columns);
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
-    set_font(&lf);
+    set_font(lf);
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
-    set_header_font(&lf);
+    set_header_font(lf);
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
-    set_group_font(&lf);
+    set_group_font(lf);
     set_edge_style(m_edge_style);
     set_show_header(m_show_column_titles);
     set_group_level_indentation_enabled(false);
@@ -707,7 +707,7 @@ void ItemProperties::s_on_font_items_change()
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
     for (auto& window : s_windows) {
-        window->set_font(&lf);
+        window->set_font(lf);
     }
 }
 
@@ -716,7 +716,7 @@ void ItemProperties::s_on_font_groups_change()
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
     for (auto& window : s_windows) {
-        window->set_group_font(&lf);
+        window->set_group_font(lf);
     }
 }
 
@@ -725,7 +725,7 @@ void ItemProperties::s_on_font_header_change()
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
     for (auto& window : s_windows) {
-        window->set_header_font(&lf);
+        window->set_header_font(lf);
     }
 }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -393,21 +393,21 @@ void PlaylistView::g_on_font_change()
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_items_font, lf);
     for (auto& window : g_windows)
-        window->set_font(&lf);
+        window->set_font(lf);
 }
 void PlaylistView::g_on_header_font_change()
 {
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_header_font, lf);
     for (auto& window : g_windows)
-        window->set_header_font(&lf);
+        window->set_header_font(lf);
 }
 void PlaylistView::g_on_group_header_font_change()
 {
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_group_header_font, lf);
     for (auto& window : g_windows)
-        window->set_group_font(&lf);
+        window->set_group_font(lf);
 }
 void PlaylistView::s_update_all_items()
 {
@@ -751,11 +751,11 @@ void PlaylistView::notify_on_initialisation()
     set_vertical_item_padding(settings::playlist_view_item_padding);
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_items_font, lf);
-    set_font(&lf);
+    set_font(lf);
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_header_font, lf);
-    set_header_font(&lf);
+    set_header_font(lf);
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_group_header_font, lf);
-    set_group_font(&lf);
+    set_group_font(lf);
     set_sorting_enabled(cfg_header_hottrack != 0);
     set_show_sort_indicators(cfg_show_sort_arrows != 0);
     set_edge_style(cfg_frame);

--- a/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
@@ -76,7 +76,7 @@ BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         LOGFONT font{};
         GetObject(GetWindowFont(wnd), sizeof(font), &font);
-        m_groups_list_view.set_font(&font);
+        m_groups_list_view.set_font(font);
 
         std::vector<uih::ListView::InsertItem> insert_items;
         insert_items.reserve(g_groups.get_groups().get_count());

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -114,7 +114,7 @@ void PlaylistSwitcher::g_on_font_items_change()
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_font, lf);
     for (auto& window : g_windows) {
-        window->set_font(&lf);
+        window->set_font(lf);
     }
 }
 void PlaylistSwitcher::notify_on_initialisation()
@@ -128,7 +128,7 @@ void PlaylistSwitcher::notify_on_initialisation()
 
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_font, lf);
-    set_font(&lf);
+    set_font(lf);
 }
 void PlaylistSwitcher::notify_on_create()
 {

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -17,7 +17,7 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
         m_presets_list_view.create(wnd, {14, 18, 240, 67}, true);
         LOGFONT font{};
         GetObject(GetWindowFont(wnd), sizeof(font), &font);
-        m_presets_list_view.set_font(&font);
+        m_presets_list_view.set_font(font);
 
         HWND wnd_mode = GetDlgItem(wnd, IDC_DARK_MODE);
         HWND wnd_theming = GetDlgItem(wnd, IDC_THEMING);

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -19,7 +19,7 @@ struct StatusBarState {
     std::string track_count_text;
     std::string volume_text;
     wil::unique_hfont font;
-    std::optional<uih::direct_write::Context> direct_write_ctx;
+    uih::direct_write::Context::Ptr direct_write_ctx;
     std::optional<uih::direct_write::TextFormat> direct_write_text_format;
     wil::unique_hbitmap lock_bitmap;
     wil::unique_hicon lock_icon;
@@ -50,7 +50,7 @@ void on_status_font_change()
 
     try {
         if (!state->direct_write_ctx)
-            state->direct_write_ctx = std::make_optional<uih::direct_write::Context>();
+            state->direct_write_ctx = uih::direct_write::Context::s_create();
     }
     CATCH_LOG();
 


### PR DESCRIPTION
#15

This makes list views (including the playlist view, playlist switcher, Filter panel and Item properties) render text using DirectWrite rather than Uniscribe.

Tooltips and inline editing edit controls remain unchanged.