### PR TITLE
Update playlist view font size menu command logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
   [#925](https://github.com/reupen/columns_ui/pull/925),
   [#926](https://github.com/reupen/columns_ui/pull/926),
   [#936](https://github.com/reupen/columns_ui/pull/936),
-  [#947](https://github.com/reupen/columns_ui/pull/947)]
+  [#947](https://github.com/reupen/columns_ui/pull/947),
+  [#953](https://github.com/reupen/columns_ui/pull/953)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).

--- a/foo_ui_columns/font_manager_v3.cpp
+++ b/foo_ui_columns/font_manager_v3.cpp
@@ -82,6 +82,22 @@ public:
         auto wss = font_description.get_wss_with_fallback();
         return fb2k::service_new<Font>(log_font, wss, size);
     }
+
+    void set_client_font_size(GUID id, float size) override
+    {
+        const auto entry = g_font_manager_data.find_by_guid(id);
+
+        if (entry->font_mode != font_mode_custom) {
+            entry->font_description = g_font_manager_data.resolve_font_description(entry);
+            entry->font_mode = font_mode_custom;
+        }
+
+        entry->font_description.set_dip_size(size);
+
+        client::ptr ptr;
+        if (client::create_by_guid(id, ptr))
+            ptr->on_font_changed();
+    }
 };
 
 service_factory_t<FontManager3> _;

--- a/foo_ui_columns/font_manager_v3.h
+++ b/foo_ui_columns/font_manager_v3.h
@@ -41,6 +41,7 @@ public:
 class NOVTABLE manager_v3 : public service_base {
 public:
     [[nodiscard]] virtual font::ptr get_client_font(GUID id) const = 0;
+    virtual void set_client_font_size(GUID id, float size) = 0;
 
     FB2K_MAKE_SERVICE_INTERFACE_ENTRYPOINT(manager_v3);
 };

--- a/foo_ui_columns/font_utils.h
+++ b/foo_ui_columns/font_utils.h
@@ -15,6 +15,9 @@ struct FontDescription {
     float dip_size{12.0f};
     std::optional<WeightStretchStyle> wss;
 
+    void set_dip_size(float size);
+    void set_point_size(float size);
+    void set_point_size_tenths(int size_tenths);
     void estimate_point_and_dip_size();
     void estimate_dip_size();
     void recalculate_log_font_height();
@@ -46,7 +49,6 @@ private:
 };
 
 std::optional<FontDescription> select_font(HWND wnd_parent, LOGFONT initial_font);
-void get_next_font_size_step(LOGFONT& log_font, bool up);
 
 LOGFONT read_font(stream_reader* stream, abort_callback& aborter);
 void write_font(stream_writer* stream, const LOGFONT& log_font, abort_callback& aborter);

--- a/foo_ui_columns/menu_items.cpp
+++ b/foo_ui_columns/menu_items.cpp
@@ -65,11 +65,11 @@ static const MainMenuCommand show_artwork{show_artwork_id, "Show artwork",
 
 static const MainMenuCommand decrease_font{
     {0xf2bc9f43, 0xf709, 0x4f6f, {0x9c, 0x65, 0x78, 0x73, 0x3b, 0x8, 0xc7, 0x77}}, "Decrease font size",
-    "Decreases the playlist view font size.", [] { panels::playlist_view::set_font_size(false); }};
+    "Decreases the playlist view font size.", [] { panels::playlist_view::set_font_size(-1.0f); }};
 
 static const MainMenuCommand increase_font{
     {0x8553d7fd, 0xebc5, 0x4ae7, {0xaa, 0x28, 0xb2, 0x6, 0xfe, 0x94, 0xa0, 0xb4}}, "Increase font size",
-    "Increases the playlist font size.", [] { panels::playlist_view::set_font_size(true); }};
+    "Increases the playlist font size.", [] { panels::playlist_view::set_font_size(1.0f); }};
 
 static const MainMenuCommand show_status_bar{
     {0x5f944522, 0x843b, 0x43d2, {0x87, 0x14, 0xe3, 0xca, 0x1b, 0x78, 0x2b, 0x1f}}, "Show status bar",

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -81,15 +81,13 @@ void ConfigGroups::remove_group(size_t index)
     PlaylistView::g_on_groups_change();
 }
 
-void set_font_size(bool up)
+void set_font_size(float point_delta)
 {
-    LOGFONT lf_ng;
-    const auto api = fb2k::std_api_get<fonts::manager>();
-    api->get_font(g_guid_items_font, lf_ng);
+    const auto api = fb2k::std_api_get<fonts::manager_v3>();
+    auto font = api->get_client_font(g_guid_items_font);
 
-    fonts::get_next_font_size_step(lf_ng, up);
-
-    api->set_font(g_guid_items_font, lf_ng);
+    const auto dip_delta = uih::direct_write::pt_to_dip(point_delta);
+    api->set_client_font_size(g_guid_items_font, font->size() + dip_delta);
 }
 
 PlaylistView::PlaylistView()

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -23,7 +23,7 @@ wil::unique_hbitmap g_create_hbitmap_from_data(
     const album_art_data_ptr& data, int& cx, int& cy, COLORREF cr_back, bool b_reflection);
 bool g_get_default_nocover_bitmap_data(album_art_data_ptr& p_out, abort_callback& p_abort);
 wil::unique_hbitmap g_get_nocover_bitmap(int cx, int cy, COLORREF cr_back, bool b_reflection, abort_callback& p_abort);
-void set_font_size(bool up);
+void set_font_size(float point_delta);
 
 struct PlaylistCacheItem {
     std::optional<GUID> playlist_id;

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -101,9 +101,7 @@ void TabFonts::save_size_edit() const
 
     auto& font_description = m_element_ptr->font_description;
 
-    font_description.point_size_tenths = gsl::narrow_cast<int>(std::roundf(font_size_float * 10.0f));
-    font_description.dip_size = uih::direct_write::pt_to_dip(font_size_float);
-    font_description.recalculate_log_font_height();
+    font_description.set_point_size(font_size_float);
 }
 
 wil::com_ptr_t<IDWriteFontFamily> TabFonts::get_icon_font_family() const
@@ -271,9 +269,7 @@ INT_PTR TabFonts::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 const auto nmupdown = reinterpret_cast<LPNMUPDOWN>(lp);
                 nmupdown->iDelta *= 10;
                 const auto new_font_size_tenths = std::clamp(nmupdown->iPos + nmupdown->iDelta, 10, 720);
-                m_element_ptr->font_description.point_size_tenths = new_font_size_tenths;
-                m_element_ptr->font_description.recalculate_log_font_height();
-                m_element_ptr->font_description.estimate_dip_size();
+                m_element_ptr->font_description.set_point_size_tenths(new_font_size_tenths);
                 update_font_size_edit();
                 on_font_changed();
                 return 0;


### PR DESCRIPTION
Resolves #928

This updates the ‘View/Playlist view/Decrease font size’ and ‘View/Playlist view/Increase font size’ menu commands to simply increase or decrease the font size by 1pt instead of trying to enumerate font sizes using GDI (which is no longer relevant, now DirectWrite is being used).

A new method was added to the preliminary `cui::fonts::manager_v3` interface to accommodate this functionality through the API.