### PR TITLE
Allow configuration of some DirectWrite rendering options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,17 @@
   [#926](https://github.com/reupen/columns_ui/pull/926),
   [#936](https://github.com/reupen/columns_ui/pull/936),
   [#947](https://github.com/reupen/columns_ui/pull/947),
-  [#953](https://github.com/reupen/columns_ui/pull/953)]
+  [#953](https://github.com/reupen/columns_ui/pull/953),
+  [#967](https://github.com/reupen/columns_ui/pull/967)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).
 
   Tabular figures (numerals) are now also used for supported fonts that default
   to proportional figures (such as some Segoe UI variants).
+
+  Some customisation of DirectWrite text rendering is available on the new Text
+  rendering tab on the Colours and fonts preferences page.
 
 - A new DirectWrite-based font picker was added to the Colours and fonts
   preferences page. [[#916](https://github.com/reupen/columns_ui/pull/916),

--- a/foo_ui_columns/config_appearance.cpp
+++ b/foo_ui_columns/config_appearance.cpp
@@ -9,6 +9,7 @@
 #include "tab_dark_mode.h"
 #include "tab_fonts.h"
 #include "setup_dialog.h"
+#include "tab_text_rendering.h"
 
 TabDarkMode g_tab_dark_mode;
 cui::colours::ColourManagerData g_colour_manager_data;
@@ -189,7 +190,8 @@ void refresh_appearance_prefs()
     }
 }
 
-static PreferencesTab* g_tabs_appearance[] = {&g_tab_dark_mode, &g_tab_appearance, &g_tab_appearance_fonts};
+static PreferencesTab* g_tabs_appearance[]
+    = {&g_tab_dark_mode, &g_tab_appearance, &g_tab_appearance_fonts, &cui::prefs::get_text_rendering_tab()};
 
 // {FA25D859-C808-485d-8AB7-FCC10F29ECE5}
 const GUID g_guid_cfg_child_appearance = {0xfa25d859, 0xc808, 0x485d, {0x8a, 0xb7, 0xfc, 0xc1, 0xf, 0x29, 0xec, 0xe5}};

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -195,7 +195,7 @@ void FilterPanel::s_on_dark_mode_status_change()
 void FilterPanel::g_on_font_items_change()
 {
     const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_filter_items_font_client);
-    const auto text_format = font->create_wil_text_format();
+    const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
 
     for (auto& window : g_windows) {
@@ -798,7 +798,7 @@ void FilterPanel::notify_on_initialisation()
 
     const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
     const auto items_font = font_api->get_client_font(g_guid_filter_items_font_client);
-    const auto items_text_format = items_font->create_wil_text_format();
+    const auto items_text_format = fonts::get_text_format(items_font);
     const auto items_log_font = items_font->log_font();
     set_font(items_text_format, items_log_font);
 

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -48,8 +48,26 @@ public:
     void deregister_common_callback(cui::fonts::common_callback* p_callback);
 
     void g_on_common_font_changed(uint32_t mask);
+    void on_rendering_options_change();
 
     pfc::ptr_list_t<cui::fonts::common_callback> m_callbacks;
 
     FontManagerData();
 };
+
+namespace cui::fonts {
+
+enum class RenderingMode : int32_t {
+    Automatic = DWRITE_RENDERING_MODE_DEFAULT,
+    Natural = DWRITE_RENDERING_MODE_NATURAL,
+    NaturalSymmetric = DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+    GdiClassic = DWRITE_RENDERING_MODE_GDI_CLASSIC,
+    GdiNatural = DWRITE_RENDERING_MODE_GDI_NATURAL,
+};
+
+extern fbh::ConfigInt32 rendering_mode;
+extern fbh::ConfigBool force_greyscale_antialiasing;
+
+DWRITE_RENDERING_MODE get_rendering_mode();
+
+} // namespace cui::fonts

--- a/foo_ui_columns/font_manager_v3.h
+++ b/foo_ui_columns/font_manager_v3.h
@@ -2,6 +2,11 @@
 
 namespace cui::fonts {
 
+struct rendering_options {
+    DWRITE_RENDERING_MODE rendering_mode{DWRITE_RENDERING_MODE_DEFAULT};
+    bool force_greyscale_antialiasing{};
+};
+
 /**
  * Part of the preliminary DirectWrite-friendly manager_v3 interface.
  *
@@ -20,6 +25,11 @@ public:
     [[nodiscard]] virtual pfc::com_ptr_t<IDWriteTextFormat> create_text_format(
         const wchar_t* locale_name = L"") noexcept
         = 0;
+
+    [[nodiscard]] virtual DWRITE_RENDERING_MODE rendering_mode() noexcept = 0;
+    [[nodiscard]] virtual bool force_greyscale_antialiasing() noexcept = 0;
+
+    rendering_options get_rendering_options() { return {rendering_mode(), force_greyscale_antialiasing()}; }
 
 #ifdef __WIL_COM_INCLUDED
     wil::com_ptr_t<IDWriteTextFormat> create_wil_text_format(const wchar_t* locale_name = L"")

--- a/foo_ui_columns/font_utils.cpp
+++ b/foo_ui_columns/font_utils.cpp
@@ -204,4 +204,31 @@ SystemFont get_menu_font_for_dpi(unsigned dpi)
     return {ncm.lfMenuFont, gsl::narrow_cast<float>(-ncm.lfMenuFont.lfHeight)};
 }
 
+std::optional<uih::direct_write::TextFormat> get_text_format(
+    const uih::direct_write::Context::Ptr& context, const font::ptr& font_api)
+{
+    if (const auto text_format = font_api->create_wil_text_format()) {
+        try {
+            return context->wrap_text_format(
+                text_format, font_api->rendering_mode(), font_api->force_greyscale_antialiasing());
+        }
+        CATCH_LOG()
+    }
+    return {};
+}
+
+std::optional<uih::direct_write::TextFormat> get_text_format(const font::ptr& font_api)
+{
+    uih::direct_write::Context::Ptr context;
+    try {
+        context = uih::direct_write::Context::s_create();
+    }
+    CATCH_LOG();
+
+    if (!context)
+        return {};
+
+    return get_text_format(context, font_api);
+}
+
 } // namespace cui::fonts

--- a/foo_ui_columns/font_utils.h
+++ b/foo_ui_columns/font_utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "font_manager_v3.h"
 
 namespace cui::fonts {
 
@@ -60,5 +61,9 @@ struct SystemFont {
 
 SystemFont get_icon_font_for_dpi(unsigned dpi);
 SystemFont get_menu_font_for_dpi(unsigned dpi);
+
+std::optional<uih::direct_write::TextFormat> get_text_format(
+    const uih::direct_write::Context::Ptr& context, const font::ptr& font_api);
+std::optional<uih::direct_write::TextFormat> get_text_format(const font::ptr& font_api);
 
 } // namespace cui::fonts

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -715,6 +715,19 @@ BEGIN
     LTEXT           "",IDC_MENU_DESC,7,196,312,10
 END
 
+IDD_PREFS_TEXT_RENDERING DIALOGEX 0, 0, 327, 268
+STYLE DS_SETFONT | DS_3DLOOK | DS_FIXEDSYS | DS_CONTROL | WS_CHILD
+EXSTYLE WS_EX_CONTROLPARENT
+FONT 8, "MS Shell Dlg", 400, 0, 0x0
+BEGIN
+    LTEXT           "DirectWrite text rendering",IDC_TITLE1,7,4,273,16
+    LTEXT           "Rendering mode",IDC_STATIC,7,28,101,8
+    COMBOBOX        IDC_RENDERING_MODE,7,39,172,12,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Force greyscale anti-aliasing",IDC_FORCE_GREYSCALE_ANTIALIASING,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,62,119,10
+    LTEXT           "The above options will only have an effect on parts of the UI that use DirectWrite for text rendering.\n\nThird-party panels may not support these settings.",IDC_STATIC,7,87,313,36
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -1015,6 +1028,14 @@ BEGIN
         RIGHTMARGIN, 319
         TOPMARGIN, 4
         BOTTOMMARGIN, 264
+    END
+
+    IDD_PREFS_TEXT_RENDERING, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 320
+        TOPMARGIN, 4
+        BOTTOMMARGIN, 261
     END
 END
 #endif    // APSTUDIO_INVOKED

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -295,6 +295,7 @@
     <ClCompile Include="tab_dark_mode.cpp" />
     <ClCompile Include="tab_playlist_swticher.cpp" />
     <ClCompile Include="tab_status_pane.cpp" />
+    <ClCompile Include="tab_text_rendering.cpp" />
     <ClCompile Include="title_formatting.cpp" />
     <ClCompile Include="version.cpp" />
     <ClCompile Include="config_defaults.cpp" />
@@ -497,6 +498,7 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="tab_colours.h" />
     <ClInclude Include="tab_fonts.h" />
+    <ClInclude Include="tab_text_rendering.h" />
     <ClInclude Include="utf8api.h" />
     <ClInclude Include="volume.h" />
     <ClInclude Include="seekbar.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -617,6 +617,9 @@
     <ClCompile Include="font_manager_v3.cpp">
       <Filter>Colours and fonts</Filter>
     </ClCompile>
+    <ClCompile Include="tab_text_rendering.cpp">
+      <Filter>Config UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -904,6 +907,9 @@
     </ClInclude>
     <ClInclude Include="item_details_text.h">
       <Filter>Item details</Filter>
+    </ClInclude>
+    <ClInclude Include="tab_text_rendering.h">
+      <Filter>Config UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -4,6 +4,8 @@
 #include "item_details.h"
 #include "item_details_text.h"
 
+#include "font_utils.h"
+
 namespace cui::panels::item_details {
 
 namespace {
@@ -78,18 +80,17 @@ std::optional<uih::direct_write::TextFormat> create_text_format(const uih::direc
 {
     const auto api = fb2k::std_api_get<cui::fonts::manager_v3>();
     const auto font = api->get_client_font(g_guid_item_details_font_client);
-    const auto text_format = font->create_wil_text_format();
+    const auto text_format = fonts::get_text_format(context, font);
 
     if (!text_format)
         return {};
 
     try {
         const auto paragraph_alignment = get_paragraph_alignment(vertical_alignment);
-        const auto wrapped_text_format = context->wrap_text_format(text_format, false);
-        wrapped_text_format.set_text_alignment(uih::direct_write::get_text_alignment(horizontal_alignment));
-        wrapped_text_format.set_paragraph_alignment(paragraph_alignment);
-        wrapped_text_format.set_word_wrapping(word_wrapping ? DWRITE_WORD_WRAPPING_WRAP : DWRITE_WORD_WRAPPING_NO_WRAP);
-        return wrapped_text_format;
+        text_format->set_text_alignment(uih::direct_write::get_text_alignment(horizontal_alignment));
+        text_format->set_paragraph_alignment(paragraph_alignment);
+        text_format->set_word_wrapping(word_wrapping ? DWRITE_WORD_WRAPPING_WRAP : DWRITE_WORD_WRAPPING_NO_WRAP);
+        return text_format;
     }
     CATCH_LOG()
 

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -175,7 +175,7 @@ void ItemProperties::notify_on_initialisation()
 
     const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
     const auto items_font = font_api->get_client_font(g_guid_selection_properties_items_font_client);
-    const auto items_text_format = items_font->create_wil_text_format();
+    const auto items_text_format = fonts::get_text_format(items_font);
     const auto items_log_font = items_font->log_font();
     set_font(items_text_format, items_log_font);
 
@@ -183,7 +183,7 @@ void ItemProperties::notify_on_initialisation()
     set_header_font(header_font->log_font());
 
     const auto group_font = font_api->get_client_font(g_guid_selection_properties_group_font_client);
-    set_group_font(group_font->create_wil_text_format());
+    set_group_font(fonts::get_text_format(group_font));
 
     set_edge_style(m_edge_style);
     set_show_header(m_show_column_titles);
@@ -708,7 +708,7 @@ void ItemProperties::s_on_font_items_change()
 {
     const auto font
         = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_selection_properties_items_font_client);
-    const auto text_format = font->create_wil_text_format();
+    const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
 
     LOGFONT lf;
@@ -722,7 +722,7 @@ void ItemProperties::s_on_font_groups_change()
 {
     const auto font
         = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_selection_properties_group_font_client);
-    const auto text_format = font->create_wil_text_format();
+    const auto text_format = fonts::get_text_format(font);
 
     for (auto& window : s_windows) {
         window->set_group_font(text_format);

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dark_mode.h"
+#include "font_utils.h"
 
 template <typename t_appearance_client, typename t_window = uie::window>
 class ListViewPanelBase

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -391,7 +391,7 @@ void PlaylistView::g_on_vertical_item_padding_change()
 void PlaylistView::g_on_font_change()
 {
     const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_items_font);
-    const auto text_format = font->create_wil_text_format();
+    const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
 
     for (auto& window : g_windows)
@@ -410,7 +410,7 @@ void PlaylistView::g_on_header_font_change()
 void PlaylistView::g_on_group_header_font_change()
 {
     const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_group_header_font);
-    const auto text_format = font->create_wil_text_format();
+    const auto text_format = fonts::get_text_format(font);
 
     for (auto& window : g_windows)
         window->set_group_font(text_format);
@@ -759,7 +759,7 @@ void PlaylistView::notify_on_initialisation()
 
     const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
     const auto items_font = font_api->get_client_font(g_guid_items_font);
-    const auto items_text_format = items_font->create_wil_text_format();
+    const auto items_text_format = fonts::get_text_format(items_font);
     const auto items_log_font = items_font->log_font();
     set_font(items_text_format, items_log_font);
 
@@ -767,7 +767,7 @@ void PlaylistView::notify_on_initialisation()
     set_header_font(header_font->log_font());
 
     const auto group_font = font_api->get_client_font(g_guid_group_header_font);
-    set_group_font(group_font->create_wil_text_format());
+    set_group_font(fonts::get_text_format(group_font));
 
     set_sorting_enabled(cfg_header_hottrack != 0);
     set_show_sort_indicators(cfg_show_sort_arrows != 0);

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -1,4 +1,6 @@
 #include "pch.h"
+
+#include "font_manager_data.h"
 #include "ng_playlist.h"
 
 namespace cui::panels::playlist_view {
@@ -95,8 +97,8 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, size_t 
 
         if (context.m_item_text_format)
             text_out_columns_and_colours(*context.m_item_text_format, context.dc, sub_item.text,
-                1_spx + (column_index == 0 ? indentation : 0), 3_spx, rc_subitem, b_selected, cr_text, true, true,
-                sub_item.alignment, cfg_ellipsis != 0);
+                1_spx + (column_index == 0 ? indentation : 0), 3_spx, rc_subitem, cr_text,
+                {.is_selected = b_selected, .align = sub_item.alignment, .enable_ellipses = cfg_ellipsis != 0});
 
         const auto frame_width = uih::scale_dpi_value(1);
 
@@ -172,7 +174,7 @@ void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t
     const auto border = 3_spx;
 
     const auto text_width = text_out_columns_and_colours(*context.m_group_text_format, context.dc, text, x_offset,
-        border, rc, false, cr, true, false, uih::ALIGN_LEFT, cfg_ellipsis != 0);
+        border, rc, cr, {.enable_ellipses = cfg_ellipsis != 0, .enable_tab_columns = false});
 
     const auto line_height = 1_spx;
     const auto line_top = rc.top + wil::rect_height(rc) / 2 - line_height / 2;

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -110,16 +110,18 @@ void PlaylistSwitcher::g_refresh_all_items()
     for (auto& window : g_windows)
         window->refresh_all_items();
 }
+
 void PlaylistSwitcher::g_on_font_items_change()
 {
     const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_font);
-    const auto text_format = font->create_wil_text_format();
+    const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
 
     for (auto& window : g_windows) {
         window->set_font(text_format, log_font);
     }
 }
+
 void PlaylistSwitcher::notify_on_initialisation()
 {
     set_use_dark_mode(colours::is_dark_mode_active());
@@ -130,7 +132,7 @@ void PlaylistSwitcher::notify_on_initialisation()
     set_vertical_item_padding(settings::playlist_switcher_item_padding);
 
     const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_font);
-    const auto text_format = font->create_wil_text_format();
+    const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
     set_font(text_format, log_font);
 }

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -93,6 +93,7 @@
 #define IDD_PREFS_PLAYLIST_SWITCHER     234
 #define IDD_PREFS_DARK_MODE             235
 #define IDD_PREFS_STATUS_PANE           236
+#define IDD_PREFS_TEXT_RENDERING        237
 #define IDC_INFOSECTIONS                1003
 #define IDC_STRING                      1006
 #define IDC_COLOUR                      1007
@@ -291,6 +292,8 @@
 #define IDC_H2_TITLE                    1192
 #define IDC_FONT_SIZE                   1192
 #define IDC_FONT_SIZE_SPIN              1193
+#define IDC_RENDERING_MODE              1194
+#define IDC_FORCE_GREYSCALE_ANTIALIASING 1196
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -300,7 +303,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        198
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1194
+#define _APS_NEXT_CONTROL_VALUE         1197
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -5,6 +5,7 @@
 
 #include "dark_mode.h"
 #include "font_manager_v3.h"
+#include "font_utils.h"
 #include "menu_items.h"
 #include "metadb_helpers.h"
 
@@ -59,7 +60,7 @@ void StatusPane::recreate_font()
         return;
 
     try {
-        m_text_format = m_direct_write_context->wrap_text_format(text_format);
+        m_text_format = fonts::get_text_format(m_direct_write_context, font);
     }
     CATCH_LOG()
 

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -126,25 +126,28 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (m_selection)
             items_text << " selected";
 
+        constexpr auto simple_text_opts
+            = uih::direct_write::TextOutOptions{.enable_colour_codes = false, .enable_tab_columns = false};
+
         uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(), mmh::to_string_view(items_text),
-            1_spx, 3_spx, rc_line_1, false, default_text_colour, false, false);
+            1_spx, 3_spx, rc_line_1, default_text_colour, simple_text_opts);
 
         if (m_item_count) {
             uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(),
-                fmt::format("Length: {}", m_length_text.c_str()), 1_spx, 3_spx, rc_line_2, false, default_text_colour,
-                false, false);
+                fmt::format("Length: {}", m_length_text.c_str()), 1_spx, 3_spx, rc_line_2, default_text_colour,
+                simple_text_opts);
         }
 
         if (m_menu_active) {
             uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(), mmh::to_string_view(m_menu_text),
-                1_spx + selected_items_width, 3_spx, rc_line_1, false, default_text_colour, false, false);
+                1_spx + selected_items_width, 3_spx, rc_line_1, default_text_colour, simple_text_opts);
         } else {
             constexpr auto playback_status_placeholder = L"Playing:  "sv;
             const auto playback_status_width = m_text_format->measure_text_width(playback_status_placeholder);
 
             uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(),
-                mmh::to_string_view(m_track_label), 4_spx + selected_items_width, 0, rc_line_1, false,
-                default_text_colour, false, false);
+                mmh::to_string_view(m_track_label), 4_spx + selected_items_width, 0, rc_line_1, default_text_colour,
+                simple_text_opts);
 
             if (playing1.get_length()) {
                 const auto now_playing_x_end = 4_spx + selected_items_width + playback_status_width;
@@ -156,13 +159,13 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
                 if (lines > 0)
                     uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(),
-                        std::string_view{formatted_title_lines[0]}, now_playing_x_end, 0, rc_line_1, false,
-                        default_text_colour, true, true);
+                        std::string_view{formatted_title_lines[0]}, now_playing_x_end, 0, rc_line_1,
+                        default_text_colour);
 
                 if (lines > 1)
                     uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(),
-                        std::string_view{formatted_title_lines[1]}, now_playing_x_end, 0, rc_line_2, false,
-                        default_text_colour, true, true);
+                        std::string_view{formatted_title_lines[1]}, now_playing_x_end, 0, rc_line_2,
+                        default_text_colour);
             }
         }
 

--- a/foo_ui_columns/tab_text_rendering.cpp
+++ b/foo_ui_columns/tab_text_rendering.cpp
@@ -1,0 +1,101 @@
+#include "pch.h"
+
+#include "tab_text_rendering.h"
+
+#include "font_manager_data.h"
+
+namespace cui::prefs {
+
+namespace {
+
+constexpr auto rendering_modes = {
+    std::make_tuple(fonts::RenderingMode::Automatic, L"Automatic"),
+    std::make_tuple(fonts::RenderingMode::Natural, L"Horizontal anti-aliasing"),
+    std::make_tuple(fonts::RenderingMode::NaturalSymmetric, L"Symmetric anti-aliasing"),
+    std::make_tuple(fonts::RenderingMode::GdiClassic, L"GDI-compatible, classic"),
+    std::make_tuple(fonts::RenderingMode::GdiNatural, L"GDI-compatible, natural"),
+};
+
+class TextRenderingTab : public PreferencesTab {
+public:
+    INT_PTR on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+
+    HWND create(HWND wnd) override
+    {
+        return m_helper.create(wnd, IDD_PREFS_TEXT_RENDERING,
+            [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
+    }
+
+    const char* get_name() override { return "Text rendering"; }
+
+    bool get_help_url(pfc::string_base& p_out) override { return false; }
+
+private:
+    HWND m_wnd{};
+    HWND m_rendering_mode_combobox{};
+    HWND m_force_greyscale_antialiasing_checkbox{};
+
+    PreferencesTabHelper m_helper{{IDC_TITLE1}};
+};
+
+INT_PTR TextRenderingTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    switch (msg) {
+    case WM_INITDIALOG: {
+        m_wnd = wnd;
+        m_rendering_mode_combobox = GetDlgItem(wnd, IDC_RENDERING_MODE);
+        m_force_greyscale_antialiasing_checkbox = GetDlgItem(wnd, IDC_FORCE_GREYSCALE_ANTIALIASING);
+
+        for (auto&& [value, name] : rendering_modes) {
+            const auto index = uih::combo_box_add_string_data(m_rendering_mode_combobox, name, WI_EnumValue(value));
+
+            if (WI_EnumValue(value) == fonts::rendering_mode && index != CB_ERR)
+                ComboBox_SetCurSel(m_rendering_mode_combobox, index);
+        }
+
+        Button_SetCheck(
+            m_force_greyscale_antialiasing_checkbox, fonts::force_greyscale_antialiasing ? BST_UNCHECKED : BST_CHECKED);
+
+        break;
+    }
+    case WM_DESTROY: {
+        m_wnd = nullptr;
+        m_rendering_mode_combobox = nullptr;
+        break;
+    }
+    case WM_COMMAND:
+        switch (wp) {
+        case IDC_RENDERING_MODE | (CBN_SELCHANGE << 16): {
+            const int index = ComboBox_GetCurSel(m_rendering_mode_combobox);
+
+            if (index == CB_ERR)
+                break;
+
+            const auto data = ComboBox_GetItemData(m_rendering_mode_combobox, index);
+
+            if (data == CB_ERR)
+                break;
+
+            fonts::rendering_mode = gsl::narrow<std::underlying_type_t<fonts::RenderingMode>>(data);
+            break;
+        }
+        case IDC_FORCE_GREYSCALE_ANTIALIASING: {
+            fonts::force_greyscale_antialiasing
+                = Button_GetCheck(m_force_greyscale_antialiasing_checkbox) == BST_CHECKED;
+            break;
+        }
+        }
+        break;
+    }
+    return 0;
+}
+
+} // namespace
+
+PreferencesTab& get_text_rendering_tab()
+{
+    static TextRenderingTab tab;
+    return tab;
+}
+
+} // namespace cui::prefs

--- a/foo_ui_columns/tab_text_rendering.h
+++ b/foo_ui_columns/tab_text_rendering.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "config_host.h"
+
+namespace cui::prefs {
+
+PreferencesTab& get_text_rendering_tab();
+
+}


### PR DESCRIPTION
Resolves #932

This allows the configuration of the DirectWrite rendering mode, and whether to force the use of greyscale anti-aliasing.

These options apply to built-in parts of the main UI that use DirectWrite for text rendering, and will also be exposed in the updated font API.

Hopefully these options should be enough to keep anyone that doesn't like the default appearance of DirectWrite text happy.