### PR TITLE
Add new $set_format() title formatting function to Item details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@
   Some legacy font types that aren’t supported by DirectWrite are also no longer
   selectable. Furthermore, some previously hidden fonts may now be visible.
 
+- New `$set_format()` and `$reset_format()` title formatting functions were
+  added to Item details.
+  [[#1004](https://github.com/reupen/columns_ui/pull/1004)]
+
+  These serve as replacements for the older `$set_font()` and `$reset_font()`
+  functions.
+
 - The `$set_font()` Item details title formatting function now allows
   non-integer font sizes to be specified.
   [[#947](https://github.com/reupen/columns_ui/pull/947)]

--- a/docs/source/item-details/title-formatting.md
+++ b/docs/source/item-details/title-formatting.md
@@ -2,7 +2,86 @@
 
 ## Functions
 
+### \$set_format
+
+```{note}
+New in Columns UI 3.0.0.
+```
+
+Changes font and text styling for subsequent text.
+
+#### Syntax
+
+```
+$set_format(
+  property-name-1: property-value-1;
+  property-name-2: property-value-2;
+  ...
+)
+```
+
+#### Properties
+
+| Property name     | Syntax                                           |
+| ----------------- | ------------------------------------------------ |
+| `font-family`     | \<font family name>    \| `initial`              |
+| `font-size`       | \<font size in points>              \| `initial` |
+| `font-weight`     | \<1–900> \| `initial`                            |
+| `font-stretch`    | \<1–9> \| `initial`                              |
+| `font-style`      | `normal` \| `italic` \| `oblique` \| `initial`   |
+| `text-decoration` | `none` \| `underline` \| `initial`               |
+
+The special `initial` value resets any particular property back to its default
+value.
+
+#### Examples
+
+##### Change the font weight temporarily
+
+```
+$set_format(
+  font-weight: 700;
+)
+
+This text is in bold.
+
+$set_format(
+  font-weight: initial;
+)
+```
+
+##### Set all properties
+
+```
+$set_format(
+  font-family: Segoe UI Variable;
+  font-size: 20;
+  font-weight: 300;
+  font-stretch: 5;
+  font-style: italic;
+  text-decoration: underline;
+)
+```
+
+### \$reset_format
+
+```{note}
+New in Columns UI 3.0.0.
+```
+
+Restores font and text styling for subsequent text to the panel defaults.
+
+#### Syntax
+
+```
+$reset_format()
+```
+
 ### \$set_font
+
+```{warning}
+Deprecated in Columns UI 3.0.0. It’s been replaced by $set_format().
+```
 
 Changes the font used for subsequent text.
 
@@ -47,7 +126,11 @@ $get(labelfont)Title$reset_font() %title%
 
 ### \$reset_font
 
-Restores the font for subsequent text to the default panel font.
+```{warning}
+Deprecated in Columns UI 3.0.0. It’s been replaced by $reset_format().
+```
+
+Restores font and text styling for subsequent text to the panel defaults.
 
 #### Syntax
 

--- a/foo_ui_columns/file_info_utils.cpp
+++ b/foo_ui_columns/file_info_utils.cpp
@@ -2,22 +2,9 @@
 
 #include "file_info_utils.h"
 
+#include "string.h"
+
 namespace cui::helpers {
-
-namespace {
-
-std::string_view trim_string(std::string_view value)
-{
-    const auto start = value.find_first_not_of(' ');
-    const auto end = value.find_last_not_of(' ');
-
-    if (start > end || start == std::string_view::npos)
-        return ""sv;
-
-    return value.substr(start, end - start + 1);
-}
-
-} // namespace
 
 std::vector<std::string> split_meta_value(std::string_view value)
 {
@@ -26,7 +13,7 @@ std::vector<std::string> split_meta_value(std::string_view value)
     for (size_t offset{};;) {
         const size_t index = value.find(";"sv, offset);
         const auto substr = value.substr(offset, index - offset);
-        const auto trimmed_substr = trim_string(substr);
+        const auto trimmed_substr = cui::string::trim(substr, " ");
 
         if (trimmed_substr.length() > 0)
             values.emplace_back(trimmed_substr);

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -274,6 +274,7 @@
     <ClCompile Include="ng_playlist\ng_playlist_config.cpp" />
     <ClCompile Include="playlist_selector.cpp" />
     <ClCompile Include="resource_utils.cpp" />
+    <ClCompile Include="string.cpp" />
     <ClCompile Include="svg.cpp" />
     <ClCompile Include="system_appearance_manager.cpp" />
     <ClCompile Include="dark_mode.cpp" />
@@ -457,6 +458,7 @@
     <ClInclude Include="metadb_helpers.h" />
     <ClInclude Include="mw_drop_target.h" />
     <ClInclude Include="resource_utils.h" />
+    <ClInclude Include="string.h" />
     <ClInclude Include="svg.h" />
     <ClInclude Include="system_appearance_manager.h" />
     <ClInclude Include="button_items.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -620,6 +620,9 @@
     <ClCompile Include="tab_text_rendering.cpp">
       <Filter>Config UI</Filter>
     </ClCompile>
+    <ClCompile Include="string.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -910,6 +913,9 @@
     </ClInclude>
     <ClInclude Include="tab_text_rendering.h">
       <Filter>Config UI</Filter>
+    </ClInclude>
+    <ClInclude Include="string.h">
+      <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -1,10 +1,11 @@
 #include "pch.h"
 
-#include "font_manager_v3.h"
 #include "item_details.h"
 #include "item_details_text.h"
 
+#include "font_manager_v3.h"
 #include "font_utils.h"
+#include "string.h"
 
 namespace cui::panels::item_details {
 
@@ -17,48 +18,191 @@ bool are_strings_equal(std::wstring_view left, std::wstring_view right)
         == CSTR_EQUAL;
 }
 
-std::optional<Font> parse_font_code(std::wstring_view text)
+std::optional<StylePropertiesMap> parse_font_code_v1(
+    const std::vector<std::wstring_view>& parts, const uih::direct_write::Context::Ptr& direct_write_context)
 {
-    const auto parts = std::views::split(text, L'\t') | ranges::to<std::vector>;
+    if (parts.size() < 4)
+        return {};
+
+    const auto& family_part = parts[1];
+    const auto& size_part = parts[2];
+
+    LOGFONT lf{};
+    wcsncpy_s(lf.lfFaceName, std::wstring(family_part).c_str(), _TRUNCATE);
+
+    std::wstring size_str(size_part.data(), size_part.size());
+    const auto size_points = string::safe_stof(size_str);
+
+    if (!size_points)
+        return {};
+
+    TextDecorationType text_decoration{TextDecorationType::None};
+    const auto& style_part = parts[3];
+    auto style_elements = std::views::split(style_part, L';');
+
+    for (auto style_element : style_elements) {
+        const std::wstring_view style_element_view(style_element.data(), style_element.size());
+
+        const auto equals_index = style_element_view.find(L'=');
+        const auto style_name = style_element_view.substr(0, equals_index);
+        const auto style_enabled = equals_index == std::wstring_view::npos
+            || are_strings_equal(style_element_view.substr(equals_index + 1), L"true");
+
+        if (!style_enabled)
+            continue;
+
+        if (are_strings_equal(style_name, L"bold")) {
+            lf.lfWeight = true;
+        } else if (are_strings_equal(style_name, L"italic")) {
+            lf.lfItalic = true;
+        } else if (are_strings_equal(style_name, L"underline")) {
+            text_decoration = TextDecorationType::Underline;
+        }
+    }
+
+    try {
+        const auto direct_write_font = direct_write_context->create_font(lf);
+
+        wil::com_ptr_t<IDWriteFontFamily> font_family;
+        THROW_IF_FAILED(direct_write_font->GetFontFamily(&font_family));
+
+        wil::com_ptr_t<IDWriteLocalizedStrings> localised_strings;
+        THROW_IF_FAILED(font_family->GetFamilyNames(&localised_strings));
+
+        const auto family_name = uih::direct_write::get_localised_string(localised_strings);
+
+        const auto weight = direct_write_font->GetWeight();
+        const auto stretch = direct_write_font->GetStretch();
+        const auto style = direct_write_font->GetStyle();
+
+        return StylePropertiesMap{{StylePropertyType::FontFamily, family_name},
+            {StylePropertyType::FontSize, *size_points}, {StylePropertyType::FontWeight, weight},
+            {StylePropertyType::FontStretch, stretch}, {StylePropertyType::FontStyle, style},
+            {StylePropertyType::TextDecoration, text_decoration}};
+    }
+    CATCH_LOG()
+
+    return {};
+}
+
+struct PropertyParser {
+    StylePropertyType property_type;
+    std::function<std::optional<StylePropertyValue>(const std::wstring_view&)> parse;
+};
+
+std::optional<StylePropertyValue> parse_font_family(const std::wstring_view& value)
+{
+    return std::wstring(value);
+}
+
+std::optional<StylePropertyValue> parse_font_size(const std::wstring_view& value)
+{
+    return string::safe_stof(std::wstring(value));
+}
+
+std::optional<StylePropertyValue> parse_font_weight(const std::wstring_view& value)
+{
+    if (const auto converted_value = string::safe_stoi(std::wstring(value)))
+        return static_cast<DWRITE_FONT_WEIGHT>(std::clamp(*converted_value, 1, 999));
+
+    return {};
+}
+
+std::optional<StylePropertyValue> parse_font_stretch(const std::wstring_view& value)
+{
+    if (const auto converted_value = string::safe_stoi(std::wstring(value)))
+        return static_cast<DWRITE_FONT_STRETCH>(std::clamp(*converted_value, 1, 9));
+
+    return {};
+}
+
+std::optional<StylePropertyValue> parse_font_style(const std::wstring_view& value)
+{
+    if (value == L"normal")
+        return DWRITE_FONT_STYLE_NORMAL;
+
+    if (value == L"italic")
+        return DWRITE_FONT_STYLE_ITALIC;
+
+    if (value == L"oblique")
+        return DWRITE_FONT_STYLE_OBLIQUE;
+
+    return {};
+}
+
+std::optional<StylePropertyValue> parse_text_decoration(const std::wstring_view& value)
+{
+    if (value == L"underline")
+        return TextDecorationType::Underline;
+
+    if (value == L"none")
+        return TextDecorationType::None;
+
+    return {};
+}
+
+const std::unordered_map<std::wstring_view, PropertyParser> property_parsers{
+    {L"font-family"sv, {StylePropertyType::FontFamily, parse_font_family}},
+    {L"font-size"sv, {StylePropertyType::FontSize, parse_font_size}},
+    {L"font-weight"sv, {StylePropertyType::FontWeight, parse_font_weight}},
+    {L"font-stretch"sv, {StylePropertyType::FontStretch, parse_font_stretch}},
+    {L"font-style"sv, {StylePropertyType::FontStyle, parse_font_style}},
+    {L"text-decoration"sv, {StylePropertyType::TextDecoration, parse_text_decoration}}};
+
+StylePropertiesMap parse_format_code(const std::vector<std::wstring_view>& parts)
+{
+    const auto& properties_part = parts[1];
+    auto property_exprs = std::views::split(properties_part, L';');
+
+    StylePropertiesMap properties;
+
+    for (const auto& property_expr : property_exprs) {
+        const std::wstring_view style_element_view(property_expr.data(), property_expr.size());
+
+        const auto colon_index = style_element_view.find(L':');
+
+        if (colon_index == std::wstring_view::npos)
+            continue;
+
+        const auto key = string::trim(style_element_view.substr(0, colon_index));
+        const auto value = string::trim(style_element_view.substr(colon_index + 1));
+
+        const auto property_parser_iter = property_parsers.find(key);
+
+        if (property_parser_iter == std::end(property_parsers))
+            continue;
+
+        const auto& [property_type, parse] = property_parser_iter->second;
+
+        if (value == L"initial")
+            properties.insert_or_assign(property_type, InitialPropertyValue{});
+        else if (auto parsed_value = parse(value))
+            properties.insert_or_assign(property_type, *parsed_value);
+    }
+
+    return properties;
+}
+
+std::optional<StylePropertiesMap> parse_font_code(
+    std::wstring_view text, const uih::direct_write::Context::Ptr& direct_write_context)
+{
+    const auto parts_split_views = std::views::split(text, L'\t') | ranges::to<std::vector>;
+    const auto parts = parts_split_views
+        | ranges::views::transform([](auto&& part) { return std::wstring_view(part.data(), part.size()); })
+        | ranges::to<std::vector>;
 
     if (parts.size() < 2)
         return {};
 
-    Font font;
-    font.family = std::wstring_view(parts[0].data(), parts[0].size());
-    try {
-        std::wstring size_str(parts[1].data(), parts[1].size());
-        font.size_points = std::stof(size_str);
-    } catch (const std::exception&) {
-        return {};
-    }
+    const auto& version = parts[0];
 
-    if (parts.size() > 2) {
-        const std::wstring_view style(parts[2].data(), parts[2].size());
-        auto style_elements = std::views::split(style, L';');
+    if (version == L"\x1"sv)
+        return parse_font_code_v1(parts, direct_write_context);
 
-        for (auto style_element : style_elements) {
-            const std::wstring_view style_element_view(style_element.data(), style_element.size());
+    if (version == L"\x2"sv)
+        return parse_format_code(parts);
 
-            const auto equals_index = style_element_view.find(L'=');
-            const auto style_name = style_element_view.substr(0, equals_index);
-            const auto style_enabled = equals_index == std::wstring_view::npos
-                || are_strings_equal(style_element_view.substr(equals_index + 1), L"true");
-
-            if (!style_enabled)
-                continue;
-
-            if (are_strings_equal(style_name, L"bold")) {
-                font.is_bold = true;
-            } else if (are_strings_equal(style_name, L"italic")) {
-                font.is_italic = true;
-            } else if (are_strings_equal(style_name, L"underline")) {
-                font.is_underline = true;
-            }
-        }
-    }
-
-    return font;
+    return {};
 }
 
 } // namespace
@@ -113,7 +257,7 @@ std::optional<uih::direct_write::TextLayout> create_text_layout(
 }
 
 std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<FontSegment>> process_colour_and_font_codes(
-    std::wstring_view text)
+    std::wstring_view text, const uih::direct_write::Context::Ptr& direct_write_context)
 {
     auto result = std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<FontSegment>>{};
     auto& [stripped_text, coloured_segments, font_segments] = result;
@@ -122,7 +266,7 @@ std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<Font
     size_t colour_segment_start{};
     size_t font_segment_start{};
     std::optional<COLORREF> cr_current;
-    std::optional<Font> current_font;
+    std::optional<StylePropertiesMap> current_font;
 
     while (true) {
         const size_t index = text.find_first_of(L"\3\7"sv, offset);
@@ -140,9 +284,14 @@ std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<Font
                 coloured_segments.emplace_back(
                     *cr_current, colour_segment_start, stripped_text.length() - colour_segment_start);
 
-            if (current_font && (is_eos || is_font_code))
+            if (current_font && (is_eos || is_font_code)) {
+                const auto cleaned_font = ranges::views::remove_if(*current_font, [](auto&& pair) {
+                    return std::holds_alternative<InitialPropertyValue>(pair.second);
+                }) | ranges::to<StylePropertiesMap>;
+
                 font_segments.emplace_back(
-                    *current_font, font_segment_start, stripped_text.length() - font_segment_start);
+                    cleaned_font, font_segment_start, stripped_text.length() - font_segment_start);
+            }
         }
 
         if (is_eos)
@@ -159,7 +308,23 @@ std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<Font
             cr_current = uih::parse_colour_code(code_text, false);
             colour_segment_start = stripped_text.size();
         } else {
-            current_font = parse_font_code(code_text);
+            auto new_properties = parse_font_code(code_text, direct_write_context);
+
+            const auto last_font_segment_end = font_segments.empty()
+                ? std::nullopt
+                : std::make_optional(font_segments.rbegin()->start_character + font_segments.rbegin()->character_count);
+            const auto continues_from_last_segment
+                = current_font && (!last_font_segment_end || *last_font_segment_end == stripped_text.size());
+
+            if (!new_properties) {
+                current_font.reset();
+            } else if (current_font && continues_from_last_segment) {
+                new_properties->merge(*current_font);
+                current_font = new_properties;
+            } else {
+                current_font = new_properties;
+            }
+
             font_segment_start = stripped_text.size();
         }
 

--- a/foo_ui_columns/item_details_text.h
+++ b/foo_ui_columns/item_details_text.h
@@ -16,21 +16,33 @@ std::optional<uih::direct_write::TextFormat> create_text_format(const uih::direc
 std::optional<uih::direct_write::TextLayout> create_text_layout(
     const uih::direct_write::TextFormat& text_format, int max_width, int max_height, std::wstring_view text);
 
-struct Font {
-    std::wstring family;
-    float size_points{10.0f};
-    bool is_bold{};
-    bool is_underline{};
-    bool is_italic{};
+enum class TextDecorationType {
+    None,
+    Underline,
 };
 
+enum class StylePropertyType {
+    FontFamily,
+    FontSize,
+    FontWeight,
+    FontStretch,
+    FontStyle,
+    TextDecoration,
+};
+
+struct InitialPropertyValue {};
+
+using StylePropertyValue = std::variant<std::wstring, float, DWRITE_FONT_WEIGHT, DWRITE_FONT_STRETCH, DWRITE_FONT_STYLE,
+    TextDecorationType, InitialPropertyValue>;
+using StylePropertiesMap = std::unordered_map<StylePropertyType, StylePropertyValue>;
+
 struct FontSegment {
-    Font font;
+    StylePropertiesMap font;
     size_t start_character{};
     size_t character_count{};
 };
 
 std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<FontSegment>> process_colour_and_font_codes(
-    std::wstring_view text);
+    std::wstring_view text, const uih::direct_write::Context::Ptr& direct_write_context);
 
 } // namespace cui::panels::item_details

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -91,6 +91,9 @@
 #include "../svg-services/api/api.h"
 #include "../columns_ui-sdk/ui_extension.h"
 #include "../ui_helpers/stdafx.h"
+#include "../ui_helpers/direct_write.h"
+#include "../ui_helpers/direct_write_text_out.h"
+#include "../ui_helpers/list_view/list_view.h"
 #include "../mmh/stdafx.h"
 #include "../fbh/stdafx.h"
 

--- a/foo_ui_columns/string.cpp
+++ b/foo_ui_columns/string.cpp
@@ -1,0 +1,25 @@
+#include "pch.h"
+
+#include "string.h"
+
+namespace cui::string {
+
+std::optional<float> safe_stof(const std::wstring& value)
+{
+    try {
+        return std::stof(value);
+    } catch (const std::exception&) {
+        return {};
+    }
+}
+
+std::optional<int> safe_stoi(const std::wstring& value)
+{
+    try {
+        return std::stoi(value);
+    } catch (const std::exception&) {
+        return {};
+    }
+}
+
+} // namespace cui::string

--- a/foo_ui_columns/string.h
+++ b/foo_ui_columns/string.h
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace cui::string {
+
+template <typename Char>
+struct TrimChars {};
+
+template <>
+struct TrimChars<wchar_t> {
+    inline static const wchar_t* whitespace = L" \u00a0\u200b\u202f\ufeff\r\n";
+};
+
+template <typename Char>
+std::basic_string_view<Char> trim(
+    const std::basic_string_view<Char>& value, const Char* chars = TrimChars<Char>::whitespace)
+{
+    const auto start = value.find_first_not_of(chars);
+    const auto end = value.find_last_not_of(chars);
+
+    if (start > end || start == std::string_view::npos)
+        return {};
+
+    return value.substr(start, end - start + 1);
+}
+
+std::optional<float> safe_stof(const std::wstring& value);
+std::optional<int> safe_stoi(const std::wstring& value);
+
+} // namespace cui::string

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -5,6 +5,7 @@
 #include "dark_mode.h"
 #include "dark_mode_active_ui.h"
 #include "dark_mode_dialog.h"
+#include "string.h"
 
 namespace {
 
@@ -314,17 +315,15 @@ void TabFonts::save_font_face() const
 void TabFonts::save_size_edit() const
 {
     const auto font_size_text = uih::get_window_text(m_font_size_edit);
-    float font_size_float{};
 
-    try {
-        font_size_float = std::stof(font_size_text);
-    } catch (const std::exception&) {
+    const auto font_size_float = cui::string::safe_stof(font_size_text);
+
+    if (!font_size_float)
         return;
-    }
 
     auto& font_description = m_element_ptr->font_description;
 
-    font_description.set_point_size(font_size_float);
+    font_description.set_point_size(*font_size_float);
 }
 
 const wchar_t* TabFonts::get_font_face_combobox_item_text(uint32_t index) const

--- a/foo_ui_columns/title_formatting.cpp
+++ b/foo_ui_columns/title_formatting.cpp
@@ -52,4 +52,13 @@ bool FieldProviderTitleformatHook::process_field(
     return std::visit(ValueVisitor(p_out), iter->second);
 }
 
+std::string_view get_param(titleformat_hook_function_params& params, size_t index)
+{
+    const char* param{};
+    size_t param_length{};
+    params.get_param(index, param, param_length);
+
+    return {param, param_length};
+}
+
 } // namespace cui::tf

--- a/foo_ui_columns/title_formatting.h
+++ b/foo_ui_columns/title_formatting.h
@@ -34,4 +34,6 @@ public:
     FieldMap m_field_map;
 };
 
+std::string_view get_param(titleformat_hook_function_params& params, size_t index);
+
 } // namespace cui::tf


### PR DESCRIPTION
#950

This adds a new title formatting function, `$set_format()`, to Item details.

This is a replacement for the older `$set_font()` function.

The new function takes a single argument, which is a CSS-like string. For example:

```
$set_format(
  font-family: Segoe UI Variable;
  font-size: 20;
  font-weight: 300;
  font-stretch: 5;
  font-style: italic;
  text-decoration: underline;
)
```

Properties can be omitted (in which case they will retain their current value).

A special value of `initial` can be used to reset any particular property to its default value.

The `$reset_format()` function can be used to reset all properties to their defaults in one go.