### PR TITLE
Protect against font callback service release during shut down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@
   [#1037](https://github.com/reupen/columns_ui/pull/1037),
   [#1039](https://github.com/reupen/columns_ui/pull/1039),
   [#1042](https://github.com/reupen/columns_ui/pull/1042),
-  [#1060](https://github.com/reupen/columns_ui/pull/1060)]
+  [#1060](https://github.com/reupen/columns_ui/pull/1060),
+  [#1064](https://github.com/reupen/columns_ui/pull/1064)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).
@@ -50,7 +51,8 @@
   [#927](https://github.com/reupen/columns_ui/pull/927),
   [#943](https://github.com/reupen/columns_ui/pull/943),
   [#1015](https://github.com/reupen/columns_ui/pull/1015),
-  [#1060](https://github.com/reupen/columns_ui/pull/1060)]
+  [#1060](https://github.com/reupen/columns_ui/pull/1060),
+  [#1064](https://github.com/reupen/columns_ui/pull/1064)]
 
   This features better grouping of font families and now allows the entry of
   non-integer font sizes (to one decimal place).

--- a/foo_ui_columns/font_manager_data.cpp
+++ b/foo_ui_columns/font_manager_data.cpp
@@ -16,6 +16,21 @@ FontManagerData::FontManagerData() : cfg_var(g_cfg_guid)
     m_common_labels_entry->font_description.estimate_point_and_dip_size();
 }
 
+FontManagerData::~FontManagerData()
+{
+    for (auto& [id, callbacks] : m_callback_map) {
+        if (callbacks.empty())
+            continue;
+
+        OutputDebugString(fmt::format(L"Columns UI: {} leaked callback(s) for font ID {} detected\n", callbacks.size(),
+            mmh::to_utf16(pfc::print_guid(id).c_str()))
+                .c_str());
+
+        for (auto& callback : callbacks)
+            callback.detach();
+    }
+}
+
 void FontManagerData::g_on_common_font_changed(uint32_t mask)
 {
     for (const auto callback : m_callbacks)

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -86,4 +86,5 @@ public:
     std::unordered_map<GUID, std::vector<cui::basic_callback::ptr>> m_callback_map;
 
     FontManagerData();
+    ~FontManagerData();
 };


### PR DESCRIPTION
This adds some protection against trying to release `cui::basic_callback` service instances (that were registered for font changes) during shut down, if something manages to leak a `cui::callback_token` (or otherwise hold on to it until components are being unloaded).