### PR TITLE
Make Items details options support dark mode when in modal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@
   Note: An item group of ‘None’ is used to execute a context menu command
   without any tracks, which isn’t normally useful.
 
+- The Item details options dialogue box now respects the current dark mode
+  setting when opened from the Layout preferences page.
+  [[#909](https://github.com/reupen/columns_ui/pull/909)]
+
 - A bug where dynamic internet radio artwork may not have been immediately shown
   after changing the ‘Displayed track’ in the Artwork view panel was fixed.
   [[#854](https://github.com/reupen/columns_ui/pull/854)]

--- a/foo_ui_columns/dark_mode_dialog.cpp
+++ b/foo_ui_columns/dark_mode_dialog.cpp
@@ -79,7 +79,8 @@ void DialogDarkModeHelper::set_window_theme(auto&& ids, const wchar_t* dark_clas
         return;
 
     for (const auto id : ids)
-        SetWindowTheme(GetDlgItem(m_wnd, id), is_dark ? dark_class : nullptr, nullptr);
+        if (const auto control_wnd = GetDlgItem(m_wnd, id))
+            SetWindowTheme(control_wnd, is_dark ? dark_class : nullptr, nullptr);
 }
 
 void DialogDarkModeHelper::apply_dark_mode_attributes()

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -17,6 +17,10 @@ std::string format_font_code(const LOGFONT& lf)
         lf.lfItalic ? "italic;"sv : ""sv);
 }
 
+const dark::DialogDarkModeConfig dark_mode_config{.button_ids = {IDC_GEN_COLOUR, IDC_GEN_FONT, IDOK, IDCANCEL},
+    .combo_box_ids = {IDC_HALIGN, IDC_VALIGN, IDC_EDGESTYLE},
+    .edit_ids = {IDC_SCRIPT, IDC_COLOUR_CODE, IDC_FONT_CODE}};
+
 } // namespace
 
 INT_PTR CALLBACK ItemDetailsConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -189,9 +193,6 @@ void ItemDetailsConfig::run_modeless(HWND wnd, ItemDetails* p_this) &&
 {
     m_modal = false;
     m_this = p_this;
-    dark::DialogDarkModeConfig dark_mode_config{.button_ids = {IDC_GEN_COLOUR, IDC_GEN_FONT, IDOK, IDCANCEL},
-        .combo_box_ids = {IDC_HALIGN, IDC_VALIGN, IDC_EDGESTYLE},
-        .edit_ids = {IDC_SCRIPT, IDC_COLOUR_CODE, IDC_FONT_CODE}};
     modeless_dialog_box(
         IDD_ITEM_DETAILS_OPTIONS, dark_mode_config, wnd, [config{std::move(*this)}](auto&&... args) mutable {
             return config.on_message(std::forward<decltype(args)>(args)...);
@@ -201,7 +202,7 @@ void ItemDetailsConfig::run_modeless(HWND wnd, ItemDetails* p_this) &&
 bool ItemDetailsConfig::run_modal(HWND wnd)
 {
     m_modal = true;
-    const auto dialog_result = uih::modal_dialog_box(IDD_ITEM_DETAILS_OPTIONS, wnd,
+    const auto dialog_result = modal_dialog_box(IDD_ITEM_DETAILS_OPTIONS, dark_mode_config, wnd,
         [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
     return dialog_result > 0;
 }


### PR DESCRIPTION
Resolves #896

When Items details options was opened in modal mode (for example from Layout preferences), it always opened in light mode.

This corrects that so it opens in dark mode when dark mode is active.