### PR TITLE
Mark various callback functions as noexcept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,9 @@
 
 ### Internal changes
 
+- Handling of fatal unexpected C++ exceptions was improved in some scenarios.
+  [[#1049](https://github.com/reupen/columns_ui/pull/1049)]
+
 - Various dependencies were updated.
   [[#920](https://github.com/reupen/columns_ui/pull/920)]
 

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -125,7 +125,7 @@ void ArtworkPanel::g_on_edge_style_change()
  * the same album as the previous track (determined using metadata, not
  * artwork equivalence).
  */
-void ArtworkPanel::on_album_art(album_art_data::ptr data)
+void ArtworkPanel::on_album_art(album_art_data::ptr data) noexcept
 {
     if (!m_artwork_loader || !m_artwork_loader->is_ready()) {
         m_dynamic_artwork_pending = true;
@@ -252,7 +252,7 @@ bool g_check_process_on_selection_changed()
     return processid == GetCurrentProcessId();
 }
 
-void ArtworkPanel::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection)
+void ArtworkPanel::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept
 {
     if (g_check_process_on_selection_changed()) {
         if (g_ui_selection_manager_is_now_playing_fallback())
@@ -273,7 +273,7 @@ void ArtworkPanel::on_selection_changed(const pfc::list_base_const_t<metadb_hand
     }
 }
 
-void ArtworkPanel::on_playback_stop(play_control::t_stop_reason p_reason)
+void ArtworkPanel::on_playback_stop(play_control::t_stop_reason p_reason) noexcept
 {
     m_dynamic_artwork_pending = false;
 
@@ -300,7 +300,7 @@ void ArtworkPanel::on_playback_stop(play_control::t_stop_reason p_reason)
     }
 }
 
-void ArtworkPanel::on_playback_new_track(metadb_handle_ptr p_track)
+void ArtworkPanel::on_playback_new_track(metadb_handle_ptr p_track) noexcept
 {
     m_dynamic_artwork_pending = false;
     if (g_track_mode_includes_now_playing(m_track_mode) && m_artwork_loader) {
@@ -385,7 +385,7 @@ void ArtworkPanel::show_next_artwork_type()
     show_stub_image();
 }
 
-void ArtworkPanel::on_playlist_switch()
+void ArtworkPanel::on_playlist_switch() noexcept
 {
     if (g_track_mode_includes_playlist(m_track_mode)
         && (!g_track_mode_includes_auto(m_track_mode) || !play_control::get()->is_playing())) {
@@ -401,7 +401,7 @@ void ArtworkPanel::on_playlist_switch()
     }
 }
 
-void ArtworkPanel::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state)
+void ArtworkPanel::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept
 {
     if (g_track_mode_includes_playlist(m_track_mode)
         && (!g_track_mode_includes_auto(m_track_mode) || !play_control::get()->is_playing())) {
@@ -638,7 +638,7 @@ colours::client::factory<ArtworkColoursClient> g_appearance_client_impl;
 
 ArtworkPanel::CompletionNotifyForwarder::CompletionNotifyForwarder(ArtworkPanel* p_this) : m_this(p_this) {}
 
-void ArtworkPanel::CompletionNotifyForwarder::on_completion(unsigned p_code)
+void ArtworkPanel::CompletionNotifyForwarder::on_completion(unsigned p_code) noexcept
 {
     m_this->on_completion(p_code);
 }

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -20,7 +20,7 @@ class ArtworkPanel
 public:
     class CompletionNotifyForwarder : public completion_notify {
     public:
-        void on_completion(unsigned p_code) override;
+        void on_completion(unsigned p_code) noexcept override;
         explicit CompletionNotifyForwarder(ArtworkPanel* p_this);
 
     private:
@@ -34,10 +34,10 @@ public:
 
     static void g_on_edge_style_change();
 
-    void on_album_art(album_art_data::ptr data) override;
+    void on_album_art(album_art_data::ptr data) noexcept override;
 
-    void on_playback_new_track(metadb_handle_ptr p_track) override;
-    void on_playback_stop(play_control::t_stop_reason p_reason) override;
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override;
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override;
 
     void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
     void on_playback_seek(double p_time) override {}
@@ -51,7 +51,7 @@ public:
     enum {
         playlist_callback_flags = flag_on_items_selection_change | flag_on_playlist_switch
     };
-    void on_playlist_switch() override;
+    void on_playlist_switch() noexcept override;
     void on_item_focus_change(size_t p_from, size_t p_to) override {}
 
     void on_items_added(
@@ -61,7 +61,7 @@ public:
     void on_items_reordered(const size_t* p_order, size_t p_count) override {}
     void on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
     void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
-    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override;
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept override;
     void on_items_modified(const bit_array& p_mask) override {}
     void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override {}
     void on_items_replaced(const bit_array& p_mask,
@@ -76,7 +76,7 @@ public:
     void on_default_format_changed() override {}
     void on_playback_order_changed(size_t p_new_index) override {}
 
-    void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) override;
+    void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept override;
 
     void on_completion(unsigned p_code);
 

--- a/foo_ui_columns/callbacks_config.cpp
+++ b/foo_ui_columns/callbacks_config.cpp
@@ -4,7 +4,7 @@
 class AlwaysOnTopNotifyReceiver : public config_object_notify {
     size_t get_watched_object_count() override { return 1; }
     GUID get_watched_object(size_t p_index) override { return standard_config_objects::bool_ui_always_on_top; }
-    void on_watched_object_changed(const service_ptr_t<config_object>& p_object) override
+    void on_watched_object_changed(const service_ptr_t<config_object>& p_object) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             bool aot = false;

--- a/foo_ui_columns/command_line.cpp
+++ b/foo_ui_columns/command_line.cpp
@@ -13,7 +13,7 @@ static const char8_t* g_help_text
 
 class HelpCommandLineHandler : public commandline_handler {
 public:
-    result on_token(const char* token) override
+    result on_token(const char* token) noexcept override
     {
         if (stricmp_utf8_partial(token, "/columnsui:help") != 0 && stricmp_utf8_partial(token, "/columnsui:?") != 0)
             return RESULT_NOT_OURS;
@@ -76,7 +76,7 @@ public:
     {
     }
 
-    result on_token(const char* token) override
+    result on_token(const char* token) noexcept override
     {
         m_is_quiet = !stricmp_utf8(token, "/columnsui:import-quiet");
         const auto is_import = m_is_quiet || !stricmp_utf8(token, "/columnsui:import");
@@ -89,8 +89,8 @@ public:
         return RESULT_PROCESSED_EXPECT_FILES;
     }
 
-    void on_file(const char* url) override { m_single_file_helper.add_file(url); }
-    void on_files_done() override
+    void on_file(const char* url) noexcept override { m_single_file_helper.add_file(url); }
+    void on_files_done() noexcept override
     {
         if (m_single_file_helper.validate_files())
             execute_import(m_single_file_helper.get_file(), m_is_quiet);
@@ -128,7 +128,7 @@ public:
     {
     }
 
-    result on_token(const char* token) override
+    result on_token(const char* token) noexcept override
     {
         m_is_quiet = !stricmp_utf8(token, "/columnsui:export-quiet");
         const auto is_import = m_is_quiet || !stricmp_utf8(token, "/columnsui:export");
@@ -141,8 +141,8 @@ public:
         return RESULT_PROCESSED_EXPECT_FILES;
     }
 
-    void on_file(const char* url) override { m_single_file_helper.add_file(url); }
-    void on_files_done() override
+    void on_file(const char* url) noexcept override { m_single_file_helper.add_file(url); }
+    void on_files_done() noexcept override
     {
         if (m_single_file_helper.validate_files())
             execute_export(m_single_file_helper.get_file(), m_is_quiet);

--- a/foo_ui_columns/dark_mode_spin.cpp
+++ b/foo_ui_columns/dark_mode_spin.cpp
@@ -244,7 +244,7 @@ std::optional<Direction> get_direction_at_point(HWND wnd, SpinType spin_type, PO
     return {};
 }
 
-LRESULT WINAPI on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     auto& window_state = state::state_map.at(wnd);
     auto call_next_window_proc

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -92,7 +92,7 @@ private:
         void on_colour_changed(uint32_t mask) const override { s_update_colours(); }
     };
 
-    static LRESULT WINAPI s_on_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+    static LRESULT WINAPI s_on_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
     {
         auto p_this = reinterpret_cast<DropDownListToolbar*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
         return p_this ? p_this->on_hook(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);

--- a/foo_ui_columns/dsp_preset.cpp
+++ b/foo_ui_columns/dsp_preset.cpp
@@ -60,7 +60,7 @@ ui_extension::window_factory<DropDownListToolbar<DspPresetToolbarArgs>> dsp_pres
 
 class DspPresetToolbarConfigCallback : public dsp_config_callback {
 public:
-    void on_core_settings_change(const dsp_chain_config& p_newdata) override
+    void on_core_settings_change(const dsp_chain_config& p_newdata) noexcept override
     {
         DropDownListToolbar<DspPresetToolbarArgs>::s_refresh_all_items_safe();
     }

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -565,7 +565,7 @@ void FilterSearchToolbar::ColourClient::on_bool_changed(uint32_t mask) const
         s_on_dark_mode_status_change();
 }
 
-LRESULT WINAPI FilterSearchToolbar::g_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI FilterSearchToolbar::g_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     auto p_this = reinterpret_cast<FilterSearchToolbar*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
     return p_this ? p_this->on_search_edit_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -81,7 +81,7 @@ private:
         config_version_current = 0
     };
 
-    static LRESULT WINAPI g_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI g_on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
 
     static void s_recreate_font();
     static void s_recreate_background_brush();

--- a/foo_ui_columns/helpers.cpp
+++ b/foo_ui_columns/helpers.cpp
@@ -126,7 +126,7 @@ struct EnumChildWindowsData {
     std::function<bool(HWND)> filter;
 };
 
-static BOOL WINAPI enum_child_windows_proc(HWND wnd, LPARAM lp)
+static BOOL WINAPI enum_child_windows_proc(HWND wnd, LPARAM lp) noexcept
 {
     auto data = reinterpret_cast<EnumChildWindowsData*>(lp);
     if (!data->filter || data->filter(wnd))

--- a/foo_ui_columns/helpers.h
+++ b/foo_ui_columns/helpers.h
@@ -12,7 +12,10 @@ BOOL uDrawPanelTitle(HDC dc, const RECT* rc_clip, const char* text, int len, boo
 namespace cui::helpers {
 
 class WindowEnum_t {
-    static BOOL CALLBACK g_EnumWindowsProc(HWND wnd, LPARAM lp) { return ((WindowEnum_t*)lp)->EnumWindowsProc(wnd); }
+    static BOOL CALLBACK g_EnumWindowsProc(HWND wnd, LPARAM lp) noexcept
+    {
+        return ((WindowEnum_t*)lp)->EnumWindowsProc(wnd);
+    }
     BOOL EnumWindowsProc(HWND wnd)
     {
         if (GetWindow(wnd, GW_OWNER) == m_wnd_owner && IsWindowVisible(wnd))

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -445,7 +445,7 @@ void ItemDetails::reset_display_info()
     m_text_rect.reset();
 }
 
-void ItemDetails::on_playback_new_track(metadb_handle_ptr p_track)
+void ItemDetails::on_playback_new_track(metadb_handle_ptr p_track) noexcept
 {
     if (s_track_mode_includes_now_playing(m_tracking_mode)) {
         m_nowplaying_active = true;
@@ -453,38 +453,38 @@ void ItemDetails::on_playback_new_track(metadb_handle_ptr p_track)
     }
 }
 
-void ItemDetails::on_playback_seek(double p_time)
+void ItemDetails::on_playback_seek(double p_time) noexcept
 {
     if (m_nowplaying_active)
         refresh_contents();
 }
-void ItemDetails::on_playback_pause(bool p_state)
+void ItemDetails::on_playback_pause(bool p_state) noexcept
 {
     if (m_nowplaying_active)
         refresh_contents();
 }
-void ItemDetails::on_playback_edited(metadb_handle_ptr p_track)
+void ItemDetails::on_playback_edited(metadb_handle_ptr p_track) noexcept
 {
     if (m_nowplaying_active)
         refresh_contents();
 }
-void ItemDetails::on_playback_dynamic_info(const file_info& p_info)
+void ItemDetails::on_playback_dynamic_info(const file_info& p_info) noexcept
 {
     if (m_nowplaying_active)
         refresh_contents();
 }
-void ItemDetails::on_playback_dynamic_info_track(const file_info& p_info)
+void ItemDetails::on_playback_dynamic_info_track(const file_info& p_info) noexcept
 {
     if (m_nowplaying_active)
         refresh_contents();
 }
-void ItemDetails::on_playback_time(double p_time)
+void ItemDetails::on_playback_time(double p_time) noexcept
 {
     if (m_nowplaying_active)
         refresh_contents();
 }
 
-void ItemDetails::on_playback_stop(play_control::t_stop_reason p_reason)
+void ItemDetails::on_playback_stop(play_control::t_stop_reason p_reason) noexcept
 {
     if (s_track_mode_includes_now_playing(m_tracking_mode) && p_reason != play_control::stop_reason_starting_another
         && p_reason != play_control::stop_reason_shutting_down) {
@@ -500,7 +500,7 @@ void ItemDetails::on_playback_stop(play_control::t_stop_reason p_reason)
     }
 }
 
-void ItemDetails::on_playlist_switch()
+void ItemDetails::on_playlist_switch() noexcept
 {
     if (s_track_mode_includes_playlist(m_tracking_mode)
         && (!s_track_mode_includes_auto(m_tracking_mode) || !play_control::get()->is_playing())) {
@@ -509,7 +509,7 @@ void ItemDetails::on_playlist_switch()
         set_handles(handles);
     }
 }
-void ItemDetails::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state)
+void ItemDetails::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept
 {
     if (s_track_mode_includes_playlist(m_tracking_mode)
         && (!s_track_mode_includes_auto(m_tracking_mode) || !play_control::get()->is_playing())) {
@@ -519,7 +519,7 @@ void ItemDetails::on_items_selection_change(const bit_array& p_affected, const b
     }
 }
 
-void ItemDetails::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook)
+void ItemDetails::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) noexcept
 {
     if (m_nowplaying_active)
         return;
@@ -544,7 +544,7 @@ bool ItemDetails::check_process_on_selection_changed()
     return processid == GetCurrentProcessId();
 }
 
-void ItemDetails::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection)
+void ItemDetails::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept
 {
     if (check_process_on_selection_changed()) {
         if (g_ui_selection_manager_is_now_playing_fallback())
@@ -1212,42 +1212,6 @@ void ItemDetails::set_horizontal_alignment(uint32_t horizontal_alignment)
     update_scrollbars(false, true);
     update_now();
 }
-
-void ItemDetails::on_playback_order_changed(size_t p_new_index) {}
-
-void ItemDetails::on_default_format_changed() {}
-
-void ItemDetails::on_playlist_locked(bool p_locked) {}
-
-void ItemDetails::on_playlist_renamed(const char* p_new_name, size_t p_new_name_len) {}
-
-void ItemDetails::on_item_ensure_visible(size_t p_idx) {}
-
-void ItemDetails::on_items_replaced(
-    const bit_array& p_mask, const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data)
-{
-}
-
-void ItemDetails::on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) {}
-
-void ItemDetails::on_items_modified(const bit_array& p_mask) {}
-
-void ItemDetails::on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) {}
-
-void ItemDetails::on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) {}
-
-void ItemDetails::on_items_reordered(const size_t* p_order, size_t p_count) {}
-
-void ItemDetails::on_items_added(
-    size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
-{
-}
-
-void ItemDetails::on_item_focus_change(size_t p_from, size_t p_to) {}
-
-void ItemDetails::on_volume_change(float p_new_val) {}
-
-void ItemDetails::on_playback_starting(play_control::t_track_command p_command, bool p_paused) {}
 
 bool ItemDetails::s_track_mode_includes_selection(size_t mode)
 {

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -160,47 +160,51 @@ public:
     void get_menu_items(ui_extension::menu_hook_t& p_hook) override;
 
     // UI SEL API
-    void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) override;
+    void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept override;
 
     // PC
-    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override;
-    void on_playback_new_track(metadb_handle_ptr p_track) override;
-    void on_playback_stop(play_control::t_stop_reason p_reason) override;
-    void on_playback_seek(double p_time) override;
-    void on_playback_pause(bool p_state) override;
-    void on_playback_edited(metadb_handle_ptr p_track) override;
-    void on_playback_dynamic_info(const file_info& p_info) override;
-    void on_playback_dynamic_info_track(const file_info& p_info) override;
-    void on_playback_time(double p_time) override;
-    void on_volume_change(float p_new_val) override;
+    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override;
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override;
+    void on_playback_seek(double p_time) noexcept override;
+    void on_playback_pause(bool p_state) noexcept override;
+    void on_playback_edited(metadb_handle_ptr p_track) noexcept override;
+    void on_playback_dynamic_info(const file_info& p_info) noexcept override;
+    void on_playback_dynamic_info_track(const file_info& p_info) noexcept override;
+    void on_playback_time(double p_time) noexcept override;
+    void on_volume_change(float p_new_val) override {}
 
     // PL
     enum {
         playlist_callback_flags = flag_on_items_selection_change | flag_on_playlist_switch
     };
-    void on_playlist_switch() override;
-    void on_item_focus_change(size_t p_from, size_t p_to) override;
+    void on_playlist_switch() noexcept override;
+    void on_item_focus_change(size_t p_from, size_t p_to) override {}
 
     void on_items_added(
-        size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override;
-    void on_items_reordered(const size_t* p_order, size_t p_count) override;
-    void on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
-    void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
-    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override;
-    void on_items_modified(const bit_array& p_mask) override;
-    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override;
+        size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override
+    {
+    }
+    void on_items_reordered(const size_t* p_order, size_t p_count) override {}
+    void on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
+    void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept override;
+    void on_items_modified(const bit_array& p_mask) override {}
+    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override {}
     void on_items_replaced(const bit_array& p_mask,
-        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override;
-    void on_item_ensure_visible(size_t p_idx) override;
+        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override
+    {
+    }
+    void on_item_ensure_visible(size_t p_idx) override {}
 
-    void on_playlist_renamed(const char* p_new_name, size_t p_new_name_len) override;
-    void on_playlist_locked(bool p_locked) override;
+    void on_playlist_renamed(const char* p_new_name, size_t p_new_name_len) override {}
+    void on_playlist_locked(bool p_locked) override {}
 
-    void on_default_format_changed() override;
-    void on_playback_order_changed(size_t p_new_index) override;
+    void on_default_format_changed() override {}
+    void on_playback_order_changed(size_t p_new_index) override {}
 
     // ML
-    void on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) override;
+    void on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) noexcept override;
 
     static void s_on_app_activate(bool b_activated);
     static void s_on_font_change();

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -598,7 +598,7 @@ void ItemProperties::refresh_contents()
         enable_redrawing();
 }
 
-void ItemProperties::on_playback_new_track(metadb_handle_ptr p_track)
+void ItemProperties::on_playback_new_track(metadb_handle_ptr p_track) noexcept
 {
     if (m_tracking_mode == track_nowplaying || m_tracking_mode == track_automatic) {
         m_handles.remove_all();
@@ -607,7 +607,7 @@ void ItemProperties::on_playback_new_track(metadb_handle_ptr p_track)
     }
 }
 
-void ItemProperties::on_playback_stop(play_control::t_stop_reason p_reason)
+void ItemProperties::on_playback_stop(play_control::t_stop_reason p_reason) noexcept
 {
     if (p_reason != play_control::stop_reason_starting_another && p_reason != play_control::stop_reason_shutting_down) {
         if (m_tracking_mode == track_nowplaying || m_tracking_mode == track_automatic) {
@@ -620,7 +620,7 @@ void ItemProperties::on_playback_stop(play_control::t_stop_reason p_reason)
     }
 }
 
-void ItemProperties::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook)
+void ItemProperties::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) noexcept
 {
     for (auto&& track : m_handles) {
         if (size_t index{};
@@ -642,7 +642,7 @@ bool ItemProperties::check_process_on_selection_changed()
     return processid == GetCurrentProcessId();
 }
 
-void ItemProperties::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection)
+void ItemProperties::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept
 {
     if (check_process_on_selection_changed()) {
         if (g_ui_selection_manager_is_now_playing_fallback())

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -163,12 +163,12 @@ public:
     void notify_save_inline_edit(const char* value) override;
 
     // UI SEL API
-    void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) override;
+    void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept override;
 
     // PC
     void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
-    void on_playback_new_track(metadb_handle_ptr p_track) override;
-    void on_playback_stop(play_control::t_stop_reason p_reason) override;
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override;
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override;
     void on_playback_seek(double p_time) override {}
     void on_playback_pause(bool p_state) override {}
     void on_playback_edited(metadb_handle_ptr p_track) override {}
@@ -177,7 +177,7 @@ public:
     void on_playback_time(double p_time) override {}
     void on_volume_change(float p_new_val) override {}
 
-    void on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) override;
+    void on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) noexcept override;
 
     static void s_on_app_activate(bool b_activated);
     static void s_redraw_all();

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -397,7 +397,7 @@ bool process_keydown(UINT msg, LPARAM lp, WPARAM wp, bool playlist, bool keyb)
 class MainWindowPlaylistCallback : public playlist_callback_single_static {
 public:
     void on_items_added(
-        size_t start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
+        size_t start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) noexcept
         override // inside any of these methods, you can call IPlaylist APIs to get exact info about what happened (but
                  // only methods that read playlist state, not those that modify it)
     {
@@ -408,15 +408,15 @@ public:
     void on_items_reordered(const size_t* order, size_t count) override {
     } // changes selection too; doesnt actually change set of items that are selected or
       // item having focus, just changes their order
-    void FB2KAPI on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {
+    void on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {
     } // called before actually removing them
-    void FB2KAPI on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override
+    void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::status_bar::set_part_sizes(cui::status_bar::t_part_length | cui::status_bar::t_part_count);
         }
     }
-    void on_items_selection_change(const bit_array& affected, const bit_array& state) override
+    void on_items_selection_change(const bit_array& affected, const bit_array& state) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::status_bar::set_part_sizes(cui::status_bar::t_part_length | cui::status_bar::t_part_count);
@@ -424,24 +424,22 @@ public:
     }
     void on_item_focus_change(size_t from, size_t to) override {
     } // focus may be -1 when no item has focus; reminder: focus may also change on other callbacks
-    void FB2KAPI on_items_modified(const bit_array& p_mask) override {}
-    void FB2KAPI on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override
-    {
-    }
+    void on_items_modified(const bit_array& p_mask) override {}
+    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override {}
     void on_items_replaced(const bit_array& p_mask,
         const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override
     {
     }
     void on_item_ensure_visible(size_t idx) override {}
 
-    void on_playlist_switch() override
+    void on_playlist_switch() noexcept override
     {
         if (cui::main_window.get_wnd()) {
             set_part_sizes(cui::status_bar::t_parts_all);
         }
     }
     void on_playlist_renamed(const char* p_new_name, size_t p_new_name_len) override {}
-    void on_playlist_locked(bool p_locked) override
+    void on_playlist_locked(bool p_locked) noexcept override
     {
         if (cui::main_window.get_wnd())
             if (g_status && main_window::config_get_status_show_lock())

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -75,7 +75,7 @@ private:
     static constexpr std::array taskbar_icon_configs{icons::built_in::stop, icons::built_in::previous,
         icons::built_in::pause, icons::built_in::play, icons::built_in::next, icons::built_in::random};
 
-    static LRESULT CALLBACK s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT CALLBACK s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     static void warn_if_ui_hacks_installed();
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);

--- a/foo_ui_columns/main_window_callbacks.cpp
+++ b/foo_ui_columns/main_window_callbacks.cpp
@@ -9,7 +9,7 @@ public:
 
     unsigned get_flags() override { return flags; }
     void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
-    void on_playback_new_track(metadb_handle_ptr p_track) override
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::main_window.update_title();
@@ -17,20 +17,20 @@ public:
         }
     }
 
-    void on_playback_stop(play_control::t_stop_reason p_reason) override
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override
     {
         if (cui::main_window.get_wnd() && p_reason != play_control::stop_reason_shutting_down) {
             cui::main_window.reset_title();
             cui::main_window.queue_taskbar_button_update();
         }
     }
-    void on_playback_seek(double p_time) override
+    void on_playback_seek(double p_time) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::main_window.update_title();
         }
     }
-    void on_playback_pause(bool b_state) override
+    void on_playback_pause(bool b_state) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::main_window.update_title();
@@ -38,26 +38,26 @@ public:
         }
     }
 
-    void on_playback_edited(metadb_handle_ptr p_track) override
+    void on_playback_edited(metadb_handle_ptr p_track) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::main_window.update_title();
         }
     }
 
-    void on_playback_dynamic_info(const file_info& p_info) override
+    void on_playback_dynamic_info(const file_info& p_info) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::main_window.update_title();
         }
     }
-    void on_playback_dynamic_info_track(const file_info& p_info) override
+    void on_playback_dynamic_info_track(const file_info& p_info) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::main_window.update_title();
         }
     }
