### PR TITLE
Add workflow to auto-merge dependency update pull requests

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,41 @@
+name: Auto-merge pull requests
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: >
+      contains(fromJSON('["dependabot[bot]", "pre-commit[bot]"]'), github.event.pull_request.user.login)
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.commits == 1
+    steps:
+      - name: Check changed files
+        if: github.event.pull_request.user.login == 'pre-commit[bot]'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const response = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const changedFiles = response.data.map(file => file.filename);
+
+            if (changedFiles.length !== 1 || changedFiles[0] !== '.pre-commit-config.yaml') {
+              core.setFailed(
+                `Unexpected files modified:\n${changedFiles.join('\n')}`
+              );
+            }
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/vc17/columns_ui-public.sln
+++ b/vc17/columns_ui-public.sln
@@ -49,6 +49,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{9697
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{9A1841D3-5B7E-4831-A6B7-8B3899D66EF2}"
 	ProjectSection(SolutionItems) = preProject
+		..\.github\workflows\auto-merge.yml = ..\.github\workflows\auto-merge.yml
 		..\.github\workflows\build.yml = ..\.github\workflows\build.yml
 	EndProjectSection
 EndProject


### PR DESCRIPTION
This adds, as a trial, a workflow to automatically merge Dependabot and pre-commit pull requests.

This is based on the example on https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions.

Pull requests with more than 1 commit are ignored, and for pre-commit PRs there is an additional check that only `.pre-commit-config.yaml` has been modified.