### PR TITLE
Work around different handling of ampersands in Windows 11 system tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,10 @@
   view using the context menu was fixed.
   [[#873](https://github.com/reupen/columns_ui/pull/873)]
 
+- Different handling of ampersands in system tray icon tooltips in Windows 11
+  compared to previous versions of Windows was worked around.
+  [[#1040](https://github.com/reupen/columns_ui/pull/1040)]
+
 - Various rendering glitches in Playlist tabs and Tab stack when dark mode is
   active were fixed. [[#851](https://github.com/reupen/columns_ui/pull/851)]
 

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -2,45 +2,20 @@
 #include "dark_mode.h"
 
 #include "system_appearance_manager.h"
+#include "win32.h"
 
 namespace cui::dark {
 
-namespace {
-
-bool check_windows_10_build(DWORD build_number)
-{
-    OSVERSIONINFOEX osviex{};
-    osviex.dwOSVersionInfoSize = sizeof(osviex);
-
-    DWORDLONG mask = VerSetConditionMask(0, VER_MAJORVERSION, VER_GREATER_EQUAL);
-    mask = VerSetConditionMask(mask, VER_MINORVERSION, VER_GREATER_EQUAL);
-    mask = VerSetConditionMask(mask, VER_BUILDNUMBER, VER_GREATER_EQUAL);
-
-    osviex.dwMajorVersion = 10;
-    osviex.dwMinorVersion = 0;
-    osviex.dwBuildNumber = build_number;
-
-    return VerifyVersionInfoW(&osviex, VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, mask) != FALSE;
-}
-
-bool is_windows_11_rtm_or_newer()
-{
-    static auto is_22000_or_newer = check_windows_10_build(22'000);
-    return is_22000_or_newer;
-}
-
-} // namespace
-
 bool does_os_support_dark_mode()
 {
-    static auto is_19041_or_newer = check_windows_10_build(19'041);
+    static auto is_19041_or_newer = win32::check_windows_10_build(19'041);
     return is_19041_or_newer;
 }
 
 bool is_native_dark_spin_available()
 {
     // Earliest known build number – exact build number unknown.
-    return check_windows_10_build(22'579);
+    return win32::check_windows_10_build(22'579);
 }
 
 bool are_private_apis_allowed()
@@ -76,7 +51,7 @@ void set_titlebar_mode(HWND wnd, bool is_dark)
 
 void force_titlebar_redraw(HWND wnd)
 {
-    if (is_windows_11_rtm_or_newer() || !IsWindowVisible(wnd))
+    if (win32::is_windows_11_rtm_or_newer() || !IsWindowVisible(wnd))
         return;
 
     // The below is a hack to force the titlebar to redraw on Windows 10 (little else works).
@@ -128,7 +103,7 @@ COLORREF get_base_dark_colour(DarkColourID colour_id)
 {
     switch (colour_id) {
     case DarkColourID::DARK_000:
-        return is_windows_11_rtm_or_newer() ? create_grey(25) : create_grey(32);
+        return win32::is_windows_11_rtm_or_newer() ? create_grey(25) : create_grey(32);
     case DarkColourID::DARK_200:
         return create_grey(51);
     case DarkColourID::DARK_250:

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -430,6 +430,7 @@
     <ClCompile Include="tab_layout_misc.cpp" />
     <ClCompile Include="tab_pview_artwork.cpp" />
     <ClCompile Include="wic.cpp" />
+    <ClCompile Include="win32.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="artwork_helpers.h" />
@@ -532,6 +533,7 @@
     <ClInclude Include="urls.h" />
     <ClInclude Include="vis_spectrum.h" />
     <ClInclude Include="wic.h" />
+    <ClInclude Include="win32.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".clang-format" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -629,6 +629,9 @@
     <ClCompile Include="font_picker.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="win32.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -925,6 +928,9 @@
     </ClInclude>
     <ClInclude Include="lexy_user_config.hpp" />
     <ClInclude Include="font_picker.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="win32.h">
       <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>

--- a/foo_ui_columns/system_tray.cpp
+++ b/foo_ui_columns/system_tray.cpp
@@ -2,6 +2,7 @@
 
 #include "system_tray.h"
 #include "main_window.h"
+#include "win32.h"
 
 extern HWND g_status;
 extern HICON g_icon;
@@ -13,7 +14,7 @@ void update_systray(bool balloon, int btitle, bool force_balloon)
         metadb_handle_ptr track;
         const auto play_api = play_control::get();
         play_api->get_now_playing(track);
-        pfc::string8 sys;
+        pfc::string8 escaped_title;
         pfc::string8 title;
 
         if (track.is_valid()) {
@@ -28,14 +29,18 @@ void update_systray(bool balloon, int btitle, bool force_balloon)
             title = core_version_info_v2::get()->get_name();
         }
 
-        uFixAmpersandChars(title, sys);
+        if (cui::win32::is_windows_11_rtm_or_newer())
+            escaped_title = title;
+        else
+            uFixAmpersandChars(title, escaped_title);
 
         if (balloon && (cfg_balloon || force_balloon)) {
-            uShellNotifyIconEx(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, sys, "", "");
-            uShellNotifyIconEx(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, sys,
+            uShellNotifyIconEx(
+                NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title, "", "");
+            uShellNotifyIconEx(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title,
                 (btitle == 0 ? "Now playing:" : (btitle == 1 ? "Unpaused:" : "Paused:")), title);
         } else
-            uShellNotifyIcon(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, sys);
+            uShellNotifyIcon(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title);
     }
 }
 

--- a/foo_ui_columns/win32.cpp
+++ b/foo_ui_columns/win32.cpp
@@ -1,0 +1,27 @@
+#include "pch.h"
+
+namespace cui::win32 {
+
+bool check_windows_10_build(DWORD build_number)
+{
+    OSVERSIONINFOEX osviex{};
+    osviex.dwOSVersionInfoSize = sizeof(osviex);
+
+    DWORDLONG mask = VerSetConditionMask(0, VER_MAJORVERSION, VER_GREATER_EQUAL);
+    mask = VerSetConditionMask(mask, VER_MINORVERSION, VER_GREATER_EQUAL);
+    mask = VerSetConditionMask(mask, VER_BUILDNUMBER, VER_GREATER_EQUAL);
+
+    osviex.dwMajorVersion = 10;
+    osviex.dwMinorVersion = 0;
+    osviex.dwBuildNumber = build_number;
+
+    return VerifyVersionInfoW(&osviex, VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, mask) != FALSE;
+}
+
+bool is_windows_11_rtm_or_newer()
+{
+    static auto is_22000_or_newer = check_windows_10_build(22'000);
+    return is_22000_or_newer;
+}
+
+} // namespace cui::win32

--- a/foo_ui_columns/win32.h
+++ b/foo_ui_columns/win32.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace cui::win32 {
+
+bool check_windows_10_build(DWORD build_number);
+bool is_windows_11_rtm_or_newer();
+
+} // namespace cui::win32


### PR DESCRIPTION
Resolves #1010

Windows 11 handles ampersands in system tray icon tooltips differently from earlier versions of Windows. Microsoft has shown no interest in fixing the problem (or even accepting that the problem exists), therefore this adds a nasty `if <is windows 11>` to work around the problem.