### PR TITLE
Improve DirectWrite multi-monitor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
   [#953](https://github.com/reupen/columns_ui/pull/953),
   [#967](https://github.com/reupen/columns_ui/pull/967),
   [#969](https://github.com/reupen/columns_ui/pull/969),
-  [#974](https://github.com/reupen/columns_ui/pull/974)]
+  [#974](https://github.com/reupen/columns_ui/pull/974),
+  [#976](https://github.com/reupen/columns_ui/pull/976)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -856,7 +856,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
             try {
                 m_text_layout->render_with_solid_background(
-                    dc.get(), x_offset, y_offset, ps.rcPaint, background_colour, text_colour);
+                    wnd, dc.get(), x_offset, y_offset, ps.rcPaint, background_colour, text_colour);
             }
             CATCH_LOG()
         }

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -89,6 +89,7 @@ private:
     pfc::string8 m_window_title;
     wil::com_ptr_t<ITaskbarList3> m_taskbar_list;
     HWND m_wnd{};
+    HMONITOR m_monitor{};
     user_interface::HookProc_t m_hook_proc{};
     bool m_should_handle_multimedia_keys{true};
     bool m_shell_hook_registered{};

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -96,7 +96,7 @@ void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, size_t 
         }
 
         if (context.m_item_text_format)
-            text_out_columns_and_colours(*context.m_item_text_format, context.dc, sub_item.text,
+            text_out_columns_and_colours(*context.m_item_text_format, context.wnd, context.dc, sub_item.text,
                 1_spx + (column_index == 0 ? indentation : 0), 3_spx, rc_subitem, cr_text,
                 {.is_selected = b_selected, .align = sub_item.alignment, .enable_ellipses = cfg_ellipsis != 0});
 
@@ -173,8 +173,8 @@ void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t
     const auto x_offset = 1_spx + indentation * gsl::narrow<int>(level);
     const auto border = 3_spx;
 
-    const auto text_width = text_out_columns_and_colours(*context.m_group_text_format, context.dc, text, x_offset,
-        border, rc, cr, {.enable_ellipses = cfg_ellipsis != 0, .enable_tab_columns = false});
+    const auto text_width = text_out_columns_and_colours(*context.m_group_text_format, context.wnd, context.dc, text,
+        x_offset, border, rc, cr, {.enable_ellipses = cfg_ellipsis != 0, .enable_tab_columns = false});
 
     const auto line_height = 1_spx;
     const auto line_top = rc.top + wil::rect_height(rc) / 2 - line_height / 2;

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -423,7 +423,8 @@ std::string_view get_draw_item_text(const StatusBarPartID part_id)
     }
 }
 
-void draw_item_content(const HDC dc, const StatusBarPartID part_id, const std::string_view text, const RECT rc)
+void draw_item_content(
+    const HWND wnd, const HDC dc, const StatusBarPartID part_id, const std::string_view text, const RECT rc)
 {
     if (text.empty())
         return;
@@ -433,7 +434,7 @@ void draw_item_content(const HDC dc, const StatusBarPartID part_id, const std::s
     if (part_id == StatusBarPartID::PlaybackInformation) {
         if (state->direct_write_text_format)
             uih::direct_write::text_out_columns_and_colours(
-                *state->direct_write_text_format, dc, text, 0, 0, rc, text_colour);
+                *state->direct_write_text_format, wnd, dc, text, 0, 0, rc, text_colour);
         return;
     }
 
@@ -466,8 +467,8 @@ void draw_item_content(const HDC dc, const StatusBarPartID part_id, const std::s
     }
 
     if (state->direct_write_text_format)
-        uih::direct_write::text_out_columns_and_colours(*state->direct_write_text_format, dc, text, x - rc.left, 0, rc,
-            text_colour, {.enable_colour_codes = false, .enable_tab_columns = false});
+        uih::direct_write::text_out_columns_and_colours(*state->direct_write_text_format, wnd, dc, text, x - rc.left, 0,
+            rc, text_colour, {.enable_colour_codes = false, .enable_tab_columns = false});
 }
 
 } // namespace
@@ -482,7 +483,7 @@ std::optional<LRESULT> handle_draw_item(const LPDRAWITEMSTRUCT lpdis)
 
     const std::string_view text = get_draw_item_text(part_id);
 
-    draw_item_content(lpdis->hDC, part_id, text, rc);
+    draw_item_content(lpdis->hwndItem, lpdis->hDC, part_id, text, rc);
 
     return TRUE;
 }

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -129,23 +129,24 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         constexpr auto simple_text_opts
             = uih::direct_write::TextOutOptions{.enable_colour_codes = false, .enable_tab_columns = false};
 
