### PR TITLE
Use reusable workflow for auto-merging

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,32 +10,4 @@ permissions:
 jobs:
   auto-merge:
     name: Enable auto-merge
-    runs-on: ubuntu-latest
-    if: >
-      contains(fromJSON('["dependabot[bot]", "pre-commit-ci[bot]"]'), github.event.pull_request.user.login)
-      && github.event.pull_request.head.repo.full_name == github.repository
-      && github.event.pull_request.commits == 1
-    steps:
-      - name: Check changed files
-        if: github.event.pull_request.user.login == 'pre-commit-ci[bot]'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const response = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-
-            const changedFiles = response.data.map(file => file.filename);
-
-            if (changedFiles.length !== 1 || changedFiles[0] !== '.pre-commit-config.yaml') {
-              core.setFailed(
-                `Unexpected files modified:\n${changedFiles.join('\n')}`
-              );
-            }
-      - name: Enable auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    uses: reupen/github-actions/.github/workflows/auto-merge.yml@v1


### PR DESCRIPTION
This switches to using a reusable workflow for enabling auto-merge on Dependabot and pre-commit pull requests.