-    void on_playback_time(double p_time) override
+    void on_playback_time(double p_time) noexcept override
     {
         if (cui::main_window.get_wnd()) {
             cui::main_window.update_title();

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -86,7 +86,7 @@ public:
     pfc::list_t<MainMenuRootGroup> m_buttons;
 
     LRESULT WINAPI hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    static LRESULT WINAPI main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
 
     bool on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp) override;
@@ -151,7 +151,7 @@ void MenuToolbar::set_window_theme()
     SetWindowTheme(wnd_menu, cui::colours::is_dark_mode_active() ? L"DarkMode" : nullptr, nullptr);
 }
 
-LRESULT WINAPI MenuToolbar::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI MenuToolbar::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     auto p_this = reinterpret_cast<MenuToolbar*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
     return p_this ? p_this->hook(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -38,7 +38,7 @@ service_ptr_t<contextmenu_manager> g_main_nowplaying;
 GetMsgHook g_get_msg_hook;
 static HWND wnd_last;
 
-LRESULT cui::MainWindow::s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT cui::MainWindow::s_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     MainWindow* self = nullptr;
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -77,15 +77,15 @@ private:
         }
 
     private:
-        void on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len) override
+        void on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len) noexcept override
         {
             m_owner->on_playlist_created(p_index, {p_name, p_name_len});
         }
