### PR TITLE
Replace uses of legacy helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,8 @@
 
 - The component is now compiled with Visual Studio 2022 17.12.
 
+- Some internal changes were made to clean up and modernise code.
+
 ## 2.1.0
 
 ### Features

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -187,7 +187,7 @@ public:
         void load_default_image(
             const service_ptr_t<uie::button>& button_ptr, COLORREF colour_btnface, int width, int height);
 
-        wil::com_ptr_t<IWICBitmapSource> m_bitmap_source;
+        wil::com_ptr<IWICBitmapSource> m_bitmap_source;
         std::optional<std::tuple<int, int>> m_bitmap_source_size;
 
         wil::unique_hbitmap m_bm;
@@ -227,8 +227,8 @@ public:
                 long drop_ref_count;
                 bool last_rmb;
                 ButtonsList* m_button_list_view;
-                wil::com_ptr_t<IDataObject> m_DataObject;
-                wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
+                wil::com_ptr<IDataObject> m_DataObject;
+                wil::com_ptr<IDropTargetHelper> m_DropTargetHelper;
                 // pfc::string
             public:
                 HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID FAR* ppvObject) override;

--- a/foo_ui_columns/buttons_config_listview.cpp
+++ b/foo_ui_columns/buttons_config_listview.cpp
@@ -17,7 +17,7 @@ void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_initialisation()
 }
 void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_create()
 {
-    wil::com_ptr_t<ButtonsListDropTarget> IDT_blv = new ButtonsListDropTarget(this);
+    wil::com_ptr<ButtonsListDropTarget> IDT_blv = new ButtonsListDropTarget(this);
     RegisterDragDrop(get_wnd(), IDT_blv.get());
 }
 void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_destroy()
