### PR TITLE
Migrate Item details to DirectWrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Features
 
 - Text in list views (such as the playlist view, playlist switcther, Filter
-  panel and Item properties) and in the status bar and pane is now rendered
-  using DirectWrite. [[#897](https://github.com/reupen/columns_ui/pull/897),
+  panel and Item properties), Item details and in the status bar and pane is now
+  rendered using DirectWrite.
+  [[#897](https://github.com/reupen/columns_ui/pull/897),
   [#904](https://github.com/reupen/columns_ui/pull/904),
   [#910](https://github.com/reupen/columns_ui/pull/910),
   [#913](https://github.com/reupen/columns_ui/pull/913),
@@ -15,7 +16,8 @@
   [#924](https://github.com/reupen/columns_ui/pull/924),
   [#925](https://github.com/reupen/columns_ui/pull/925),
   [#926](https://github.com/reupen/columns_ui/pull/926),
-  [#936](https://github.com/reupen/columns_ui/pull/936)]
+  [#936](https://github.com/reupen/columns_ui/pull/936),
+  [#947](https://github.com/reupen/columns_ui/pull/947)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).
@@ -38,6 +40,10 @@
 
   Some legacy font types that aren’t supported by DirectWrite are also no longer
   selectable. Furthermore, some previously hidden fonts may now be visible.
+
+- The `$set_font()` Item details title formatting function now allows
+  non-integer font sizes to be specified.
+  [[#947](https://github.com/reupen/columns_ui/pull/947)]
 
 - The positioning of tooltips in list views for centre- and right-aligned
   columns was improved. [[#910](https://github.com/reupen/columns_ui/pull/910)]

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -450,6 +450,7 @@
     <ClInclude Include="get_msg_hook.h" />
     <ClInclude Include="icons.h" />
     <ClInclude Include="item_details.h" />
+    <ClInclude Include="item_details_text.h" />
     <ClInclude Include="item_properties.h" />
     <ClInclude Include="menu_helpers.h" />
     <ClInclude Include="metadb_helpers.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -902,6 +902,9 @@
     <ClInclude Include="font_manager_v3.h">
       <Filter>Colours and fonts</Filter>
     </ClInclude>
+    <ClInclude Include="item_details_text.h">
+      <Filter>Item details</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".clang-format" />

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "item_details.h"
 
+#include "item_details_text.h"
+
 namespace cui::panels::item_details {
 
 // {59B4F428-26A5-4a51-89E5-3945D327B4CB}
@@ -50,7 +52,8 @@ pfc::string8 cfg_item_details_script = "$set_font(%default_font_face%,$add(%defa
 #endif
 cfg_bool cfg_item_details_hscroll(g_guid_item_details_hscroll, false);
 cfg_uint cfg_item_details_horizontal_alignment(g_guid_item_details_horizontal_alignment, uih::ALIGN_CENTRE);
-cfg_uint cfg_item_details_vertical_alignment(g_guid_item_details_vertical_alignment, uih::ALIGN_CENTRE);
+cfg_uint cfg_item_details_vertical_alignment(
+    g_guid_item_details_vertical_alignment, WI_EnumValue(VerticalAlignment::Centre));
 cfg_bool cfg_item_details_word_wrapping(g_guid_item_details_word_wrapping, true);
 
 void ItemDetails::MenuNodeOptions::execute()
@@ -92,7 +95,7 @@ bool ItemDetails::show_config_popup(HWND wnd_parent)
         m_horizontal_alignment = dialog.m_horizontal_alignment;
         m_vertical_alignment = dialog.m_vertical_alignment;
         cfg_item_details_horizontal_alignment = m_horizontal_alignment;
-        cfg_item_details_vertical_alignment = m_vertical_alignment;
+        cfg_item_details_vertical_alignment = WI_EnumValue(m_vertical_alignment);
 
         if (get_wnd()) {
             m_to.release();
@@ -119,7 +122,8 @@ void ItemDetails::set_config(stream_reader* p_reader, size_t p_size, abort_callb
                 p_reader->read_lendian_t(m_word_wrapping, p_abort);
                 if (version >= 2) {
                     p_reader->read_lendian_t(m_edge_style, p_abort);
-                    p_reader->read_lendian_t(m_vertical_alignment, p_abort);
+
+                    m_vertical_alignment = static_cast<VerticalAlignment>(p_reader->read_lendian_t<int32_t>(p_abort));
                 }
             }
         }
@@ -135,7 +139,7 @@ void ItemDetails::get_config(stream_writer* p_writer, abort_callback& p_abort) c
     p_writer->write_lendian_t(m_horizontal_alignment, p_abort);
     p_writer->write_lendian_t(m_word_wrapping, p_abort);
     p_writer->write_lendian_t(m_edge_style, p_abort);
-    p_writer->write_lendian_t(m_vertical_alignment, p_abort);
+    p_writer->write_lendian_t(static_cast<int32_t>(m_vertical_alignment), p_abort);
 }
 
 void ItemDetails::get_menu_items(ui_extension::menu_hook_t& p_hook)
@@ -151,11 +155,9 @@ void ItemDetails::get_menu_items(ui_extension::menu_hook_t& p_hook)
     p_hook.add_node(p_node);
 }
 
-std::vector<ItemDetails*> ItemDetails::g_windows;
-
-void ItemDetails::g_on_app_activate(bool b_activated)
+void ItemDetails::s_on_app_activate(bool b_activated)
 {
-    for (auto& window : g_windows)
+    for (auto& window : s_windows)
         window->on_app_activate(b_activated);
 }
 void ItemDetails::on_app_activate(bool b_activated)
@@ -200,7 +202,12 @@ void ItemDetails::deregister_callback()
 
 void ItemDetails::update_scrollbar(ScrollbarType scrollbar_type, bool reset_position)
 {
-    update_font_change_info();
+    if (m_is_updating_scroll_bars)
+        return;
+
+    m_is_updating_scroll_bars = true;
+    auto _ = gsl::finally([this] { m_is_updating_scroll_bars = false; });
+
     update_display_info();
 
     double percentage_scrolled{};
@@ -211,8 +218,8 @@ void ItemDetails::update_scrollbar(ScrollbarType scrollbar_type, bool reset_posi
 
         GetScrollInfo(get_wnd(), static_cast<int>(scrollbar_type), &si_old);
 
-        if (si_old.nMax > 0)
-            percentage_scrolled = static_cast<double>(si_old.nPos) / static_cast<double>(si_old.nMax);
+        if (const auto range = si_old.nMax - si_old.nMin + 1; range > 0)
+            percentage_scrolled = static_cast<double>(si_old.nPos - si_old.nMin) / static_cast<double>(range);
     }
 
     SCROLLINFO si_new{};
@@ -222,25 +229,32 @@ void ItemDetails::update_scrollbar(ScrollbarType scrollbar_type, bool reset_posi
     GetClientRect(get_wnd(), &rc);
 
     si_new.fMask = SIF_RANGE | SIF_PAGE | SIF_POS;
-    si_new.nMin = 0;
 
     if (scrollbar_type == ScrollbarType::vertical) {
         si_new.nPage = std::max(wil::rect_height(rc), 1l);
-        si_new.nMax = std::max(m_display_sz.cy - 1, 1l);
+        si_new.nMin = m_text_rect ? m_text_rect->top : 0l;
+        si_new.nMax = m_text_rect ? std::max(m_text_rect->bottom - 1, m_text_rect->top) : 0l;
     } else {
-        const auto padding_size = 2_spx * 2;
         si_new.nPage = std::max(wil::rect_width(rc), 1l);
-        si_new.nMax = m_hscroll ? std::max(m_display_sz.cx + padding_size - 1, 1l) : 0l;
+        si_new.nMin = m_text_rect ? m_text_rect->left : 0l;
+        si_new.nMax
+            = m_text_rect && m_hscroll && !m_word_wrapping ? std::max(m_text_rect->right - 1, m_text_rect->left) : 0l;
     }
 
-    if (si_new.nMax >= gsl::narrow<int>(si_new.nPage)) {
+    const auto range = si_new.nMax - si_new.nMin + 1;
+
+    if (range >= gsl::narrow<int>(si_new.nPage)) {
         if (!reset_position) {
-            si_new.nPos = static_cast<int>(percentage_scrolled * static_cast<double>(si_new.nMax));
-        } else if (scrollbar_type == ScrollbarType::horizontal) {
+            si_new.nPos = si_new.nMin + static_cast<int>(percentage_scrolled * static_cast<double>(range));
+        } else if (scrollbar_type == ScrollbarType::vertical) {
+            si_new.nPos = si_new.nMin;
+        } else {
             if (m_horizontal_alignment == uih::ALIGN_RIGHT)
-                si_new.nPos = si_new.nMax - gsl::narrow<int>(si_new.nPage) - 1;
+                si_new.nPos = si_new.nMax;
             else if (m_horizontal_alignment == uih::ALIGN_CENTRE)
-                si_new.nPos = (si_new.nMax + 1 - gsl::narrow<int>(si_new.nPage)) / 2;
+                si_new.nPos = si_new.nMin + (range - gsl::narrow<int>(si_new.nPage)) / 2;
+            else
+                si_new.nPos = si_new.nMin;
         }
     }
 
@@ -249,8 +263,13 @@ void ItemDetails::update_scrollbar(ScrollbarType scrollbar_type, bool reset_posi
 
 void ItemDetails::update_scrollbars(bool reset_vertical_position, bool reset_horizontal_position)
 {
+    const auto last_client_height = m_last_cy;
+    const auto last_client_width = m_last_cx;
     update_scrollbar(ScrollbarType::vertical, reset_vertical_position);
     update_scrollbar(ScrollbarType::horizontal, reset_horizontal_position);
+
+    if (m_last_cy != last_client_height || (m_word_wrapping && m_last_cx != last_client_width))
+        update_scrollbar(ScrollbarType::vertical, reset_vertical_position);
 }
 
 void ItemDetails::set_handles(const metadb_handle_list& handles)
@@ -326,8 +345,8 @@ void ItemDetails::release_all_full_file_info_requests()
 
 void ItemDetails::refresh_contents(bool reset_vertical_scroll_position, bool reset_horizontal_scroll_position)
 {
-    // DisableRedrawing noRedraw(get_wnd());
-    bool b_Update = true;
+    bool b_update = true;
+
     if (m_handles.get_count()) {
         LOGFONT lf;
         fb2k::std_api_get<fonts::manager>()->get_font(g_guid_item_details_font_client, lf);
@@ -349,27 +368,16 @@ void ItemDetails::refresh_contents(bool reset_vertical_scroll_position, bool res
             }
         }
 
-        pfc::stringcvt::string_wide_from_utf8 wide_text(temp);
-        if (std::wstring_view(wide_text.get_ptr(), wide_text.length()) != m_current_text_raw) {
-            m_current_text_raw = wide_text;
-
-            m_raw_font_changes.set_size(0);
-            m_font_changes.reset(true);
-            m_font_change_info_valid = false;
-
-            const auto multiline_text = g_get_text_line_lengths(wide_text, m_line_lengths);
-
-            m_current_text = g_get_raw_font_changes(multiline_text.c_str(), m_raw_font_changes);
+        auto utf16_text = mmh::to_utf16(mmh::to_string_view(temp));
+        if (utf16_text != m_formatted_text) {
+            m_formatted_text = std::move(utf16_text);
         } else
-            b_Update = false;
+            b_update = false;
     } else {
-        m_current_text.clear();
-        m_current_text_raw.clear();
-        reset_font_change_info();
-        m_line_lengths.clear();
+        m_formatted_text.clear();
     }
 
-    if (b_Update) {
+    if (b_update) {
         reset_display_info();
 
         update_scrollbars(reset_vertical_scroll_position, reset_horizontal_scroll_position);
@@ -378,58 +386,58 @@ void ItemDetails::refresh_contents(bool reset_vertical_scroll_position, bool res
     }
 }
 
-void ItemDetails::update_display_info(HDC dc)
-{
-    if (!m_display_info_valid) {
-        RECT rc;
-        GetClientRect(get_wnd(), &rc);
-        const auto padding_size = uih::scale_dpi_value(2) * 2;
-
-        const auto widthMax = rc.right > padding_size ? rc.right - padding_size : 0;
-        m_current_display_text = m_current_text;
-
-        auto display_info = g_get_multiline_text_dimensions(
-            dc, m_current_display_text, m_line_lengths, m_font_changes, m_word_wrapping, widthMax);
-
-        m_line_sizes = std::move(display_info.line_sizes);
-        m_display_sz = std::move(display_info.sz);
-
-        m_display_info_valid = true;
-    }
-}
-
 void ItemDetails::update_display_info()
 {
-    if (!m_display_info_valid) {
-        HDC dc = GetDC(get_wnd());
-        HFONT fnt_old = SelectFont(dc, m_font_changes.m_default_font->m_font.get());
-        update_display_info(dc);
-        SelectFont(dc, fnt_old);
-        ReleaseDC(get_wnd(), dc);
+    create_text_layout();
+
+    if (!m_text_layout || m_text_rect)
+        return;
+
+    DWRITE_TEXT_METRICS text_metrics{};
+    DWRITE_OVERHANG_METRICS overhang_metrics{};
+
+    try {
+        text_metrics = m_text_layout->get_metrics();
+        overhang_metrics = m_text_layout->get_overhang_metrics();
     }
+    CATCH_LOG_RETURN()
+
+    const auto scaling_factor = uih::direct_write::get_default_scaling_factor();
+    const auto layout_width = m_text_layout->get_max_width();
+    const auto layout_height = m_text_layout->get_max_height();
+    const auto padding = s_get_padding();
+
+    RECT client_rect{};
+    GetClientRect(get_wnd(), &client_rect);
+
+    const auto scale_min
+        = [scaling_factor](float value) { return gsl::narrow_cast<long>(std::floor(value * scaling_factor)); };
+    const auto scale_max
+        = [scaling_factor](float value) { return gsl::narrow_cast<long>(std::ceil(value * scaling_factor)); };
+
+    RECT text_rect = {
+        scale_min(text_metrics.left),
+        scale_min(text_metrics.top),
+        scale_max(text_metrics.left + text_metrics.width),
+        scale_max(text_metrics.top + text_metrics.height),
+    };
+
+    RECT overhang_rect = {
+        scale_min(-overhang_metrics.left),
+        scale_min(-overhang_metrics.top),
+        scale_max(layout_width + overhang_metrics.right),
+        scale_max(layout_height + overhang_metrics.bottom),
+    };
+
+    m_text_rect = {std::min(text_rect.left, overhang_rect.left) - padding,
+        std::min(text_rect.top, overhang_rect.top) - padding, std::max(text_rect.right, overhang_rect.right) + padding,
+        std::max(text_rect.bottom, overhang_rect.bottom) + padding};
 }
+
 void ItemDetails::reset_display_info()
 {
-    m_current_display_text.clear();
-    m_line_sizes.clear();
-    m_display_sz.cy = (m_display_sz.cx = 0);
-    m_display_info_valid = false;
-}
-
-void ItemDetails::update_font_change_info()
-{
-    if (!m_font_change_info_valid) {
-        g_get_font_changes(m_raw_font_changes, m_font_changes);
-        m_raw_font_changes.set_size(0);
-        m_font_change_info_valid = true;
-    }
-}
-
-void ItemDetails::reset_font_change_info()
-{
-    m_raw_font_changes.remove_all();
-    m_font_changes.reset();
-    m_font_change_info_valid = false;
+    m_text_layout.reset();
+    m_text_rect.reset();
 }
 
 void ItemDetails::on_playback_new_track(metadb_handle_ptr p_track)
@@ -589,7 +597,20 @@ void ItemDetails::on_size()
 
 void ItemDetails::on_size(size_t cx, size_t cy)
 {
-    reset_display_info();
+    if (m_text_layout) {
+        const auto padding = s_get_padding();
+        const auto max_width = std::max(0, gsl::narrow<int>(cx) - padding * 2);
+        const auto max_height = std::max(0, gsl::narrow<int>(cy) - padding * 2);
+
+        try {
+            m_text_layout->set_max_width(uih::direct_write::px_to_dip(gsl::narrow_cast<float>(max_width)));
+            m_text_layout->set_max_height(uih::direct_write::px_to_dip(gsl::narrow_cast<float>(max_height)));
+        }
+        CATCH_LOG()
+
+        m_text_rect.reset();
+    }
+
     invalidate_all(false);
 
     if (cx != m_last_cx) {
@@ -654,15 +675,17 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         playlist_manager_v3::get()->register_callback(this, playlist_callback_flags);
         metadb_io_v3::get()->register_callback(this);
 
-        m_font_changes.m_default_font = std::make_shared<Font>();
-        m_font_changes.m_default_font->m_font.reset(
-            fb2k::std_api_get<fonts::manager>()->get_font(g_guid_item_details_font_client));
-        m_font_changes.m_default_font->m_height = uih::get_font_height(m_font_changes.m_default_font->m_font.get());
+        try {
+            m_direct_write_context = uih::direct_write::Context::s_create();
+        }
+        CATCH_LOG()
 
-        if (g_windows.empty())
+        recreate_text_format();
+
+        if (s_windows.empty())
             s_create_message_window();
 
-        g_windows.push_back(this);
+        s_windows.push_back(this);
 
         titleformat_compiler::get()->compile_safe(m_to, m_script);
 
@@ -671,12 +694,10 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         refresh_contents(true, true);
     } break;
     case WM_DESTROY: {
-        std::erase(g_windows, this);
+        std::erase(s_windows, this);
 
-        if (g_windows.empty())
+        if (s_windows.empty())
             s_destroy_message_window();
-
-        m_font_changes.m_default_font.reset();
 
         play_callback_manager::get()->unregister_callback(this);
         metadb_io_v3::get()->unregister_callback(this);
@@ -687,6 +708,9 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_selection_handles.remove_all();
         m_selection_holder.release();
         m_to.release();
+        m_text_format.reset();
+        m_text_layout.reset();
+        m_direct_write_context.reset();
         m_last_cx = 0;
         m_last_cy = 0;
     } break;
@@ -717,7 +741,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         UINT scroll_lines = 3; // 3 is default
         SystemParametersInfo(SPI_GETWHEELSCROLLLINES, 0, &scroll_lines, 0); // we don't support Win9X
 
-        int line_height = m_font_changes.m_default_font->m_height + 2;
+        const auto line_height = m_text_format ? m_text_format->get_minimum_height() : 0;
 
         if (!si.nPage)
             si.nPage++;
@@ -731,8 +755,6 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         if (scroll_lines == 0)
             scroll_lines = 1;
-
-        // console::formatter() << zDelta;
 
         int delta = -MulDiv(zDelta, scroll_lines, 120);
 
@@ -761,7 +783,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         int new_pos = si.nPos;
 
-        int line_height = m_font_changes.m_default_font->m_height + 2;
+        const auto line_height = m_text_format ? m_text_format->get_minimum_height() : 0;
 
         WORD p_value = LOWORD(wp);
 
@@ -803,108 +825,144 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_ERASEBKGND:
         return TRUE;
     case WM_PAINT: {
-        PAINTSTRUCT ps;
-        BeginPaint(wnd, &ps);
+        PAINTSTRUCT ps{};
+        auto dc = wil::BeginPaint(wnd, &ps);
 
         SCROLLINFO siv{};
         siv.cbSize = sizeof(siv);
-        siv.fMask = SIF_POS;
+        siv.fMask = SIF_POS | SIF_RANGE | SIF_PAGE;
         SCROLLINFO sih = siv;
         GetScrollInfo(wnd, SB_VERT, &siv);
         GetScrollInfo(wnd, SB_HORZ, &sih);
 
-        HDC dc_mem = CreateCompatibleDC(ps.hdc);
-
-        RECT& rc = ps.rcPaint;
-        HBITMAP bm_mem = CreateCompatibleBitmap(ps.hdc, wil::rect_width(rc), wil::rect_height(rc));
-        HBITMAP bm_old = SelectBitmap(dc_mem, bm_mem);
-
-        OffsetWindowOrgEx(dc_mem, +rc.left, +rc.top, nullptr);
-
         colours::helper p_helper(g_guid_item_details_colour_client);
 
-        HFONT fnt_old = SelectFont(dc_mem, m_font_changes.m_default_font->m_font.get());
-
-        update_font_change_info();
-        update_display_info(dc_mem);
+        update_display_info();
 
         RECT rc_client;
         GetClientRect(wnd, &rc_client);
 
-        const int client_height = wil::rect_height(rc_client);
-        const int client_width = wil::rect_width(rc_client);
+        const auto background_colour = p_helper.get_colour(colours::colour_background);
+        const auto text_colour = p_helper.get_colour(colours::colour_text);
 
-        auto background_colour = p_helper.get_colour(colours::colour_background);
-        FillRect(dc_mem, &rc, wil::unique_hbrush(CreateSolidBrush(background_colour)).get());
+        if (m_text_layout && m_text_rect) {
+            const auto is_horizontal_scroll_bar_visible
+                = m_hscroll && !m_word_wrapping && (sih.nMax - sih.nMin - 1) > gsl::narrow_cast<int>(sih.nPage);
+            const auto is_vertical_scroll_bar_visible = (siv.nMax - siv.nMin - 1) > gsl::narrow_cast<int>(siv.nPage);
+            const auto x_offset = uih::direct_write::px_to_dip(
+                gsl::narrow_cast<float>(is_horizontal_scroll_bar_visible ? -sih.nPos : 0));
+            const auto y_offset
+                = uih::direct_write::px_to_dip(gsl::narrow_cast<float>(is_vertical_scroll_bar_visible ? -siv.nPos : 0));
 
-        const int padding = uih::scale_dpi_value(2);
-        const int width
-            = m_hscroll ? std::max(client_width, gsl::narrow<int>(m_display_sz.cx) + padding * 2) : client_width;
-
-        RECT rc_placement{};
-        rc_placement.left = rc_client.left + padding - sih.nPos;
-        rc_placement.right = std::max(rc_placement.left + width - padding * 2, rc_placement.left);
-        rc_placement.top = rc_client.top - siv.nPos;
-
-        if (m_display_sz.cy < client_height) {
-            int extra = client_height - m_display_sz.cy;
-            if (m_vertical_alignment == uih::ALIGN_CENTRE)
-                rc_placement.top += extra / 2;
-            else if (m_vertical_alignment == uih::ALIGN_RIGHT)
-                rc_placement.top += extra;
+            try {
+                m_text_layout->render_with_solid_background(
+                    dc.get(), x_offset, y_offset, ps.rcPaint, background_colour, text_colour);
+            }
+            CATCH_LOG()
         }
-
-        rc_placement.bottom = rc_placement.top + m_display_sz.cy;
-
-        g_text_out_multiline_font(dc_mem, rc_placement, m_current_text.c_str(), m_font_changes, m_line_sizes,
-            p_helper.get_colour(colours::colour_text), (uih::alignment)m_horizontal_alignment);
-        SelectFont(dc_mem, fnt_old);
-
-        BitBlt(ps.hdc, rc.left, rc.top, wil::rect_width(rc), wil::rect_height(rc), dc_mem, rc.left, rc.top, SRCCOPY);
-
-        SelectBitmap(dc_mem, bm_old);
-        DeleteObject(bm_mem);
-        DeleteDC(dc_mem);
-
-        EndPaint(wnd, &ps);
     }
         return 0;
     }
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-void ItemDetails::g_on_font_change()
+void ItemDetails::s_on_font_change()
 {
-    for (auto& window : g_windows) {
+    for (auto& window : s_windows) {
         window->on_font_change();
     }
 }
 
 void ItemDetails::s_on_dark_mode_status_change()
 {
-    for (auto&& window : g_windows) {
+    for (auto&& window : s_windows) {
         window->set_window_theme();
     }
 }
 
-void ItemDetails::g_on_colours_change()
+void ItemDetails::s_on_colours_change()
 {
-    for (auto& window : g_windows) {
+    for (auto& window : s_windows) {
         window->on_colours_change();
+    }
+}
+
+void ItemDetails::recreate_text_format()
+{
+    if (!m_direct_write_context)
+        return;
+
+    m_text_format = create_text_format(m_direct_write_context, static_cast<uih::alignment>(m_horizontal_alignment),
+        m_vertical_alignment, m_word_wrapping);
+    reset_display_info();
+}
+
+void ItemDetails::create_text_layout()
+{
+    if (!m_text_format || m_text_layout)
+        return;
+
+    RECT rect{};
+    GetClientRect(get_wnd(), &rect);
+
+    auto [render_text, colour_segments, font_segments] = process_colour_and_font_codes(m_formatted_text);
+
+    const auto padding = s_get_padding();
+    const auto max_width = std::max(0, gsl::narrow<int>(wil::rect_width(rect)) - padding * 2);
+    const auto max_height = std::max(0, gsl::narrow<int>(wil::rect_height(rect)) - padding * 2);
+    m_text_layout = item_details::create_text_layout(*m_text_format, max_width, max_height, render_text);
+
+    if (!m_text_layout)
+        return;
+
+    for (auto& [colour, start_character, character_count] : colour_segments) {
+        try {
+            m_text_layout->set_colour(
+                colour, {gsl::narrow<uint32_t>(start_character), gsl::narrow<uint32_t>(character_count)});
+        }
+        CATCH_LOG()
+    }
+
+    for (auto& [font, start_character, character_count] : font_segments) {
+        LOGFONT lf{};
+        wcsncpy_s(lf.lfFaceName, font.family.c_str(), _TRUNCATE);
+
+        if (font.is_bold)
+            lf.lfWeight = FW_BOLD;
+
+        if (font.is_underline)
+            lf.lfUnderline = TRUE;
+
+        if (font.is_italic)
+            lf.lfItalic = TRUE;
+
+        try {
+            const auto direct_write_font = m_direct_write_context->create_font(lf);
+
+            const auto weight = direct_write_font->GetWeight();
+            const auto stretch = direct_write_font->GetStretch();
+            const auto style = direct_write_font->GetStyle();
+            const auto size = uih::direct_write::pt_to_dip(font.size_points);
+            const auto text_range
+                = DWRITE_TEXT_RANGE{gsl::narrow<uint32_t>(start_character), gsl::narrow<uint32_t>(character_count)};
+
+            m_text_layout->set_font(font.family.c_str(), weight, stretch, style, size, text_range);
+
+            if (font.is_underline)
+                m_text_layout->set_underline(true, text_range);
+        }
+        CATCH_LOG()
     }
 }
 
 void ItemDetails::on_font_change()
 {
-    m_font_changes.m_default_font->m_font.reset(
-        fb2k::std_api_get<fonts::manager>()->get_font(g_guid_item_details_font_client));
-    refresh_contents();
-    /*
-    invalidate_all(false);
-    update_scrollbar_range();
-    update_now();
-    */
+    recreate_text_format();
+    reset_display_info();
+    update_scrollbars(false, false);
+    invalidate_all();
 }
+
 void ItemDetails::on_colours_change()
 {
     invalidate_all();
@@ -914,7 +972,7 @@ ItemDetails::ItemDetails()
     : m_tracking_mode(cfg_item_details_tracking_mode)
     , m_script(cfg_item_details_script)
     , m_horizontal_alignment(cfg_item_details_horizontal_alignment)
-    , m_vertical_alignment(cfg_item_details_vertical_alignment)
+    , m_vertical_alignment(static_cast<VerticalAlignment>(cfg_item_details_vertical_alignment.get_value()))
     , m_edge_style(cfg_item_details_edge_style)
     , m_hscroll(cfg_item_details_hscroll)
     , m_word_wrapping(cfg_item_details_word_wrapping)
@@ -932,7 +990,7 @@ void ItemDetails::s_create_message_window()
     s_message_window = std::make_unique<uie::container_window_v3>(
         config, [](auto&& wnd, auto&& msg, auto&& wp, auto&& lp) -> LRESULT {
             if (msg == WM_ACTIVATEAPP)
-                g_on_app_activate(wp != 0);
+                s_on_app_activate(wp != 0);
             return DefWindowProc(wnd, msg, wp, lp);
         });
     s_message_window->create(nullptr);
@@ -982,24 +1040,47 @@ void ItemDetails::set_edge_style(uint32_t edge_style)
     }
 }
 
-void ItemDetails::set_vertical_alignment(uint32_t vertical_alignment)
+void ItemDetails::set_vertical_alignment(VerticalAlignment vertical_alignment)
 {
-    if (get_wnd()) {
-        m_vertical_alignment = vertical_alignment;
-        invalidate_all(false);
-        update_scrollbars(false, false);
-        update_now();
+    if (!get_wnd())
+        return;
+
+    m_vertical_alignment = vertical_alignment;
+
+    if (m_text_format) {
+        const auto paragraph_alignment = get_paragraph_alignment(m_vertical_alignment);
+
+        try {
+            m_text_format->set_paragraph_alignment(paragraph_alignment);
+        }
+        CATCH_LOG()
     }
+
+    reset_display_info();
+    invalidate_all(false);
+    update_scrollbars(false, false);
+    update_now();
 }
 
 void ItemDetails::set_horizontal_alignment(uint32_t horizontal_alignment)
 {
-    if (get_wnd()) {
-        m_horizontal_alignment = horizontal_alignment;
-        invalidate_all(false);
-        update_scrollbars(false, true);
-        update_now();
+    if (!get_wnd())
+        return;
+
+    m_horizontal_alignment = horizontal_alignment;
+
+    if (m_text_format) {
+        try {
+            m_text_format->set_text_alignment(
+                uih::direct_write::get_text_alignment(static_cast<uih::alignment>(horizontal_alignment)));
+        }
+        CATCH_LOG()
     }
+
+    reset_display_info();
+    invalidate_all(false);
+    update_scrollbars(false, true);
+    update_now();
 }
 
 void ItemDetails::on_playback_order_changed(size_t p_new_index) {}
@@ -1078,6 +1159,15 @@ void ItemDetails::MenuNodeWordWrap::execute()
 {
     p_this->m_word_wrapping = !p_this->m_word_wrapping;
     cfg_item_details_word_wrapping = p_this->m_word_wrapping;
+
+    if (p_this->m_text_format) {
+        try {
+            p_this->m_text_format->set_word_wrapping(
+                p_this->m_word_wrapping ? DWRITE_WORD_WRAPPING_WRAP : DWRITE_WORD_WRAPPING_NO_WRAP);
+        }
+        CATCH_LOG()
+    }
+
     p_this->reset_display_info();
     p_this->invalidate_all(false);
     p_this->update_scrollbars(false, true);

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -442,7 +442,7 @@ void ItemDetails::reset_display_info()
 
 void ItemDetails::on_playback_new_track(metadb_handle_ptr p_track)
 {
-    if (g_track_mode_includes_now_playing(m_tracking_mode)) {
+    if (s_track_mode_includes_now_playing(m_tracking_mode)) {
         m_nowplaying_active = true;
         set_handles(pfc::list_single_ref_t<metadb_handle_ptr>(p_track));
     }
@@ -481,7 +481,7 @@ void ItemDetails::on_playback_time(double p_time)
 
 void ItemDetails::on_playback_stop(play_control::t_stop_reason p_reason)
 {
-    if (g_track_mode_includes_now_playing(m_tracking_mode) && p_reason != play_control::stop_reason_starting_another
+    if (s_track_mode_includes_now_playing(m_tracking_mode) && p_reason != play_control::stop_reason_starting_another
         && p_reason != play_control::stop_reason_shutting_down) {
         m_nowplaying_active = false;
 
@@ -497,8 +497,8 @@ void ItemDetails::on_playback_stop(play_control::t_stop_reason p_reason)
 
 void ItemDetails::on_playlist_switch()
 {
-    if (g_track_mode_includes_plalist(m_tracking_mode)
-        && (!g_track_mode_includes_auto(m_tracking_mode) || !play_control::get()->is_playing())) {
+    if (s_track_mode_includes_playlist(m_tracking_mode)
+        && (!s_track_mode_includes_auto(m_tracking_mode) || !play_control::get()->is_playing())) {
         metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
         playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
         set_handles(handles);
@@ -506,8 +506,8 @@ void ItemDetails::on_playlist_switch()
 }
 void ItemDetails::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state)
 {
-    if (g_track_mode_includes_plalist(m_tracking_mode)
-        && (!g_track_mode_includes_auto(m_tracking_mode) || !play_control::get()->is_playing())) {
+    if (s_track_mode_includes_playlist(m_tracking_mode)
+        && (!s_track_mode_includes_auto(m_tracking_mode) || !play_control::get()->is_playing())) {
         metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
         playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
         set_handles(handles);
@@ -547,8 +547,8 @@ void ItemDetails::on_selection_changed(const pfc::list_base_const_t<metadb_handl
         else
             m_selection_handles = p_selection;
 
-        if (g_track_mode_includes_selection(m_tracking_mode)
-            && (!g_track_mode_includes_auto(m_tracking_mode) || !play_control::get()->is_playing())) {
+        if (s_track_mode_includes_selection(m_tracking_mode)
+            && (!s_track_mode_includes_auto(m_tracking_mode) || !play_control::get()->is_playing())) {
             set_handles(m_selection_handles);
         }
     }
@@ -565,14 +565,14 @@ void ItemDetails::on_tracking_mode_change()
 
     m_nowplaying_active = false;
 
-    if (g_track_mode_includes_now_playing(m_tracking_mode) && play_control::get()->is_playing()) {
+    if (s_track_mode_includes_now_playing(m_tracking_mode) && play_control::get()->is_playing()) {
         metadb_handle_ptr item;
         if (playback_control::get()->get_now_playing(item))
             handles.add_item(item);
         m_nowplaying_active = true;
-    } else if (g_track_mode_includes_plalist(m_tracking_mode)) {
+    } else if (s_track_mode_includes_playlist(m_tracking_mode)) {
         playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
-    } else if (g_track_mode_includes_selection(m_tracking_mode)) {
+    } else if (s_track_mode_includes_selection(m_tracking_mode)) {
         handles = m_selection_handles;
     }
     set_handles(handles);
@@ -1119,17 +1119,17 @@ void ItemDetails::on_volume_change(float p_new_val) {}
 
 void ItemDetails::on_playback_starting(play_control::t_track_command p_command, bool p_paused) {}
 
-bool ItemDetails::g_track_mode_includes_selection(size_t mode)
+bool ItemDetails::s_track_mode_includes_selection(size_t mode)
 {
     return mode == track_auto_selection_playing || mode == track_selection;
 }
 
-bool ItemDetails::g_track_mode_includes_auto(size_t mode)
+bool ItemDetails::s_track_mode_includes_auto(size_t mode)
 {
     return mode == track_auto_playlist_playing || mode == track_auto_selection_playing;
 }
 
-bool ItemDetails::g_track_mode_includes_plalist(size_t mode)
+bool ItemDetails::s_track_mode_includes_playlist(size_t mode)
 {
     return mode == track_auto_playlist_playing || mode == track_playlist;
 }
@@ -1146,7 +1146,7 @@ uie::container_window_v3_config ItemDetails::get_window_config()
     return config;
 }
 
-bool ItemDetails::g_track_mode_includes_now_playing(size_t mode)
+bool ItemDetails::s_track_mode_includes_now_playing(size_t mode)
 {
     return mode == track_auto_playlist_playing || mode == track_auto_selection_playing || mode == track_playing;
 }

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -62,13 +62,13 @@ public:
         track_selection,
     };
 
-    bool g_track_mode_includes_now_playing(size_t mode);
+    bool s_track_mode_includes_now_playing(size_t mode);
 
-    bool g_track_mode_includes_plalist(size_t mode);
+    bool s_track_mode_includes_playlist(size_t mode);
 
-    bool g_track_mode_includes_auto(size_t mode);
+    bool s_track_mode_includes_auto(size_t mode);
 
-    bool g_track_mode_includes_selection(size_t mode);
+    bool s_track_mode_includes_selection(size_t mode);
 
     class MenuNodeTrackMode : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemDetails> p_this;
@@ -297,7 +297,7 @@ private:
     bool m_word_wrapping{};
     bool m_is_updating_scroll_bars{};
 
-    HWND m_wnd_config{nullptr};
+    HWND m_wnd_config{};
 };
 
 class ItemDetailsConfig {

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -2,6 +2,7 @@
 
 #include "pch.h"
 #include "file_info_reader.h"
+#include "item_details_text.h"
 
 namespace cui::panels::item_details {
 
@@ -22,84 +23,6 @@ extern cfg_bool cfg_item_details_hscroll;
 extern cfg_uint cfg_item_details_horizontal_alignment;
 extern cfg_uint cfg_item_details_vertical_alignment;
 extern cfg_bool cfg_item_details_word_wrapping;
-
-struct LineSize {
-    size_t m_length{};
-    int m_width{0};
-    int m_height{0};
-};
-
-struct RawFont {
-    std::wstring m_face;
-    uint32_t m_point{10};
-    bool m_bold{false};
-    bool m_underline{false};
-    bool m_italic{false};
-
-    static bool s_are_equal(const RawFont& item1, const RawFont& item2);
-};
-
-bool operator==(const RawFont& item1, const RawFont& item2);
-
-class RawFontChange {
-public:
-    RawFont m_font_data;
-    bool m_reset{false};
-    size_t m_character_index{NULL};
-
-    RawFontChange() = default;
-};
-
-using RawFontChanges = pfc::list_t<RawFontChange, pfc::alloc_fast_aggressive>;
-
-using LineLengths = std::vector<size_t>;
-using LineSizes = std::vector<LineSize>;
-
-class Font {
-public:
-    using Ptr = std::shared_ptr<Font>;
-
-    RawFont m_raw_font;
-
-    wil::unique_hfont m_font;
-    int m_height{};
-};
-
-using Fonts = pfc::list_t<Font::Ptr>;
-
-class FontChanges {
-public:
-    class FontChange {
-    public:
-        size_t m_text_index{};
-        Font::Ptr m_font;
-    };
-
-    Fonts m_fonts;
-    std::vector<FontChange> m_font_changes;
-    Font::Ptr m_default_font;
-
-    bool find_font(const RawFont& raw_font, size_t& index);
-
-    void reset(bool keep_handles = false);
-};
-
-struct DisplayInfo {
-    SIZE sz{};
-    std::vector<LineSize> line_sizes;
-};
-
-DisplayInfo g_get_multiline_text_dimensions(HDC dc, std::wstring_view text, const LineLengths& line_lengths,
-    const FontChanges& font_data, bool word_wrapping, int max_width);
-
-std::wstring g_get_text_line_lengths(const wchar_t* text, LineLengths& line_lengths);
-
-void g_parse_font_format_string(const wchar_t* str, size_t len, RawFont& p_out);
-std::wstring g_get_raw_font_changes(const wchar_t* formatted_text, RawFontChanges& p_out);
-void g_get_font_changes(const RawFontChanges& raw_font_changes, FontChanges& font_changes);
-
-void g_text_out_multiline_font(HDC dc, RECT rc_placement, const wchar_t* text, const FontChanges& font_changes,
-    const LineSizes& wrapped_line_sizes, COLORREF cr_text, uih::alignment align);
 
 class TitleformatHookChangeFont : public titleformat_hook {
 public:
@@ -279,13 +202,13 @@ public:
     // ML
     void on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) override;
 
-    static void g_on_app_activate(bool b_activated);
-    static void g_on_font_change();
+    static void s_on_app_activate(bool b_activated);
+    static void s_on_font_change();
     static void s_on_dark_mode_status_change();
-    static void g_on_colours_change();
+    static void s_on_colours_change();
 
     void set_horizontal_alignment(uint32_t horizontal_alignment);
-    void set_vertical_alignment(uint32_t vertical_alignment);
+    void set_vertical_alignment(VerticalAlignment vertical_alignment);
 
     void set_edge_style(uint32_t edge_style);
 
@@ -300,6 +223,7 @@ public:
 private:
     static void s_create_message_window();
     static void s_destroy_message_window();
+    static int s_get_padding() { return 2_spx; }
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
 
@@ -314,9 +238,6 @@ private:
     void release_aborted_full_file_info_requests();
     void release_all_full_file_info_requests();
 
-    void update_font_change_info();
-    void reset_font_change_info();
-    void update_display_info(HDC dc);
     void update_display_info();
     void reset_display_info();
     void on_tracking_mode_change();
@@ -339,10 +260,12 @@ private:
     void on_size();
     void on_size(size_t cx, size_t cy);
 
+    void recreate_text_format();
+    void create_text_layout();
     void on_font_change();
     void on_colours_change();
 
-    static std::vector<ItemDetails*> g_windows;
+    inline static std::vector<ItemDetails*> s_windows;
 
     size_t m_last_cx{};
     size_t m_last_cy{};
@@ -353,31 +276,26 @@ private:
     std::shared_ptr<helpers::FullFileInfoRequest> m_full_file_info_request;
     std::vector<std::shared_ptr<helpers::FullFileInfoRequest>> m_aborting_full_file_info_requests;
     bool m_full_file_info_requested{};
-    bool m_callback_registered{false};
-    bool m_nowplaying_active{false};
+    bool m_callback_registered{};
+    bool m_nowplaying_active{};
     uint32_t m_tracking_mode;
 
-    bool m_font_change_info_valid{false};
-    FontChanges m_font_changes;
-    RawFontChanges m_raw_font_changes;
+    uih::direct_write::Context::Ptr m_direct_write_context;
+    std::optional<uih::direct_write::TextFormat> m_text_format;
+    std::optional<uih::direct_write::TextLayout> m_text_layout;
 
-    LineLengths m_line_lengths;
-    LineSizes m_line_sizes;
-    bool m_display_info_valid{false};
-
-    SIZE m_display_sz{};
+    std::optional<RECT> m_text_rect{};
 
     pfc::string8 m_script;
-    std::wstring m_current_text_raw;
-    std::wstring m_current_text;
-    std::wstring m_current_display_text;
+    std::wstring m_formatted_text;
     titleformat_object::ptr m_to;
 
-    uint32_t m_horizontal_alignment;
-    uint32_t m_vertical_alignment;
-    uint32_t m_edge_style;
-    bool m_hscroll;
-    bool m_word_wrapping;
+    uint32_t m_horizontal_alignment{};
+    VerticalAlignment m_vertical_alignment{};
+    uint32_t m_edge_style{};
+    bool m_hscroll{};
+    bool m_word_wrapping{};
+    bool m_is_updating_scroll_bars{};
 
     HWND m_wnd_config{nullptr};
 };
@@ -387,7 +305,7 @@ public:
     pfc::string8 m_script;
     uint32_t m_edge_style{};
     uint32_t m_horizontal_alignment{};
-    uint32_t m_vertical_alignment{};
+    VerticalAlignment m_vertical_alignment{};
     LOGFONT m_code_generator_selected_font{};
     bool m_modal{};
     bool m_timer_active{};
@@ -398,7 +316,7 @@ public:
         timer_id = 100
     };
 
-    ItemDetailsConfig(const char* p_text, uint32_t edge_style, uint32_t halign, uint32_t valign);
+    ItemDetailsConfig(const char* p_text, uint32_t edge_style, uint32_t halign, VerticalAlignment valign);
 
     ItemDetailsConfig(const ItemDetailsConfig&) = default;
     ItemDetailsConfig(ItemDetailsConfig&&) = default;

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -153,10 +153,10 @@ INT_PTR CALLBACK ItemDetailsConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
         case IDC_VALIGN:
             switch (HIWORD(wp)) {
             case CBN_SELCHANGE:
-                m_vertical_alignment = ComboBox_GetCurSel((HWND)lp);
+                m_vertical_alignment = static_cast<VerticalAlignment>(ComboBox_GetCurSel((HWND)lp));
                 if (!m_modal) {
                     m_this->set_vertical_alignment(m_vertical_alignment);
-                    cfg_item_details_vertical_alignment = m_vertical_alignment;
+                    cfg_item_details_vertical_alignment = WI_EnumValue(m_vertical_alignment);
                 }
                 break;
             }
@@ -207,7 +207,7 @@ bool ItemDetailsConfig::run_modal(HWND wnd)
     return dialog_result > 0;
 }
 
-ItemDetailsConfig::ItemDetailsConfig(const char* p_text, uint32_t edge_style, uint32_t halign, uint32_t valign)
+ItemDetailsConfig::ItemDetailsConfig(const char* p_text, uint32_t edge_style, uint32_t halign, VerticalAlignment valign)
     : m_script(p_text)
     , m_edge_style(edge_style)
     , m_horizontal_alignment(halign)

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -1,514 +1,171 @@
 #include "pch.h"
+
+#include "font_manager_v3.h"
 #include "item_details.h"
+#include "item_details_text.h"
 
 namespace cui::panels::item_details {
 
-std::wstring g_get_raw_font_changes(const wchar_t* formatted_text, RawFontChanges& p_out)
+namespace {
+
+bool are_strings_equal(std::wstring_view left, std::wstring_view right)
 {
-    std::wstring p_new_text;
+    return CompareStringEx(LOCALE_NAME_INVARIANT, NORM_IGNORECASE, left.data(), gsl::narrow<int>(left.length()),
+               right.data(), gsl::narrow<int>(right.length()), nullptr, nullptr, 0)
+        == CSTR_EQUAL;
+}
 
-    const wchar_t* ptr = formatted_text;
+std::optional<Font> parse_font_code(std::wstring_view text)
+{
+    const auto parts = std::views::split(text, L'\t') | ranges::to<std::vector>;
 
-    while (*ptr) {
-        const wchar_t* addStart = ptr;
-        while (*ptr && *ptr != '\x7')
-            ptr++;
-        p_new_text.append(addStart, ptr - addStart);
-        if (*ptr == '\x7') {
-            ptr++;
-            const wchar_t* start = ptr;
+    if (parts.size() < 2)
+        return {};
 
-            while (*ptr && *ptr != '\x7' && *ptr != '\t')
-                ptr++;
+    Font font;
+    font.family = std::wstring_view(parts[0].data(), parts[0].size());
+    try {
+        std::wstring size_str(parts[1].data(), parts[1].size());
+        font.size_points = std::stof(size_str);
+    } catch (const std::exception&) {
+        return {};
+    }
 
-            bool b_tab = false;
+    if (parts.size() > 2) {
+        const std::wstring_view style(parts[2].data(), parts[2].size());
+        auto style_elements = std::views::split(style, L';');
 
-            if ((b_tab = *ptr == '\t') || *ptr == '\x7') {
-                RawFontChange temp;
-                size_t count = ptr - start;
-                ptr++;
+        for (auto style_element : style_elements) {
+            const std::wstring_view style_element_view(style_element.data(), style_element.size());
 
-                if (b_tab) {
-                    const wchar_t* size_start = ptr;
-                    while (*ptr && *ptr != '\x7' && *ptr != '\t')
-                        ptr++;
-                    size_t size_len = ptr - size_start;
+            const auto equals_index = style_element_view.find(L'=');
+            const auto style_name = style_element_view.substr(0, equals_index);
+            const auto style_enabled = equals_index == std::wstring_view::npos
+                || are_strings_equal(style_element_view.substr(equals_index + 1), L"true");
 
-                    temp.m_font_data.m_point = mmh::strtoul_n(size_start, size_len);
-                    if ((b_tab = *ptr == '\t') || *ptr == '\x7')
-                        ptr++;
+            if (!style_enabled)
+                continue;
 
-                    if (b_tab) {
-                        const wchar_t* format_start = ptr;
-                        while (*ptr && *ptr != '\x7')
-                            ptr++;
-                        size_t format_len = ptr - format_start;
-                        if (*ptr == '\x7') {
-                            ptr++;
-                            g_parse_font_format_string(format_start, format_len, temp.m_font_data);
-                        }
-                    }
-                } else if (count == 0)
-                    temp.m_reset = true;
-
-                temp.m_font_data.m_face = std::wstring_view(start, count);
-                temp.m_character_index = p_new_text.length();
-                p_out.add_item(temp);
+            if (are_strings_equal(style_name, L"bold")) {
+                font.is_bold = true;
+            } else if (are_strings_equal(style_name, L"italic")) {
+                font.is_italic = true;
+            } else if (are_strings_equal(style_name, L"underline")) {
+                font.is_underline = true;
             }
         }
     }
-    return p_new_text;
+
+    return font;
 }
 
-void g_get_font_changes(const RawFontChanges& raw_font_changes, FontChanges& font_changes)
+} // namespace
+
+DWRITE_PARAGRAPH_ALIGNMENT get_paragraph_alignment(VerticalAlignment alignment)
 {
-    size_t count = raw_font_changes.get_count();
-    if (count) {
-        pfc::list_t<bool> fonts_to_keep_mask;
-
-        fonts_to_keep_mask.add_items_repeat(false, font_changes.m_fonts.get_count());
-        font_changes.m_font_changes.resize(count);
-
-        HDC dc = GetDC(nullptr);
-        LOGFONT lf_base{};
-
-        for (size_t i = 0; i < count; i++) {
-            if (raw_font_changes[i].m_reset) {
-                font_changes.m_font_changes[i].m_font = font_changes.m_default_font;
-            } else {
-                LOGFONT lf = lf_base;
-                wcsncpy_s(lf.lfFaceName, raw_font_changes[i].m_font_data.m_face.c_str(), _TRUNCATE);
-                lf.lfHeight = -MulDiv(raw_font_changes[i].m_font_data.m_point, GetDeviceCaps(dc, LOGPIXELSY), 72);
-                if (raw_font_changes[i].m_font_data.m_bold)
-                    lf.lfWeight = FW_BOLD;
-                if (raw_font_changes[i].m_font_data.m_underline)
-                    lf.lfUnderline = TRUE;
-                if (raw_font_changes[i].m_font_data.m_italic)
-                    lf.lfItalic = TRUE;
-
-                size_t index;
-                if (font_changes.find_font(raw_font_changes[i].m_font_data, index)) {
-                    if (index < fonts_to_keep_mask.get_count())
-                        fonts_to_keep_mask[index] = true;
-                } else {
-                    Font::Ptr font = std::make_shared<Font>();
-                    font->m_font.reset(CreateFontIndirect(&lf));
-                    font->m_height = uih::get_font_height(font->m_font.get());
-                    font->m_raw_font = raw_font_changes[i].m_font_data;
-                    index = font_changes.m_fonts.add_item(font);
-                }
-
-                font_changes.m_font_changes[i].m_font = font_changes.m_fonts[index];
-            }
-            font_changes.m_font_changes[i].m_text_index = raw_font_changes[i].m_character_index;
-        }
-        font_changes.m_fonts.remove_mask(pfc::bit_array_not(
-            pfc::bit_array_table(fonts_to_keep_mask.get_ptr(), fonts_to_keep_mask.get_count(), true)));
-
-        ReleaseDC(nullptr, dc);
+    switch (alignment) {
+    default:
+        return DWRITE_PARAGRAPH_ALIGNMENT_NEAR;
+    case VerticalAlignment::Centre:
+        return DWRITE_PARAGRAPH_ALIGNMENT_CENTER;
+    case VerticalAlignment::Bottom:
+        return DWRITE_PARAGRAPH_ALIGNMENT_FAR;
     }
 }
 
-bool g_text_ptr_skip_font_change(const wchar_t*& ptr)
+std::optional<uih::direct_write::TextFormat> create_text_format(const uih::direct_write::Context::Ptr& context,
+    uih::alignment horizontal_alignment, VerticalAlignment vertical_alignment, bool word_wrapping)
 {
-    if (*ptr == '\x7') {
-        ptr++;
+    const auto api = fb2k::std_api_get<cui::fonts::manager_v3>();
+    const auto font = api->get_client_font(g_guid_item_details_font_client);
+    const auto text_format = font->create_wil_text_format();
 
-        while (*ptr && *ptr != '\x7')
-            ptr++;
+    if (!text_format)
+        return {};
 
-        if (*ptr == '\x7')
-            ptr++;
-
-        return true;
+    try {
+        const auto paragraph_alignment = get_paragraph_alignment(vertical_alignment);
+        const auto wrapped_text_format = context->wrap_text_format(text_format, false);
+        wrapped_text_format.set_text_alignment(uih::direct_write::get_text_alignment(horizontal_alignment));
+        wrapped_text_format.set_paragraph_alignment(paragraph_alignment);
+        wrapped_text_format.set_word_wrapping(word_wrapping ? DWRITE_WORD_WRAPPING_WRAP : DWRITE_WORD_WRAPPING_NO_WRAP);
+        return wrapped_text_format;
     }
-    return false;
+    CATCH_LOG()
+
+    return {};
 }
 
-std::wstring g_get_text_line_lengths(const wchar_t* text, LineLengths& line_lengths)
+std::optional<uih::direct_write::TextLayout> create_text_layout(
+    const uih::direct_write::TextFormat& text_format, int max_width, int max_height, std::wstring_view text)
 {
-    std::wstring p_out;
-    line_lengths.clear();
-    line_lengths.reserve(256);
+    try {
+        const auto width = gsl::narrow_cast<float>(max_width);
+        const auto height = gsl::narrow_cast<float>(max_height);
 
-    const wchar_t* ptr = text;
-    while (*ptr) {
-        const wchar_t* start = ptr;
-        size_t counter = 0;
-        while (*ptr && *ptr != '\r' && *ptr != '\n') {
-            if (!g_text_ptr_skip_font_change(ptr)) {
-                ptr++;
-                counter++;
-            }
-        }
-
-        line_lengths.emplace_back(counter);
-
-        p_out.append(start, ptr - start);
-
-        if (*ptr == '\r')
-            ptr++;
-        if (*ptr == '\n')
-            ptr++;
+        return text_format.create_text_layout(
+            text, uih::direct_write::px_to_dip(width), uih::direct_write::px_to_dip(height));
     }
-    return p_out;
+    CATCH_LOG();
+
+    return {};
 }
 
-std::vector<std::wstring_view> get_colour_fragments(std::wstring_view text)
+std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<FontSegment>> process_colour_and_font_codes(
+    std::wstring_view text)
 {
-    std::vector<std::wstring_view> fragments;
+    auto result = std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<FontSegment>>{};
+    auto& [stripped_text, coloured_segments, font_segments] = result;
 
     size_t offset{};
+    size_t colour_segment_start{};
+    size_t font_segment_start{};
+    std::optional<COLORREF> cr_current;
+    std::optional<Font> current_font;
+
     while (true) {
-        const size_t index = text.find(L"\3"sv, offset);
+        const size_t index = text.find_first_of(L"\3\7"sv, offset);
 
         const auto fragment_length = index == std::wstring_view::npos ? std::wstring_view::npos : index - offset;
         const auto fragment = text.substr(offset, fragment_length);
+        const auto is_eos = index == std::wstring_view::npos;
+        const auto is_colour_code = !is_eos && text[index] == L'\3';
+        const auto is_font_code = !is_eos && text[index] == L'\7';
 
-        if (fragment.length() > 0)
-            fragments.emplace_back(fragment);
+        if (!fragment.empty()) {
+            stripped_text.append(fragment);
 
-        if (index == std::wstring_view::npos)
+            if (cr_current && (is_eos || is_colour_code))
+                coloured_segments.emplace_back(
+                    *cr_current, colour_segment_start, stripped_text.length() - colour_segment_start);
+
+            if (current_font && (is_eos || is_font_code))
+                font_segments.emplace_back(
+                    *current_font, font_segment_start, stripped_text.length() - font_segment_start);
+        }
+
+        if (is_eos)
             break;
 
-        offset = text.find(L"\3"sv, index + 1);
+        offset = text.find(is_colour_code ? L'\3' : L'\7', index + 1);
 
         if (offset == std::wstring_view::npos)
             break;
 
+        const auto code_text = text.substr(index + 1, offset - index - 1);
+
+        if (is_colour_code) {
+            cr_current = uih::parse_colour_code(code_text, false);
+            colour_segment_start = stripped_text.size();
+        } else {
+            current_font = parse_font_code(code_text);
+            font_segment_start = stripped_text.size();
+        }
+
         ++offset;
     }
 
-    return fragments;
-}
-
-auto split_lines_into_fragments(
-    std::wstring_view text, std::vector<std::wstring_view> lines, const FontChanges& font_data)
-{
-    std::vector<std::tuple<std::wstring_view, std::vector<std::wstring_view>>> sub_fragments_by_line;
-    auto&& font_changes = font_data.m_font_changes;
-    auto font_change_iter = font_changes.begin();
-
-    for (auto&& line : lines) {
-        std::vector<std::wstring_view> sub_fragments;
-        size_t line_character_pos{};
-
-        while (line_character_pos < line.length()) {
-            const size_t character_pos = line.data() + line_character_pos - text.data();
-
-            // There could be multiple font changes in a row, so this needs to be a loop.
-            while (font_change_iter != font_changes.end() && font_change_iter->m_text_index < character_pos)
-                ++font_change_iter;
-
-            size_t font_fragment_length{line.length()};
-
-            assert(font_change_iter == font_changes.end() || font_change_iter->m_text_index >= character_pos);
-
-            while (font_change_iter != font_changes.end()) {
-                if (font_change_iter->m_text_index > character_pos) {
-                    font_fragment_length = font_change_iter->m_text_index - character_pos;
-                    break;
-                }
-                ++font_change_iter;
-            }
-
-            const auto font_fragment = line.substr(line_character_pos, font_fragment_length);
-            ranges::push_back(sub_fragments, get_colour_fragments(font_fragment));
-
-            line_character_pos += font_fragment.length();
-        }
-
-        sub_fragments_by_line.emplace_back(line, sub_fragments);
-    }
-    return sub_fragments_by_line;
-}
-
-auto get_text_truncate_point(std::wstring_view text)
-{
-    const auto all_break_chars = L" -–—\u200B"sv;
-    const auto break_after_chars = L" -\u200B"sv;
-
-    auto pos = text.find_last_not_of(break_after_chars);
-
-    if (pos == std::wstring_view::npos)
-        return text.length();
-
-    pos = text.find_last_of(all_break_chars, pos - 1);
-
-    if (pos == std::wstring_view::npos)
-        return text.length();
-
-    return pos + 1;
-}
-
-DisplayInfo g_get_multiline_text_dimensions(HDC dc, std::wstring_view text, const LineLengths& line_lengths,
-    const FontChanges& font_data, bool word_wrapping, int max_width)
-{
-    auto&& font_changes = font_data.m_font_changes;
-    const int vertical_line_padding = uih::scale_dpi_value(2);
-
-    DisplayInfo display_info;
-    std::vector<std::wstring_view> lines;
-
-    std::wstring::size_type line_start{};
-    for (auto&& line_length : line_lengths) {
-        lines.emplace_back(text.data() + line_start, line_length);
-        line_start += line_length;
-    }
-
-    // Break each line into sub-strings each of the same colour and font.
-    // Note: The input string contains colour codes. They need to be accounted
-    // for when calculating offsets.
-    auto fragments_by_line = split_lines_into_fragments(text, lines, font_data);
-
-    wil::unique_select_object selected_font;
-    size_t last_append_pos{};
-    auto font_iter = font_changes.begin();
-
-    for (auto&& [line, fragments] : fragments_by_line) {
-        int line_height{uih::get_dc_font_height(dc)};
-        bool is_line_height_explicitly_set{};
-        int line_width{};
-
-        for (auto&& [fragment_index, fragment] : ranges::views::enumerate(fragments)) {
-            const size_t character_pos = fragment.data() - text.data();
-            size_t fragment_character_pos{};
-
-            while (font_iter != font_changes.end() && font_iter->m_text_index <= character_pos) {
-                selected_font.reset();
-                selected_font = wil::SelectObject(dc, font_iter->m_font->m_font.get());
-                if (fragment_index == 0 && !is_line_height_explicitly_set) {
-                    line_height = font_iter->m_font->m_height;
-                    is_line_height_explicitly_set = true;
-                } else {
-                    line_height = std::max(line_height, font_iter->m_font->m_height);
-                    is_line_height_explicitly_set = true;
-                }
-                ++font_iter;
-            }
-
-            while (fragment_character_pos < fragment.length()) {
-                size_t max_chars{};
-                uih::UniscribeTextRenderer script_string;
-
-                script_string.analyse(dc, fragment.data() + fragment_character_pos,
-                    gsl::narrow<int>(fragment.length() - fragment_character_pos), std::max(max_width - line_width, 0),
-                    word_wrapping, true, line_width);
-
-                if (word_wrapping) {
-                    max_chars = gsl::narrow<size_t>(script_string.get_output_character_count());
-
-                    if (max_chars > fragment.length()) {
-                        uBugCheck();
-                    }
-                }
-
-                // Note: Despite indications in its documentation otherwise, Uniscribe appears to use UTF-16
-                // code units and not Unicode code points (otherwise this comparison would not work correctly).
-                if (word_wrapping && max_chars < fragment.substr(fragment_character_pos).length()) {
-                    std::vector<int> character_extents(fragment.length());
-                    script_string.get_character_logical_extents(character_extents.data());
-
-                    // Wrap at the end of the last word within this fragment
-                    max_chars = get_text_truncate_point(fragment.substr(fragment_character_pos, max_chars));
-
-                    // If no characters fit in the available space, put one in to avoid weirdness and
-                    // the risk of an infinite loop.
-                    if (max_chars == 0)
-                        ++max_chars;
-
-                    line_width += character_extents.at(max_chars - 1);
-
-                    const auto* wrapped_line_start = text.data() + last_append_pos;
-                    const auto* wrapped_line_end = fragment.data() + fragment_character_pos + max_chars;
-
-                    const size_t wrapped_line_length = wrapped_line_end - wrapped_line_start;
-
-                    display_info.line_sizes.push_back(
-                        {wrapped_line_length, line_width, line_height + vertical_line_padding});
-
-                    fragment_character_pos += max_chars;
-                    last_append_pos = wrapped_line_end - text.data();
-                    line_height = uih::get_dc_font_height(dc);
-                    is_line_height_explicitly_set = false;
-                    line_width = 0;
-                } else {
-                    fragment_character_pos += fragment.size();
-                    line_width += script_string.get_output_width();
-                }
-            }
-        }
-
-        if (line.empty() || last_append_pos < gsl::narrow<size_t>(line.data() + line.size() - text.data())) {
-            const size_t length = line.data() + line.size() - text.data() - last_append_pos;
-            display_info.line_sizes.push_back({length, line_width, line_height + vertical_line_padding});
-            last_append_pos += length;
-        }
-    }
-
-    display_info.sz.cx = ranges::accumulate(
-        display_info.line_sizes, 0, [](auto&& val, auto&& line_info) { return std::max(val, line_info.m_width); });
-
-    display_info.sz.cy = ranges::accumulate(
-        display_info.line_sizes, 0, [](auto&& val, auto&& line_info) { return val + line_info.m_height; });
-
-    return display_info;
-}
-
-void g_text_out_multiline_font(HDC dc, RECT rc_placement, const wchar_t* text, const FontChanges& font_changes,
-    const LineSizes& wrapped_line_sizes, COLORREF cr_text, uih::alignment align)
-{
-    pfc::stringcvt::string_utf8_from_wide utf8_converter;
-
-    const auto half_padding_size = uih::scale_dpi_value(2);
-
-    const COLORREF cr_old = GetTextColor(dc);
-
-    SetTextColor(dc, cr_text);
-
-    const size_t font_change_count = font_changes.m_font_changes.size();
-    size_t font_index = 0;
-
-    const size_t line_count = wrapped_line_sizes.size();
-    size_t start_line = 0;
-
-    RECT rc_line = rc_placement;
-    const size_t y_start_pos = rc_placement.top < 0 ? 0 - rc_placement.top : 0;
-
-    for (size_t line_index{0}, running_height{0}; line_index < line_count; line_index++) {
-        running_height += wrapped_line_sizes[line_index].m_height;
-
-        if (running_height > y_start_pos)
-            break;
-
-        start_line = line_index;
-
-        if (line_index)
-            rc_line.top += wrapped_line_sizes[line_index - 1].m_height;
-    }
-
-    const wchar_t* text_ptr = text;
-    for (size_t line_index = 0; line_index < start_line; line_index++) {
-        if (line_index < line_count) {
-            text_ptr += wrapped_line_sizes[line_index].m_length;
-
-            while (font_index < font_change_count
-                && gsl::narrow<size_t>(text_ptr - text) > font_changes.m_font_changes[font_index].m_text_index)
-                font_index++;
-        }
-    }
-
-    bool was_font_changed = false;
-    HFONT fnt_old = nullptr;
-
-    if (font_index) {
-        HFONT fnt = SelectFont(dc, font_changes.m_font_changes[font_index - 1].m_font->m_font.get());
-        if (!was_font_changed) {
-            fnt_old = fnt;
-            was_font_changed = true;
-        }
-    }
-
-    if (start_line) {
-        // Back track to the last colour code and render it
-        if (*text_ptr != '\x3') {
-            const wchar_t* ptr = text_ptr;
-            while (ptr-- >= text) {
-                if (*ptr == '\x3') {
-                    const wchar_t* code_end = ptr;
-                    do {
-                        ptr--;
-                    } while (ptr >= text && *ptr != '\x3');
-                    if (ptr >= text && code_end != ptr && *ptr == '\x3') {
-                        utf8_converter.convert(ptr, code_end - ptr + 1);
-                        text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_line, false, cr_text, false,
-                            false, uih::ALIGN_LEFT, nullptr, false, false);
-                    }
-                    break;
-                }
-            }
-        }
-    }
-
-    for (size_t line_index = start_line; line_index < line_count; line_index++) {
-        const wchar_t* start_of_line = text_ptr;
-
-        if (rc_line.top > rc_placement.bottom)
-            break;
-
-        size_t line_font_change_count = 0;
-        size_t num_characters_remaining = wrapped_line_sizes[line_index].m_length;
-
-        while ((font_index + line_font_change_count < font_change_count
-            && (text_ptr - text + num_characters_remaining)
-                > (font_changes.m_font_changes[font_index + line_font_change_count].m_text_index))) {
-            line_font_change_count++;
-        }
-
-        const auto line_height = wrapped_line_sizes[line_index].m_height;
-
-        rc_line.bottom = rc_line.top + line_height;
-        rc_line.left = rc_placement.left;
-        rc_line.right = rc_placement.right;
-
-        const auto line_width = wil::rect_width(rc_line);
-        const auto line_text_width = wrapped_line_sizes[line_index].m_width;
-
-        if (line_text_width < line_width) {
-            if (align == uih::ALIGN_CENTRE)
-                rc_line.left += (line_width - line_text_width) / 2;
-            else if (align == uih::ALIGN_RIGHT)
-                rc_line.left += (line_width - line_text_width);
-        }
-
-        const auto left_padding = rc_line.left;
-
-        while (line_font_change_count) {
-            int end_x_position = NULL;
-            size_t num_characters_to_render = num_characters_remaining;
-            if (gsl::narrow<size_t>(text_ptr - text) < font_changes.m_font_changes[font_index].m_text_index)
-                num_characters_to_render = font_changes.m_font_changes[font_index].m_text_index - (text_ptr - text);
-            else if (line_font_change_count > 1)
-                num_characters_to_render = font_changes.m_font_changes[font_index + 1].m_text_index - (text_ptr - text);
-
-            if (gsl::narrow<size_t>(text_ptr - text) >= font_changes.m_font_changes[font_index].m_text_index) {
-                HFONT fnt = SelectFont(dc, font_changes.m_font_changes[font_index].m_font->m_font.get());
-                if (!was_font_changed) {
-                    fnt_old = fnt;
-                    was_font_changed = true;
-                }
-                font_index++;
-                line_font_change_count--;
-            }
-            RECT rc_font = rc_line;
-            rc_font.bottom -= half_padding_size;
-
-            utf8_converter.convert(text_ptr, num_characters_to_render);
-            text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_font, false, cr_text, false, false,
-                uih::ALIGN_LEFT, nullptr, false, false, &end_x_position, rc_line.left - left_padding);
-            rc_line.left = end_x_position;
-            text_ptr += num_characters_to_render;
-            num_characters_remaining -= num_characters_to_render;
-        }
-
-        if (num_characters_remaining) {
-            RECT rc_font = rc_line;
-            rc_font.bottom -= half_padding_size;
-
-            utf8_converter.convert(text_ptr, num_characters_remaining);
-            text_out_colours_tab(dc, utf8_converter, pfc_infinite, 0, 0, &rc_font, false, cr_text, false, false,
-                uih::ALIGN_LEFT, nullptr, false, false, nullptr, rc_line.left - left_padding);
-        }
-
-        if (line_index < line_count)
-            text_ptr = start_of_line + wrapped_line_sizes[line_index].m_length;
-
-        rc_line.top = rc_line.bottom;
-    }
-
-    SetTextColor(dc, cr_old);
-    if (was_font_changed)
-        SelectFont(dc, fnt_old);
+    return result;
 }
 
 } // namespace cui::panels::item_details

--- a/foo_ui_columns/item_details_text.h
+++ b/foo_ui_columns/item_details_text.h
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace cui::panels::item_details {
+
+enum class VerticalAlignment {
+    Top,
+    Centre,
+    Bottom,
+};
+
+DWRITE_PARAGRAPH_ALIGNMENT get_paragraph_alignment(VerticalAlignment alignment);
+
+std::optional<uih::direct_write::TextFormat> create_text_format(const uih::direct_write::Context::Ptr& context,
+    uih::alignment horizontal_alignment, VerticalAlignment vertical_alignment, bool word_wrapping);
+
+std::optional<uih::direct_write::TextLayout> create_text_layout(
+    const uih::direct_write::TextFormat& text_format, int max_width, int max_height, std::wstring_view text);
+
+struct Font {
+    std::wstring family;
+    float size_points{10.0f};
+    bool is_bold{};
+    bool is_underline{};
+    bool is_italic{};
+};
+
+struct FontSegment {
+    Font font;
+    size_t start_character{};
+    size_t character_count{};
+};
+
+std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<FontSegment>> process_colour_and_font_codes(
+    std::wstring_view text);
+
+} // namespace cui::panels::item_details

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -415,7 +415,7 @@ std::optional<INT_PTR> TabFonts::handle_wm_drawitem(LPDRAWITEMSTRUCT dis)
     try {
         const auto& text_format = is_family ? get_family_text_format(index) : get_face_text_format(index);
         const auto text_layout = text_format.create_text_layout(text, max_width, max_height);
-        text_layout.render(buffered_dc.get(), dis->rcItem, text_colour);
+        text_layout.render_with_transparent_background(buffered_dc.get(), dis->rcItem, text_colour);
     }
     CATCH_LOG()
 


### PR DESCRIPTION
Resolves #929

This makes the Item details panel render text using DirectWrite rather than Uniscribe.

All the custom text layout and word wrapping code has been removed as DirectWrite handles this natively.

Note that, currently, it's only possible to specify GDI-compatible fonts using the `$set_font()` title formatting function. (`$set_font()` does now accept non-integer font sizes, however.)