### PR TITLE
Fix crash in status bar with very small font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,9 @@
   preferences now scales with the system display scale (DPI setting).
   [[#925](https://github.com/reupen/columns_ui/pull/925)]
 
+- A bug where the status bar may crash when using a very small font size was
+  fixed. [[#935](https://github.com/reupen/columns_ui/pull/935)]
+
 - A bug where dynamic internet radio artwork may not have been immediately shown
   after changing the ‘Displayed track’ in the Artwork view panel was fixed.
   [[#854](https://github.com/reupen/columns_ui/pull/854)]

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -449,7 +449,7 @@ void draw_item_content(const HDC dc, const StatusBarPartID part_id, const std::s
     const auto icon_size = font_height - 2_spx;
     int x = rc.left;
 
-    if (part_id == StatusBarPartID::PlaylistLock) {
+    if (part_id == StatusBarPartID::PlaylistLock && icon_size > 0) {
         const auto icon_y = rc.top + (wil::rect_height(rc) - icon_size) / 2;
 
         if (icons::use_svg_icon(icon_size, icon_size)) {


### PR DESCRIPTION
This fixes a crash in the status bar when:

- it's configured with a very small font size (~1 pt)
- the playlist lock section is enabled and a locked playlist is active
- SVG services is installed