### PR TITLE
Save DirectWrite font family, weight, stretch, style and DIP size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   [#904](https://github.com/reupen/columns_ui/pull/904),
   [#910](https://github.com/reupen/columns_ui/pull/910),
   [#913](https://github.com/reupen/columns_ui/pull/913),
-  [#915](https://github.com/reupen/columns_ui/pull/915)]
+  [#915](https://github.com/reupen/columns_ui/pull/915),
+  [#919](https://github.com/reupen/columns_ui/pull/919)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).
@@ -19,13 +20,15 @@
   to proportional figures (such as some Segoe UI variants).
 
 - A new DirectWrite-based font picker was added to the Colours and fonts
-  preferences page. [[#916](https://github.com/reupen/columns_ui/pull/916)]
+  preferences page. [[#916](https://github.com/reupen/columns_ui/pull/916),
+  [#919](https://github.com/reupen/columns_ui/pull/919)]
 
   This features better grouping of font families and now allows the entry of
   non-integer font sizes (to one decimal place).
 
-  Note that some font styles will currently revert to the closest supported GDI
-  equivalent when selected.
+  Note that some font styles will revert to the closest supported GDI equivalent
+  when used with a panel that doesn’t use DirectWrite and the latest Columns UI
+  API.
 
   Some legacy font types that aren’t supported by DirectWrite are also no longer
   selectable. Furthermore, some previously hidden fonts may now be visible.

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -581,7 +581,7 @@ INT_PTR TabColumns::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         LOGFONT font{};
         GetObject(GetWindowFont(wnd), sizeof(font), &font);
-        m_columns_list_view.set_font(font);
+        m_columns_list_view.set_font_from_log_font(font);
 
         m_columns.set_entries_copy(g_columns, true);
 

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -4,6 +4,7 @@
 #include "filter_config_var.h"
 #include "filter_search_bar.h"
 #include "filter_utils.h"
+#include "font_manager_v3.h"
 
 namespace cui::panels::filter {
 
@@ -193,19 +194,22 @@ void FilterPanel::s_on_dark_mode_status_change()
 
 void FilterPanel::g_on_font_items_change()
 {
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_filter_items_font_client, lf);
+    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_filter_items_font_client);
+    const auto text_format = font->create_wil_text_format();
+    const auto log_font = font->log_font();
+
     for (auto& window : g_windows) {
-        window->set_font(lf);
+        window->set_font(text_format, log_font);
     }
 }
 
 void FilterPanel::g_on_font_header_change()
 {
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_filter_header_font_client, lf);
+    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_filter_header_font_client);
+    const auto log_font = font->log_font();
+
     for (auto& window : g_windows) {
-        window->set_header_font(lf);
+        window->set_header_font(log_font);
     }
 }
 void FilterPanel::g_redraw_all()
@@ -792,11 +796,14 @@ void FilterPanel::notify_on_initialisation()
     set_sorting_enabled(cfg_allow_sorting);
     set_show_sort_indicators(cfg_show_sort_indicators);
 
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_filter_items_font_client, lf);
-    set_font(lf);
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_filter_header_font_client, lf);
-    set_header_font(lf);
+    const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
+    const auto items_font = font_api->get_client_font(g_guid_filter_items_font_client);
+    const auto items_text_format = items_font->create_wil_text_format();
+    const auto items_log_font = items_font->log_font();
+    set_font(items_text_format, items_log_font);
+
+    const auto header_font = font_api->get_client_font(g_guid_filter_header_font_client);
+    set_header_font(header_font->log_font());
 
     size_t index = g_windows.size();
     if (index == 0) {

--- a/foo_ui_columns/font_manager.cpp
+++ b/foo_ui_columns/font_manager.cpp
@@ -24,6 +24,7 @@ public:
 
     void get_font(const fonts::font_type_t p_type, LOGFONT& p_out) const override
     {
+        system_appearance_manager::initialise();
         FontManagerData::entry_ptr_t p_entry;
         if (p_type == fonts::font_type_items)
             p_entry = g_font_manager_data.m_common_items_entry;
@@ -45,7 +46,7 @@ public:
         const auto p_entry = g_font_manager_data.find_by_guid(p_guid);
         p_entry->font_mode = fonts::font_mode_custom;
         p_entry->font_description.log_font = p_font;
-        p_entry->font_description.estimate_point_size();
+        p_entry->font_description.estimate_point_and_dip_size();
         fonts::client::ptr ptr;
         if (fonts::client::create_by_guid(p_guid, ptr))
             ptr->on_font_changed();
@@ -80,6 +81,7 @@ public:
 
     [[nodiscard]] LOGFONT get_common_font(const fonts::font_type_t p_type, unsigned dpi) const override
     {
+        system_appearance_manager::initialise();
         FontManagerData::entry_ptr_t entry;
         if (p_type == fonts::font_type_items)
             entry = g_font_manager_data.m_common_items_entry;

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -40,6 +40,7 @@ public:
     entry_ptr_t m_common_labels_entry;
 
     entry_ptr_t find_by_guid(GUID id);
+    cui::fonts::FontDescription resolve_font_description(const entry_ptr_t& entry);
 
     void register_common_callback(cui::fonts::common_callback* p_callback);
     void deregister_common_callback(cui::fonts::common_callback* p_callback);

--- a/foo_ui_columns/font_manager_v3.cpp
+++ b/foo_ui_columns/font_manager_v3.cpp
@@ -1,0 +1,89 @@
+#include "pch.h"
+
+#include "font_manager_v3.h"
+
+#include "config_appearance.h"
+#include "font_utils.h"
+#include "system_appearance_manager.h"
+
+namespace cui::fonts {
+
+const GUID font::class_guid{0x6e7708d5, 0x4799, 0x45e5, {0x8f, 0x41, 0x2d, 0x68, 0xf1, 0x5d, 0x08, 0x50}};
+const GUID manager_v3::class_guid{0x471a234d, 0xb81a, 0x4f6a, {0x84, 0x94, 0x5c, 0x9f, 0xff, 0x2c, 0xf6, 0x1f}};
+
+class Font : public font {
+public:
+    Font(LOGFONT log_font, WeightStretchStyle wss, const float size)
+        : m_log_font(std::move(log_font))
+        , m_wss(std::move(wss))
+        , m_size(size) {};
+
+    const wchar_t* family_name() noexcept final { return m_wss.family_name.c_str(); }
+    DWRITE_FONT_WEIGHT weight() noexcept final { return m_wss.weight; }
+    DWRITE_FONT_STRETCH stretch() noexcept final { return m_wss.stretch; }
+    DWRITE_FONT_STYLE style() noexcept final { return m_wss.style; }
+    float size() noexcept final { return m_size > 0 ? m_size : 9.0f; }
+
+    LOGFONT log_font() noexcept override
+    {
+        LOGFONT scaled_log_font{m_log_font};
+        scaled_log_font.lfHeight = -gsl::narrow_cast<long>(uih::direct_write::dip_to_px(m_size) + 0.5f);
+        return scaled_log_font;
+    }
+
+    pfc::com_ptr_t<IDWriteTextFormat> create_text_format(const wchar_t* locale_name = L"") noexcept final
+    {
+        uih::direct_write::Context::Ptr context;
+
+        try {
+            context = uih::direct_write::Context::s_create();
+        } catch (...) {
+            LOG_CAUGHT_EXCEPTION();
+            return {};
+        }
+
+        try {
+            pfc::com_ptr_t<IDWriteTextFormat> text_format;
+            THROW_IF_FAILED(context->factory()->CreateTextFormat(
+                family_name(), nullptr, weight(), style(), stretch(), size(), locale_name, text_format.receive_ptr()));
+
+            return text_format;
+        }
+        CATCH_LOG()
+
+        try {
+            pfc::com_ptr_t<IDWriteTextFormat> text_format;
+            THROW_IF_FAILED(context->factory()->CreateTextFormat(
+                L"", nullptr, weight(), style(), stretch(), size(), locale_name, text_format.receive_ptr()));
+
+            return text_format;
+        }
+        CATCH_LOG()
+
+        return {};
+    }
+
+private:
+    LOGFONT m_log_font;
+    WeightStretchStyle m_wss;
+    float m_size{};
+};
+
+class FontManager3 : public manager_v3 {
+public:
+    font::ptr get_client_font(GUID id) const override
+    {
+        system_appearance_manager::initialise();
+        const auto entry = g_font_manager_data.find_by_guid(id);
+        auto font_description = g_font_manager_data.resolve_font_description(entry);
+
+        const auto& log_font = font_description.log_font;
+        auto size = font_description.dip_size;
+        auto wss = font_description.get_wss_with_fallback();
+        return fb2k::service_new<Font>(log_font, wss, size);
+    }
+};
+
+service_factory_t<FontManager3> _;
+
+} // namespace cui::fonts

--- a/foo_ui_columns/font_manager_v3.h
+++ b/foo_ui_columns/font_manager_v3.h
@@ -1,0 +1,48 @@
+#pragma once
+
+namespace cui::fonts {
+
+/**
+ * Part of the preliminary DirectWrite-friendly manager_v3 interface.
+ *
+ * Subject to change, only currently for internal use.
+ */
+class NOVTABLE font : public service_base {
+public:
+    [[nodiscard]] virtual const wchar_t* family_name() noexcept = 0;
+    [[nodiscard]] virtual DWRITE_FONT_WEIGHT weight() noexcept = 0;
+    [[nodiscard]] virtual DWRITE_FONT_STRETCH stretch() noexcept = 0;
+    [[nodiscard]] virtual DWRITE_FONT_STYLE style() noexcept = 0;
+    [[nodiscard]] virtual float size() noexcept = 0;
+
+    [[nodiscard]] virtual LOGFONT log_font() noexcept = 0;
+
+    [[nodiscard]] virtual pfc::com_ptr_t<IDWriteTextFormat> create_text_format(
+        const wchar_t* locale_name = L"") noexcept
+        = 0;
+
+#ifdef __WIL_COM_INCLUDED
+    wil::com_ptr_t<IDWriteTextFormat> create_wil_text_format(const wchar_t* locale_name = L"")
+    {
+        wil::com_ptr_t<IDWriteTextFormat> text_format;
+        text_format.attach(create_text_format(locale_name).detach());
+        return text_format;
+    }
+#endif
+
+    FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(font);
+};
+
+/**
+ * Preliminary DirectWrite-friendly manager_v3 interface.
+ *
+ * Subject to change, only currently for internal use.
+ */
+class NOVTABLE manager_v3 : public service_base {
+public:
+    [[nodiscard]] virtual font::ptr get_client_font(GUID id) const = 0;
+
+    FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(manager_v3);
+};
+
+} // namespace cui::fonts

--- a/foo_ui_columns/font_utils.h
+++ b/foo_ui_columns/font_utils.h
@@ -2,12 +2,24 @@
 
 namespace cui::fonts {
 
+struct WeightStretchStyle {
+    std::wstring family_name{L"Segoe UI"sv};
+    DWRITE_FONT_WEIGHT weight{DWRITE_FONT_WEIGHT_REGULAR};
+    DWRITE_FONT_STRETCH stretch{DWRITE_FONT_STRETCH_NORMAL};
+    DWRITE_FONT_STYLE style{DWRITE_FONT_STYLE_NORMAL};
+};
+
 struct FontDescription {
     LOGFONT log_font{};
-    int point_size_tenths{};
+    int point_size_tenths{90};
+    float dip_size{12.0f};
+    std::optional<WeightStretchStyle> wss;
 
-    void estimate_point_size();
+    void estimate_point_and_dip_size();
+    void estimate_dip_size();
     void recalculate_log_font_height();
+    void fill_wss();
+    WeightStretchStyle get_wss_with_fallback();
 };
 
 class ConfigFontDescription : public cfg_var {

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -268,6 +268,7 @@
     <ClCompile Include="dark_mode_spin.cpp" />
     <ClCompile Include="file_info_utils.cpp" />
     <ClCompile Include="font_manager.cpp" />
+    <ClCompile Include="font_manager_v3.cpp" />
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="icons.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_config.cpp" />
@@ -442,6 +443,7 @@
     <ClInclude Include="dark_mode_spin.h" />
     <ClInclude Include="event_token.h" />
     <ClInclude Include="file_info_utils.h" />
+    <ClInclude Include="font_manager_v3.h" />
     <ClInclude Include="font_manager_data.h" />
     <ClInclude Include="gdi.h" />
     <ClInclude Include="gdiplus.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -614,6 +614,9 @@
     <ClCompile Include="font_utils.cpp">
       <Filter>Colours and fonts</Filter>
     </ClCompile>
+    <ClCompile Include="font_manager_v3.cpp">
+      <Filter>Colours and fonts</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -894,6 +897,9 @@
       <Filter>Utilities</Filter>
     </ClInclude>
     <ClInclude Include="font_utils.h">
+      <Filter>Colours and fonts</Filter>
+    </ClInclude>
+    <ClInclude Include="font_manager_v3.h">
       <Filter>Colours and fonts</Filter>
     </ClInclude>
   </ItemGroup>

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -2,6 +2,7 @@
 #include "item_properties.h"
 
 #include "file_info_utils.h"
+#include "font_manager_v3.h"
 
 namespace cui::panels::item_properties {
 
@@ -171,13 +172,19 @@ void ItemProperties::notify_on_initialisation()
 {
     set_use_dark_mode(colours::is_dark_mode_active());
     set_autosize(m_autosizing_columns);
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
-    set_font(lf);
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
-    set_header_font(lf);
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
-    set_group_font(lf);
+
+    const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
+    const auto items_font = font_api->get_client_font(g_guid_selection_properties_items_font_client);
+    const auto items_text_format = items_font->create_wil_text_format();
+    const auto items_log_font = items_font->log_font();
+    set_font(items_text_format, items_log_font);
+
+    const auto header_font = font_api->get_client_font(g_guid_selection_properties_header_font_client);
+    set_header_font(header_font->log_font());
+
+    const auto group_font = font_api->get_client_font(g_guid_selection_properties_group_font_client);
+    set_group_font(group_font->create_wil_text_format());
+
     set_edge_style(m_edge_style);
     set_show_header(m_show_column_titles);
     set_group_level_indentation_enabled(false);
@@ -699,28 +706,37 @@ public:
 };
 void ItemProperties::s_on_font_items_change()
 {
+    const auto font
+        = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_selection_properties_items_font_client);
+    const auto text_format = font->create_wil_text_format();
+    const auto log_font = font->log_font();
+
     LOGFONT lf;
     fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_items_font_client, lf);
     for (auto& window : s_windows) {
-        window->set_font(lf);
+        window->set_font(text_format, log_font);
     }
 }
 
 void ItemProperties::s_on_font_groups_change()
 {
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_group_font_client, lf);
+    const auto font
+        = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_selection_properties_group_font_client);
+    const auto text_format = font->create_wil_text_format();
+
     for (auto& window : s_windows) {
-        window->set_group_font(lf);
+        window->set_group_font(text_format);
     }
 }
 
 void ItemProperties::s_on_font_header_change()
 {
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_selection_properties_header_font_client, lf);
+    const auto font
+        = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_selection_properties_header_font_client);
+    const auto log_font = font->log_font();
+
     for (auto& window : s_windows) {
-        window->set_header_font(lf);
+        window->set_header_font(log_font);
     }
 }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -2,6 +2,7 @@
 
 #include "ng_playlist.h"
 
+#include "font_manager_v3.h"
 #include "ng_playlist_groups.h"
 #include "../config_columns_v2.h"
 #include "../playlist_item_helpers.h"
@@ -388,27 +389,35 @@ void PlaylistView::g_on_vertical_item_padding_change()
     for (auto& window : g_windows)
         window->set_vertical_item_padding(settings::playlist_view_item_padding);
 }
+
 void PlaylistView::g_on_font_change()
 {
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_items_font, lf);
+    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_items_font);
+    const auto text_format = font->create_wil_text_format();
+    const auto log_font = font->log_font();
+
     for (auto& window : g_windows)
-        window->set_font(lf);
+        window->set_font(text_format, log_font);
 }
+
 void PlaylistView::g_on_header_font_change()
 {
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_header_font, lf);
+    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_header_font);
+    const auto log_font = font->log_font();
+
     for (auto& window : g_windows)
-        window->set_header_font(lf);
+        window->set_header_font(log_font);
 }
+
 void PlaylistView::g_on_group_header_font_change()
 {
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_group_header_font, lf);
+    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_group_header_font);
+    const auto text_format = font->create_wil_text_format();
+
     for (auto& window : g_windows)
