### PR TITLE
Use modal_dialog_scope and modeless_dialog_manager consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,10 @@
 - Command-line help was updated to include previously undocumented export
   commands. [[#1048](https://github.com/reupen/columns_ui/pull/1048)]
 
+- Concurrent modal dialogue boxes are now morely consistently avoided in line
+  with foobar2000 conventions.
+  [[#1050](https://github.com/reupen/columns_ui/pull/1050)]
+
 ### Internal changes
 
 - Handling of fatal unexpected C++ exceptions was improved in some scenarios.

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -268,7 +268,6 @@ public:
 
         ConfigParam();
 
-        modal_dialog_scope m_scope;
         // uih::ListView m_button_list;
         bool m_initialising{};
         Button* m_selection{nullptr};
@@ -378,7 +377,6 @@ private:
     void deinitialise(HWND wnd);
     INT_PTR on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
-    modal_dialog_scope m_scope;
     std::vector<std::unique_ptr<CommandData>> m_commands;
     HWND m_wnd{};
     HWND wnd_group{};

--- a/foo_ui_columns/buttons_command_picker.cpp
+++ b/foo_ui_columns/buttons_command_picker.cpp
@@ -252,7 +252,6 @@ INT_PTR CommandPickerDialog::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
 {
     switch (msg) {
     case WM_INITDIALOG: {
-        m_scope.initialize(FindOwningPopup(wnd));
         initialise(wnd);
         populate_commands();
         SendMessage(wnd_filter, LB_SETCURSEL, static_cast<WPARAM>(m_data.filter), 0);

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -242,7 +242,6 @@ INT_PTR ButtonsToolbar::ConfigParam::on_dialog_message(HWND wnd, UINT msg, WPARA
     case WM_INITDIALOG: {
         const auto _ = pfc::vartoggle_t(m_initialising, true);
         m_wnd = wnd;
-        m_scope.initialize(FindOwningPopup(wnd));
 
         m_h1_font.reset(prefs::create_default_ui_font(12));
         m_h2_font.reset(prefs::create_default_ui_font(10));

--- a/foo_ui_columns/dark_mode_dialog.cpp
+++ b/foo_ui_columns/dark_mode_dialog.cpp
@@ -288,7 +288,7 @@ void DialogDarkModeHelper::on_dark_mode_change()
 INT_PTR modal_dialog_box(UINT resource_id, DialogDarkModeConfig dark_mode_config, HWND parent_window,
     std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
 {
-    return uih::modal_dialog_box(resource_id, parent_window,
+    return fbh::modal_dialog_box(resource_id, parent_window,
         [helper = std::make_shared<DialogDarkModeHelper>(std::move(dark_mode_config)),
             on_message{std::move(on_message)}](HWND wnd, UINT msg, WPARAM wp, LPARAM lp) {
             if (const auto result = helper->handle_message(wnd, msg, wp, lp))
@@ -301,7 +301,7 @@ INT_PTR modal_dialog_box(UINT resource_id, DialogDarkModeConfig dark_mode_config
 HWND modeless_dialog_box(UINT resource_id, DialogDarkModeConfig dark_mode_config, HWND parent_window,
     std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
 {
-    const auto wnd = uih::modeless_dialog_box(resource_id, parent_window,
+    const auto wnd = fbh::modeless_dialog_box(resource_id, parent_window,
         [helper = std::make_shared<DialogDarkModeHelper>(std::move(dark_mode_config)),
             on_message{std::move(on_message)}](HWND wnd, UINT msg, WPARAM wp, LPARAM lp) {
             if (const auto result = helper->handle_message(wnd, msg, wp, lp))

--- a/foo_ui_columns/fcl.cpp
+++ b/foo_ui_columns/fcl.cpp
@@ -224,7 +224,6 @@ private:
     {
         switch (msg) {
         case WM_INITDIALOG: {
-            modeless_dialog_manager::g_add(wnd);
             SetWindowText(wnd, L"FCL import results");
             SetWindowText(GetDlgItem(wnd, IDC_CAPTION),
                 m_aborted ? L"The layout import was aborted because the following required panels are not installed:"
@@ -251,9 +250,6 @@ private:
         case WM_CLOSE:
             DestroyWindow(wnd);
             return 0;
-        case WM_NCDESTROY:
-            modeless_dialog_manager::g_remove(wnd);
-            break;
         }
 
         return FALSE;

--- a/foo_ui_columns/font_picker.cpp
+++ b/foo_ui_columns/font_picker.cpp
@@ -86,7 +86,6 @@ private:
     {
         switch (msg) {
         case WM_INITDIALOG: {
-            m_scope.initialize(wnd);
             m_wnd = wnd;
             m_axis_wnd = GetDlgItem(wnd, IDC_AXIS);
 
@@ -205,7 +204,6 @@ private:
     uih::direct_write::AxisValues m_axis_values;
     uih::direct_write::AxisValues m_initial_axis_values;
     std::function<void(const uih::direct_write::AxisValues&)> m_on_values_change;
-    modal_dialog_scope m_scope;
     HWND m_wnd{};
     HWND m_axis_wnd{};
     int m_spin_step{10};

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -61,7 +61,6 @@ INT_PTR CALLBACK ItemDetailsConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
         m_wnd = wnd;
 
         if (!m_modal) {
-            modeless_dialog_manager::g_add(wnd);
             m_this->set_config_wnd(wnd);
             ShowWindow(GetDlgItem(wnd, IDOK), SW_HIDE);
             SetWindowText(GetDlgItem(wnd, IDCANCEL), L"Close");
@@ -106,9 +105,6 @@ INT_PTR CALLBACK ItemDetailsConfig::on_message(HWND wnd, UINT msg, WPARAM wp, LP
         break;
     case WM_NCDESTROY:
         m_wnd = nullptr;
-        if (!m_modal) {
-            modeless_dialog_manager::g_remove(wnd);
-        }
         break;
     case WM_CLOSE:
         if (m_modal) {
@@ -217,8 +213,6 @@ void ItemDetailsConfig::open_format_code_generator()
 
             switch (msg) {
             case WM_INITDIALOG: {
-                modeless_dialog_manager::g_add(wnd);
-
                 const auto font
                     = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_item_details_font_client);
 
@@ -241,7 +235,6 @@ void ItemDetailsConfig::open_format_code_generator()
             }
             case WM_DESTROY:
                 SendMessage(wnd_parent, MSG_FORMAT_GENERATOR_CLOSED, 0, 0);
-                modeless_dialog_manager::g_remove(wnd);
                 break;
             case WM_COMMAND:
                 if (wp == IDCANCEL)

--- a/foo_ui_columns/rename_dialog.cpp
+++ b/foo_ui_columns/rename_dialog.cpp
@@ -9,7 +9,6 @@ class RenameDialogBoxState {
 public:
     pfc::string8 m_text;
     pfc::string8 m_title;
-    modal_dialog_scope m_scope;
 };
 
 static INT_PTR CALLBACK show_rename_dialog_box_proc(
@@ -17,7 +16,6 @@ static INT_PTR CALLBACK show_rename_dialog_box_proc(
 {
     switch (msg) {
     case WM_INITDIALOG:
-        state.m_scope.initialize(FindOwningPopup(wnd));
         uSetWindowText(wnd, state.m_title);
         uih::enhance_edit_control(wnd, IDC_EDIT);
         uSetDlgItemText(wnd, IDC_EDIT, state.m_text);

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -11,7 +11,6 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
     switch (msg) {
     case WM_INITDIALOG: {
         m_wnd = wnd;
-        modeless_dialog_manager::g_add(wnd);
         s_instances.emplace_back(this);
 
         m_presets_list_view.create(wnd, {14, 18, 240, 67}, true);
@@ -147,7 +146,6 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
     case WM_DESTROY:
         m_presets_list_view.destroy();
         std::erase(s_instances, this);
-        modeless_dialog_manager::g_remove(wnd);
         break;
     case WM_NCDESTROY:
         return FALSE;

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -255,7 +255,6 @@ void SpectrumAnalyserVisualisation::disable()
 
 class SpectrumAnalyserConfigData {
 public:
-    modal_dialog_scope m_scope;
     unsigned mode;
     uint32_t m_scale;
     uint32_t m_vertical_scale;
@@ -284,8 +283,6 @@ static INT_PTR CALLBACK SpectrumPopupProc(SpectrumAnalyserConfigData& state, HWN
 {
     switch (msg) {
     case WM_INITDIALOG: {
-        state.m_scope.initialize(FindOwningPopup(wnd));
-
         SendDlgItemMessage(wnd, IDC_BARS, BM_SETCHECK, state.ptr->mode == MODE_BARS, 0);
         HWND wnd_combo = GetDlgItem(wnd, IDC_FRAME_COMBO);
         EnableWindow(wnd_combo, state.b_show_frame);


### PR DESCRIPTION
This switches to using new fbh helpers for modeless and modal dialogs that handle `ModalDialogPrologue()`, `modal_dialog_scope` and `modeless_dialog_manager` automatically.

This in turn makes usage of `ModalDialogPrologue()` and `modal_dialog_scope` for modal dialogs more consistent than it was previously.