-        uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(), mmh::to_string_view(items_text),
+        uih::direct_write::text_out_columns_and_colours(*m_text_format, wnd, dc.get(), mmh::to_string_view(items_text),
             1_spx, 3_spx, rc_line_1, default_text_colour, simple_text_opts);
 
         if (m_item_count) {
-            uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(),
+            uih::direct_write::text_out_columns_and_colours(*m_text_format, wnd, dc.get(),
                 fmt::format("Length: {}", m_length_text.c_str()), 1_spx, 3_spx, rc_line_2, default_text_colour,
                 simple_text_opts);
         }
 
         if (m_menu_active) {
-            uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(), mmh::to_string_view(m_menu_text),
-                1_spx + selected_items_width, 3_spx, rc_line_1, default_text_colour, simple_text_opts);
+            uih::direct_write::text_out_columns_and_colours(*m_text_format, wnd, dc.get(),
+                mmh::to_string_view(m_menu_text), 1_spx + selected_items_width, 3_spx, rc_line_1, default_text_colour,
+                simple_text_opts);
         } else {
             constexpr auto playback_status_placeholder = L"Playing:  "sv;
             const auto playback_status_width = m_text_format->measure_text_width(playback_status_placeholder);
 
-            uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(),
+            uih::direct_write::text_out_columns_and_colours(*m_text_format, wnd, dc.get(),
                 mmh::to_string_view(m_track_label), 4_spx + selected_items_width, 0, rc_line_1, default_text_colour,
                 simple_text_opts);
 
@@ -158,12 +159,12 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 size_t lines = formatted_title_lines.get_count();
 
                 if (lines > 0)
-                    uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(),
+                    uih::direct_write::text_out_columns_and_colours(*m_text_format, wnd, dc.get(),
                         std::string_view{formatted_title_lines[0]}, now_playing_x_end, 0, rc_line_1,
                         default_text_colour);
 
                 if (lines > 1)
-                    uih::direct_write::text_out_columns_and_colours(*m_text_format, dc.get(),
+                    uih::direct_write::text_out_columns_and_colours(*m_text_format, wnd, dc.get(),
                         std::string_view{formatted_title_lines[1]}, now_playing_x_end, 0, rc_line_2,
                         default_text_colour);
             }

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -411,7 +411,7 @@ std::optional<INT_PTR> TabFonts::handle_wm_drawitem(LPDRAWITEMSTRUCT dis)
     try {
         const auto& text_format = is_family ? get_family_text_format(index) : get_face_text_format(index);
         const auto text_layout = text_format.create_text_layout(text, max_width, max_height);
-        text_layout.render_with_transparent_background(buffered_dc.get(), dis->rcItem, text_colour);
+        text_layout.render_with_transparent_background(m_wnd, buffered_dc.get(), dis->rcItem, text_colour);
     }
     CATCH_LOG()
 


### PR DESCRIPTION
Resolves #931 

This improves DirectWrite multi-monitor support by using monitor-specific rendering parameters.

As a result, the main window now invalidates itself and all children when moving between monitors. (In theory, other top-level windows containing panels should too, but that is difficult to enforce...)