-        window->set_group_font(lf);
+        window->set_group_font(text_format);
 }
+
 void PlaylistView::s_update_all_items()
 {
     for (auto& window : g_windows)
@@ -749,13 +758,19 @@ void PlaylistView::notify_on_initialisation()
     set_always_show_focus(
         config_object::g_get_data_bool_simple(standard_config_objects::bool_playback_follows_cursor, false));
     set_vertical_item_padding(settings::playlist_view_item_padding);
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_items_font, lf);
-    set_font(lf);
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_header_font, lf);
-    set_header_font(lf);
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_group_header_font, lf);
-    set_group_font(lf);
+
+    const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
+    const auto items_font = font_api->get_client_font(g_guid_items_font);
+    const auto items_text_format = items_font->create_wil_text_format();
+    const auto items_log_font = items_font->log_font();
+    set_font(items_text_format, items_log_font);
+
+    const auto header_font = font_api->get_client_font(g_guid_header_font);
+    set_header_font(header_font->log_font());
+
+    const auto group_font = font_api->get_client_font(g_guid_group_header_font);
+    set_group_font(group_font->create_wil_text_format());
+
     set_sorting_enabled(cfg_header_hottrack != 0);
     set_show_sort_indicators(cfg_show_sort_arrows != 0);
     set_edge_style(cfg_frame);

