### PR TITLE
Fix restoration of 'Force greyscale anti-aliasing' option in preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
   [#936](https://github.com/reupen/columns_ui/pull/936),
   [#947](https://github.com/reupen/columns_ui/pull/947),
   [#953](https://github.com/reupen/columns_ui/pull/953),
-  [#967](https://github.com/reupen/columns_ui/pull/967)]
+  [#967](https://github.com/reupen/columns_ui/pull/967),
+  [#969](https://github.com/reupen/columns_ui/pull/969)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).

--- a/foo_ui_columns/tab_text_rendering.cpp
+++ b/foo_ui_columns/tab_text_rendering.cpp
@@ -54,7 +54,7 @@ INT_PTR TextRenderingTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
 
         Button_SetCheck(
-            m_force_greyscale_antialiasing_checkbox, fonts::force_greyscale_antialiasing ? BST_UNCHECKED : BST_CHECKED);
+            m_force_greyscale_antialiasing_checkbox, fonts::force_greyscale_antialiasing ? BST_CHECKED : BST_UNCHECKED);
 
         break;
     }


### PR DESCRIPTION
This fixes a problem where when the 'Text rendering' preferences tab would initially show the inverse value of the 'Force greyscale anti-aliasing' option.