-        void on_playlists_reorder(const size_t* p_order, size_t p_count) override
+        void on_playlists_reorder(const size_t* p_order, size_t p_count) noexcept override
         {
             m_owner->on_playlists_reorder({p_order, p_count});
         }
-        void on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override
+        void on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept override
         {
             m_owner->on_playlists_removed(p_mask, p_old_count, p_new_count);
         }
@@ -480,7 +480,7 @@ private:
     public:
         using ptr_t = std::shared_ptr<ArtworkCompletionNotify>;
 
-        void on_completion(const std::shared_ptr<ArtworkReader>& p_reader) override
+        void on_completion(const std::shared_ptr<ArtworkReader>& p_reader) noexcept override
         {
             m_window->on_artwork_read_complete(m_group, p_reader);
         }
@@ -518,20 +518,22 @@ private:
     void reset_items();
 
     void on_items_added(size_t playlist, size_t start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const bit_array& p_selection) override;
-    void on_items_reordered(size_t playlist, const size_t* p_order, size_t p_count) override;
-    void on_items_removed(size_t playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
-    void on_items_selection_change(size_t playlist, const bit_array& p_affected, const bit_array& p_state) override;
-    void on_item_focus_change(size_t playlist, size_t p_from, size_t p_to) override;
-    void on_items_modified(size_t playlist, const bit_array& p_mask) override;
+        const bit_array& p_selection) noexcept override;
+    void on_items_reordered(size_t playlist, const size_t* p_order, size_t p_count) noexcept override;
+    void on_items_removed(
+        size_t playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept override;
+    void on_items_selection_change(
+        size_t playlist, const bit_array& p_affected, const bit_array& p_state) noexcept override;
+    void on_item_focus_change(size_t playlist, size_t p_from, size_t p_to) noexcept override;
+    void on_items_modified(size_t playlist, const bit_array& p_mask) noexcept override;
     void on_items_modified_fromplayback(
-        size_t playlist, const bit_array& p_mask, play_control::t_display_level p_level) override;
+        size_t playlist, const bit_array& p_mask, play_control::t_display_level p_level) noexcept override;
     void on_items_replaced(size_t playlist, const bit_array& p_mask,
-        const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) override;
-    void on_item_ensure_visible(size_t playlist, size_t p_idx) override;
+        const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) noexcept override;
+    void on_item_ensure_visible(size_t playlist, size_t p_idx) noexcept override;
 