--- a/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
@@ -76,7 +76,11 @@ BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         LOGFONT font{};
         GetObject(GetWindowFont(wnd), sizeof(font), &font);
-        m_groups_list_view.set_font(font);
+        try {
+            auto context = uih::direct_write::Context::s_create();
+            m_groups_list_view.set_font_from_log_font(font);
+        }
+        CATCH_LOG()
 
         std::vector<uih::ListView::InsertItem> insert_items;
         insert_items.reserve(g_groups.get_groups().get_count());

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "playlist_switcher_v2.h"
 
+#include "font_manager_v3.h"
 #include "playlist_switcher_title_formatting.h"
 
 namespace cui::panels::playlist_switcher {
@@ -111,10 +112,12 @@ void PlaylistSwitcher::g_refresh_all_items()
 }
 void PlaylistSwitcher::g_on_font_items_change()
 {
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_font, lf);
+    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_font);
+    const auto text_format = font->create_wil_text_format();
+    const auto log_font = font->log_font();
+
     for (auto& window : g_windows) {
-        window->set_font(lf);
+        window->set_font(text_format, log_font);
     }
 }
 void PlaylistSwitcher::notify_on_initialisation()
@@ -126,9 +129,10 @@ void PlaylistSwitcher::notify_on_initialisation()
     set_edge_style(cfg_plistframe);
     set_vertical_item_padding(settings::playlist_switcher_item_padding);
 
