### PR TITLE
Update fonts::manager_v3 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
   [#1031](https://github.com/reupen/columns_ui/pull/1031),
   [#1037](https://github.com/reupen/columns_ui/pull/1037),
   [#1039](https://github.com/reupen/columns_ui/pull/1039),
-  [#1042](https://github.com/reupen/columns_ui/pull/1042)]
+  [#1042](https://github.com/reupen/columns_ui/pull/1042),
+  [#1060](https://github.com/reupen/columns_ui/pull/1060)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).
@@ -48,7 +49,8 @@
   [#919](https://github.com/reupen/columns_ui/pull/919),
   [#927](https://github.com/reupen/columns_ui/pull/927),
   [#943](https://github.com/reupen/columns_ui/pull/943),
-  [#1015](https://github.com/reupen/columns_ui/pull/1015)]
+  [#1015](https://github.com/reupen/columns_ui/pull/1015),
+  [#1060](https://github.com/reupen/columns_ui/pull/1060)]
 
   This features better grouping of font families and now allows the entry of
   non-integer font sizes (to one decimal place).

--- a/foo_ui_columns/fcl_fonts.cpp
+++ b/foo_ui_columns/fcl_fonts.cpp
@@ -131,10 +131,9 @@ class FontsDataSet : public fcl::dataset {
         }
         refresh_appearance_prefs();
         g_font_manager_data.g_on_common_font_changed(pfc_infinite);
-        service_enum_t<fonts::client> font_enum;
-        fonts::client::ptr ptr;
-        while (font_enum.next(ptr))
-            ptr->on_font_changed();
+
+        for (const auto ptr : fonts::client::enumerate())
+            g_font_manager_data.dispatch_client_font_changed(ptr);
     }
 };
 

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -193,7 +193,7 @@ void FilterPanel::s_on_dark_mode_status_change()
 
 void FilterPanel::g_on_font_items_change()
 {
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_filter_items_font_client);
+    const auto font = fonts::get_font(g_guid_filter_items_font_client);
     const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
 
@@ -204,7 +204,7 @@ void FilterPanel::g_on_font_items_change()
 
 void FilterPanel::g_on_font_header_change()
 {
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_filter_header_font_client);
+    const auto font = fonts::get_font(g_guid_filter_header_font_client);
     const auto log_font = font->log_font();
     const auto text_format = fonts::get_text_format(font);
 
@@ -797,12 +797,12 @@ void FilterPanel::notify_on_initialisation()
     set_show_sort_indicators(cfg_show_sort_indicators);
 
     const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
-    const auto items_font = font_api->get_client_font(g_guid_filter_items_font_client);
+    const auto items_font = font_api->get_font(g_guid_filter_items_font_client);
     const auto items_text_format = fonts::get_text_format(items_font);
     const auto items_log_font = items_font->log_font();
     set_font(items_text_format, items_log_font);
 
-    const auto header_font = font_api->get_client_font(g_guid_filter_header_font_client);
+    const auto header_font = font_api->get_font(g_guid_filter_header_font_client);
     set_header_font(fonts::get_text_format(header_font), header_font->log_font());
 
     size_t index = g_windows.size();

--- a/foo_ui_columns/font_manager.cpp
+++ b/foo_ui_columns/font_manager.cpp
@@ -14,9 +14,9 @@ public:
         system_appearance_manager::initialise();
         const auto p_entry = g_font_manager_data.find_by_id(p_guid);
 
-        if (!p_entry || p_entry->font_mode == fonts::font_mode_common_items)
+        if (!p_entry || p_entry->font_mode == fonts::FontMode::CommonItems)
             get_font(fonts::font_type_items, p_out);
-        else if (p_entry->font_mode == fonts::font_mode_common_labels)
+        else if (p_entry->font_mode == fonts::FontMode::CommonLabels)
             get_font(fonts::font_type_labels, p_out);
         else
             p_out = p_entry->get_normalised_font();
@@ -31,7 +31,7 @@ public:
         else
             p_entry = g_font_manager_data.m_common_labels_entry;
 
-        if (p_entry->font_mode == fonts::font_mode_system) {
+        if (p_entry->font_mode == fonts::FontMode::System) {
             if (p_type == fonts::font_type_items)
                 uGetIconFont(&p_out);
             else
@@ -48,7 +48,7 @@ public:
         if (!p_entry)
             return;
 
-        p_entry->font_mode = fonts::font_mode_custom;
+        p_entry->font_mode = fonts::FontMode::Custom;
         p_entry->font_description.log_font = p_font;
         p_entry->font_description.estimate_point_and_dip_size();
         fonts::client::ptr ptr;
@@ -74,10 +74,10 @@ public:
         system_appearance_manager::initialise();
         auto p_entry = g_font_manager_data.find_by_id(p_guid);
 
-        if (!p_entry || p_entry->font_mode == fonts::font_mode_common_items)
+        if (!p_entry || p_entry->font_mode == fonts::FontMode::CommonItems)
             return get_common_font(fonts::font_type_items, dpi);
 
-        if (p_entry->font_mode == fonts::font_mode_common_labels)
+        if (p_entry->font_mode == fonts::FontMode::CommonLabels)
             return get_common_font(fonts::font_type_labels, dpi);
 
         return p_entry->get_normalised_font(dpi);
@@ -92,7 +92,7 @@ public:
         else
             entry = g_font_manager_data.m_common_labels_entry;
 
-        if (entry->font_mode == fonts::font_mode_system) {
+        if (entry->font_mode == fonts::FontMode::System) {
             if (p_type == fonts::font_type_items) {
                 return fonts::get_icon_font_for_dpi(dpi).log_font;
             }
@@ -110,7 +110,7 @@ public:
         if (!p_entry)
             return;
 
-        p_entry->font_mode = fonts::font_mode_custom;
+        p_entry->font_mode = fonts::FontMode::Custom;
         p_entry->font_description.log_font = p_font;
         p_entry->font_description.point_size_tenths = point_size_tenths;
 

--- a/foo_ui_columns/font_manager_data.cpp
+++ b/foo_ui_columns/font_manager_data.cpp
@@ -91,9 +91,9 @@ FontManagerData::entry_ptr_t FontManagerData::find_by_id(GUID id)
 
     if (cui::fonts::client::create_by_guid(id, ptr)) {
         if (ptr->get_default_font_type() == cui::fonts::font_type_items)
-            entry->font_mode = cui::fonts::font_mode_common_items;
+            entry->font_mode = cui::fonts::FontMode::CommonItems;
         else
-            entry->font_mode = cui::fonts::font_mode_common_labels;
+            entry->font_mode = cui::fonts::FontMode::CommonLabels;
         m_entries.add_item(entry);
         return entry;
     }
@@ -103,8 +103,8 @@ FontManagerData::entry_ptr_t FontManagerData::find_by_id(GUID id)
 
 cui::fonts::FontDescription FontManagerData::resolve_font_description(const entry_ptr_t& entry)
 {
-    const auto is_common_items = entry->font_mode == cui::fonts::font_mode_common_items;
-    const auto is_common_labels = entry->font_mode == cui::fonts::font_mode_common_labels;
+    const auto is_common_items = entry->font_mode == cui::fonts::FontMode::CommonItems;
+    const auto is_common_labels = entry->font_mode == cui::fonts::FontMode::CommonLabels;
 
     const auto resolved_entry = [&] {
         if (is_common_items)
@@ -116,7 +116,7 @@ cui::fonts::FontDescription FontManagerData::resolve_font_description(const entr
         return entry;
     }();
 
-    if (resolved_entry->font_mode == cui::fonts::font_mode_system) {
+    if (resolved_entry->font_mode == cui::fonts::FontMode::System) {
         const auto system_font = is_common_items ? cui::fonts::get_icon_font_for_dpi(USER_DEFAULT_SCREEN_DPI)
                                                  : cui::fonts::get_menu_font_for_dpi(USER_DEFAULT_SCREEN_DPI);
 
@@ -305,7 +305,7 @@ void FontManagerData::Entry::_export(stream_writer* p_stream, abort_callback& p_
     fbh::fcl::Writer out(p_stream, p_abort);
     out.write_item(identifier_guid, guid);
     out.write_item(identifier_mode, (uint32_t)font_mode);
-    if (font_mode == cui::fonts::font_mode_custom) {
+    if (font_mode == cui::fonts::FontMode::Custom) {
         out.write_item(identifier_font, font_description.log_font);
 
         if (font_description.wss) {

--- a/foo_ui_columns/font_manager_data.cpp
+++ b/foo_ui_columns/font_manager_data.cpp
@@ -18,9 +18,18 @@ FontManagerData::FontManagerData() : cfg_var(g_cfg_guid)
 
 void FontManagerData::g_on_common_font_changed(uint32_t mask)
 {
-    size_t count = m_callbacks.get_count();
-    for (size_t i = 0; i < count; i++)
-        m_callbacks[i]->on_font_changed(mask);
+    for (const auto callback : m_callbacks)
+        callback->on_font_changed(mask);
+
+    if (mask & cui::fonts::font_type_flag_items)
+        if (const auto iter = m_callback_map.find(cui::fonts::items_font_id); iter != m_callback_map.end())
+            for (const auto& callback : iter->second)
+                (*callback)();
+
+    if (mask & cui::fonts::font_type_flag_labels)
+        if (const auto iter = m_callback_map.find(cui::fonts::labels_font_id); iter != m_callback_map.end())
+            for (const auto& callback : iter->second)
+                (*callback)();
 }
 
 void FontManagerData::on_rendering_options_change()
@@ -28,8 +37,28 @@ void FontManagerData::on_rendering_options_change()
     g_on_common_font_changed(cui::fonts::font_type_flag_items | cui::fonts::font_type_flag_labels);
 
     for (const auto& client_ptr : cui::fonts::client::enumerate()) {
-        client_ptr->on_font_changed();
+        g_font_manager_data.dispatch_client_font_changed(client_ptr);
     }
+}
+
+void FontManagerData::add_callback(GUID id, cui::basic_callback::ptr callback)
+{
+    m_callback_map[id].emplace_back(std::move(callback));
+}
+
+void FontManagerData::remove_callback(GUID id, cui::basic_callback::ptr callback)
+{
+    if (const auto iter = m_callback_map.find(id); iter != m_callback_map.end())
+        std::erase(iter->second, callback);
+}
+
+void FontManagerData::dispatch_client_font_changed(cui::fonts::client::ptr client)
+{
+    client->on_font_changed();
+
+    if (const auto iter = m_callback_map.find(client->get_client_guid()); iter != m_callback_map.end())
+        for (const auto& callback : iter->second)
+            (*callback)();
 }
 
 void FontManagerData::deregister_common_callback(cui::fonts::common_callback* p_callback)
@@ -42,8 +71,14 @@ void FontManagerData::register_common_callback(cui::fonts::common_callback* p_ca
     m_callbacks.add_item(p_callback);
 }
 
-FontManagerData::entry_ptr_t FontManagerData::find_by_guid(GUID id)
+FontManagerData::entry_ptr_t FontManagerData::find_by_id(GUID id)
 {
+    if (id == cui::fonts::items_font_id)
+        return m_common_items_entry;
+
+    if (id == cui::fonts::labels_font_id)
+        return m_common_labels_entry;
+
     for (auto&& entry : m_entries) {
         if (entry->guid == id) {
             return entry;
@@ -59,11 +94,11 @@ FontManagerData::entry_ptr_t FontManagerData::find_by_guid(GUID id)
             entry->font_mode = cui::fonts::font_mode_common_items;
         else
             entry->font_mode = cui::fonts::font_mode_common_labels;
+        m_entries.add_item(entry);
+        return entry;
     }
 
-    m_entries.add_item(entry);
-
-    return entry;
+    return {};
 }
 
 cui::fonts::FontDescription FontManagerData::resolve_font_description(const entry_ptr_t& entry)

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -3,11 +3,11 @@
 
 namespace cui::fonts {
 
-enum font_mode_t {
-    font_mode_common_items,
-    font_mode_common_labels,
-    font_mode_custom,
-    font_mode_system,
+enum class FontMode {
+    CommonItems,
+    CommonLabels,
+    Custom,
+    System,
 };
 
 enum class RenderingMode : int32_t {
@@ -48,7 +48,7 @@ public:
         };
         GUID guid{};
         cui::fonts::FontDescription font_description{};
-        cui::fonts::font_mode_t font_mode{cui::fonts::font_mode_system};
+        cui::fonts::FontMode font_mode{cui::fonts::FontMode::System};
 
         LOGFONT get_normalised_font(unsigned dpi = uih::get_system_dpi_cached().cy);
 

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -1,6 +1,30 @@
 #pragma once
 #include "font_utils.h"
 
+namespace cui::fonts {
+
+enum font_mode_t {
+    font_mode_common_items,
+    font_mode_common_labels,
+    font_mode_custom,
+    font_mode_system,
+};
+
+enum class RenderingMode : int32_t {
+    Automatic = DWRITE_RENDERING_MODE_DEFAULT,
+    Natural = DWRITE_RENDERING_MODE_NATURAL,
+    NaturalSymmetric = DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+    GdiClassic = DWRITE_RENDERING_MODE_GDI_CLASSIC,
+    GdiNatural = DWRITE_RENDERING_MODE_GDI_NATURAL,
+};
+
+extern fbh::ConfigInt32 rendering_mode;
+extern fbh::ConfigBool force_greyscale_antialiasing;
+
+DWRITE_RENDERING_MODE get_rendering_mode();
+
+} // namespace cui::fonts
+
 class FontManagerData : public cfg_var {
 public:
     static const GUID g_cfg_guid;
@@ -45,8 +69,12 @@ public:
     entry_ptr_t m_common_items_entry;
     entry_ptr_t m_common_labels_entry;
 
-    entry_ptr_t find_by_guid(GUID id);
+    entry_ptr_t find_by_id(GUID id);
     cui::fonts::FontDescription resolve_font_description(const entry_ptr_t& entry);
+
+    void add_callback(GUID id, cui::basic_callback::ptr callback);
+    void remove_callback(GUID id, cui::basic_callback::ptr callback);
+    void dispatch_client_font_changed(cui::fonts::client::ptr client);
 
     void register_common_callback(cui::fonts::common_callback* p_callback);
     void deregister_common_callback(cui::fonts::common_callback* p_callback);
@@ -55,23 +83,7 @@ public:
     void on_rendering_options_change();
 
     pfc::ptr_list_t<cui::fonts::common_callback> m_callbacks;
+    std::unordered_map<GUID, std::vector<cui::basic_callback::ptr>> m_callback_map;
 
     FontManagerData();
 };
-
-namespace cui::fonts {
-
-enum class RenderingMode : int32_t {
-    Automatic = DWRITE_RENDERING_MODE_DEFAULT,
-    Natural = DWRITE_RENDERING_MODE_NATURAL,
-    NaturalSymmetric = DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
-    GdiClassic = DWRITE_RENDERING_MODE_GDI_CLASSIC,
-    GdiNatural = DWRITE_RENDERING_MODE_GDI_NATURAL,
-};
-
-extern fbh::ConfigInt32 rendering_mode;
-extern fbh::ConfigBool force_greyscale_antialiasing;
-
-DWRITE_RENDERING_MODE get_rendering_mode();
-
-} // namespace cui::fonts

--- a/foo_ui_columns/font_manager_v3.cpp
+++ b/foo_ui_columns/font_manager_v3.cpp
@@ -6,7 +6,7 @@
 
 namespace cui::fonts {
 
-class Font : public font {
+class NOVTABLE Font : public font {
 public:
     Font(LOGFONT log_font, uih::direct_write::WeightStretchStyle wss, std::wstring typographic_family_name,
         std::vector<DWRITE_FONT_AXIS_VALUE> axis_values, const float size, DWRITE_RENDERING_MODE rendering_mode,
@@ -44,9 +44,13 @@ public:
 
     LOGFONT log_font() noexcept override
     {
-        LOGFONT scaled_log_font{m_log_font};
-        scaled_log_font.lfHeight = -gsl::narrow_cast<long>(uih::direct_write::dip_to_px(m_size) + 0.5f);
-        return scaled_log_font;
+        return log_font_for_scaling_factor(uih::direct_write::get_default_scaling_factor());
+    }
+
+    LOGFONT log_font_for_dpi(unsigned dpi) noexcept override
+    {
+        const auto scaling_factor = gsl::narrow_cast<float>(dpi) / gsl::narrow_cast<float>(USER_DEFAULT_SCREEN_DPI);
+        return log_font_for_scaling_factor(scaling_factor);
     }
 
     pfc::com_ptr_t<IDWriteTextFormat> create_text_format(const wchar_t* locale_name = L"") noexcept final
@@ -103,6 +107,13 @@ public:
     bool force_greyscale_antialiasing() noexcept override { return m_force_greyscale_antialiasing; }
 
 private:
+    LOGFONT log_font_for_scaling_factor(float scaling_factor) noexcept
+    {
+        LOGFONT scaled_log_font{m_log_font};
+        scaled_log_font.lfHeight = -gsl::narrow_cast<long>(uih::direct_write::dip_to_px(m_size, scaling_factor) + 0.5f);
+        return scaled_log_font;
+    }
+
     LOGFONT m_log_font{};
     uih::direct_write::WeightStretchStyle m_wss{};
     std::wstring m_typographic_family_name;
@@ -112,12 +123,16 @@ private:
     bool m_force_greyscale_antialiasing{};
 };
 
-class FontManager3 : public manager_v3 {
+class NOVTABLE FontManager3 : public manager_v3 {
 public:
-    font::ptr get_client_font(GUID id) const override
+    font::ptr get_font(GUID id) const override
     {
         system_appearance_manager::initialise();
-        const auto entry = g_font_manager_data.find_by_guid(id);
+        const auto entry = g_font_manager_data.find_by_id(id);
+
+        if (!entry)
+            throw exception_font_client_not_found();
+
         auto font_description = g_font_manager_data.resolve_font_description(entry);
 
         const auto& log_font = font_description.log_font;
@@ -129,9 +144,12 @@ public:
             size, static_cast<DWRITE_RENDERING_MODE>(rendering_mode.get()), force_greyscale_antialiasing.get());
     }
 
-    void set_client_font_size(GUID id, float size) override
+    void set_font_size(GUID id, float size) override
     {
-        const auto entry = g_font_manager_data.find_by_guid(id);
+        const auto entry = g_font_manager_data.find_by_id(id);
+
+        if (!entry)
+            throw exception_font_client_not_found();
 
         if (entry->font_mode != font_mode_custom) {
             entry->font_description = g_font_manager_data.resolve_font_description(entry);
@@ -142,10 +160,20 @@ public:
 
         client::ptr ptr;
         if (client::create_by_guid(id, ptr))
-            ptr->on_font_changed();
+            g_font_manager_data.dispatch_client_font_changed(ptr);
+    }
+
+    [[nodiscard]] callback_token::ptr on_font_changed(GUID id, basic_callback::ptr callback) override
+    {
+        g_font_manager_data.add_callback(id, callback);
+
+        return fb2k::service_new<lambda_callback_token>(
+            [id, callback] { g_font_manager_data.remove_callback(id, callback); });
     }
 };
 
+namespace {
 service_factory_t<FontManager3> _;
+}
 
 } // namespace cui::fonts

--- a/foo_ui_columns/font_manager_v3.cpp
+++ b/foo_ui_columns/font_manager_v3.cpp
@@ -151,9 +151,9 @@ public:
         if (!entry)
             throw exception_font_client_not_found();
 
-        if (entry->font_mode != font_mode_custom) {
+        if (entry->font_mode != FontMode::Custom) {
             entry->font_description = g_font_manager_data.resolve_font_description(entry);
-            entry->font_mode = font_mode_custom;
+            entry->font_mode = FontMode::Custom;
         }
 
         entry->font_description.set_dip_size(size);

--- a/foo_ui_columns/item_details_config.cpp
+++ b/foo_ui_columns/item_details_config.cpp
@@ -213,8 +213,7 @@ void ItemDetailsConfig::open_format_code_generator()
 
             switch (msg) {
             case WM_INITDIALOG: {
-                const auto font
-                    = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_item_details_font_client);
+                const auto font = fonts::get_font(g_guid_item_details_font_client);
 
                 fonts::FontDescription font_description;
                 font_description.wss = uih::direct_write::WeightStretchStyle{

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -144,7 +144,7 @@ std::optional<uih::direct_write::TextFormat> create_text_format(const uih::direc
     uih::alignment horizontal_alignment, VerticalAlignment vertical_alignment, bool word_wrapping)
 {
     const auto api = fb2k::std_api_get<cui::fonts::manager_v3>();
-    const auto font = api->get_client_font(g_guid_item_details_font_client);
+    const auto font = api->get_font(g_guid_item_details_font_client);
     const auto text_format = fonts::get_text_format(context, font);
 
     if (!text_format)

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -173,15 +173,15 @@ void ItemProperties::notify_on_initialisation()
     set_autosize(m_autosizing_columns);
 
     const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
-    const auto items_font = font_api->get_client_font(g_guid_selection_properties_items_font_client);
+    const auto items_font = font_api->get_font(g_guid_selection_properties_items_font_client);
     const auto items_text_format = fonts::get_text_format(items_font);
     const auto items_log_font = items_font->log_font();
     set_font(items_text_format, items_log_font);
 
-    const auto header_font = font_api->get_client_font(g_guid_selection_properties_header_font_client);
+    const auto header_font = font_api->get_font(g_guid_selection_properties_header_font_client);
     set_header_font(fonts::get_text_format(header_font), header_font->log_font());
 
-    const auto group_font = font_api->get_client_font(g_guid_selection_properties_group_font_client);
+    const auto group_font = font_api->get_font(g_guid_selection_properties_group_font_client);
     set_group_font(fonts::get_text_format(group_font));
 
     set_edge_style(m_edge_style);
@@ -705,8 +705,7 @@ public:
 };
 void ItemProperties::s_on_font_items_change()
 {
-    const auto font
-        = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_selection_properties_items_font_client);
+    const auto font = fonts::get_font(g_guid_selection_properties_items_font_client);
     const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
 
@@ -719,8 +718,7 @@ void ItemProperties::s_on_font_items_change()
 
 void ItemProperties::s_on_font_groups_change()
 {
-    const auto font
-        = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_selection_properties_group_font_client);
+    const auto font = fonts::get_font(g_guid_selection_properties_group_font_client);
     const auto text_format = fonts::get_text_format(font);
 
     for (auto& window : s_windows) {
@@ -730,8 +728,7 @@ void ItemProperties::s_on_font_groups_change()
 
 void ItemProperties::s_on_font_header_change()
 {
-    const auto font
-        = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_selection_properties_header_font_client);
+    const auto font = fonts::get_font(g_guid_selection_properties_header_font_client);
     const auto log_font = font->log_font();
     const auto text_format = fonts::get_text_format(font);
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -83,10 +83,10 @@ void ConfigGroups::remove_group(size_t index)
 void set_font_size(float point_delta)
 {
     const auto api = fb2k::std_api_get<fonts::manager_v3>();
-    auto font = api->get_client_font(g_guid_items_font);
+    auto font = api->get_font(g_guid_items_font);
 
     const auto dip_delta = uih::direct_write::pt_to_dip(point_delta);
-    api->set_client_font_size(g_guid_items_font, font->size() + dip_delta);
+    api->set_font_size(g_guid_items_font, font->size() + dip_delta);
 }
 
 PlaylistView::PlaylistView()
@@ -391,7 +391,7 @@ void PlaylistView::g_on_vertical_item_padding_change()
 
 void PlaylistView::g_on_font_change()
 {
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_items_font);
+    const auto font = fonts::get_font(g_guid_items_font);
     const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
 
@@ -401,7 +401,7 @@ void PlaylistView::g_on_font_change()
 
 void PlaylistView::g_on_header_font_change()
 {
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_header_font);
+    const auto font = fonts::get_font(g_guid_header_font);
     const auto log_font = font->log_font();
     const auto text_format = fonts::get_text_format(font);
 
@@ -411,7 +411,7 @@ void PlaylistView::g_on_header_font_change()
 
 void PlaylistView::g_on_group_header_font_change()
 {
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_group_header_font);
+    const auto font = fonts::get_font(g_guid_group_header_font);
     const auto text_format = fonts::get_text_format(font);
 
     for (auto& window : g_windows)
@@ -760,15 +760,15 @@ void PlaylistView::notify_on_initialisation()
     set_vertical_item_padding(settings::playlist_view_item_padding);
 
     const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
-    const auto items_font = font_api->get_client_font(g_guid_items_font);
+    const auto items_font = font_api->get_font(g_guid_items_font);
     const auto items_text_format = fonts::get_text_format(items_font);
     const auto items_log_font = items_font->log_font();
     set_font(items_text_format, items_log_font);
 
-    const auto header_font = font_api->get_client_font(g_guid_header_font);
+    const auto header_font = font_api->get_font(g_guid_header_font);
     set_header_font(fonts::get_text_format(header_font), header_font->log_font());
 
-    const auto group_font = font_api->get_client_font(g_guid_group_header_font);
+    const auto group_font = font_api->get_font(g_guid_group_header_font);
     set_group_font(fonts::get_text_format(group_font));
 
     set_sorting_enabled(cfg_header_hottrack != 0);

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -112,7 +112,7 @@ void PlaylistSwitcher::g_refresh_all_items()
 
 void PlaylistSwitcher::g_on_font_items_change()
 {
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_font);
+    const auto font = fonts::get_font(g_guid_font);
     const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
 
@@ -130,7 +130,7 @@ void PlaylistSwitcher::notify_on_initialisation()
     set_edge_style(cfg_plistframe);
     set_vertical_item_padding(settings::playlist_switcher_item_padding);
 
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_font);
+    const auto font = fonts::get_font(g_guid_font);
     const auto text_format = fonts::get_text_format(font);
     const auto log_font = font->log_font();
     set_font(text_format, log_font);

--- a/foo_ui_columns/status_bar.cpp
+++ b/foo_ui_columns/status_bar.cpp
@@ -41,7 +41,7 @@ void on_status_font_change()
     state->lock_icon.reset();
     state->lock_bitmap.reset();
 
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(font_client_status_guid);
+    const auto font = fonts::get_font(font_client_status_guid);
     const auto log_font = font->log_font();
     state->font.reset(CreateFontIndirect(&log_font));
     state->direct_write_text_format.reset();

--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -52,7 +52,7 @@ void StatusPane::recreate_font()
 {
     m_text_format.reset();
 
-    const auto font = fb2k::std_api_get<fonts::manager_v3>()->get_client_font(g_guid_font);
+    const auto font = fonts::get_font(g_guid_font);
     const auto text_format = font->create_wil_text_format();
 
     if (!(m_direct_write_context && text_format))

--- a/foo_ui_columns/system_appearance_manager.cpp
+++ b/foo_ui_columns/system_appearance_manager.cpp
@@ -167,18 +167,15 @@ private:
                     && g_font_manager_data.m_common_items_entry->font_mode == fonts::font_mode_system)
                 || (wp == SPI_GETNONCLIENTMETRICS && g_font_manager_data.m_common_labels_entry
                     && g_font_manager_data.m_common_labels_entry->font_mode == fonts::font_mode_system)) {
-                FontsClientList m_fonts_client_list;
-                FontsClientList::g_get_list(m_fonts_client_list);
-                size_t count = m_fonts_client_list.get_count();
                 g_font_manager_data.g_on_common_font_changed(
                     wp == SPI_GETICONTITLELOGFONT ? fonts::font_type_flag_items : fonts::font_type_flag_labels);
-                for (size_t i = 0; i < count; i++) {
-                    const auto p_data = g_font_manager_data.find_by_guid(m_fonts_client_list[i].m_guid);
 
-                    if (wp == SPI_GETNONCLIENTMETRICS && p_data->font_mode == fonts::font_mode_common_items)
-                        m_fonts_client_list[i].m_ptr->on_font_changed();
-                    else if (wp == SPI_GETICONTITLELOGFONT && p_data->font_mode == fonts::font_mode_common_labels)
-                        m_fonts_client_list[i].m_ptr->on_font_changed();
+                for (auto client_ptr : fonts::client::enumerate()) {
+                    const auto p_data = g_font_manager_data.find_by_id(client_ptr->get_client_guid());
+
+                    if ((wp == SPI_GETNONCLIENTMETRICS && p_data->font_mode == fonts::font_mode_common_items)
+                        || (wp == SPI_GETICONTITLELOGFONT && p_data->font_mode == fonts::font_mode_common_labels))
+                        g_font_manager_data.dispatch_client_font_changed(client_ptr);
                 }
             }
             break;

--- a/foo_ui_columns/system_appearance_manager.cpp
+++ b/foo_ui_columns/system_appearance_manager.cpp
@@ -164,17 +164,17 @@ private:
         } break;
         case WM_SETTINGCHANGE:
             if ((wp == SPI_GETICONTITLELOGFONT && g_font_manager_data.m_common_items_entry
-                    && g_font_manager_data.m_common_items_entry->font_mode == fonts::font_mode_system)
+                    && g_font_manager_data.m_common_items_entry->font_mode == fonts::FontMode::System)
                 || (wp == SPI_GETNONCLIENTMETRICS && g_font_manager_data.m_common_labels_entry
-                    && g_font_manager_data.m_common_labels_entry->font_mode == fonts::font_mode_system)) {
+                    && g_font_manager_data.m_common_labels_entry->font_mode == fonts::FontMode::System)) {
                 g_font_manager_data.g_on_common_font_changed(
                     wp == SPI_GETICONTITLELOGFONT ? fonts::font_type_flag_items : fonts::font_type_flag_labels);
 
                 for (auto client_ptr : fonts::client::enumerate()) {
                     const auto p_data = g_font_manager_data.find_by_id(client_ptr->get_client_guid());
 
-                    if ((wp == SPI_GETNONCLIENTMETRICS && p_data->font_mode == fonts::font_mode_common_items)
-                        || (wp == SPI_GETICONTITLELOGFONT && p_data->font_mode == fonts::font_mode_common_labels))
+                    if ((wp == SPI_GETNONCLIENTMETRICS && p_data->font_mode == fonts::FontMode::CommonItems)
+                        || (wp == SPI_GETICONTITLELOGFONT && p_data->font_mode == fonts::FontMode::CommonLabels))
                         g_font_manager_data.dispatch_client_font_changed(client_ptr);
                 }
             }

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -76,7 +76,7 @@ INT_PTR TabFonts::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         case IDC_FONT_MODE | (CBN_SELCHANGE << 16): {
             const int idx = ComboBox_GetCurSel(reinterpret_cast<HWND>(lp));
             m_element_ptr->font_mode
-                = static_cast<cui::fonts::font_mode_t>(ComboBox_GetItemData(reinterpret_cast<HWND>(lp), idx));
+                = static_cast<cui::fonts::FontMode>(ComboBox_GetItemData(reinterpret_cast<HWND>(lp), idx));
             restore_font_selection_state();
             enable_or_disable_font_selection();
             on_font_changed();
@@ -121,8 +121,8 @@ void TabFonts::on_font_changed()
 
     for (auto&& client : m_fonts_client_list) {
         const auto p_data = g_font_manager_data.find_by_id(client.m_guid);
-        if ((index_element == 0 && p_data->font_mode == cui::fonts::font_mode_common_items)
-            || (index_element == 1 && p_data->font_mode == cui::fonts::font_mode_common_labels))
+        if ((index_element == 0 && p_data->font_mode == cui::fonts::FontMode::CommonItems)
+            || (index_element == 1 && p_data->font_mode == cui::fonts::FontMode::CommonLabels))
             g_font_manager_data.dispatch_client_font_changed(client.m_ptr);
     }
 }
@@ -135,7 +135,7 @@ void TabFonts::restore_font_selection_state()
 
 void TabFonts::enable_or_disable_font_selection() const
 {
-    const auto is_custom_mode = m_element_ptr->font_mode == cui::fonts::font_mode_custom;
+    const auto is_custom_mode = m_element_ptr->font_mode == cui::fonts::FontMode::Custom;
     m_direct_write_font_picker->set_font_selection_allowed(is_custom_mode);
 }
 
@@ -143,10 +143,10 @@ FontManagerData::entry_ptr_t TabFonts::get_current_resolved_entry() const
 {
     auto entry = m_element_ptr;
 
-    if (entry->font_mode == cui::fonts::font_mode_common_items)
+    if (entry->font_mode == cui::fonts::FontMode::CommonItems)
         return g_font_manager_data.m_common_items_entry;
 
-    if (entry->font_mode == cui::fonts::font_mode_common_labels)
+    if (entry->font_mode == cui::fonts::FontMode::CommonLabels)
         return g_font_manager_data.m_common_labels_entry;
 
     return entry;
@@ -159,15 +159,16 @@ void TabFonts::update_mode_combobox() const
     const size_t index_element = ComboBox_GetCurSel(m_element_combobox);
     if (index_element <= 1) {
         index = ComboBox_AddString(m_mode_combobox, L"System");
-        ComboBox_SetItemData(m_mode_combobox, index, cui::fonts::font_mode_system);
+        ComboBox_SetItemData(m_mode_combobox, index, cui::fonts::FontMode::System);
     } else {
         index = ComboBox_AddString(m_mode_combobox, L"Common (list items)");
-        ComboBox_SetItemData(m_mode_combobox, index, cui::fonts::font_mode_common_items);
+        ComboBox_SetItemData(m_mode_combobox, index, cui::fonts::FontMode::CommonItems);
         index = ComboBox_AddString(m_mode_combobox, L"Common (labels)");
-        ComboBox_SetItemData(m_mode_combobox, index, cui::fonts::font_mode_common_labels);
+        ComboBox_SetItemData(m_mode_combobox, index, cui::fonts::FontMode::CommonLabels);
     }
     index = ComboBox_AddString(m_mode_combobox, L"Custom");
-    ComboBox_SetItemData(m_mode_combobox, index, cui::fonts::font_mode_custom);
+    ComboBox_SetItemData(m_mode_combobox, index, cui::fonts::FontMode::Custom);
 
-    ComboBox_SetCurSel(m_mode_combobox, uih::combo_box_find_item_by_data(m_mode_combobox, m_element_ptr->font_mode));
+    ComboBox_SetCurSel(
+        m_mode_combobox, uih::combo_box_find_item_by_data(m_mode_combobox, WI_EnumValue(m_element_ptr->font_mode)));
 }

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -92,7 +92,7 @@ INT_PTR TabFonts::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     m_element_ptr = g_font_manager_data.m_common_labels_entry;
                 else if (idx >= 2) {
                     m_element_api = m_fonts_client_list[idx - 2].m_ptr;
-                    m_element_ptr = g_font_manager_data.find_by_guid(m_fonts_client_list[idx - 2].m_guid);
+                    m_element_ptr = g_font_manager_data.find_by_id(m_fonts_client_list[idx - 2].m_guid);
                 }
             }
             update_mode_combobox();
@@ -109,7 +109,7 @@ INT_PTR TabFonts::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 void TabFonts::on_font_changed()
 {
     if (m_element_api.is_valid()) {
-        m_element_api->on_font_changed();
+        g_font_manager_data.dispatch_client_font_changed(m_element_api);
         return;
     }
 
@@ -120,11 +120,10 @@ void TabFonts::on_font_changed()
     g_font_manager_data.g_on_common_font_changed(1 << index_element);
 
     for (auto&& client : m_fonts_client_list) {
-        const auto p_data = g_font_manager_data.find_by_guid(client.m_guid);
-        if (index_element == 0 && p_data->font_mode == cui::fonts::font_mode_common_items) {
-            client.m_ptr->on_font_changed();
-        } else if (index_element == 1 && p_data->font_mode == cui::fonts::font_mode_common_labels)
-            client.m_ptr->on_font_changed();
+        const auto p_data = g_font_manager_data.find_by_id(client.m_guid);
+        if ((index_element == 0 && p_data->font_mode == cui::fonts::font_mode_common_items)
+            || (index_element == 1 && p_data->font_mode == cui::fonts::font_mode_common_labels))
+            g_font_manager_data.dispatch_client_font_changed(client.m_ptr);
     }
 }
 


### PR DESCRIPTION
This:

- updates the Columns UI SDK
- updates the `fonts::manager_v3` implementation to match the latest iteration of the service declaration
- moves `font_mode_t` from the Columns UI SDK to here
