### PR TITLE
Add new font properties and text rendering options to FCL files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
   [#981](https://github.com/reupen/columns_ui/pull/989),
   [#1030](https://github.com/reupen/columns_ui/pull/1030),
   [#1031](https://github.com/reupen/columns_ui/pull/1031),
-  [#1037](https://github.com/reupen/columns_ui/pull/1037)]
+  [#1037](https://github.com/reupen/columns_ui/pull/1037),
+  [#1039](https://github.com/reupen/columns_ui/pull/1039)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -17,6 +17,10 @@ public:
             identifier_mode,
             identifier_font,
             identifier_point_size_tenths,
+            identifier_weight_stretch_style,
+            identifier_dip_size,
+            identifier_typographic_font_family,
+            identifier_axis_values,
         };
         GUID guid{};
         cui::fonts::FontDescription font_description{};


### PR DESCRIPTION
Resolves #962

This adds reading and writing of new DirectWrite-related font properties and text rendering options to FCL files.