-    LOGFONT lf;
-    fb2k::std_api_get<fonts::manager>()->get_font(g_guid_font, lf);
-    set_font(lf);
+    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_font);
+    const auto text_format = font->create_wil_text_format();
+    const auto log_font = font->log_font();
+    set_font(text_format, log_font);
 }
 void PlaylistSwitcher::notify_on_create()
 {

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -17,7 +17,7 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
         m_presets_list_view.create(wnd, {14, 18, 240, 67}, true);
         LOGFONT font{};
         GetObject(GetWindowFont(wnd), sizeof(font), &font);
-        m_presets_list_view.set_font(font);
+        m_presets_list_view.set_font_from_log_font(font);
 
         HWND wnd_mode = GetDlgItem(wnd, IDC_DARK_MODE);
         HWND wnd_theming = GetDlgItem(wnd, IDC_THEMING);

--- a/foo_ui_columns/tab_fonts.h
+++ b/foo_ui_columns/tab_fonts.h
@@ -18,8 +18,8 @@ public:
 private:
     std::optional<INT_PTR> handle_wm_drawitem(LPDRAWITEMSTRUCT dis);
 
-    LOGFONT get_current_log_font() const;
     int get_current_font_size_tenths() const;
+    FontManagerData::entry_ptr_t get_current_resolved_entry() const;
     void on_font_changed();
 
     void on_family_change();
@@ -54,7 +54,7 @@ private:
     std::vector<std::optional<uih::direct_write::TextFormat>> m_font_families_text_formats;
     std::vector<std::optional<uih::direct_write::TextFormat>> m_font_faces_text_formats;
     std::optional<std::reference_wrapper<uih::direct_write::FontFamily>> m_font_family;
-    std::optional<uih::direct_write::Font> m_font_face;
+    std::optional<std::reference_wrapper<uih::direct_write::Font>> m_font_face;
 
     cui::prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}};
 };


### PR DESCRIPTION
This makes changes to how fonts selected in the Colours and fonts preferences page are saved so that DirectWrite-compatible properties are retained and the selected DirectWrite font can be used by panels.

A preliminary version of a `cui::fonts::manager_v3` interface was added in order to allow panels to access the extended font configuration.

Note that none of this yet fully supports the [typographic font family model](https://learn.microsoft.com/en-us/windows/win32/directwrite/font-selection#typographic-font-family-model) and variable font axes.