-    void on_playlist_activate(size_t p_old, size_t p_new) override;
-    void on_playlist_renamed(size_t playlist, const char* p_new_name, size_t p_new_name_len) override;
+    void on_playlist_activate(size_t p_old, size_t p_new) noexcept override;
+    void on_playlist_renamed(size_t playlist, const char* p_new_name, size_t p_new_name_len) noexcept override;
 
     void on_items_removing(size_t playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
     void on_default_format_changed() override {}

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -3,7 +3,7 @@
 
 namespace cui::panels::playlist_view {
 void PlaylistView::on_items_added(size_t playlist, size_t start,
-    const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
+    const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) noexcept
 {
     if (playlist != m_playlist_api->get_active_playlist())
         return;
@@ -15,7 +15,7 @@ void PlaylistView::on_items_added(size_t playlist, size_t start,
     refresh_all_items_text();
 }
 
-void PlaylistView::on_items_reordered(size_t playlist, const size_t* p_order, size_t p_count)
+void PlaylistView::on_items_reordered(size_t playlist, const size_t* p_order, size_t p_count) noexcept
 {
     if (playlist != m_playlist_api->get_active_playlist())
         return;
@@ -34,7 +34,8 @@ void PlaylistView::on_items_reordered(size_t playlist, const size_t* p_order, si
     }
 }
 
-void PlaylistView::on_items_removed(size_t playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
+void PlaylistView::on_items_removed(
+    size_t playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept
 {
     if (playlist != m_playlist_api->get_active_playlist())
         return;
@@ -50,7 +51,8 @@ void PlaylistView::on_items_removed(size_t playlist, const bit_array& p_mask, si
     refresh_all_items_text();
 }
 
-void PlaylistView::on_items_selection_change(size_t playlist, const bit_array& p_affected, const bit_array& p_state)
+void PlaylistView::on_items_selection_change(
+    size_t playlist, const bit_array& p_affected, const bit_array& p_state) noexcept
 {
     if (m_ignore_callback || playlist != m_playlist_api->get_active_playlist())
         return;
@@ -58,7 +60,7 @@ void PlaylistView::on_items_selection_change(size_t playlist, const bit_array& p
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
 }
 
-void PlaylistView::on_item_focus_change(size_t playlist, size_t p_from, size_t p_to)
+void PlaylistView::on_item_focus_change(size_t playlist, size_t p_from, size_t p_to) noexcept
 {
     if (playlist != m_playlist_api->get_active_playlist()) {
         m_playlist_cache.set_item(playlist, std::nullopt);
@@ -70,7 +72,7 @@ void PlaylistView::on_item_focus_change(size_t playlist, size_t p_from, size_t p
     on_focus_change(p_from, p_to);
 }
 
-void PlaylistView::on_items_modified(size_t playlist, const bit_array& p_mask)
+void PlaylistView::on_items_modified(size_t playlist, const bit_array& p_mask) noexcept
 {
     if (playlist != m_playlist_api->get_active_playlist())
         return;
@@ -92,7 +94,7 @@ void PlaylistView::on_items_modified(size_t playlist, const bit_array& p_mask)
 }
 
 void PlaylistView::on_items_modified_fromplayback(
-    size_t playlist, const bit_array& p_mask, play_control::t_display_level p_level)
+    size_t playlist, const bit_array& p_mask, play_control::t_display_level p_level) noexcept
 {
     if (core_api::is_shutting_down() || playlist != m_playlist_api->get_active_playlist())
         return;
@@ -111,12 +113,12 @@ void PlaylistView::on_items_modified_fromplayback(
 }
 
 void PlaylistView::on_items_replaced(
-    size_t playlist, const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
+    size_t playlist, const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) noexcept
 {
     on_items_modified(playlist, p_mask);
 }
 
-void PlaylistView::on_item_ensure_visible(size_t playlist, size_t p_idx)
+void PlaylistView::on_item_ensure_visible(size_t playlist, size_t p_idx) noexcept
 {
     if (playlist != m_playlist_api->get_active_playlist())
         return;
@@ -124,7 +126,7 @@ void PlaylistView::on_item_ensure_visible(size_t playlist, size_t p_idx)
     ensure_visible(p_idx);
 }
 
-void PlaylistView::on_playlist_activate(size_t p_old, size_t p_new)
+void PlaylistView::on_playlist_activate(size_t p_old, size_t p_new) noexcept
 {
     if (p_old != std::numeric_limits<size_t>::max()) {
         m_playlist_cache.set_item(p_old, save_scroll_position());
@@ -150,7 +152,7 @@ void PlaylistView::on_playlist_activate(size_t p_old, size_t p_new)
         ensure_visible(focus);
 }
 
-void PlaylistView::on_playlist_renamed(size_t playlist, const char* p_new_name, size_t p_new_name_len)
+void PlaylistView::on_playlist_renamed(size_t playlist, const char* p_new_name, size_t p_new_name_len) noexcept
 {
     if (playlist != m_playlist_api->get_active_playlist())
         return;

--- a/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
@@ -287,7 +287,7 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::Drop(
                     playlist_position_reference_tracker m_insertIndexTracker;
                     service_ptr_t<PlaylistView> p_playlist;
 
-                    void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) override
+                    void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) noexcept override
                     {
                         const auto playlist_api = playlist_manager::get();
                         if (m_insertIndexTracker.m_playlist != pfc_infinite && p_items.get_count()) {

--- a/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
@@ -11,7 +11,7 @@ struct edit_view_param {
     bool b_new{};
 };
 
-static INT_PTR CALLBACK EditViewProc(edit_view_param& state, HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+static INT_PTR CALLBACK EditViewProc(edit_view_param& state, HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     switch (msg) {
     case WM_INITDIALOG: {

--- a/foo_ui_columns/order_dropdown.cpp
+++ b/foo_ui_columns/order_dropdown.cpp
@@ -72,7 +72,7 @@ public:
     void on_playlist_renamed(const char* p_new_name, size_t p_new_name_len) override {}
     void on_playlist_locked(bool p_locked) override {}
     void on_default_format_changed() override {}
-    void on_playback_order_changed(size_t p_new_index) override
+    void on_playback_order_changed(size_t p_new_index) noexcept override
     {
         DropDownListToolbar<PlaybackOrderToolbarArgs>::s_update_active_item_safe();
     }

--- a/foo_ui_columns/playlist_switcher_callbacks.cpp
+++ b/foo_ui_columns/playlist_switcher_callbacks.cpp
@@ -4,28 +4,28 @@
 namespace cui::panels::playlist_switcher {
 
 void PlaylistSwitcher::on_items_added(size_t p_playlist, size_t p_start,
-    const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
+    const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) noexcept
 {
     refresh_items(p_playlist, 1);
 }
 void PlaylistSwitcher::on_items_removed(
-    size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
+    size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept
 {
     refresh_items(p_playlist, 1);
 }
 
-void PlaylistSwitcher::on_items_modified(size_t p_playlist, const bit_array& p_mask)
+void PlaylistSwitcher::on_items_modified(size_t p_playlist, const bit_array& p_mask) noexcept
 {
     refresh_items(p_playlist, 1);
 }
 
-void PlaylistSwitcher::on_items_replaced(
-    size_t p_playlist, const bit_array& p_mask, const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data)
+void PlaylistSwitcher::on_items_replaced(size_t p_playlist, const bit_array& p_mask,
+    const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) noexcept
 {
     refresh_items(p_playlist, 1);
 }
 
-void PlaylistSwitcher::on_playlist_activate(size_t p_old, size_t p_new)
+void PlaylistSwitcher::on_playlist_activate(size_t p_old, size_t p_new) noexcept
 {
     if (p_old != pfc_infinite && p_old < get_item_count())
         refresh_items(p_old, 1, false);
@@ -36,12 +36,12 @@ void PlaylistSwitcher::on_playlist_activate(size_t p_old, size_t p_new)
     } else
         set_selection_state(bit_array_true(), bit_array_false(), false);
 }
-void PlaylistSwitcher::on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len)
+void PlaylistSwitcher::on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len) noexcept
 {
     refresh_playing_playlist();
     add_items(p_index, 1);
 }
-void PlaylistSwitcher::on_playlists_reorder(const size_t* p_order, size_t p_count)
+void PlaylistSwitcher::on_playlists_reorder(const size_t* p_order, size_t p_count) noexcept
 {
     refresh_playing_playlist();
     size_t start = 0;
@@ -56,30 +56,30 @@ void PlaylistSwitcher::on_playlists_reorder(const size_t* p_order, size_t p_coun
     if (index != pfc_infinite)
         set_item_selected_single(index, false);
 }
-void PlaylistSwitcher::on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
+void PlaylistSwitcher::on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept
 {
     refresh_playing_playlist();
     remove_items(p_mask);
 }
-void PlaylistSwitcher::on_playlist_renamed(size_t p_index, const char* p_new_name, size_t p_new_name_len)
+void PlaylistSwitcher::on_playlist_renamed(size_t p_index, const char* p_new_name, size_t p_new_name_len) noexcept
 {
     refresh_items(p_index, 1);
 }
 
-void PlaylistSwitcher::on_playlist_locked(size_t p_playlist, bool p_locked)
+void PlaylistSwitcher::on_playlist_locked(size_t p_playlist, bool p_locked) noexcept
 {
     refresh_items(p_playlist, 1);
 }
 
-void PlaylistSwitcher::on_playback_starting(play_control::t_track_command p_command, bool p_paused)
+void PlaylistSwitcher::on_playback_starting(play_control::t_track_command p_command, bool p_paused) noexcept
 {
     on_playing_playlist_change(get_playing_playlist());
 }
-void PlaylistSwitcher::on_playback_new_track(metadb_handle_ptr p_track)
+void PlaylistSwitcher::on_playback_new_track(metadb_handle_ptr p_track) noexcept
 {
     on_playing_playlist_change(get_playing_playlist());
 }
-void PlaylistSwitcher::on_playback_stop(play_control::t_stop_reason p_reason)
+void PlaylistSwitcher::on_playback_stop(play_control::t_stop_reason p_reason) noexcept
 {
     if (p_reason != play_control::stop_reason_shutting_down)
         on_playing_playlist_change(get_playing_playlist());

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -403,7 +403,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
                         bool m_new_playlist{false};
                         pfc::string8 m_playlist_name;
 
-                        void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) override
+                        void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) noexcept override
                         {
                             const auto playlist_api = playlist_manager_v4::get();
                             if ((m_new_playlist || m_insertIndexTracker.m_playlist != pfc_infinite)

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -268,40 +268,41 @@ public:
     void refresh_playing_playlist() { m_playing_playlist = get_playing_playlist(); }
 
     void on_items_added(size_t p_playlist, size_t p_start, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
-        const bit_array& p_selection) override;
+        const bit_array& p_selection) noexcept override;
     void on_items_reordered(size_t p_playlist, const size_t* p_order, size_t p_count) override {}
     void on_items_removing(size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override
     {
     }
-    void on_items_removed(size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
+    void on_items_removed(
+        size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept override;
     void on_items_selection_change(size_t p_playlist, const bit_array& p_affected, const bit_array& p_state) override {}
     void on_item_focus_change(size_t p_playlist, size_t p_from, size_t p_to) override {}
 
-    void on_items_modified(size_t p_playlist, const bit_array& p_mask) override;
+    void on_items_modified(size_t p_playlist, const bit_array& p_mask) noexcept override;
     void on_items_modified_fromplayback(
         size_t p_playlist, const bit_array& p_mask, play_control::t_display_level p_level) override
     {
     }
 
     void on_items_replaced(size_t p_playlist, const bit_array& p_mask,
-        const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) override;
+        const pfc::list_base_const_t<t_on_items_replaced_entry>& p_data) noexcept override;
 
     void on_item_ensure_visible(size_t p_playlist, size_t p_idx) override {}
 
-    void on_playlist_activate(size_t p_old, size_t p_new) override;
-    void on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len) override;
-    void on_playlists_reorder(const size_t* p_order, size_t p_count) override;
+    void on_playlist_activate(size_t p_old, size_t p_new) noexcept override;
+    void on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len) noexcept override;
+    void on_playlists_reorder(const size_t* p_order, size_t p_count) noexcept override;
     void on_playlists_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
-    void on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
-    void on_playlist_renamed(size_t p_index, const char* p_new_name, size_t p_new_name_len) override;
+    void on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept override;
+    void on_playlist_renamed(size_t p_index, const char* p_new_name, size_t p_new_name_len) noexcept override;
 
     void on_default_format_changed() override {}
     void on_playback_order_changed(size_t p_new_index) override {}
-    void on_playlist_locked(size_t p_playlist, bool p_locked) override;
+    void on_playlist_locked(size_t p_playlist, bool p_locked) noexcept override;
 
-    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override;
-    void on_playback_new_track(metadb_handle_ptr p_track) override;
-    void on_playback_stop(play_control::t_stop_reason p_reason) override;
+    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) noexcept override;
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override;
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override;
     void on_playback_seek(double p_time) override {}
     void on_playback_pause(bool p_state) override {}
     void on_playback_edited(metadb_handle_ptr p_track) override {}

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -121,7 +121,7 @@ void PlaylistTabs::switch_to_playlist_delayed2(unsigned idx)
 
 PlaylistTabs::~PlaylistTabs() = default;
 
-LRESULT WINAPI PlaylistTabs::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI PlaylistTabs::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     auto p_this = reinterpret_cast<PlaylistTabs*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
     return p_this ? p_this->hook(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
@@ -710,33 +710,7 @@ void PlaylistTabs::set_styles(bool visible /*= true*/)
     }
 }
 
-void PlaylistTabs::on_playlist_locked(size_t, bool) {}
-
-void PlaylistTabs::on_playback_order_changed(size_t) {}
-
-void PlaylistTabs::on_default_format_changed() {}
-
-void PlaylistTabs::on_playlists_removing(const bit_array&, size_t, size_t) {}
-
-void PlaylistTabs::on_item_ensure_visible(size_t, size_t) {}
-
-void PlaylistTabs::on_items_replaced(size_t, const bit_array&, const pfc::list_base_const_t<t_on_items_replaced_entry>&)
-{
-}
-
-void PlaylistTabs::on_items_modified_fromplayback(size_t, const bit_array&, play_control::t_display_level) {}
-
-void PlaylistTabs::on_items_modified(size_t, const bit_array&) {}
-
-void PlaylistTabs::on_item_focus_change(size_t, size_t, size_t) {}
-
-void PlaylistTabs::on_items_selection_change(size_t, const bit_array&, const bit_array&) {}
-
-void PlaylistTabs::on_items_reordered(size_t, const size_t*, size_t) {}
-
-void PlaylistTabs::on_items_added(size_t, size_t, const pfc::list_base_const_t<metadb_handle_ptr>&, const bit_array&) {}
-
-void PlaylistTabs::on_playlist_renamed(size_t p_index, const char* p_new_name, size_t p_new_name_len)
+void PlaylistTabs::on_playlist_renamed(size_t p_index, const char* p_new_name, size_t p_new_name_len) noexcept
 {
     if (wnd_tabs) {
         uTabCtrl_InsertItemText(wnd_tabs, gsl::narrow<int>(p_index), pfc::string8(p_new_name, p_new_name_len), false);
@@ -745,7 +719,7 @@ void PlaylistTabs::on_playlist_renamed(size_t p_index, const char* p_new_name, s
     }
 }
 
-void PlaylistTabs::on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
+void PlaylistTabs::on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept
 {
     bool need_move = false;
 
@@ -767,7 +741,7 @@ void PlaylistTabs::on_playlists_removed(const bit_array& p_mask, size_t p_old_co
         on_size();
 }
 
-void PlaylistTabs::on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len)
+void PlaylistTabs::on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len) noexcept
 {
     if (wnd_tabs) {
         uTabCtrl_InsertItemText(wnd_tabs, gsl::narrow<int>(p_index), pfc::string8(p_name, p_name_len));
@@ -778,7 +752,7 @@ void PlaylistTabs::on_playlist_created(size_t p_index, const char* p_name, size_
         on_size();
 }
 
-void PlaylistTabs::on_playlists_reorder(const size_t* p_order, size_t p_count)
+void PlaylistTabs::on_playlists_reorder(const size_t* p_order, size_t p_count) noexcept
 {
     if (wnd_tabs) {
         const auto playlist_api = playlist_manager::get();
@@ -797,21 +771,11 @@ void PlaylistTabs::on_playlists_reorder(const size_t* p_order, size_t p_count)
     }
 }
 
-void PlaylistTabs::on_playlist_activate(size_t p_old, size_t p_new)
+void PlaylistTabs::on_playlist_activate(size_t p_old, size_t p_new) noexcept
 {
     if (wnd_tabs) {
         TabCtrl_SetCurSel(wnd_tabs, p_new);
     }
-}
-
-void FB2KAPI PlaylistTabs::on_items_removed(
-    size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
-{
-}
-
-void FB2KAPI PlaylistTabs::on_items_removing(
-    size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
-{
 }
 
 void g_on_autohide_tabs_change()

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -50,7 +50,7 @@ public:
 
     HWND wnd_tabs{nullptr};
     LRESULT WINAPI hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    static LRESULT WINAPI main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     PlaylistTabs() = default;
 
@@ -78,31 +78,34 @@ public:
         wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
     };
 
-    void FB2KAPI on_items_removing(
-        size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
-    // called before actually removing them
-    void FB2KAPI on_items_removed(
-        size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
+    void on_items_removing(size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override
+    {
+    }
+    void on_items_removed(size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override
+    {
+    }
 
-    void on_playlist_activate(size_t p_old, size_t p_new) override;
+    void on_playlist_activate(size_t p_old, size_t p_new) noexcept override;
 
-    void on_playlists_reorder(const size_t* p_order, size_t p_count) override;
-    void on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len) override;
-    void on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
-    void on_playlist_renamed(size_t p_index, const char* p_new_name, size_t p_new_name_len) override;
+    void on_playlists_reorder(const size_t* p_order, size_t p_count) noexcept override;
+    void on_playlist_created(size_t p_index, const char* p_name, size_t p_name_len) noexcept override;
+    void on_playlists_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept override;
+    void on_playlist_renamed(size_t p_index, const char* p_new_name, size_t p_new_name_len) noexcept override;
 
-    void on_items_added(size_t, size_t, const pfc::list_base_const_t<metadb_handle_ptr>&, const bit_array&) override;
-    void on_items_reordered(size_t, const size_t*, size_t) override;
-    void on_items_selection_change(size_t, const bit_array&, const bit_array&) override;
-    void on_item_focus_change(size_t, size_t, size_t) override;
-    void on_items_modified(size_t, const bit_array&) override;
-    void on_items_modified_fromplayback(size_t, const bit_array&, play_control::t_display_level) override;
-    void on_items_replaced(size_t, const bit_array&, const pfc::list_base_const_t<t_on_items_replaced_entry>&) override;
-    void on_item_ensure_visible(size_t, size_t) override;
-    void on_playlists_removing(const bit_array&, size_t, size_t) override;
-    void on_default_format_changed() override;
-    void on_playback_order_changed(size_t) override;
-    void on_playlist_locked(size_t, bool) override;
+    void on_items_added(size_t, size_t, const pfc::list_base_const_t<metadb_handle_ptr>&, const bit_array&) override {}
+    void on_items_reordered(size_t, const size_t*, size_t) override {}
+    void on_items_selection_change(size_t, const bit_array&, const bit_array&) override {}
+    void on_item_focus_change(size_t, size_t, size_t) override {}
+    void on_items_modified(size_t, const bit_array&) override {}
+    void on_items_modified_fromplayback(size_t, const bit_array&, play_control::t_display_level) override {}
+    void on_items_replaced(size_t, const bit_array&, const pfc::list_base_const_t<t_on_items_replaced_entry>&) override
+    {
+    }
+    void on_item_ensure_visible(size_t, size_t) override {}
+    void on_playlists_removing(const bit_array&, size_t, size_t) override {}
+    void on_default_format_changed() override {}
+    void on_playback_order_changed(size_t) override {}
+    void on_playlist_locked(size_t, bool) override {}
 
     void kill_switch_timer();
 

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -787,7 +787,7 @@ void RebarWindow::refresh_bands()
     fix_z_order();
 }
 
-LRESULT RebarWindow::s_handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT RebarWindow::s_handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     const auto self = reinterpret_cast<RebarWindow*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
     return self ? self->handle_hooked_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -128,7 +128,7 @@ public:
     }
 
 private:
-    static LRESULT WINAPI s_handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI s_handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
 
     LRESULT WINAPI handle_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     void destroy_bands();

--- a/foo_ui_columns/seekbar.cpp
+++ b/foo_ui_columns/seekbar.cpp
@@ -75,7 +75,7 @@ void SeekBarToolbar::update_seek_pos()
     }
 }
 
-VOID CALLBACK SeekBarToolbar::SeekTimerProc(HWND wnd, UINT msg, UINT event, DWORD time)
+VOID CALLBACK SeekBarToolbar::SeekTimerProc(HWND wnd, UINT msg, UINT event, DWORD time) noexcept
 {
     if (windows.get_count() && playback_control::get()->is_playing())
         update_seekbars(true);

--- a/foo_ui_columns/seekbar.h
+++ b/foo_ui_columns/seekbar.h
@@ -29,7 +29,7 @@ public:
     unsigned get_type() const override;
 
     static void update_seek_timer();
-    static VOID CALLBACK SeekTimerProc(HWND wnd, UINT msg, UINT event, DWORD time);
+    static VOID CALLBACK SeekTimerProc(HWND wnd, UINT msg, UINT event, DWORD time) noexcept;
     static void update_seekbars(bool positions_only = false);
 
 private:

--- a/foo_ui_columns/seekbar_callbacks.cpp
+++ b/foo_ui_columns/seekbar_callbacks.cpp
@@ -7,20 +7,20 @@ class SeekBarPlayCallback : public play_callback_static {
 public:
     unsigned get_flags() override { return flags; }
     void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
-    void on_playback_new_track(metadb_handle_ptr p_track) override
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override
     {
         SeekBarToolbar::update_seekbars();
         SeekBarToolbar::update_seek_timer();
     }
 
-    void on_playback_stop(play_control::t_stop_reason p_reason) override
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override
     {
         SeekBarToolbar::update_seek_timer();
         if (p_reason != play_control::stop_reason_shutting_down)
             SeekBarToolbar::update_seekbars();
     }
-    void on_playback_seek(double p_time) override { SeekBarToolbar::update_seekbars(true); }
-    void on_playback_pause(bool b_state) override { SeekBarToolbar::update_seek_timer(); }
+    void on_playback_seek(double p_time) noexcept override { SeekBarToolbar::update_seekbars(true); }
+    void on_playback_pause(bool b_state) noexcept override { SeekBarToolbar::update_seek_timer(); }
 
     void on_playback_edited(metadb_handle_ptr p_track) override {}
 

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -983,7 +983,7 @@ void TabStackPanel::on_active_tab_changed(int signed_index_to, bool from_interac
         SetFocus(m_wnd_tabs);
 }
 
-LRESULT WINAPI TabStackPanel::g_hook_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI TabStackPanel::g_hook_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     auto p_this = reinterpret_cast<TabStackPanel*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
     return p_this ? p_this->on_hooked_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -114,7 +114,7 @@ public:
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     LRESULT WINAPI on_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    static LRESULT WINAPI g_hook_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI g_hook_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     WNDPROC m_tab_proc{nullptr};
 
     void create_tabs();

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -75,7 +75,7 @@ StatusBarFontClient::factory<StatusBarFontClient> g_font_client_status;
 
 } // namespace
 
-LRESULT WINAPI g_status_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI g_status_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
     switch (msg) {
     case WM_ERASEBKGND:

--- a/foo_ui_columns/status_bar_callbacks.cpp
+++ b/foo_ui_columns/status_bar_callbacks.cpp
@@ -13,28 +13,28 @@ public:
 
     unsigned get_flags() override { return flags; }
 
-    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override
+    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) noexcept override
     {
         set_playback_information("Loading track.."sv);
     }
 
-    void on_playback_new_track(metadb_handle_ptr p_track) override { regenerate_text(); }
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override { regenerate_text(); }
 
-    void on_playback_stop(play_control::t_stop_reason p_reason) override
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override
     {
         if (p_reason != play_control::stop_reason_shutting_down) {
             set_playback_information({core_version_info::g_get_version_string()});
         }
     }
-    void on_playback_seek(double p_time) override { regenerate_text(); }
-    void on_playback_pause(bool b_state) override { regenerate_text(); }
+    void on_playback_seek(double p_time) noexcept override { regenerate_text(); }
+    void on_playback_pause(bool b_state) noexcept override { regenerate_text(); }
 
-    void on_playback_edited(metadb_handle_ptr p_track) override { regenerate_text(); }
+    void on_playback_edited(metadb_handle_ptr p_track) noexcept override { regenerate_text(); }
 
-    void on_playback_dynamic_info(const file_info& p_info) override { regenerate_text(); }
-    void on_playback_dynamic_info_track(const file_info& p_info) override { regenerate_text(); }
-    void on_playback_time(double p_time) override { regenerate_text(); }
-    void on_volume_change(float p_new_val) override { set_part_sizes(t_part_volume); }
+    void on_playback_dynamic_info(const file_info& p_info) noexcept override { regenerate_text(); }
+    void on_playback_dynamic_info_track(const file_info& p_info) noexcept override { regenerate_text(); }
+    void on_playback_time(double p_time) noexcept override { regenerate_text(); }
+    void on_volume_change(float p_new_val) noexcept override { set_part_sizes(t_part_volume); }
 };
 
 static play_callback_static_factory_t<StatusBarPlayCalllback> status_bar_play_callback;
@@ -68,7 +68,7 @@ class StatusBarPlaylistCallback : public playlist_callback_static {
     }
     void on_item_ensure_visible(size_t p_playlist, size_t idx) override {}
 
-    void on_playlist_activate(size_t p_old, size_t p_new) override
+    void on_playlist_activate(size_t p_old, size_t p_new) noexcept override
     {
         if (main_window::config_get_status_show_lock())
             set_part_sizes(t_part_lock);
@@ -82,7 +82,7 @@ class StatusBarPlaylistCallback : public playlist_callback_static {
 
     void on_default_format_changed() override {}
     void on_playback_order_changed(size_t p_new_index) override {}
-    void on_playlist_locked(size_t p_playlist, bool p_locked) override
+    void on_playlist_locked(size_t p_playlist, bool p_locked) noexcept override
     {
         if (main_window::config_get_status_show_lock())
             set_part_sizes(t_part_lock);

--- a/foo_ui_columns/status_pane.h
+++ b/foo_ui_columns/status_pane.h
@@ -42,18 +42,18 @@ class StatusPane
     };
 
     /** PLAYLIST CALLBACKS */
-    void on_items_added(
-        size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override
+    void on_items_added(size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
+        const bit_array& p_selection) noexcept override
     {
         on_playlist_change();
     }
     void on_items_reordered(const size_t* p_order, size_t p_count) override {}
     void on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
-    void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override
+    void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) noexcept override
     {
         on_playlist_change();
     }
-    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) override
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept override
     {
         on_playlist_change();
     }
@@ -66,7 +66,7 @@ class StatusPane
     }
     void on_item_ensure_visible(size_t p_idx) override {}
 
-    void on_playlist_switch() override { on_playlist_change(); }
+    void on_playlist_switch() noexcept override { on_playlist_change(); }
     void on_playlist_renamed(const char* p_new_name, size_t p_new_name_len) override {}
     void on_playlist_locked(bool p_locked) override {}
 
@@ -74,13 +74,13 @@ class StatusPane
     void on_playback_order_changed(size_t p_new_index) override {}
 
     /** PLAY CALLBACKS */
-    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override
+    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) noexcept override
     {
         m_track_label = "Opening...";
         invalidate_all();
     }
 
-    void on_playback_new_track(metadb_handle_ptr p_track) override
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override
     {
         // Note: On start-up, playback can actually be paused when we get here
         // (and on_playback_pause() won't be called).
@@ -89,7 +89,7 @@ class StatusPane
         invalidate_all();
     }
 
-    void on_playback_stop(play_control::t_stop_reason p_reason) override
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override
     {
         if (p_reason != playback_control::stop_reason_shutting_down) {
             m_track_label = "";
@@ -98,33 +98,33 @@ class StatusPane
         }
     }
 
-    void on_playback_seek(double p_time) override
+    void on_playback_seek(double p_time) noexcept override
     {
         update_playing_text();
         invalidate_all();
     }
-    void on_playback_pause(bool p_state) override
+    void on_playback_pause(bool p_state) noexcept override
     {
         m_track_label = p_state ? "Paused:" : "Playing:";
         update_playing_text();
         invalidate_all();
     }
-    void on_playback_edited(metadb_handle_ptr p_track) override
+    void on_playback_edited(metadb_handle_ptr p_track) noexcept override
     {
         update_playing_text();
         invalidate_all();
     }
-    void on_playback_dynamic_info(const file_info& p_info) override
+    void on_playback_dynamic_info(const file_info& p_info) noexcept override
     {
         update_playing_text();
         invalidate_all();
     }
-    void on_playback_dynamic_info_track(const file_info& p_info) override
+    void on_playback_dynamic_info_track(const file_info& p_info) noexcept override
     {
         update_playing_text();
         invalidate_all();
     }
-    void on_playback_time(double p_time) override
+    void on_playback_time(double p_time) noexcept override
     {
         update_playing_text();
         invalidate_all();

--- a/foo_ui_columns/system_appearance_manager.cpp
+++ b/foo_ui_columns/system_appearance_manager.cpp
@@ -202,7 +202,7 @@ AppearanceMessageWindow message_window;
 
 class InitQuit : public initquit {
     void on_init() override {}
-    void on_quit() override { message_window.deinitialise(); }
+    void on_quit() noexcept override { message_window.deinitialise(); }
 };
 
 initquit_factory_t<InitQuit> _;

--- a/foo_ui_columns/system_tray_callbacks.cpp
+++ b/foo_ui_columns/system_tray_callbacks.cpp
@@ -9,9 +9,9 @@ class SystemTrayPlayCallback : public play_callback_static {
 public:
     unsigned get_flags() override { return flags; }
     void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
-    void on_playback_new_track(metadb_handle_ptr p_track) override { update_systray(true); }
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override { update_systray(true); }
 
-    void on_playback_stop(play_control::t_stop_reason p_reason) override
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override
     {
         if (g_icon_created && p_reason != play_control::stop_reason_shutting_down) {
             uShellNotifyIcon(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon,
@@ -19,12 +19,12 @@ public:
         }
     }
     void on_playback_seek(double p_time) override {}
-    void on_playback_pause(bool b_state) override { update_systray(true, b_state ? 2 : 1); }
+    void on_playback_pause(bool b_state) noexcept override { update_systray(true, b_state ? 2 : 1); }
 
     void on_playback_edited(metadb_handle_ptr p_track) override {}
 
     void on_playback_dynamic_info(const file_info& p_info) override {}
-    void on_playback_dynamic_info_track(const file_info& p_info) override { update_systray(true); }
+    void on_playback_dynamic_info_track(const file_info& p_info) noexcept override { update_systray(true); }
     void on_playback_time(double p_time) override {}
     void on_volume_change(float p_new_val) override {}
 

--- a/foo_ui_columns/user_interface_impl.cpp
+++ b/foo_ui_columns/user_interface_impl.cpp
@@ -238,7 +238,7 @@ public:
 };
 
 class InitQuit : public initquit {
-    void on_init() override { fbh::enable_wil_console_logging(); }
+    void on_init() noexcept override { fbh::enable_wil_console_logging(); }
     void on_quit() override {}
 };
 

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -145,7 +145,7 @@ private:
     inline static wil::unique_hbrush s_foreground_brush;
     inline static wil::unique_hbrush s_background_brush;
 
-    static void CALLBACK g_timer_proc(HWND wnd, UINT msg, UINT_PTR id_event, DWORD time);
+    static void CALLBACK g_timer_proc(HWND wnd, UINT msg, UINT_PTR id_event, DWORD time) noexcept;
 
     void refresh(const audio_chunk* p_chunk);
     static void s_create_timer()
@@ -164,9 +164,9 @@ private:
         }
     }
 
-    void FB2KAPI on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
-    void FB2KAPI on_playback_new_track(metadb_handle_ptr p_track) override { g_register_stream(this); }
-    void FB2KAPI on_playback_stop(play_control::t_stop_reason p_reason) override
+    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override { g_register_stream(this); }
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override
     {
         const auto should_clear = p_reason != play_control::stop_reason_shutting_down;
         g_deregister_stream(this, !should_clear);
@@ -174,19 +174,19 @@ private:
         if (should_clear)
             s_flush_brushes();
     }
-    void FB2KAPI on_playback_seek(double p_time) override {}
-    void FB2KAPI on_playback_pause(bool p_state) override
+    void on_playback_seek(double p_time) override {}
+    void on_playback_pause(bool p_state) noexcept override
     {
         if (p_state)
             g_deregister_stream(this, true);
         else
             g_register_stream(this);
     }
-    void FB2KAPI on_playback_edited(metadb_handle_ptr p_track) override {}
-    void FB2KAPI on_playback_dynamic_info(const file_info& p_info) override {}
-    void FB2KAPI on_playback_dynamic_info_track(const file_info& p_info) override {}
-    void FB2KAPI on_playback_time(double p_time) override {}
-    void FB2KAPI on_volume_change(float p_new_val) override {}
+    void on_playback_edited(metadb_handle_ptr p_track) override {}
+    void on_playback_dynamic_info(const file_info& p_info) override {}
+    void on_playback_dynamic_info_track(const file_info& p_info) override {}
+    void on_playback_time(double p_time) override {}
+    void on_volume_change(float p_new_val) override {}
 };
 
 SpectrumAnalyserVisualisation::SpectrumAnalyserVisualisation()
@@ -360,7 +360,7 @@ bool SpectrumAnalyserVisualisation::show_config_popup(HWND wnd_parent)
     return false;
 }
 
-void CALLBACK SpectrumAnalyserVisualisation::g_timer_proc(HWND wnd, UINT msg, UINT_PTR id_event, DWORD time)
+void CALLBACK SpectrumAnalyserVisualisation::g_timer_proc(HWND wnd, UINT msg, UINT_PTR id_event, DWORD time) noexcept
 {
     s_refresh_all();
 }

--- a/foo_ui_columns/volume.h
+++ b/foo_ui_columns/volume.h
@@ -350,16 +350,16 @@ private:
         return uGetTextExtentPoint32(dc.get(), label_text.data(), gsl::narrow<UINT>(label_text.size()), &p_out) != 0;
     }
 
-    void FB2KAPI on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
-    void FB2KAPI on_playback_new_track(metadb_handle_ptr p_track) override {}
-    void FB2KAPI on_playback_stop(play_control::t_stop_reason p_reason) override {}
-    void FB2KAPI on_playback_seek(double p_time) override {}
-    void FB2KAPI on_playback_pause(bool p_state) override {}
-    void FB2KAPI on_playback_edited(metadb_handle_ptr p_track) override {}
-    void FB2KAPI on_playback_dynamic_info(const file_info& p_info) override {}
-    void FB2KAPI on_playback_dynamic_info_track(const file_info& p_info) override {}
-    void FB2KAPI on_playback_time(double p_time) override {}
-    void FB2KAPI on_volume_change(float p_new_val) override { update_position(p_new_val); }
+    void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
+    void on_playback_new_track(metadb_handle_ptr p_track) override {}
+    void on_playback_stop(play_control::t_stop_reason p_reason) override {}
+    void on_playback_seek(double p_time) override {}
+    void on_playback_pause(bool p_state) override {}
+    void on_playback_edited(metadb_handle_ptr p_track) override {}
+    void on_playback_dynamic_info(const file_info& p_info) override {}
+    void on_playback_dynamic_info_track(const file_info& p_info) override {}
+    void on_playback_time(double p_time) override {}
+    void on_volume_change(float p_new_val) noexcept override { update_position(p_new_val); }
 
     constexpr static auto label_text = "Volume"sv;
 


### PR DESCRIPTION
This marks various callback functions passed to the Win32 and foobar2000 APIs as noexcept.

This is as they aren't allowed to throw C++ exceptions. `noexcept` will result in `std::terminate` being called if an unhandled C++ exception occurs.