@@ -34,7 +34,7 @@ void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_selection_change(
 bool ButtonsToolbar::ConfigParam::ButtonsList::do_drag_drop(WPARAM wp)
 {
     UINT cf = g_clipformat();
-    wil::com_ptr_t<IDataObject> pDO = new CDataObject;
+    wil::com_ptr<IDataObject> pDO = new CDataObject;
 
     DDData data = {0, get_wnd()};
     uih::ole::set_blob(pDO.get(), cf, &data, sizeof(data));

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -29,7 +29,7 @@ public:
         return column <= 1 && indices.get_count() == 1;
     }
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-        pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override
+        pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override
     {
         size_t indices_count = indices.get_count();
         if (indices_count == 1 && indices[0] < cui::panels::filter::cfg_field_list.get_count()) {

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -204,7 +204,7 @@ private:
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<size_t>& indices, size_t column, bool b_source_mouse) override;
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-        pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override;
+        pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
     void notify_exit_inline_edit() override;
     void notify_on_set_focus(HWND wnd_lost) override;

--- a/foo_ui_columns/filter_inline_edit.cpp
+++ b/foo_ui_columns/filter_inline_edit.cpp
@@ -10,7 +10,7 @@ bool FilterPanel::notify_before_create_inline_edit(
         && indices[0] != 0;
 }
 bool FilterPanel::notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-    pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
+    pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries)
 {
     size_t indices_count = indices.get_count();
     if (!m_field_data.m_use_script && !m_field_data.m_fields.empty() && indices_count == 1

--- a/foo_ui_columns/font_manager_v3.cpp
+++ b/foo_ui_columns/font_manager_v3.cpp
@@ -66,7 +66,7 @@ public:
             pfc::com_ptr_t<IDWriteTextFormat> text_format;
 
             if (factory_7 && !m_axis_values.empty()) {
-                wil::com_ptr_t<IDWriteTextFormat3> text_format_3;
+                wil::com_ptr<IDWriteTextFormat3> text_format_3;
                 THROW_IF_FAILED(factory_7->CreateTextFormat(m_typographic_family_name.c_str(), nullptr,
                     m_axis_values.data(), gsl::narrow<uint32_t>(m_axis_values.size()), size(), L"", &text_format_3));
                 text_format.attach(text_format_3.detach());
@@ -83,7 +83,7 @@ public:
             pfc::com_ptr_t<IDWriteTextFormat> text_format;
 
             if (factory_7 && !m_axis_values.empty()) {
-                wil::com_ptr_t<IDWriteTextFormat3> text_format_3;
+                wil::com_ptr<IDWriteTextFormat3> text_format_3;
                 THROW_IF_FAILED(factory_7->CreateTextFormat(L"", nullptr, m_axis_values.data(),
                     gsl::narrow<uint32_t>(m_axis_values.size()), size(), L"", &text_format_3));
                 text_format.attach(text_format_3.detach());

--- a/foo_ui_columns/font_picker.cpp
+++ b/foo_ui_columns/font_picker.cpp
@@ -538,14 +538,14 @@ const wchar_t* DirectWriteFontPicker::get_font_face_combobox_item_text(uint32_t 
     return custom_axis_values_label;
 }
 
-wil::com_ptr_t<IDWriteFontFamily> DirectWriteFontPicker::get_icon_font_family() const
+wil::com_ptr<IDWriteFontFamily> DirectWriteFontPicker::get_icon_font_family() const
 {
     LOGFONT log_font{};
     THROW_IF_WIN32_BOOL_FALSE(SystemParametersInfo(SPI_GETICONTITLELOGFONT, 0, &log_font, 0));
 
     const auto font = m_direct_write_context->create_font(log_font);
 
-    wil::com_ptr_t<IDWriteFontFamily> font_family;
+    wil::com_ptr<IDWriteFontFamily> font_family;
     THROW_IF_FAILED(font->GetFontFamily(&font_family));
 
     return font_family;

--- a/foo_ui_columns/font_picker.h
+++ b/foo_ui_columns/font_picker.h
@@ -21,7 +21,7 @@ private:
     std::optional<INT_PTR> handle_wm_draw_item(LPDRAWITEMSTRUCT dis);
 
     const wchar_t* get_font_face_combobox_item_text(uint32_t index) const;
-    wil::com_ptr_t<IDWriteFontFamily> get_icon_font_family() const;
+    wil::com_ptr<IDWriteFontFamily> get_icon_font_family() const;
     uih::direct_write::TextFormat& get_family_text_format(size_t index);
     uih::direct_write::TextFormat& get_face_text_format(size_t index);
 

--- a/foo_ui_columns/font_utils.cpp
+++ b/foo_ui_columns/font_utils.cpp
@@ -47,16 +47,16 @@ void FontDescription::fill_wss()
     if (wss)
         return;
 
-    wil::com_ptr_t<IDWriteFont> font;
+    wil::com_ptr<IDWriteFont> font;
     std::wstring family_name;
     try {
         const auto context = uih::direct_write::Context::s_create();
         font = context->create_font(log_font);
 
-        wil::com_ptr_t<IDWriteFontFamily> font_family;
+        wil::com_ptr<IDWriteFontFamily> font_family;
         THROW_IF_FAILED(font->GetFontFamily(&font_family));
 
-        wil::com_ptr_t<IDWriteLocalizedStrings> family_names;
+        wil::com_ptr<IDWriteLocalizedStrings> family_names;
         THROW_IF_FAILED(font_family->GetFamilyNames(&family_names));
 
         family_name = uih::direct_write::get_localised_string(family_names);

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -85,10 +85,10 @@ std::optional<FormatProperties> parse_font_code(
     try {
         const auto direct_write_font = direct_write_context->create_font(lf);
 
-        wil::com_ptr_t<IDWriteFontFamily> font_family;
+        wil::com_ptr<IDWriteFontFamily> font_family;
         THROW_IF_FAILED(direct_write_font->GetFontFamily(&font_family));
 
-        wil::com_ptr_t<IDWriteLocalizedStrings> localised_strings;
+        wil::com_ptr<IDWriteLocalizedStrings> localised_strings;
         THROW_IF_FAILED(font_family->GetFamilyNames(&localised_strings));
 
         auto family_name = uih::direct_write::get_localised_string(localised_strings);

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -803,7 +803,7 @@ void ItemProperties::notify_save_inline_edit(const char* value)
 }
 
 bool ItemProperties::notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-    pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
+    pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries)
 {
     const size_t indices_count = indices.get_count();
 
@@ -822,14 +822,14 @@ bool ItemProperties::notify_create_inline_edit(const pfc::list_base_const_t<size
     }
 
     p_flags |= inline_edit_autocomplete;
-    pfc::com_ptr_t<IUnknown> autocomplete_entries;
+    pfc::com_ptr_t<IUnknown> local_autocomplete_entries;
 
     if (m_library_autocomplete_v2.is_valid())
-        m_library_autocomplete_v2->get_value_list_async(m_edit_field, autocomplete_entries);
+        m_library_autocomplete_v2->get_value_list_async(m_edit_field, local_autocomplete_entries);
     else
-        m_library_autocomplete_v1->get_value_list(m_edit_field, autocomplete_entries);
+        m_library_autocomplete_v1->get_value_list(m_edit_field, local_autocomplete_entries);
 
-    pAutocompleteEntries = autocomplete_entries.get_ptr();
+    autocomplete_entries.attach(local_autocomplete_entries.detach());
     helpers::EditMetadataFieldValueAggregator aggregator;
 
     for (const auto& track : m_edit_handles) {

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -35,7 +35,7 @@ public:
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<size_t>& indices, size_t column, bool b_source_mouse) override;
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-        pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override;
+        pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
 
 private:
@@ -159,7 +159,7 @@ public:
         const pfc::list_base_const_t<size_t>& indices, size_t column, bool b_source_mouse) override;
     static void s_print_field(const char* field, const file_info& p_info, pfc::string_base& p_out);
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-        pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override;
+        pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
 
     // UI SEL API

--- a/foo_ui_columns/item_properties_config_list_view.cpp
+++ b/foo_ui_columns/item_properties_config_list_view.cpp
@@ -18,7 +18,7 @@ void FieldsList::notify_save_inline_edit(const char* value)
 }
 
 bool FieldsList::notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-    pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
+    pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries)
 {
     size_t indices_count = indices.get_count();
     if (indices_count == 1 && indices[0] < m_fields.get_count()) {

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -87,7 +87,7 @@ private:
     void update_taskbar_buttons(bool update) const;
 
     pfc::string8 m_window_title;
-    wil::com_ptr_t<ITaskbarList3> m_taskbar_list;
+    wil::com_ptr<ITaskbarList3> m_taskbar_list;
     HWND m_wnd{};
     HMONITOR m_monitor{};
     user_interface::HookProc_t m_hook_proc{};

--- a/foo_ui_columns/mw_drop_target.h
+++ b/foo_ui_columns/mw_drop_target.h
@@ -21,6 +21,6 @@ private:
 
     long drop_ref_count{0};
     POINTL last_over{};
-    wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
-    wil::com_ptr_t<IDataObject> m_DataObject;
+    wil::com_ptr<IDropTargetHelper> m_DropTargetHelper;
+    wil::com_ptr<IDataObject> m_DataObject;
 };

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -150,7 +150,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (cfg_show_systray)
             create_systray_icon();
 
-        wil::com_ptr_t<MainWindowDropTarget> drop_handler = new MainWindowDropTarget;
+        wil::com_ptr<MainWindowDropTarget> drop_handler = new MainWindowDropTarget;
         RegisterDragDrop(m_wnd, drop_handler.get());
 
         create_child_windows();

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -803,7 +803,7 @@ void PlaylistView::notify_on_create()
             & ~(flag_on_default_format_changed | flag_on_playlist_locked | flag_on_playlist_created
                 | flag_on_playlists_reorder | flag_on_playlists_removed | flag_on_playlists_removing));
 
-    wil::com_ptr_t<PlaylistViewDropTarget> IDT_playlist = new PlaylistViewDropTarget(this);
+    wil::com_ptr<PlaylistViewDropTarget> IDT_playlist = new PlaylistViewDropTarget(this);
     RegisterDragDrop(get_wnd(), IDT_playlist.get());
 
     if (g_windows.empty())

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -362,7 +362,7 @@ public:
     void set_config(stream_reader* p_reader, size_t p_size, abort_callback& p_abort) override;
 
     bool m_dragging{false};
-    wil::com_ptr_t<IDataObject> m_DataObject;
+    wil::com_ptr<IDataObject> m_DataObject;
     size_t m_dragging_initial_playlist;
 
 protected:
@@ -711,8 +711,8 @@ private:
     bool last_rmb;
     bool m_is_accepted_type;
     service_ptr_t<PlaylistView> p_playlist;
-    wil::com_ptr_t<IDataObject> m_DataObject;
-    wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
+    wil::com_ptr<IDataObject> m_DataObject;
+    wil::com_ptr<IDropTargetHelper> m_DropTargetHelper;
 };
 
 class PlaylistViewDropSource : public IDropSource {

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -654,7 +654,7 @@ private:
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<size_t>& indices, size_t column, bool b_source_mouse) override;
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-        pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override;
+        pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
     void notify_exit_inline_edit() override;
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_clipboard.cpp
@@ -6,7 +6,7 @@ namespace playlist_utils {
 bool check_clipboard()
 {
     const auto api = ole_interaction::get();
-    wil::com_ptr_t<IDataObject> data_object;
+    wil::com_ptr<IDataObject> data_object;
 
     if (FAILED(OleGetClipboard(&data_object)))
         return false;
@@ -56,7 +56,7 @@ bool paste(HWND wnd, size_t index)
 {
     const auto playlist_api = playlist_manager::get();
     const auto ole_api = ole_interaction::get();
-    wil::com_ptr_t<IDataObject> pDO;
+    wil::com_ptr<IDataObject> pDO;
 
     if (FAILED(OleGetClipboard(&pDO)))
         return false;

--- a/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
@@ -13,7 +13,7 @@ bool PlaylistView::notify_before_create_inline_edit(
 }
 
 bool PlaylistView::notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-    pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
+    pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries)
 {
     const size_t indices_count = indices.get_count();
     m_edit_handles.remove_all();
@@ -54,14 +54,14 @@ bool PlaylistView::notify_create_inline_edit(const pfc::list_base_const_t<size_t
     }
 
     p_flags |= inline_edit_autocomplete;
-    pfc::com_ptr_t<IUnknown> autocomplete_entries;
+    pfc::com_ptr_t<IUnknown> local_autocomplete_entries;
 
     if (m_library_autocomplete_v2.is_valid())
-        m_library_autocomplete_v2->get_value_list_async(m_edit_field, autocomplete_entries);
+        m_library_autocomplete_v2->get_value_list_async(m_edit_field, local_autocomplete_entries);
     else
-        m_library_autocomplete_v1->get_value_list(m_edit_field, autocomplete_entries);
+        m_library_autocomplete_v1->get_value_list(m_edit_field, local_autocomplete_entries);
 
-    pAutocompleteEntries = autocomplete_entries.get_ptr();
+    autocomplete_entries.attach(local_autocomplete_entries.detach());
 
     return true;
 }

--- a/foo_ui_columns/playlist_manager_utils.cpp
+++ b/foo_ui_columns/playlist_manager_utils.cpp
@@ -28,7 +28,7 @@ void rename_playlist(size_t index, HWND wnd_parent)
 bool check_clipboard()
 {
     const auto api = ole_interaction::get();
-    wil::com_ptr_t<IDataObject> pDO;
+    wil::com_ptr<IDataObject> pDO;
 
     HRESULT hr = OleGetClipboard(&pDO);
     if (FAILED(hr))
@@ -96,7 +96,7 @@ bool paste(HWND wnd, size_t index_insert)
 {
     const auto m_playlist_api = playlist_manager::get();
     const auto api = ole_interaction::get();
-    wil::com_ptr_t<IDataObject> pDO;
+    wil::com_ptr<IDataObject> pDO;
 
     HRESULT hr = OleGetClipboard(&pDO);
     if (FAILED(hr))

--- a/foo_ui_columns/playlist_switcher_inline_edit.cpp
+++ b/foo_ui_columns/playlist_switcher_inline_edit.cpp
@@ -9,7 +9,7 @@ bool PlaylistSwitcher::notify_before_create_inline_edit(
     return column == 0 && indices.get_count() == 1;
 }
 bool PlaylistSwitcher::notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-    pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries)
+    pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries)
 {
     size_t indices_count = indices.get_count();
     if (indices_count == 1 && indices[0] < m_playlist_api->get_playlist_count()) {

--- a/foo_ui_columns/playlist_switcher_title_formatting.cpp
+++ b/foo_ui_columns/playlist_switcher_title_formatting.cpp
@@ -67,8 +67,7 @@ pfc::string8 format_playlist_title(size_t index)
 
     LazyFieldCalculator lazy_fields{index};
 
-    auto file_size_getter
-        = [&lazy_fields]() { return std::string(mmh::FileSizeFormatter(lazy_fields.total_file_size())); };
+    auto file_size_getter = [&lazy_fields]() { return mmh::format_file_size(lazy_fields.total_file_size()); };
 
     auto file_size_raw_getter
         = [&lazy_fields]() { return std::string(pfc::format_uint(lazy_fields.total_file_size())); };

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -149,7 +149,7 @@ void PlaylistSwitcher::notify_on_create()
     m_playlist_api->register_callback(this, flag_all);
     standard_api_create_t<play_callback_manager>()->register_callback(this, flag_on_playback_all, false);
 
-    wil::com_ptr_t<DropTarget> drop_target = new DropTarget(this);
+    wil::com_ptr<DropTarget> drop_target = new DropTarget(this);
     RegisterDragDrop(get_wnd(), drop_target.get());
 
     g_windows.push_back(this);

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -67,10 +67,10 @@ class PlaylistSwitcher
         bool m_is_playlists;
         bool m_is_accepted_type;
         service_ptr_t<PlaylistSwitcher> m_window;
-        wil::com_ptr_t<IDataObject> m_DataObject;
+        wil::com_ptr<IDataObject> m_DataObject;
         service_ptr_t<ole_interaction_v2> m_ole_api;
         service_ptr_t<playlist_manager_v4> m_playlist_api;
-        wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
+        wil::com_ptr<IDropTargetHelper> m_DropTargetHelper;
     };
 
 public:
@@ -349,7 +349,7 @@ private:
     std::shared_ptr<playlist_position_reference_tracker> m_switch_playlist;
 
     bool m_dragging{false};
-    wil::com_ptr_t<IDataObject> m_DataObject;
+    wil::com_ptr<IDataObject> m_DataObject;
 
     std::shared_ptr<playlist_position_reference_tracker> m_edit_playlist;
     size_t m_playing_playlist;

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -137,7 +137,7 @@ public:
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<size_t>& indices, size_t column, bool b_source_mouse) override;
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
-        pfc::string_base& p_text, size_t& p_flags, mmh::ComPtr<IUnknown>& pAutocompleteEntries) override;
+        pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
 
     const char* get_drag_unit_singular() const override { return "playlist"; }

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -74,8 +74,8 @@ public:
         long drop_ref_count{};
         POINTL last_over{};
         service_ptr_t<PlaylistTabs> p_list;
-        wil::com_ptr_t<IDataObject> m_DataObject;
-        wil::com_ptr_t<IDropTargetHelper> m_DropTargetHelper;
+        wil::com_ptr<IDataObject> m_DataObject;
+        wil::com_ptr<IDropTargetHelper> m_DropTargetHelper;
     };
 
     void on_items_removing(size_t p_playlist, const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -35,7 +35,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CREATE: {
         initialised = true;
         list_wnd.add_item(this);
-        wil::com_ptr_t<PlaylistTabsDropTarget> m_drop_target = new PlaylistTabsDropTarget(this);
+        wil::com_ptr<PlaylistTabsDropTarget> m_drop_target = new PlaylistTabsDropTarget(this);
         RegisterDragDrop(wnd, m_drop_target.get());
 
         create_tabs();

--- a/foo_ui_columns/wic.cpp
+++ b/foo_ui_columns/wic.cpp
@@ -8,55 +8,55 @@ namespace cui::wic {
 
 namespace {
 
-wil::com_ptr_t<IWICBitmapDecoder> create_decoder_from_path(std::string_view path)
+wil::com_ptr<IWICBitmapDecoder> create_decoder_from_path(std::string_view path)
 {
     const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
 
     pfc::stringcvt::string_wide_from_utf8 utf16_path(path.data(), path.size());
 
-    wil::com_ptr_t<IWICBitmapDecoder> bitmap_decoder;
+    wil::com_ptr<IWICBitmapDecoder> bitmap_decoder;
     check_hresult(imaging_factory->CreateDecoderFromFilename(
         utf16_path.get_ptr(), nullptr, GENERIC_READ, WICDecodeMetadataCacheOnDemand, &bitmap_decoder));
 
     return bitmap_decoder;
 }
 
-wil::com_ptr_t<IWICBitmapDecoder> create_decoder_from_data(const void* data, size_t size)
+wil::com_ptr<IWICBitmapDecoder> create_decoder_from_data(const void* data, size_t size)
 {
     const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
 
-    wil::com_ptr_t<IStream> stream;
+    wil::com_ptr<IStream> stream;
     stream.attach(SHCreateMemStream(static_cast<const BYTE*>(data), gsl::narrow<UINT>(size)));
 
-    wil::com_ptr_t<IWICBitmapDecoder> bitmap_decoder;
+    wil::com_ptr<IWICBitmapDecoder> bitmap_decoder;
     check_hresult(imaging_factory->CreateDecoderFromStream(
         stream.get(), nullptr, WICDecodeMetadataCacheOnDemand, &bitmap_decoder));
 
     return bitmap_decoder;
 }
 
-wil::com_ptr_t<IWICBitmap> create_bitmap_from_hbitmap(HBITMAP bitmap)
+wil::com_ptr<IWICBitmap> create_bitmap_from_hbitmap(HBITMAP bitmap)
 {
     const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
 
-    wil::com_ptr_t<IWICBitmap> wic_bitmap;
+    wil::com_ptr<IWICBitmap> wic_bitmap;
     check_hresult(imaging_factory->CreateBitmapFromHBITMAP(bitmap, nullptr, WICBitmapUseAlpha, &wic_bitmap));
 
     return wic_bitmap;
 }
 
-wil::com_ptr_t<IWICBitmapSource> get_image_frame(const wil::com_ptr_t<IWICBitmapDecoder>& bitmap_decoder)
+wil::com_ptr<IWICBitmapSource> get_image_frame(const wil::com_ptr<IWICBitmapDecoder>& bitmap_decoder)
 {
-    wil::com_ptr_t<IWICBitmapFrameDecode> bitmap_frame_decode;
+    wil::com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
     check_hresult(bitmap_decoder->GetFrame(0, &bitmap_frame_decode));
 
-    wil::com_ptr_t<IWICBitmapSource> converted_bitmap;
+    wil::com_ptr<IWICBitmapSource> converted_bitmap;
     check_hresult(WICConvertBitmapSource(GUID_WICPixelFormat32bppBGRA, bitmap_frame_decode.get(), &converted_bitmap));
 
     return converted_bitmap;
 }
 
-BitmapData decode_image(const wil::com_ptr_t<IWICBitmapSource>& bitmap_source)
+BitmapData decode_image(const wil::com_ptr<IWICBitmapSource>& bitmap_source)
 {
     BitmapData image_data{};
     check_hresult(bitmap_source->GetSize(&image_data.width, &image_data.height));
@@ -82,12 +82,12 @@ void check_hresult(HRESULT hr)
         throw wic_error(message << "WIC error: " << format_win32_error(hr));
 }
 
-wil::com_ptr_t<IWICBitmapSource> resize_bitmap_source(
-    const wil::com_ptr_t<IWICBitmapSource>& original_bitmap, int width, int height)
+wil::com_ptr<IWICBitmapSource> resize_bitmap_source(
+    const wil::com_ptr<IWICBitmapSource>& original_bitmap, int width, int height)
 {
     const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
 
-    wil::com_ptr_t<IWICBitmapScaler> bitmap_scaler;
+    wil::com_ptr<IWICBitmapScaler> bitmap_scaler;
     check_hresult(imaging_factory->CreateBitmapScaler(&bitmap_scaler));
 
     try {
@@ -103,21 +103,21 @@ wil::com_ptr_t<IWICBitmapSource> resize_bitmap_source(
 
 wil::unique_hbitmap resize_hbitmap(HBITMAP hbitmap, int width, int height)
 {
-    wil::com_ptr_t<IWICBitmapSource> bitmap_source = create_bitmap_from_hbitmap(hbitmap);
+    wil::com_ptr<IWICBitmapSource> bitmap_source = create_bitmap_from_hbitmap(hbitmap);
     bitmap_source = resize_bitmap_source(bitmap_source, width, height);
     return create_hbitmap_from_bitmap_source(bitmap_source);
 }
 
-wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_path(const char* path)
+wil::com_ptr<IWICBitmapSource> create_bitmap_source_from_path(const char* path)
 {
     const auto decoder = create_decoder_from_path(path);
     return get_image_frame(decoder);
 }
 
-wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const BitmapData& bitmap_data)
+wil::com_ptr<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const BitmapData& bitmap_data)
 {
     const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
-    wil::com_ptr_t<IWICBitmap> bitmap;
+    wil::com_ptr<IWICBitmap> bitmap;
 
     check_hresult(imaging_factory->CreateBitmapFromMemory(bitmap_data.width, bitmap_data.height,
         GUID_WICPixelFormat32bppBGRA, bitmap_data.stride, gsl::narrow<UINT>(bitmap_data.data.size()),
@@ -126,7 +126,7 @@ wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const Bit
     return bitmap;
 }
 
-wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr_t<IWICBitmapSource>& source)
+wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr<IWICBitmapSource>& source)
 {
     const auto bitmap_data = decode_image(source);
 

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -15,11 +15,11 @@ struct BitmapData {
 };
 
 void check_hresult(HRESULT hr);
-wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_path(const char* path);
-wil::com_ptr_t<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const BitmapData& bitmap_data);
-wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr_t<IWICBitmapSource>& source);
-wil::com_ptr_t<IWICBitmapSource> resize_bitmap_source(
-    const wil::com_ptr_t<IWICBitmapSource>& original_bitmap, int width, int height);
+wil::com_ptr<IWICBitmapSource> create_bitmap_source_from_path(const char* path);
+wil::com_ptr<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const BitmapData& bitmap_data);
+wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr<IWICBitmapSource>& source);
+wil::com_ptr<IWICBitmapSource> resize_bitmap_source(
+    const wil::com_ptr<IWICBitmapSource>& original_bitmap, int width, int height);
 wil::unique_hbitmap resize_hbitmap(HBITMAP original_bitmap, int width, int height);
 
 BitmapData decode_image_data(const void* data, size_t size);


### PR DESCRIPTION
This updates mmh, ui_helpers and fbh, and replaces some uses of some legacy helpers that have been removed from those libraries.