### PR TITLE
Add support for percentage font-stretch values in Item details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@
   added to Item details.
   [[#1004](https://github.com/reupen/columns_ui/pull/1004),
   [#1011](https://github.com/reupen/columns_ui/pull/1011),
-  [#1018](https://github.com/reupen/columns_ui/pull/1018)]
+  [#1018](https://github.com/reupen/columns_ui/pull/1018),
+  [#1023](https://github.com/reupen/columns_ui/pull/1023)]
 
   These serve as replacements for the older `$set_font()` and `$reset_font()`
   functions.

--- a/docs/source/item-details/title-formatting.md
+++ b/docs/source/item-details/title-formatting.md
@@ -27,12 +27,15 @@ $set_format(
 | `font-family`     | \<font family name> \| `initial`               |
 | `font-size`       | \<font size in points> \| `initial`            |
 | `font-weight`     | \<1–900> \| `initial`                          |
-| `font-stretch`    | \<1–9> \| `initial`                            |
+| `font-stretch`    | \<1–9> \| <percentage> \| `initial`            |
 | `font-style`      | `normal` \| `italic` \| `oblique` \| `initial` |
 | `text-decoration` | `none` \| `underline` \| `initial`             |
 
 The special `initial` value resets any particular property back to its default
 value.
+
+Percentages must use the suffix `%%` or `pc`, for example `150%%` or `150pc`
+(`%%` is an escaped `%` in the title formatting language).
 
 #### Examples
 
@@ -57,7 +60,7 @@ $set_format(
   font-family: Segoe UI Variable;
   font-size: 20;
   font-weight: 300;
-  font-stretch: 5;
+  font-stretch: 100%%;
   font-style: italic;
   text-decoration: underline;
 )

--- a/foo_ui_columns/font_manager_data.cpp
+++ b/foo_ui_columns/font_manager_data.cpp
@@ -87,7 +87,7 @@ cui::fonts::FontDescription FontManagerData::resolve_font_description(const entr
 
         cui::fonts::FontDescription description{system_font.log_font};
         description.fill_wss();
-        const auto point_size = system_font.size * 72.0f / gsl::narrow_cast<float>(USER_DEFAULT_SCREEN_DPI);
+        const auto point_size = uih::direct_write::dip_to_pt(system_font.size);
         description.point_size_tenths = gsl::narrow_cast<int>(point_size * 10.0f + 0.5f);
         description.dip_size = system_font.size;
         return description;

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -962,7 +962,7 @@ void process_wss_style_property(const std::vector<FontSegment>& segments,
 {
     struct CurrentValue {
         DWRITE_FONT_WEIGHT weight{};
-        DWRITE_FONT_STRETCH stretch{};
+        std::variant<DWRITE_FONT_STRETCH, float> stretch{};
         DWRITE_FONT_STYLE style{};
         size_t start{};
         size_t count{};
@@ -997,14 +997,18 @@ void process_wss_style_property(const std::vector<FontSegment>& segments,
 
     for (auto& [properties, start_character, character_count] : segments) {
         std::optional<DWRITE_FONT_WEIGHT> weight;
-        std::optional<DWRITE_FONT_STRETCH> stretch;
+        std::optional<std::variant<DWRITE_FONT_STRETCH, float>> stretch;
         std::optional<DWRITE_FONT_STYLE> style;
 
         if (properties.font_weight)
             weight = std::get<DWRITE_FONT_WEIGHT>(*properties.font_weight);
 
-        if (properties.font_stretch)
-            stretch = std::get<DWRITE_FONT_STRETCH>(*properties.font_stretch);
+        if (properties.font_stretch) {
+            if (std::holds_alternative<float>(*properties.font_stretch))
+                stretch = std::get<float>(*properties.font_stretch);
+            else
+                stretch = std::get<DWRITE_FONT_STRETCH>(*properties.font_stretch);
+        }
 
         if (properties.font_style)
             style = std::get<DWRITE_FONT_STYLE>(*properties.font_style);

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -20,7 +20,7 @@ std::wstring create_set_format_snippet(const fonts::FontDescription& font_descri
     const auto font_family
         = desc.typographic_family_name.empty() ? desc.wss->family_name : desc.typographic_family_name;
 
-    const auto font_size = font_description.dip_size * 72.0f / gsl::narrow_cast<float>(USER_DEFAULT_SCREEN_DPI);
+    const auto font_size = uih::direct_write::dip_to_pt(font_description.dip_size);
     const auto font_style = [style{desc.wss->style}] {
         switch (style) {
         default:

--- a/foo_ui_columns/item_details_format_parser.cpp
+++ b/foo_ui_columns/item_details_format_parser.cpp
@@ -56,13 +56,19 @@ struct FontWeightValue {
 };
 
 struct FontStretchValue {
-    struct Stretch {
+    struct StretchClass {
         static constexpr auto rule = dsl::integer<int>;
         static constexpr auto value = lexy::callback<DWRITE_FONT_STRETCH>(
             [](int value) { return static_cast<DWRITE_FONT_STRETCH>(std::clamp(value, 1, 9)); });
     };
 
-    static constexpr auto rule = dsl::p<Initial> | dsl::p<Stretch>;
+    struct Percentage {
+        static constexpr auto rule = dsl::p<Float> + (dsl::lit<"pc"> | dsl::lit_c<'%'>);
+        static constexpr auto value = lexy::forward<float>;
+    };
+
+    static constexpr auto rule
+        = dsl::p<Initial> | dsl::peek(dsl::p<Percentage>) >> dsl::p<Percentage> | dsl::p<StretchClass>;
     static constexpr auto value = lexy::forward<decltype(FormatProperties::font_stretch)>;
 };
 

--- a/foo_ui_columns/item_details_format_parser.h
+++ b/foo_ui_columns/item_details_format_parser.h
@@ -13,7 +13,7 @@ struct FormatProperties {
     std::optional<std::variant<std::wstring, InitialPropertyValue>> font_family;
     std::optional<std::variant<float, InitialPropertyValue>> font_size;
     std::optional<std::variant<DWRITE_FONT_WEIGHT, InitialPropertyValue>> font_weight;
-    std::optional<std::variant<DWRITE_FONT_STRETCH, InitialPropertyValue>> font_stretch;
+    std::optional<std::variant<DWRITE_FONT_STRETCH, float, InitialPropertyValue>> font_stretch;
     std::optional<std::variant<DWRITE_FONT_STYLE, InitialPropertyValue>> font_style;
     std::optional<std::variant<TextDecorationType, InitialPropertyValue>> text_decoration;
 };

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <optional>
 #include <ranges>
+#include <regex>
 #include <set>
 #include <span>
 #include <string_view>


### PR DESCRIPTION
Resolves #950

This adds support for percentage `font-stretch` values when using `$set_format()` in Item details.

Note that a `%` character needs to be escaped in title formatting, therefore percentages for `font-stretch` need to be written as e.g. `100%%` or `100pc`.

The percentage values are most useful on recent versions of Windows where variable font axes are supported.