### PR TITLE
Add better Item details format string parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@
 
 - New `$set_format()` and `$reset_format()` title formatting functions were
   added to Item details.
-  [[#1004](https://github.com/reupen/columns_ui/pull/1004)]
+  [[#1004](https://github.com/reupen/columns_ui/pull/1004),
+  [#1011](https://github.com/reupen/columns_ui/pull/1011)]
 
   These serve as replacements for the older `$set_font()` and `$reset_font()`
   functions.

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -271,6 +271,7 @@
     <ClCompile Include="font_manager_v3.cpp" />
     <ClCompile Include="gdi.cpp" />
     <ClCompile Include="icons.cpp" />
+    <ClCompile Include="item_details_format_parser.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_config.cpp" />
     <ClCompile Include="playlist_selector.cpp" />
     <ClCompile Include="resource_utils.cpp" />
@@ -452,8 +453,10 @@
     <ClInclude Include="get_msg_hook.h" />
     <ClInclude Include="icons.h" />
     <ClInclude Include="item_details.h" />
+    <ClInclude Include="item_details_format_parser.h" />
     <ClInclude Include="item_details_text.h" />
     <ClInclude Include="item_properties.h" />
+    <ClInclude Include="lexy_user_config.hpp" />
     <ClInclude Include="menu_helpers.h" />
     <ClInclude Include="metadb_helpers.h" />
     <ClInclude Include="mw_drop_target.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -623,6 +623,9 @@
     <ClCompile Include="string.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="item_details_format_parser.cpp">
+      <Filter>Item details</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -917,6 +920,10 @@
     <ClInclude Include="string.h">
       <Filter>Utilities</Filter>
     </ClInclude>
+    <ClInclude Include="item_details_format_parser.h">
+      <Filter>Item details</Filter>
+    </ClInclude>
+    <ClInclude Include="lexy_user_config.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".clang-format" />

--- a/foo_ui_columns/item_details_format_parser.cpp
+++ b/foo_ui_columns/item_details_format_parser.cpp
@@ -1,0 +1,154 @@
+#include "pch.h"
+
+#include "item_details_format_parser.h"
+
+#ifdef __clang__
+#pragma clang diagnostic warning "-Wshift-op-parentheses"
+#endif
+
+namespace cui::panels::item_details {
+
+namespace {
+
+namespace dsl = lexy::dsl;
+
+struct Initial {
+    static constexpr auto rule = dsl::lit<"initial">;
+    static constexpr auto value = lexy::constant(InitialPropertyValue{});
+};
+
+struct Float {
+    static constexpr auto rule = [] {
+        constexpr auto whole_part = dsl::digits<>;
+        constexpr auto fractional_part = dsl::period >> dsl::digits<>;
+        constexpr auto decimal = dsl::token(whole_part + dsl::if_(fractional_part));
+        return dsl::capture(decimal);
+    }();
+
+    static constexpr auto value = lexy::as_string<std::wstring, lexy::utf16_encoding>
+        | lexy::callback<float>([](std::wstring&& str) { return std::stof(str); });
+};
+
+struct FontFamilyValue {
+    struct String : lexy::token_production {
+        static constexpr auto rule = dsl::list(dsl::capture(dsl::unicode::character - dsl::lit_c<';'>));
+        static constexpr auto value = lexy::as_string<std::wstring, lexy::utf16_encoding>;
+    };
+
+    static constexpr auto rule = dsl::p<Initial> | dsl::else_ >> dsl::p<String>;
+    static constexpr auto value = lexy::forward<decltype(FormatProperties::font_family)>;
+};
+
+struct FontSizeValue {
+    static constexpr auto rule = dsl::p<Initial> | dsl::p<Float>;
+    static constexpr auto value = lexy::forward<decltype(FormatProperties::font_size)>;
+};
+
+struct FontWeightValue {
+    struct Weight {
+        static constexpr auto rule = dsl::integer<int>;
+        static constexpr auto value = lexy::callback<DWRITE_FONT_WEIGHT>(
+            [](int value) { return static_cast<DWRITE_FONT_WEIGHT>(std::clamp(value, 1, 999)); });
+    };
+
+    static constexpr auto rule = dsl::p<Initial> | dsl::p<Weight>;
+    static constexpr auto value = lexy::forward<decltype(FormatProperties::font_weight)>;
+};
+
+struct FontStretchValue {
+    struct Stretch {
+        static constexpr auto rule = dsl::integer<int>;
+        static constexpr auto value = lexy::callback<DWRITE_FONT_STRETCH>(
+            [](int value) { return static_cast<DWRITE_FONT_STRETCH>(std::clamp(value, 1, 9)); });
+    };
+
+    static constexpr auto rule = dsl::p<Initial> | dsl::p<Stretch>;
+    static constexpr auto value = lexy::forward<decltype(FormatProperties::font_stretch)>;
+};
+
+struct FontStyleValue {
+    struct Normal {
+        static constexpr auto rule = dsl::lit<"normal">;
+        static constexpr auto value = lexy::constant(DWRITE_FONT_STYLE_NORMAL);
+    };
+
+    struct Italic {
+        static constexpr auto rule = dsl::lit<"italic">;
+        static constexpr auto value = lexy::constant(DWRITE_FONT_STYLE_ITALIC);
+    };
+
+    struct Oblique {
+        static constexpr auto rule = dsl::lit<"oblique">;
+        static constexpr auto value = lexy::constant(DWRITE_FONT_STYLE_OBLIQUE);
+    };
+
+    static constexpr auto rule = dsl::p<Initial> | dsl::p<Normal> | dsl::p<Italic> | dsl::p<Oblique>;
+    static constexpr auto value = lexy::forward<decltype(FormatProperties::font_style)>;
+};
+
+struct TextDecorationValue {
+    struct None {
+        static constexpr auto rule = dsl::lit<"none">;
+        static constexpr auto value = lexy::constant(TextDecorationType::None);
+    };
+
+    struct Underline {
+        static constexpr auto rule = dsl::lit<"underline">;
+        static constexpr auto value = lexy::constant(TextDecorationType::Underline);
+    };
+
+    static constexpr auto rule = dsl::p<Initial> | dsl::p<None> | dsl::p<Underline>;
+    static constexpr auto value = lexy::forward<decltype(FormatProperties::text_decoration)>;
+};
+
+struct UnknownProperty {
+    static constexpr auto rule = dsl::until(dsl::lit_c<';'>);
+};
+
+template <typename Name, typename ValueRule, typename Member>
+constexpr auto make_property(Name name, ValueRule value_rule, Member member)
+{
+    return name >> dsl::try_(dsl::lit_c<':'> + (member = value_rule) + (dsl::lit_c<';'> | dsl::eof),
+               dsl::until(dsl::lit_c<';'>).or_eof());
+}
+
+struct FormatPropertiesProduction {
+    static constexpr auto whitespace = dsl::unicode::space;
+
+    static constexpr auto rule = dsl::partial_combination(
+        make_property(dsl::lit<"font-family">, dsl::p<FontFamilyValue>, dsl::member<&FormatProperties::font_family>),
+        make_property(dsl::lit<"font-size">, dsl::p<FontSizeValue>, dsl::member<&FormatProperties::font_size>),
+        make_property(dsl::lit<"font-weight">, dsl::p<FontWeightValue>, dsl::member<&FormatProperties::font_weight>),
+        make_property(dsl::lit<"font-stretch">, dsl::p<FontStretchValue>, dsl::member<&FormatProperties::font_stretch>),
+        make_property(dsl::lit<"font-style">, dsl::p<FontStyleValue>, dsl::member<&FormatProperties::font_style>),
+        make_property(
+            dsl::lit<"text-decoration">, dsl::p<TextDecorationValue>, dsl::member<&FormatProperties::text_decoration>),
+        dsl::inline_<UnknownProperty>);
+
+    static constexpr auto value = lexy::as_aggregate<FormatProperties>;
+};
+
+} // namespace
+
+std::optional<FormatProperties> parse_format_properties(std::wstring_view input)
+{
+    auto input_buffer = lexy::string_input<lexy::utf16_encoding>(input);
+
+#ifdef _DEBUG
+    std::ostringstream stream;
+    auto result = lexy::parse<FormatPropertiesProduction>(
+        input_buffer, lexy_ext::report_error.to(std::ostream_iterator<const char>(stream)));
+
+    if (const auto errors = stream.view(); !errors.empty())
+        console::print(fmt::format("Item details: $set_format() error: {}", errors).c_str());
+#else
+    auto result = lexy::parse<FormatPropertiesProduction>(input_buffer, lexy::noop);
+#endif
+
+    if (result.has_value())
+        return result.value();
+
+    return {};
+}
+
+} // namespace cui::panels::item_details

--- a/foo_ui_columns/item_details_format_parser.h
+++ b/foo_ui_columns/item_details_format_parser.h
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace cui::panels::item_details {
+
+struct InitialPropertyValue {};
+
+enum class TextDecorationType : int8_t {
+    None,
+    Underline,
+};
+
+struct FormatProperties {
+    std::optional<std::variant<std::wstring, InitialPropertyValue>> font_family;
+    std::optional<std::variant<float, InitialPropertyValue>> font_size;
+    std::optional<std::variant<DWRITE_FONT_WEIGHT, InitialPropertyValue>> font_weight;
+    std::optional<std::variant<DWRITE_FONT_STRETCH, InitialPropertyValue>> font_stretch;
+    std::optional<std::variant<DWRITE_FONT_STYLE, InitialPropertyValue>> font_style;
+    std::optional<std::variant<TextDecorationType, InitialPropertyValue>> text_decoration;
+};
+
+std::optional<FormatProperties> parse_format_properties(std::wstring_view input);
+
+} // namespace cui::panels::item_details

--- a/foo_ui_columns/item_details_text.h
+++ b/foo_ui_columns/item_details_text.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "item_details_format_parser.h"
+
 namespace cui::panels::item_details {
 
 enum class VerticalAlignment {
@@ -16,28 +18,8 @@ std::optional<uih::direct_write::TextFormat> create_text_format(const uih::direc
 std::optional<uih::direct_write::TextLayout> create_text_layout(
     const uih::direct_write::TextFormat& text_format, int max_width, int max_height, std::wstring_view text);
 
-enum class TextDecorationType {
-    None,
-    Underline,
-};
-
-enum class StylePropertyType {
-    FontFamily,
-    FontSize,
-    FontWeight,
-    FontStretch,
-    FontStyle,
-    TextDecoration,
-};
-
-struct InitialPropertyValue {};
-
-using StylePropertyValue = std::variant<std::wstring, float, DWRITE_FONT_WEIGHT, DWRITE_FONT_STRETCH, DWRITE_FONT_STYLE,
-    TextDecorationType, InitialPropertyValue>;
-using StylePropertiesMap = std::unordered_map<StylePropertyType, StylePropertyValue>;
-
 struct FontSegment {
-    StylePropertiesMap font;
+    FormatProperties font;
     size_t start_character{};
     size_t character_count{};
 };

--- a/foo_ui_columns/lexy_user_config.hpp
+++ b/foo_ui_columns/lexy_user_config.hpp
@@ -1,0 +1,2 @@
+#define LEXY_HAS_NTTP 1
+#define LEXY_HAS_UNICODE_DATABASE 1

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -61,6 +61,7 @@
 #include <Uxtheme.h>
 #include <wincodec.h>
 #include <strsafe.h>
+#include <strstream>
 
 #include <wil/cppwinrt.h>
 #include <wil/com.h>
@@ -69,6 +70,12 @@
 
 #include <winrt/windows.foundation.h>
 #include <winrt/windows.ui.viewmanagement.h>
+
+#include <lexy/action/parse.hpp>
+#include <lexy/callback.hpp>
+#include <lexy/dsl.hpp>
+#include <lexy/input/string_input.hpp>
+#include <lexy_ext/report_error.hpp>
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/foo_ui_columns/string.cpp
+++ b/foo_ui_columns/string.cpp
@@ -13,13 +13,4 @@ std::optional<float> safe_stof(const std::wstring& value)
     }
 }
 
-std::optional<int> safe_stoi(const std::wstring& value)
-{
-    try {
-        return std::stoi(value);
-    } catch (const std::exception&) {
-        return {};
-    }
-}
-
 } // namespace cui::string

--- a/foo_ui_columns/string.h
+++ b/foo_ui_columns/string.h
@@ -3,16 +3,7 @@
 namespace cui::string {
 
 template <typename Char>
-struct TrimChars {};
-
-template <>
-struct TrimChars<wchar_t> {
-    inline static const wchar_t* whitespace = L" \u00a0\u200b\u202f\ufeff\r\n";
-};
-
-template <typename Char>
-std::basic_string_view<Char> trim(
-    const std::basic_string_view<Char>& value, const Char* chars = TrimChars<Char>::whitespace)
+std::basic_string_view<Char> trim(const std::basic_string_view<Char>& value, const Char* chars)
 {
     const auto start = value.find_first_not_of(chars);
     const auto end = value.find_last_not_of(chars);
@@ -24,6 +15,5 @@ std::basic_string_view<Char> trim(
 }
 
 std::optional<float> safe_stof(const std::wstring& value);
-std::optional<int> safe_stoi(const std::wstring& value);
 
 } // namespace cui::string

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,3 @@
+{
+  "overlay-ports": ["vcpkg-ports"]
+}

--- a/vcpkg-ports/foonathan-lexy/portfile.cmake
+++ b/vcpkg-ports/foonathan-lexy/portfile.cmake
@@ -1,0 +1,31 @@
+vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO foonathan/lexy
+    REF "3f203d88af8729b5972782bccdf0d9ed932cbd7f"
+    SHA512 5375e1fdc028649caaa2b6bfecc307227d27d9ea00111b30e043721b786dc6aff78280d350640517c5c9b175667c7c3be9a07c7b3a98c9c35b93a237bb534cbb
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DLEXY_BUILD_BENCHMARKS=OFF
+        -DLEXY_BUILD_EXAMPLES=OFF
+        -DLEXY_BUILD_TESTS=OFF
+        -DLEXY_BUILD_DOCS=OFF
+        -DLEXY_BUILD_PACKAGE=OFF
+        -DLEXY_ENABLE_INSTALL=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME lexy
+    CONFIG_PATH lib/cmake/lexy
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/vcpkg-ports/foonathan-lexy/vcpkg.json
+++ b/vcpkg-ports/foonathan-lexy/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "foonathan-lexy",
+  "version": "2024.11.15",
+  "description": "C++ parsing DSL",
+  "homepage": "https://github.com/foonathan/lexy",
+  "license": "BSL-1.0",
+  "supports": "x86 | x64 | arm64",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "columns-ui",
   "version-string": "git",
   "builtin-baseline": "6062c8fe02d38b10d5291411bc235ae4d02cfe6c",
-  "dependencies": ["fmt", "ms-gsl", "range-v3", "wil"],
+  "dependencies": ["fmt", "foonathan-lexy", "ms-gsl", "range-v3", "wil"],
   "overrides": [
     {
       "name": "fmt",


### PR DESCRIPTION
#950 

This replaces with previous primitive Item details format string parser with a much better one using [lexy](https://github.com/foonathan/lexy).

For now, the library has been forked to fix Win32 (x86) builds in Visual Studio.