### PR TITLE
Fix problem with some Item details colour and format codes being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
   [#981](https://github.com/reupen/columns_ui/pull/981),
   [#981](https://github.com/reupen/columns_ui/pull/989),
   [#1030](https://github.com/reupen/columns_ui/pull/1030),
-  [#1031](https://github.com/reupen/columns_ui/pull/1031)]
+  [#1031](https://github.com/reupen/columns_ui/pull/1031),
+  [#1037](https://github.com/reupen/columns_ui/pull/1037)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -198,24 +198,22 @@ std::tuple<std::wstring, std::vector<uih::ColouredTextSegment>, std::vector<Font
         const auto is_colour_code = !is_eos && text[index] == L'\3';
         const auto is_font_code = !is_eos && text[index] == L'\7';
 
-        if (!fragment.empty()) {
+        if (!fragment.empty())
             stripped_text.append(fragment);
 
-            if (cr_current && (is_eos || is_colour_code))
-                coloured_segments.emplace_back(
-                    *cr_current, colour_segment_start, stripped_text.length() - colour_segment_start);
+        if (cr_current && (is_eos || is_colour_code) && stripped_text.length() > colour_segment_start)
+            coloured_segments.emplace_back(
+                *cr_current, colour_segment_start, stripped_text.length() - colour_segment_start);
 
-            if (current_font && (is_eos || is_font_code)) {
-                FormatProperties cleaned_font{*current_font};
-                for_each_property(cleaned_font, [](auto&& member) {
-                    if (member && std::holds_alternative<InitialPropertyValue>(*member)) {
-                        member.reset();
-                    }
-                });
+        if (current_font && (is_eos || is_font_code) && stripped_text.length() > font_segment_start) {
+            FormatProperties cleaned_font{*current_font};
+            for_each_property(cleaned_font, [](auto&& member) {
+                if (member && std::holds_alternative<InitialPropertyValue>(*member)) {
+                    member.reset();
+                }
+            });
 
-                font_segments.emplace_back(
-                    cleaned_font, font_segment_start, stripped_text.length() - font_segment_start);
-            }
+            font_segments.emplace_back(cleaned_font, font_segment_start, stripped_text.length() - font_segment_start);
         }
 
         if (is_eos)


### PR DESCRIPTION
Resolves #1036

This resolves a problem where some colour and format codes were ignored in Item details. This occurred when a format code appeared after a colour code, and vice versa, immediately followed by the end of the string.