### PR TITLE
Eliminate Playlist tabs and Tab stack spin control flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,10 @@
 - Various rendering glitches in Playlist tabs and Tab stack when dark mode is
   active were fixed. [[#851](https://github.com/reupen/columns_ui/pull/851)]
 
+- Flickering of scroll buttons in the Playlist tabs and Tab stack when resizing
+  the panels was eliminated.
+  [[#1033](https://github.com/reupen/columns_ui/pull/1033)]
+
 - When switching tabs, the Tab stack panel now updates the keyboard focus to the
   first focusable element in the new tab.
   [[#817](https://github.com/reupen/columns_ui/pull/817)]
@@ -190,7 +194,7 @@
   [[#833](https://github.com/reupen/columns_ui/pull/833),
   [#970](https://github.com/reupen/columns_ui/pull/970)]
 
-- The component is now compiled with Visual Studio 2022 17.11.
+- The component is now compiled with Visual Studio 2022 17.12.
 
 ## 2.1.0
 

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -277,6 +277,7 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
             if (!wcsncmp(UPDOWN_CLASSW, class_name.data(), class_name.size())) {
                 m_up_down_control_wnd = child_window;
+                uih::subclass_window_and_paint_with_buffering(child_window);
                 set_up_down_window_theme();
             }
             break;

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -795,18 +795,12 @@ LRESULT RebarWindow::s_handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPAR
 
 LRESULT RebarWindow::handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
-    switch (msg) {
-    case WM_ERASEBKGND: {
-        const auto dc = reinterpret_cast<HDC>(wp);
-        if (WindowFromDC(dc) != wnd)
-            return CallWindowProc(m_rebar_wnd_proc, wnd, WM_ERASEBKGND, wp, lp);
+    if (const auto result = uih::handle_subclassed_window_buffered_painting(m_rebar_wnd_proc, wnd, msg, wp, lp);
+        result) {
+        return *result;
+    }
 
-        return FALSE;
-    }
-    case WM_PAINT: {
-        uih::paint_subclassed_window_with_buffering(wnd, m_rebar_wnd_proc);
-        return 0;
-    }
+    switch (msg) {
     case WM_THEMECHANGED:
         on_themechanged();
         break;

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -1001,6 +1001,7 @@ LRESULT WINAPI TabStackPanel::on_hooked_message(HWND wnd, UINT msg, WPARAM wp, L
 
             if (!wcsncmp(UPDOWN_CLASSW, class_name.data(), class_name.size())) {
                 m_up_down_control_wnd = child_window;
+                uih::subclass_window_and_paint_with_buffering(child_window);
                 set_up_down_window_theme();
             }
             break;


### PR DESCRIPTION
This subclasses the Tab stack and Playlist tabs spin control to eliminate flickering when resizing the panel.