### PR TITLE
Fix incorrect behaviour when typing a font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 
 - A new DirectWrite-based font picker was added to the Colours and fonts
   preferences page. [[#916](https://github.com/reupen/columns_ui/pull/916),
-  [#919](https://github.com/reupen/columns_ui/pull/919)]
+  [#919](https://github.com/reupen/columns_ui/pull/919),
+  [#927](https://github.com/reupen/columns_ui/pull/927)]
 
   This features better grouping of font families and now allows the entry of
   non-integer font sizes (to one decimal place).

--- a/foo_ui_columns/font_utils.cpp
+++ b/foo_ui_columns/font_utils.cpp
@@ -7,7 +7,7 @@ namespace cui::fonts {
 void FontDescription::estimate_point_and_dip_size()
 {
     point_size_tenths = -MulDiv(log_font.lfHeight, 720, uih::get_system_dpi_cached().cy);
-    dip_size = uih::direct_write::px_to_dip(gsl::narrow_cast<float>(log_font.lfHeight));
+    dip_size = uih::direct_write::px_to_dip(gsl::narrow_cast<float>(-log_font.lfHeight));
 }
 
 void FontDescription::estimate_dip_size()

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -102,7 +102,7 @@ void TabFonts::save_size_edit() const
     auto& font_description = m_element_ptr->font_description;
 
     font_description.point_size_tenths = gsl::narrow_cast<int>(std::roundf(font_size_float * 10.0f));
-    font_description.dip_size = font_size_float;
+    font_description.dip_size = uih::direct_write::pt_to_dip(font_size_float);
     font_description.recalculate_log_font_height();
 }
 


### PR DESCRIPTION
This resolves a problems where the font size wasn't set correctly when it was typed (rather than when using the arrow buttons) in preferences.

It also fixes a problem where the correct sign wasn't used when importing font sizes from fairly old versions of Columns UI.