### PR TITLE
Store extended font configuration in backwards-compatible way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
 - A new DirectWrite-based font picker was added to the Colours and fonts
   preferences page. [[#916](https://github.com/reupen/columns_ui/pull/916),
   [#919](https://github.com/reupen/columns_ui/pull/919),
-  [#927](https://github.com/reupen/columns_ui/pull/927)]
+  [#927](https://github.com/reupen/columns_ui/pull/927),
+  [#943](https://github.com/reupen/columns_ui/pull/943)]
 
   This features better grouping of font families and now allows the entry of
   non-integer font sizes (to one decimal place).

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -25,9 +25,11 @@ public:
         LOGFONT get_normalised_font(unsigned dpi = uih::get_system_dpi_cached().cy);
 
         void write(stream_writer* p_stream, abort_callback& p_abort);
-        void write_extra_data(stream_writer* p_stream, abort_callback& p_abort);
+        void write_extra_data(stream_writer* stream, abort_callback& aborter) const;
+        void write_extra_data_v2(stream_writer* stream, abort_callback& aborter) const;
         void read(uint32_t version, stream_reader* p_stream, abort_callback& p_abort);
-        void read_extra_data(stream_reader* p_stream, abort_callback& p_abort);
+        void read_extra_data(stream_reader* stream, abort_callback& aborter);
+        void read_extra_data_v2(stream_reader* stream, abort_callback& aborter);
         void _export(stream_writer* p_stream, abort_callback& p_abort);
         void import(stream_reader* p_reader, size_t stream_size, uint32_t type, abort_callback& p_abort);
         void reset_fonts();


### PR DESCRIPTION
Unfortunately, due to a bug in the font configuration data reader, downgrading to the release version of Columns UI was causing incorrect custom font sizes to be read.

This reworks how the font configuration data is written so that things remain backwards compatible with the release version of Columns UI.

Note that the extended DirectWrite-specific font configuration data written by recent development versions of Columns UI won't be read by this version due to the change in how the configuration data is written (and therefore font configuration will be reimported from the old GDI-based configuration structures).