### PR TITLE
Fix rare drag-and-drop crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,9 @@
   panels where it wasn’t possible to click on autocomplete suggestions was
   fixed. [[#886](https://github.com/reupen/columns_ui/pull/886)]
 
+- A rare drag-and-drop crash was fixed.
+  [[#1067](https://github.com/reupen/columns_ui/pull/1067)]
+
 - A bug where files copied in File Explorer couldn’t be pasted in the playlist
   view using the context menu was fixed.
   [[#873](https://github.com/reupen/columns_ui/pull/873)]

--- a/foo_ui_columns/buttons_config_droptarget.cpp
+++ b/foo_ui_columns/buttons_config_droptarget.cpp
@@ -75,9 +75,7 @@ HRESULT STDMETHODCALLTYPE ButtonsToolbar::ConfigParam::ButtonsList::ButtonsListD
         m_DropTargetHelper->DragOver(&pt, *pdwEffect);
 
     last_rmb = ((grfKeyState & MK_RBUTTON) != 0);
-    POINT pti;
-    pti.y = ptl.y;
-    pti.x = ptl.x;
+    POINT pti{ptl.x, ptl.y};
 
     *pdwEffect = DROPEFFECT_NONE;
     if (check_do(m_DataObject.get() /*, pdwEffect*/)) {

--- a/foo_ui_columns/mw_drop_target.cpp
+++ b/foo_ui_columns/mw_drop_target.cpp
@@ -27,7 +27,10 @@ bool MainWindowDropTarget::check_window_allowed(HWND wnd)
 HRESULT STDMETHODCALLTYPE MainWindowDropTarget::Drop(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
+    m_DataObject.reset();
+
     POINT pt = {ptl.x, ptl.y};
+
     if (m_DropTargetHelper)
         m_DropTargetHelper->Drop(pDataObj, &pt, *pdwEffect);
 
@@ -39,10 +42,10 @@ HRESULT STDMETHODCALLTYPE MainWindowDropTarget::Drop(
 
     *pdwEffect = is_allowed_window ? DROPEFFECT_COPY : DROPEFFECT_NONE;
 
-    bool process = !ui_drop_item_callback::g_on_drop(pDataObj) && is_allowed_window;
+    if (ui_drop_item_callback::g_on_drop(pDataObj) || !is_allowed_window)
+        return S_OK;
 
-    if (process && g_last_rmb) {
-        process = false;
+    if (g_last_rmb) {
         enum {
             ID_DROP = 1,
             ID_CANCEL
@@ -58,28 +61,21 @@ HRESULT STDMETHODCALLTYPE MainWindowDropTarget::Drop(
             menu, TPM_RIGHTBUTTON | TPM_NONOTIFY | TPM_RETURNCMD, pt.x, pt.y, 0, cui::main_window.get_wnd(), nullptr);
         DestroyMenu(menu);
 
-        if (cmd) {
-            switch (cmd) {
-            case ID_DROP:
-                process = true;
-                break;
-            }
+        switch (cmd) {
+        case ID_DROP:
+            break;
+        default:
+            return S_OK;
         }
     }
 
-    if (process) {
-        metadb_handle_list data;
+    metadb_handle_list data;
 
-        incoming_api->process_dropped_files(pDataObj, data, true, cui::main_window.get_wnd());
+    incoming_api->process_dropped_files(pDataObj, data, true, cui::main_window.get_wnd());
 
-        playlist_api->activeplaylist_undo_backup();
-        playlist_api->activeplaylist_clear_selection();
-        playlist_api->activeplaylist_add_items(data, bit_array_true());
-
-        data.remove_all();
-    }
-
-    m_DataObject.reset();
+    playlist_api->activeplaylist_undo_backup();
+    playlist_api->activeplaylist_clear_selection();
+    playlist_api->activeplaylist_add_items(data, bit_array_true());
 
     return S_OK;
 }
@@ -90,8 +86,6 @@ HRESULT STDMETHODCALLTYPE MainWindowDropTarget::DragLeave()
         m_DropTargetHelper->DragLeave();
     uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
 
-    last_over.x = 0;
-    last_over.y = 0;
     m_DataObject.reset();
     return S_OK;
 }
@@ -106,24 +100,20 @@ HRESULT STDMETHODCALLTYPE MainWindowDropTarget::DragOver(DWORD grfKeyState, POIN
 
     HWND wnd = WindowFromPoint(pt);
     bool is_allowed_window = check_window_allowed(wnd);
-    bool uid_handled = ui_drop_item_callback::g_is_accepted_type(m_DataObject.get(), pdwEffect);
 
-    // if (last_over.x != pt.x || last_over.y != pt.y)
-    if (!uid_handled) {
-        if (is_allowed_window
-            && playlist_incoming_item_filter::get()->process_dropped_files_check(m_DataObject.get())) {
-            *pdwEffect = DROPEFFECT_COPY;
+    if (ui_drop_item_callback::g_is_accepted_type(m_DataObject.get(), pdwEffect))
+        return S_OK;
 
-            pfc::string8 name;
-            playlist_manager::get()->activeplaylist_get_name(name);
-            uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_COPY, "Add to %1", name);
-        } else {
-            *pdwEffect = DROPEFFECT_NONE;
-            uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
-        }
+    if (is_allowed_window && playlist_incoming_item_filter::get()->process_dropped_files_check(m_DataObject.get())) {
+        *pdwEffect = DROPEFFECT_COPY;
+
+        pfc::string8 name;
+        playlist_manager::get()->activeplaylist_get_name(name);
+        uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_COPY, "Add to %1", name);
+    } else {
+        *pdwEffect = DROPEFFECT_NONE;
+        uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
     }
-
-    last_over = ptl;
 
     return S_OK;
 }
@@ -137,26 +127,25 @@ HRESULT STDMETHODCALLTYPE MainWindowDropTarget::DragEnter(
 
     m_DataObject = pDataObj;
 
-    last_over.x = 0;
-    last_over.y = 0;
     g_last_rmb = ((grfKeyState & MK_RBUTTON) != 0);
 
     HWND wnd = WindowFromPoint(pt);
-    bool is_allowed_window = check_window_allowed(wnd);
-    bool uid_handled = ui_drop_item_callback::g_is_accepted_type(pDataObj, pdwEffect);
 
-    if (!uid_handled) {
-        if (is_allowed_window && playlist_incoming_item_filter::get()->process_dropped_files_check(pDataObj)) {
-            *pdwEffect = DROPEFFECT_COPY;
-            pfc::string8 name;
-            playlist_manager::get()->activeplaylist_get_name(name);
-            uih::ole::set_drop_description(pDataObj, DROPIMAGE_COPY, "Add to %1", name);
-        } else {
-            *pdwEffect = DROPEFFECT_NONE;
-            uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
-        }
+    if (ui_drop_item_callback::g_is_accepted_type(pDataObj, pdwEffect))
+        return S_OK;
+
+    const auto is_allowed_window = check_window_allowed(wnd);
+    if (is_allowed_window && playlist_incoming_item_filter::get()->process_dropped_files_check(pDataObj)) {
+        *pdwEffect = DROPEFFECT_COPY;
+        pfc::string8 name;
+        playlist_manager::get()->activeplaylist_get_name(name);
+        uih::ole::set_drop_description(pDataObj, DROPIMAGE_COPY, "Add to %1", name);
+    } else {
+        *pdwEffect = DROPEFFECT_NONE;
+        uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
     }
-    return S_OK; //??
+
+    return S_OK;
 }
 
 ULONG STDMETHODCALLTYPE MainWindowDropTarget::Release()

--- a/foo_ui_columns/mw_drop_target.cpp
+++ b/foo_ui_columns/mw_drop_target.cpp
@@ -79,10 +79,6 @@ HRESULT STDMETHODCALLTYPE MainWindowDropTarget::Drop(
         data.remove_all();
     }
 
-    if (m_DropTargetHelper)
-        m_DropTargetHelper->DragLeave();
-    uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
-
     m_DataObject.reset();
 
     return S_OK;

--- a/foo_ui_columns/mw_drop_target.h
+++ b/foo_ui_columns/mw_drop_target.h
@@ -20,7 +20,6 @@ private:
     static bool check_window_allowed(HWND wnd);
 
     long drop_ref_count{0};
-    POINTL last_over{};
     wil::com_ptr<IDropTargetHelper> m_DropTargetHelper;
     wil::com_ptr<IDataObject> m_DataObject;
 };

--- a/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_droptarget.cpp
@@ -2,6 +2,35 @@
 #include "ng_playlist.h"
 
 namespace cui::panels::playlist_view {
+
+namespace {
+
+class DelayedDropTargetProcesser : public process_locations_notify {
+public:
+    playlist_position_reference_tracker m_insertIndexTracker;
+    service_ptr_t<PlaylistView> p_playlist;
+
+    void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) noexcept override
+    {
+        const auto playlist_api = playlist_manager::get();
+        if (m_insertIndexTracker.m_playlist != pfc_infinite && p_items.get_count()) {
+            if (m_insertIndexTracker.m_item == pfc_infinite)
+                m_insertIndexTracker.m_item = playlist_api->playlist_get_item_count(m_insertIndexTracker.m_playlist);
+            playlist_api->playlist_undo_backup(m_insertIndexTracker.m_playlist);
+            bool b_redraw = p_playlist->disable_redrawing();
+            playlist_api->playlist_clear_selection(m_insertIndexTracker.m_playlist);
+            playlist_api->playlist_insert_items(
+                m_insertIndexTracker.m_playlist, m_insertIndexTracker.m_item, p_items, bit_array_true());
+            playlist_api->playlist_set_focus_item(m_insertIndexTracker.m_playlist, m_insertIndexTracker.m_item);
+            if (b_redraw)
+                p_playlist->enable_redrawing();
+        }
+    }
+    void on_aborted() override {}
+};
+
+} // namespace
+
 HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::QueryInterface(REFIID riid, LPVOID FAR* ppvObject)
 {
     if (ppvObject == nullptr)
@@ -44,21 +73,23 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::DragEnter(
     if (m_DropTargetHelper)
         m_DropTargetHelper->DragEnter(p_playlist->get_wnd(), pDataObj, &pt, *pdwEffect);
 
-    bool uid_handled = ui_drop_item_callback::g_is_accepted_type(pDataObj, pdwEffect);
-
-    m_is_accepted_type = uid_handled || playlist_incoming_item_filter::get()->process_dropped_files_check(pDataObj);
-    if (!uid_handled) {
-        if (m_is_accepted_type) {
-            *pdwEffect
-                = p_playlist->m_dragging && p_playlist->m_DataObject == pDataObj && (0 == (grfKeyState & MK_CONTROL))
-                ? DROPEFFECT_MOVE
-                : DROPEFFECT_COPY;
-            UpdateDropDescription(m_DataObject.get(), *pdwEffect);
-        } else {
-            *pdwEffect = DROPEFFECT_NONE;
-            uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
-        }
+    if (ui_drop_item_callback::g_is_accepted_type(pDataObj, pdwEffect)) {
+        m_is_accepted_type = true;
+        return S_OK;
     }
+
+    m_is_accepted_type = playlist_incoming_item_filter::get()->process_dropped_files_check(pDataObj);
+
+    if (m_is_accepted_type) {
+        *pdwEffect = p_playlist->m_dragging && p_playlist->m_DataObject == pDataObj && (0 == (grfKeyState & MK_CONTROL))
+            ? DROPEFFECT_MOVE
+            : DROPEFFECT_COPY;
+        UpdateDropDescription(m_DataObject.get(), *pdwEffect);
+    } else {
+        *pdwEffect = DROPEFFECT_NONE;
+        uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
+    }
+
     return S_OK;
 }
 
@@ -69,9 +100,8 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::DragOver(DWORD grfKeyState, PO
         m_DropTargetHelper->DragOver(&pt, *pdwEffect);
 
     last_rmb = ((grfKeyState & MK_RBUTTON) != 0);
-    POINT pti;
-    pti.y = ptl.y;
-    pti.x = ptl.x;
+
+    POINT pti{ptl.x, ptl.y};
 
     if (!m_is_accepted_type) {
         *pdwEffect = DROPEFFECT_NONE;
@@ -90,37 +120,35 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::DragOver(DWORD grfKeyState, PO
     if (p_playlist->get_wnd()) {
         uih::ListView::HitTestResult hi;
 
-        {
-            POINT ptt = pti;
-            ScreenToClient(p_playlist->get_wnd(), &ptt);
+        POINT ptt = pti;
+        ScreenToClient(p_playlist->get_wnd(), &ptt);
 
-            RECT rc_items = p_playlist->get_items_rect();
+        RECT rc_items = p_playlist->get_items_rect();
 
-            rc_items.top += p_playlist->get_item_height();
-            rc_items.bottom -= p_playlist->get_item_height();
+        rc_items.top += p_playlist->get_item_height();
+        rc_items.bottom -= p_playlist->get_item_height();
 
-            if (ptt.y < rc_items.top && ptt.y < rc_items.bottom) {
-                p_playlist->create_timer_scroll_up();
-            } else
-                p_playlist->destroy_timer_scroll_up();
+        if (ptt.y < rc_items.top && ptt.y < rc_items.bottom) {
+            p_playlist->create_timer_scroll_up();
+        } else
+            p_playlist->destroy_timer_scroll_up();
 
-            if (ptt.y >= rc_items.top && ptt.y >= rc_items.bottom) {
-                p_playlist->create_timer_scroll_down();
-            } else
-                p_playlist->destroy_timer_scroll_down();
+        if (ptt.y >= rc_items.top && ptt.y >= rc_items.bottom) {
+            p_playlist->create_timer_scroll_down();
+        } else
+            p_playlist->destroy_timer_scroll_down();
 
-            if (*pdwEffect == DROPEFFECT_COPY && cfg_drop_at_end)
-                p_playlist->set_insert_mark(p_playlist->get_item_count());
-            else {
-                p_playlist->hit_test_ex(ptt, hi);
-                if (hi.category == uih::ListView::HitTestCategory::OnUnobscuredItem
-                    || hi.category == uih::ListView::HitTestCategory::OnGroupHeader
-                    || hi.category == uih::ListView::HitTestCategory::OnItemObscuredBelow
-                    || hi.category == uih::ListView::HitTestCategory::NotOnItem)
-                    p_playlist->set_insert_mark(hi.insertion_index);
-                else
-                    p_playlist->remove_insert_mark();
-            }
+        if (*pdwEffect == DROPEFFECT_COPY && cfg_drop_at_end)
+            p_playlist->set_insert_mark(p_playlist->get_item_count());
+        else {
+            p_playlist->hit_test_ex(ptt, hi);
+            if (hi.category == uih::ListView::HitTestCategory::OnUnobscuredItem
+                || hi.category == uih::ListView::HitTestCategory::OnGroupHeader
+                || hi.category == uih::ListView::HitTestCategory::OnItemObscuredBelow
+                || hi.category == uih::ListView::HitTestCategory::NotOnItem)
+                p_playlist->set_insert_mark(hi.insertion_index);
+            else
+                p_playlist->remove_insert_mark();
         }
     }
     return S_OK;
@@ -130,6 +158,7 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::DragLeave()
 {
     if (m_DropTargetHelper)
         m_DropTargetHelper->DragLeave();
+
     uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
     p_playlist->remove_insert_mark();
     p_playlist->destroy_timer_scroll_up();
@@ -142,12 +171,14 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::Drop(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
     POINT pt = {ptl.x, ptl.y};
+
     if (m_DropTargetHelper)
         m_DropTargetHelper->Drop(pDataObj, &pt, *pdwEffect);
 
     *pdwEffect = p_playlist->m_dragging && p_playlist->m_DataObject == pDataObj && (0 == (grfKeyState & MK_CONTROL))
         ? DROPEFFECT_MOVE
         : DROPEFFECT_COPY;
+
     m_DataObject.reset();
     p_playlist->destroy_timer_scroll_up();
     p_playlist->destroy_timer_scroll_down();
@@ -158,169 +189,116 @@ HRESULT STDMETHODCALLTYPE PlaylistViewDropTarget::Drop(
         return S_OK;
     }
 
-    POINT pti;
-    pti.y = ptl.y;
-    pti.x = ptl.x;
-    if (p_playlist->get_wnd()) {
-        bool process = !ui_drop_item_callback::g_on_drop(pDataObj);
+    if (ui_drop_item_callback::g_on_drop(pDataObj))
+        return S_OK;
 
-        /*if (process && last_rmb)
-        {
-        process = false;
-        enum {ID_DROP = 1, ID_CANCEL };
+    if (!p_playlist->get_wnd())
+        return S_OK;
 
-        HMENU menu = CreatePopupMenu();
+    POINT pti{ptl.x, ptl.y};
 
-        uAppendMenu(menu,(MF_STRING),ID_DROP,"&Add files here");
-        uAppendMenu(menu,MF_SEPARATOR,0,0);
-        uAppendMenu(menu,MF_STRING,ID_CANCEL,"&Cancel");
+    metadb_handle_list data;
 
-        int cmd =
-        TrackPopupMenu(menu,TPM_RIGHTBUTTON|TPM_NONOTIFY|TPM_RETURNCMD,pt.x,pt.y,0,p_playlist->wnd_playlist,0);
-        DestroyMenu(menu);
+    const auto ole_api = ole_interaction::get();
 
-        if (cmd)
-        {
-        switch(cmd)
-        {
-        case ID_DROP:
-        process = true;
-        break;
-        }
-        }
-        }*/
+    dropped_files_data_impl dropped_data;
+    ole_api->parse_dataobject(pDataObj, dropped_data);
 
-        if (process) {
-            metadb_handle_list data;
+    const auto playlist_api = playlist_manager::get();
 
-            const auto ole_api = ole_interaction::get();
+    size_t idx = playlist_api->activeplaylist_get_item_count();
+    uih::ListView::HitTestResult hi;
 
-            dropped_files_data_impl dropped_data;
-            ole_api->parse_dataobject(pDataObj, dropped_data);
+    {
+        POINT ptt = pti;
+        ScreenToClient(p_playlist->get_wnd(), &ptt);
+        p_playlist->hit_test_ex(ptt, hi);
+    }
 
-            const auto playlist_api = playlist_manager::get();
+    if (hi.category == uih::ListView::HitTestCategory::OnUnobscuredItem
+        || hi.category == uih::ListView::HitTestCategory::OnGroupHeader
+        || hi.category == uih::ListView::HitTestCategory::OnItemObscuredBelow
+        || hi.category == uih::ListView::HitTestCategory::OnItemObscuredAbove
+        || hi.category == uih::ListView::HitTestCategory::NotOnItem) {
+        idx = hi.insertion_index;
+    }
 
-            size_t idx = playlist_api->activeplaylist_get_item_count();
-            uih::ListView::HitTestResult hi;
+    if (*pdwEffect == DROPEFFECT_COPY && cfg_drop_at_end)
+        idx = playlist_api->activeplaylist_get_item_count();
 
-            {
-                POINT ptt = pti;
-                ScreenToClient(p_playlist->get_wnd(), &ptt);
-                // p_playlist->hit_test(ptt, idx);
-                p_playlist->hit_test_ex(ptt, hi);
-            }
+    if (p_playlist->m_dragging) {
+        dropped_data.to_handles(data, false, p_playlist->get_wnd());
+        pfc::list_t<bool> selection;
+        std::vector<size_t> permutation_move;
 
-            if (hi.category == uih::ListView::HitTestCategory::OnUnobscuredItem
-                || hi.category == uih::ListView::HitTestCategory::OnGroupHeader
-                || hi.category == uih::ListView::HitTestCategory::OnItemObscuredBelow
-                || hi.category == uih::ListView::HitTestCategory::OnItemObscuredAbove
-                || hi.category == uih::ListView::HitTestCategory::NotOnItem) {
-                idx = hi.insertion_index;
-            }
+        size_t active_playlist = playlist_api->get_active_playlist();
 
-            if (*pdwEffect == DROPEFFECT_COPY && cfg_drop_at_end)
-                idx = playlist_api->activeplaylist_get_item_count();
+        if (p_playlist->m_dragging) {
+            selection.set_size(playlist_api->playlist_get_item_count(p_playlist->m_dragging_initial_playlist));
+            pfc::bit_array_var_table bitsel(selection.get_ptr(), selection.get_count());
+            playlist_api->playlist_get_selection_mask(p_playlist->m_dragging_initial_playlist, bitsel);
+            permutation_move.resize(selection.get_count());
+            ranges::iota(permutation_move, size_t{});
 
-            if (p_playlist->m_dragging) {
-                dropped_data.to_handles(data, false, p_playlist->get_wnd());
-                pfc::list_t<bool> selection;
-                std::vector<size_t> permutation_move;
-
-                size_t active_playlist = playlist_api->get_active_playlist();
-
-                if (p_playlist->m_dragging) {
-                    selection.set_size(playlist_api->playlist_get_item_count(p_playlist->m_dragging_initial_playlist));
-                    pfc::bit_array_var_table bitsel(selection.get_ptr(), selection.get_count());
-                    playlist_api->playlist_get_selection_mask(p_playlist->m_dragging_initial_playlist, bitsel);
-                    permutation_move.resize(selection.get_count());
-                    ranges::iota(permutation_move, size_t{});
-
-                    if (p_playlist->m_dragging_initial_playlist == active_playlist) {
-                        if (*pdwEffect == DROPEFFECT_MOVE) {
-                            size_t count = selection.get_count();
-                            size_t counter{};
-                            for (size_t i = 0; i < count; i++) {
-                                if (selection[i]) {
-                                    permutation_move.insert(permutation_move.begin() + idx + counter, i);
-                                    ++counter;
-                                }
-                            }
-
-                            selection.insert_items_repeat(false, counter, idx);
-
-                            for (size_t i{selection.get_size()}; i; --i) {
-                                const auto index = i - 1;
-                                if (selection[index]) {
-                                    permutation_move.erase(permutation_move.begin() + index);
-                                }
-                            }
-                        } else {
-                            selection.insert_items_repeat(false, data.get_count(), idx);
+            if (p_playlist->m_dragging_initial_playlist == active_playlist) {
+                if (*pdwEffect == DROPEFFECT_MOVE) {
+                    size_t count = selection.get_count();
+                    size_t counter{};
+                    for (size_t i = 0; i < count; i++) {
+                        if (selection[i]) {
+                            permutation_move.insert(permutation_move.begin() + idx + counter, i);
+                            ++counter;
                         }
-                    } else if (*pdwEffect == DROPEFFECT_MOVE)
-                        playlist_api->playlist_undo_backup(p_playlist->m_dragging_initial_playlist);
-                }
+                    }
 
-                playlist_api->activeplaylist_undo_backup();
-                bool b_redraw = p_playlist->disable_redrawing();
+                    selection.insert_items_repeat(false, counter, idx);
 
-                if (p_playlist->m_dragging && p_playlist->m_dragging_initial_playlist == active_playlist
-                    && *pdwEffect == DROPEFFECT_MOVE) {
-                    playlist_api->activeplaylist_reorder_items(permutation_move.data(), permutation_move.size());
+                    for (size_t i{selection.get_size()}; i; --i) {
+                        const auto index = i - 1;
+                        if (selection[index]) {
+                            permutation_move.erase(permutation_move.begin() + index);
+                        }
+                    }
                 } else {
-                    playlist_api->activeplaylist_clear_selection();
-                    size_t index_insert = playlist_api->activeplaylist_insert_items(idx, data, bit_array_true());
-                    playlist_api->activeplaylist_set_focus_item(index_insert);
-                    if (p_playlist->m_dragging && *pdwEffect == DROPEFFECT_MOVE) {
-                        playlist_api->playlist_remove_items(p_playlist->m_dragging_initial_playlist,
-                            pfc::bit_array_table(selection.get_ptr(), selection.get_count()));
-                    }
+                    selection.insert_items_repeat(false, data.get_count(), idx);
                 }
-                p_playlist->remove_insert_mark();
+            } else if (*pdwEffect == DROPEFFECT_MOVE)
+                playlist_api->playlist_undo_backup(p_playlist->m_dragging_initial_playlist);
+        }
 
-                SetFocus(p_playlist->get_wnd());
-                if (b_redraw)
-                    p_playlist->enable_redrawing();
-            } else {
-                class DelayedDropTargetProcesser : public process_locations_notify {
-                public:
-                    playlist_position_reference_tracker m_insertIndexTracker;
-                    service_ptr_t<PlaylistView> p_playlist;
+        playlist_api->activeplaylist_undo_backup();
+        bool b_redraw = p_playlist->disable_redrawing();
 
-                    void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) noexcept override
-                    {
-                        const auto playlist_api = playlist_manager::get();
-                        if (m_insertIndexTracker.m_playlist != pfc_infinite && p_items.get_count()) {
-                            if (m_insertIndexTracker.m_item == pfc_infinite)
-                                m_insertIndexTracker.m_item
-                                    = playlist_api->playlist_get_item_count(m_insertIndexTracker.m_playlist);
-                            playlist_api->playlist_undo_backup(m_insertIndexTracker.m_playlist);
-                            bool b_redraw = p_playlist->disable_redrawing();
-                            playlist_api->playlist_clear_selection(m_insertIndexTracker.m_playlist);
-                            playlist_api->playlist_insert_items(m_insertIndexTracker.m_playlist,
-                                m_insertIndexTracker.m_item, p_items, bit_array_true());
-                            playlist_api->playlist_set_focus_item(
-                                m_insertIndexTracker.m_playlist, m_insertIndexTracker.m_item);
-                            if (b_redraw)
-                                p_playlist->enable_redrawing();
-                        }
-                    }
-                    void on_aborted() override {}
-                };
-
-                service_ptr_t<DelayedDropTargetProcesser> ptr = new service_impl_t<DelayedDropTargetProcesser>;
-                ptr->p_playlist = p_playlist;
-                ptr->m_insertIndexTracker.m_playlist = playlist_api->get_active_playlist();
-                ptr->m_insertIndexTracker.m_item = idx;
-                dropped_data.to_handles_async(true, p_playlist->get_wnd(), ptr);
-                p_playlist->remove_insert_mark();
-                SetFocus(p_playlist->get_wnd());
+        if (p_playlist->m_dragging && p_playlist->m_dragging_initial_playlist == active_playlist
+            && *pdwEffect == DROPEFFECT_MOVE) {
+            playlist_api->activeplaylist_reorder_items(permutation_move.data(), permutation_move.size());
+        } else {
+            playlist_api->activeplaylist_clear_selection();
+            size_t index_insert = playlist_api->activeplaylist_insert_items(idx, data, bit_array_true());
+            playlist_api->activeplaylist_set_focus_item(index_insert);
+            if (p_playlist->m_dragging && *pdwEffect == DROPEFFECT_MOVE) {
+                playlist_api->playlist_remove_items(p_playlist->m_dragging_initial_playlist,
+                    pfc::bit_array_table(selection.get_ptr(), selection.get_count()));
             }
         }
+        p_playlist->remove_insert_mark();
+
+        SetFocus(p_playlist->get_wnd());
+        if (b_redraw)
+            p_playlist->enable_redrawing();
+    } else {
+        service_ptr_t<DelayedDropTargetProcesser> ptr = new service_impl_t<DelayedDropTargetProcesser>;
+        ptr->p_playlist = p_playlist;
+        ptr->m_insertIndexTracker.m_playlist = playlist_api->get_active_playlist();
+        ptr->m_insertIndexTracker.m_item = idx;
+        dropped_data.to_handles_async(true, p_playlist->get_wnd(), ptr);
+        p_playlist->remove_insert_mark();
+        SetFocus(p_playlist->get_wnd());
     }
 
     return S_OK;
 }
+
 PlaylistViewDropTarget::PlaylistViewDropTarget(PlaylistView* playlist)
     : drop_ref_count(0)
     , last_rmb(false)
@@ -329,6 +307,7 @@ PlaylistViewDropTarget::PlaylistViewDropTarget(PlaylistView* playlist)
 {
     m_DropTargetHelper = wil::CoCreateInstanceNoThrow<IDropTargetHelper>(CLSID_DragDropHelper);
 }
+
 HRESULT PlaylistViewDropTarget::UpdateDropDescription(IDataObject* pDataObj, DWORD pdwEffect)
 {
     const auto playlist_api = playlist_manager::get();

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -5,6 +5,52 @@
 
 namespace cui::panels::playlist_switcher {
 
+namespace {
+
+class DelayedDropTargetProcesser : public process_locations_notify {
+public:
+    playlist_position_reference_tracker m_insertIndexTracker;
+    service_ptr_t<PlaylistSwitcher> m_window;
+    bool m_new_playlist{false};
+    pfc::string8 m_playlist_name;
+
+    void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) noexcept override
+    {
+        const auto playlist_api = playlist_manager_v4::get();
+        if ((m_new_playlist || m_insertIndexTracker.m_playlist != pfc_infinite) && p_items.get_count()) {
+            if (m_new_playlist) {
+                if (!m_playlist_name.length()) {
+                    if (cfg_pgen_tf)
+                        m_playlist_name = StringFormatCommonTrackTitle(p_items, cfg_pgenstring);
+                    else
+                        m_playlist_name = "Untitled";
+                }
+
+                m_insertIndexTracker.m_playlist
+                    = playlist_api->create_playlist(m_playlist_name, pfc_infinite, m_insertIndexTracker.m_playlist);
+            } else {
+                playlist_api->playlist_undo_backup(m_insertIndexTracker.m_playlist);
+                playlist_api->playlist_clear_selection(m_insertIndexTracker.m_playlist);
+            }
+
+            const auto index = fbh::as_optional(playlist_api->playlist_insert_items(
+                m_insertIndexTracker.m_playlist, fbh::max_size_t, p_items, bit_array_true()));
+
+            if (!index)
+                return;
+
+            playlist_api->playlist_set_focus_item(m_insertIndexTracker.m_playlist, *index);
+
+            if (main_window::config_get_activate_target_playlist_on_dropped_items()) {
+                playlist_api->set_active_playlist(m_insertIndexTracker.m_playlist);
+            }
+        }
+    }
+    void on_aborted() override {}
+
+    DelayedDropTargetProcesser() : m_insertIndexTracker(false) {}
+};
+
 bool g_query_dataobj_supports_format(CLIPFORMAT cf, IDataObject* pDataObj)
 {
     FORMATETC fe;
@@ -58,6 +104,8 @@ bool g_get_folder_name(IDataObject* pDataObj, pfc::string8& p_out)
     }
     return ret;
 }
+
+} // namespace
 
 HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::QueryInterface(REFIID riid, LPVOID FAR* ppvObject)
 {
@@ -118,6 +166,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::DragEnter(
 
     m_is_accepted_type = ui_drop_item_callback::g_is_accepted_type(pDataObj, pdwEffect)
         || SUCCEEDED(m_ole_api->check_dataobject(pDataObj, dummy, native));
+
     if (!m_is_accepted_type) {
         *pdwEffect = DROPEFFECT_NONE;
         uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
@@ -149,86 +198,75 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::DragOver(DWORD grfKeySta
         : DROPEFFECT_COPY;
     m_last_rmb = ((grfKeyState & MK_RBUTTON) != 0);
 
-    POINT pti;
-    pti.y = ptl.y;
-    pti.x = ptl.x;
-    if (m_window->get_wnd()) {
-        HitTestResult hi;
+    POINT pti{ptl.x, ptl.y};
 
-        {
-            POINT ptt = pti;
-            ScreenToClient(m_window->get_wnd(), &ptt);
+    if (!m_window->get_wnd())
+        return S_OK;
 
-            RECT rc_items = m_window->get_items_rect();
+    HitTestResult hi;
 
-            rc_items.top += m_window->get_item_height();
-            rc_items.bottom -= m_window->get_item_height();
+    POINT ptt = pti;
+    ScreenToClient(m_window->get_wnd(), &ptt);
 
-            if (ptt.y < rc_items.top && ptt.y < rc_items.bottom) {
-                m_window->create_timer_scroll_up();
-            } else
-                m_window->destroy_timer_scroll_up();
+    RECT rc_items = m_window->get_items_rect();
 
-            if (ptt.y >= rc_items.top && ptt.y >= rc_items.bottom) {
-                m_window->create_timer_scroll_down();
-            } else
-                m_window->destroy_timer_scroll_down();
+    rc_items.top += m_window->get_item_height();
+    rc_items.bottom -= m_window->get_item_height();
 
-            /*if (*pdwEffect == DROPEFFECT_COPY && cfg_drop_at_end)
-            {
-                m_window->set_insert_mark(m_window->get_item_count());
+    if (ptt.y < rc_items.top && ptt.y < rc_items.bottom) {
+        m_window->create_timer_scroll_up();
+    } else
+        m_window->destroy_timer_scroll_up();
+
+    if (ptt.y >= rc_items.top && ptt.y >= rc_items.bottom) {
+        m_window->create_timer_scroll_down();
+    } else
+        m_window->destroy_timer_scroll_down();
+
+    m_window->hit_test_ex(ptt, hi);
+    if (hi.category == HitTestCategory::OnUnobscuredItem || hi.category == HitTestCategory::OnGroupHeader
+        || hi.category == HitTestCategory::OnItemObscuredBelow) {
+        if (m_is_playlists) {
+            m_window->set_insert_mark(hi.insertion_index);
+            m_window->destroy_switch_timer();
+            uih::ole::set_drop_description(m_DataObject.get(),
+                *pdwEffect == DROPEFFECT_MOVE ? DROPIMAGE_MOVE : DROPIMAGE_COPY,
+                *pdwEffect == DROPEFFECT_MOVE ? "Move here" : "Copy here", "");
+        } else {
+            if (isAltDown) {
+                m_window->set_insert_mark(hi.insertion_index);
                 m_window->destroy_switch_timer();
-            }
-            else*/
-            {
-                m_window->hit_test_ex(ptt, hi);
-                if (hi.category == HitTestCategory::OnUnobscuredItem || hi.category == HitTestCategory::OnGroupHeader
-                    || hi.category == HitTestCategory::OnItemObscuredBelow) {
-                    if (m_is_playlists) {
-                        m_window->set_insert_mark(hi.insertion_index);
-                        m_window->destroy_switch_timer();
-                        uih::ole::set_drop_description(m_DataObject.get(),
-                            *pdwEffect == DROPEFFECT_MOVE ? DROPIMAGE_MOVE : DROPIMAGE_COPY,
-                            *pdwEffect == DROPEFFECT_MOVE ? "Move here" : "Copy here", "");
-                    } else {
-                        if (isAltDown) {
-                            m_window->set_insert_mark(hi.insertion_index);
-                            m_window->destroy_switch_timer();
-                            m_window->remove_highlight_item();
-                            uih::ole::set_drop_description(
-                                m_DataObject.get(), DROPIMAGE_COPY, "Add to new playlist", "");
-                        } else {
-                            m_window->remove_insert_mark();
-                            m_window->set_highlight_item(hi.index);
-                            if (cfg_drag_autoswitch)
-                                m_window->set_switch_timer(hi.index);
-                            pfc::string8 name;
-                            playlist_manager::get()->playlist_get_name(hi.index, name);
-                            uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_COPY, "Add to %1", name);
-                        }
-                    }
-                } else if (hi.category == HitTestCategory::NotOnItem) {
-                    m_window->remove_highlight_item();
-                    m_window->set_insert_mark(hi.insertion_index);
-                    m_window->destroy_switch_timer();
-                    pfc::string8 message;
-                    if (*pdwEffect == DROPEFFECT_MOVE)
-                        message = "Move here";
-                    else if (m_is_playlists)
-                        message = "Copy here";
-                    else
-                        message = "Add to new playlist";
-
-                    uih::ole::set_drop_description(m_DataObject.get(),
-                        *pdwEffect == DROPEFFECT_MOVE ? DROPIMAGE_MOVE : DROPIMAGE_COPY, message, "");
-                } else {
-                    m_window->remove_insert_mark();
-                    m_window->remove_highlight_item();
-                    m_window->destroy_switch_timer();
-                    uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_COPY, "Add to new playlist", "");
-                }
+                m_window->remove_highlight_item();
+                uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_COPY, "Add to new playlist", "");
+            } else {
+                m_window->remove_insert_mark();
+                m_window->set_highlight_item(hi.index);
+                if (cfg_drag_autoswitch)
+                    m_window->set_switch_timer(hi.index);
+                pfc::string8 name;
+                playlist_manager::get()->playlist_get_name(hi.index, name);
+                uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_COPY, "Add to %1", name);
             }
         }
+    } else if (hi.category == HitTestCategory::NotOnItem) {
+        m_window->remove_highlight_item();
+        m_window->set_insert_mark(hi.insertion_index);
+        m_window->destroy_switch_timer();
+        pfc::string8 message;
+        if (*pdwEffect == DROPEFFECT_MOVE)
+            message = "Move here";
+        else if (m_is_playlists)
+            message = "Copy here";
+        else
+            message = "Add to new playlist";
+
+        uih::ole::set_drop_description(
+            m_DataObject.get(), *pdwEffect == DROPEFFECT_MOVE ? DROPIMAGE_MOVE : DROPIMAGE_COPY, message, "");
+    } else {
+        m_window->remove_insert_mark();
+        m_window->remove_highlight_item();
+        m_window->destroy_switch_timer();
+        uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_COPY, "Add to new playlist", "");
     }
     return S_OK;
 }
@@ -259,8 +297,17 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::DragLeave()
 HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
     IDataObject* pDataObj, DWORD grfKeyState, POINTL ptl, DWORD* pdwEffect)
 {
+    auto _ = gsl::finally([this] {
+        m_window->remove_insert_mark();
+        m_window->remove_highlight_item();
+
+        m_is_playlists = false;
+        m_is_accepted_type = false;
+    });
+
     POINT pt = {ptl.x, ptl.y};
     bool isAltDown = (grfKeyState & MK_ALT) != 0;
+
     if (m_DropTargetHelper)
         m_DropTargetHelper->Drop(pDataObj, &pt, *pdwEffect);
 
@@ -270,6 +317,7 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
     *pdwEffect = m_window->m_dragging && m_window->m_DataObject == pDataObj && (0 == (grfKeyState & MK_CONTROL))
         ? DROPEFFECT_MOVE
         : DROPEFFECT_COPY;
+
     m_DataObject.reset();
     m_window->destroy_timer_scroll_up();
     m_window->destroy_timer_scroll_down();
@@ -277,187 +325,123 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
 
     if (!m_is_accepted_type) {
         *pdwEffect = DROPEFFECT_NONE;
-        m_window->remove_insert_mark();
-        m_window->remove_highlight_item();
-        m_is_playlists = false;
         return S_OK;
     }
 
-    POINT pti;
-    pti.y = ptl.y;
-    pti.x = ptl.x;
-    if (m_window->get_wnd()) {
-        bool process = !ui_drop_item_callback::g_on_drop(pDataObj);
+    if (ui_drop_item_callback::g_on_drop(pDataObj))
+        return S_OK;
 
-        if (process) {
-            HitTestResult hi;
-            {
-                POINT ptt = pti;
-                ScreenToClient(m_window->get_wnd(), &ptt);
-                m_window->hit_test_ex(ptt, hi);
-            }
+    POINT pti{ptl.x, ptl.y};
 
-            playlist_dataobject_desc_impl data;
+    if (!m_window->get_wnd())
+        return S_OK;
 
-            bool b_internal_move = false;
-
-            if (m_is_playlists
-                && ((b_internal_move
-                        = m_window->m_dragging && m_window->m_DataObject == pDataObj && *pdwEffect == DROPEFFECT_MOVE)
-                    || SUCCEEDED(m_ole_api->parse_dataobject_playlists(pDataObj, data)))) {
-                if (b_internal_move) {
-                    if (hi.category == HitTestCategory::OnUnobscuredItem
-                        || hi.category == HitTestCategory::OnGroupHeader
-                        || hi.category == HitTestCategory::OnItemObscuredBelow
-                        || hi.category == HitTestCategory::OnItemObscuredAbove
-                        || hi.category == HitTestCategory::NotOnItem) {
-                        size_t count = m_playlist_api->get_playlist_count();
-                        order_helper order(count);
-                        {
-                            size_t from = m_window->get_selected_item_single();
-                            if (from != pfc_infinite) {
-                                size_t to = hi.insertion_index;
-                                if (to > from)
-                                    to--;
-                                if (from != to && to < count) {
-                                    if (from < to)
-                                        while (from < to && from < count) {
-                                            order.swap(from, from + 1);
-                                            from++;
-                                        }
-                                    else if (from > to)
-                                        while (from > to && from > 0) {
-                                            order.swap(from, from - 1);
-                                            from--;
-                                        }
-                                    {
-                                        m_playlist_api->reorder(order.get_ptr(), count);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    {
-                        size_t index_insert = m_playlist_api->get_playlist_count();
-
-                        if (hi.category == HitTestCategory::OnUnobscuredItem
-                            || hi.category == HitTestCategory::OnGroupHeader
-                            || hi.category == HitTestCategory::OnItemObscuredBelow
-                            || hi.category == HitTestCategory::OnItemObscuredAbove
-                            || hi.category == HitTestCategory::NotOnItem)
-                            index_insert = hi.insertion_index;
-
-                        size_t index_activate = NULL;
-
-                        size_t count = data.get_entry_count();
-                        for (size_t i = 0; i < count; i++) {
-                            pfc::string8 name;
-                            metadb_handle_list handles;
-                            mem_block_container_impl sidedata;
-
-                            data.get_entry_name(i, name);
-                            data.get_entry_content(i, handles);
-                            data.get_side_data(i, sidedata);
-                            stream_reader_memblock_ref side_data_reader(
-                                static_cast<uint8_t*>(sidedata.get_ptr()), sidedata.get_size());
-                            abort_callback_dummy p_abort;
-                            size_t index = m_playlist_api->create_playlist_ex(
-                                name, pfc_infinite, index_insert + i, handles, &side_data_reader, p_abort);
-                            if (i == 0)
-                                index_activate = index;
-                        }
-                        if (count)
-                            m_playlist_api->set_active_playlist(index_activate);
-                    }
-                }
-            } else {
-                pfc::string8 playlist_name;
-
-                metadb_handle_list data;
-
-                dropped_files_data_impl dropped_data;
-                m_ole_api->parse_dataobject(pDataObj, dropped_data);
-
-                bool create_new = true;
-                size_t idx = pfc_infinite;
-
-                if (hi.category == HitTestCategory::OnUnobscuredItem || hi.category == HitTestCategory::OnGroupHeader
-                    || hi.category == HitTestCategory::OnItemObscuredBelow
-                    || hi.category == HitTestCategory::OnItemObscuredAbove) {
-                    create_new = isAltDown;
-                    idx = create_new ? hi.insertion_index : hi.index;
-                } else if (hi.category == HitTestCategory::NotOnItem) {
-                    create_new = true;
-                }
-
-                if (create_new)
-                    if (g_get_folder_name(pDataObj, playlist_name) && cfg_replace_drop_underscores)
-                        playlist_name.replace_char('_', ' ');
-
-                {
-                    class DelayedDropTargetProcesser : public process_locations_notify {
-                    public:
-                        playlist_position_reference_tracker m_insertIndexTracker;
-                        service_ptr_t<PlaylistSwitcher> m_window;
-                        bool m_new_playlist{false};
-                        pfc::string8 m_playlist_name;
-
-                        void on_completion(const pfc::list_base_const_t<metadb_handle_ptr>& p_items) noexcept override
-                        {
-                            const auto playlist_api = playlist_manager_v4::get();
-                            if ((m_new_playlist || m_insertIndexTracker.m_playlist != pfc_infinite)
-                                && p_items.get_count()) {
-                                if (m_new_playlist) {
-                                    if (!m_playlist_name.length()) {
-                                        if (cfg_pgen_tf)
-                                            m_playlist_name = StringFormatCommonTrackTitle(p_items, cfg_pgenstring);
-                                        else
-                                            m_playlist_name = "Untitled";
-                                    }
-
-                                    m_insertIndexTracker.m_playlist = playlist_api->create_playlist(
-                                        m_playlist_name, pfc_infinite, m_insertIndexTracker.m_playlist);
-                                } else {
-                                    playlist_api->playlist_undo_backup(m_insertIndexTracker.m_playlist);
-                                    playlist_api->playlist_clear_selection(m_insertIndexTracker.m_playlist);
-                                }
-
-                                const auto index = fbh::as_optional(playlist_api->playlist_insert_items(
-                                    m_insertIndexTracker.m_playlist, fbh::max_size_t, p_items, bit_array_true()));
-
-                                if (!index)
-                                    return;
-
-                                playlist_api->playlist_set_focus_item(m_insertIndexTracker.m_playlist, *index);
-
-                                if (main_window::config_get_activate_target_playlist_on_dropped_items()) {
-                                    playlist_api->set_active_playlist(m_insertIndexTracker.m_playlist);
-                                }
-                            }
-                        }
-                        void on_aborted() override {}
-
-                        DelayedDropTargetProcesser() : m_insertIndexTracker(false) {}
-                    };
-
-                    service_ptr_t<DelayedDropTargetProcesser> ptr = new service_impl_t<DelayedDropTargetProcesser>;
-                    ptr->m_window = m_window;
-                    ptr->m_insertIndexTracker.m_playlist = idx;
-                    ptr->m_new_playlist = create_new;
-                    ptr->m_playlist_name = playlist_name;
-                    dropped_data.to_handles_async(true, m_window->get_wnd(), ptr);
-                    SetFocus(m_window->get_wnd());
-                }
-            }
-        }
+    HitTestResult hi;
+    {
+        POINT ptt = pti;
+        ScreenToClient(m_window->get_wnd(), &ptt);
+        m_window->hit_test_ex(ptt, hi);
     }
 
-    m_window->remove_insert_mark();
-    m_window->remove_highlight_item();
+    playlist_dataobject_desc_impl data;
 
-    m_is_playlists = false;
-    m_is_accepted_type = false;
+    bool b_internal_move = false;
+
+    if (m_is_playlists
+        && ((b_internal_move
+                = m_window->m_dragging && m_window->m_DataObject == pDataObj && *pdwEffect == DROPEFFECT_MOVE)
+            || SUCCEEDED(m_ole_api->parse_dataobject_playlists(pDataObj, data)))) {
+        if (b_internal_move) {
+            if (hi.category == HitTestCategory::OnUnobscuredItem || hi.category == HitTestCategory::OnGroupHeader
+                || hi.category == HitTestCategory::OnItemObscuredBelow
+                || hi.category == HitTestCategory::OnItemObscuredAbove || hi.category == HitTestCategory::NotOnItem) {
+                size_t count = m_playlist_api->get_playlist_count();
+                order_helper order(count);
+                {
+                    size_t from = m_window->get_selected_item_single();
+                    if (from != pfc_infinite) {
+                        size_t to = hi.insertion_index;
+                        if (to > from)
+                            to--;
+                        if (from != to && to < count) {
+                            if (from < to)
+                                while (from < to && from < count) {
+                                    order.swap(from, from + 1);
+                                    from++;
+                                }
+                            else if (from > to)
+                                while (from > to && from > 0) {
+                                    order.swap(from, from - 1);
+                                    from--;
+                                }
+                            {
+                                m_playlist_api->reorder(order.get_ptr(), count);
+                            }
+                        }
+                    }
+                }
+            }
+            return S_OK;
+        }
+
+        size_t index_insert = m_playlist_api->get_playlist_count();
+
+        if (hi.category == HitTestCategory::OnUnobscuredItem || hi.category == HitTestCategory::OnGroupHeader
+            || hi.category == HitTestCategory::OnItemObscuredBelow
+            || hi.category == HitTestCategory::OnItemObscuredAbove || hi.category == HitTestCategory::NotOnItem)
+            index_insert = hi.insertion_index;
+
+        size_t index_activate = NULL;
+
+        size_t count = data.get_entry_count();
+        for (size_t i = 0; i < count; i++) {
+            pfc::string8 name;
+            metadb_handle_list handles;
+            mem_block_container_impl sidedata;
+
+            data.get_entry_name(i, name);
+            data.get_entry_content(i, handles);
+            data.get_side_data(i, sidedata);
+            stream_reader_memblock_ref side_data_reader(static_cast<uint8_t*>(sidedata.get_ptr()), sidedata.get_size());
+            abort_callback_dummy p_abort;
+            size_t index = m_playlist_api->create_playlist_ex(
+                name, pfc_infinite, index_insert + i, handles, &side_data_reader, p_abort);
+            if (i == 0)
+                index_activate = index;
+        }
+        if (count)
+            m_playlist_api->set_active_playlist(index_activate);
+
+        return S_OK;
+    }
+
+    pfc::string8 playlist_name;
+
+    dropped_files_data_impl dropped_data;
+    m_ole_api->parse_dataobject(pDataObj, dropped_data);
+
+    bool create_new = true;
+    size_t idx = pfc_infinite;
+
+    if (hi.category == HitTestCategory::OnUnobscuredItem || hi.category == HitTestCategory::OnGroupHeader
+        || hi.category == HitTestCategory::OnItemObscuredBelow || hi.category == HitTestCategory::OnItemObscuredAbove) {
+        create_new = isAltDown;
+        idx = create_new ? hi.insertion_index : hi.index;
+    } else if (hi.category == HitTestCategory::NotOnItem) {
+        create_new = true;
+    }
+
+    if (create_new)
+        if (g_get_folder_name(pDataObj, playlist_name) && cfg_replace_drop_underscores)
+            playlist_name.replace_char('_', ' ');
+
+    service_ptr_t<DelayedDropTargetProcesser> ptr = new service_impl_t<DelayedDropTargetProcesser>;
+    ptr->m_window = m_window;
+    ptr->m_insertIndexTracker.m_playlist = idx;
+    ptr->m_new_playlist = create_new;
+    ptr->m_playlist_name = playlist_name;
+    dropped_data.to_handles_async(true, m_window->get_wnd(), ptr);
+    SetFocus(m_window->get_wnd());
 
     return S_OK;
 }

--- a/foo_ui_columns/playlist_switcher_drop_target.cpp
+++ b/foo_ui_columns/playlist_switcher_drop_target.cpp
@@ -455,7 +455,6 @@ HRESULT STDMETHODCALLTYPE PlaylistSwitcher::DropTarget::Drop(
 
     m_window->remove_insert_mark();
     m_window->remove_highlight_item();
-    uih::ole::set_drop_description(pDataObj, DROPIMAGE_INVALID, "", "");
 
     m_is_playlists = false;
     m_is_accepted_type = false;

--- a/foo_ui_columns/playlist_tabs_drop_target.cpp
+++ b/foo_ui_columns/playlist_tabs_drop_target.cpp
@@ -156,10 +156,8 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Drop(
     last_over.x = 0;
     last_over.y = 0;
 
-    if (!m_is_accepted_type) {
-        uih::ole::set_drop_description(m_DataObject.get(), DROPIMAGE_INVALID, "", "");
+    if (!m_is_accepted_type)
         return S_OK;
-    }
 
     const auto playlist_api = playlist_manager::get();
 

--- a/foo_ui_columns/playlist_tabs_drop_target.cpp
+++ b/foo_ui_columns/playlist_tabs_drop_target.cpp
@@ -44,6 +44,7 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::DragEnter(
     POINT pt = {ptl.x, ptl.y};
     if (m_DropTargetHelper)
         m_DropTargetHelper->DragEnter(p_list->get_wnd(), pDataObj, &pt, *pdwEffect);
+
     m_DataObject = pDataObj;
 
     last_over.x = 0;
@@ -93,13 +94,6 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::DragOver(
 
         HWND wnd = ChildWindowFromPointEx(p_list->get_wnd(), ptm, CWP_SKIPINVISIBLE);
 
-        //    RECT plist;
-
-        //    GetWindowRect(g_plist, &plist);
-        //    RECT tabs;
-
-        //    GetWindowRect(g_tab, &tabs);
-
         if (p_list->wnd_tabs) {
             POINT pttab = pti;
 
@@ -134,6 +128,7 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::DragLeave()
 {
     if (m_DropTargetHelper)
         m_DropTargetHelper->DragLeave();
+
     last_over.x = 0;
     last_over.y = 0;
     p_list->kill_switch_timer();
@@ -148,6 +143,7 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Drop(
 {
     POINT pt = {ptl.x, ptl.y};
     bool isAltDown = (grfKeyState & MK_ALT) != 0;
+
     if (m_DropTargetHelper)
         m_DropTargetHelper->Drop(pDataObj, &pt, *pdwEffect);
 
@@ -170,162 +166,135 @@ HRESULT STDMETHODCALLTYPE PlaylistTabs::PlaylistTabsDropTarget::Drop(
 
     HWND wnd = ChildWindowFromPointEx(p_list->get_wnd(), ptm, CWP_SKIPINVISIBLE);
 
-    if (wnd) {
-        bool process = !ui_drop_item_callback::g_on_drop(pDataObj);
+    if (!wnd)
+        return S_OK;
 
-        bool send_new_playlist = false;
+    if (ui_drop_item_callback::g_on_drop(pDataObj))
+        return S_OK;
 
-        if (process && m_last_rmb) {
-            process = false;
-            enum {
-                ID_DROP = 1,
-                ID_NEW_PLAYLIST,
-                ID_CANCEL
-            };
+    bool send_new_playlist = false;
 
-            HMENU menu = CreatePopupMenu();
+    if (m_last_rmb) {
+        enum {
+            ID_DROP = 1,
+            ID_NEW_PLAYLIST,
+            ID_CANCEL
+        };
 
-            uAppendMenu(menu, (MF_STRING), ID_DROP, "&Add files here");
-            uAppendMenu(menu, (MF_STRING), ID_NEW_PLAYLIST, "&Add files to new playlist");
-            uAppendMenu(menu, MF_SEPARATOR, 0, nullptr);
-            uAppendMenu(menu, MF_STRING, ID_CANCEL, "&Cancel");
+        HMENU menu = CreatePopupMenu();
 
-            int cmd = TrackPopupMenu(
-                menu, TPM_RIGHTBUTTON | TPM_NONOTIFY | TPM_RETURNCMD, pt.x, pt.y, 0, p_list->get_wnd(), nullptr);
-            DestroyMenu(menu);
+        uAppendMenu(menu, (MF_STRING), ID_DROP, "&Add files here");
+        uAppendMenu(menu, (MF_STRING), ID_NEW_PLAYLIST, "&Add files to new playlist");
+        uAppendMenu(menu, MF_SEPARATOR, 0, nullptr);
+        uAppendMenu(menu, MF_STRING, ID_CANCEL, "&Cancel");
 
-            if (cmd) {
-                switch (cmd) {
-                case ID_DROP:
-                    process = true;
-                    break;
-                case ID_NEW_PLAYLIST:
-                    process = true;
-                    send_new_playlist = true;
-                    break;
+        int cmd = TrackPopupMenu(
+            menu, TPM_RIGHTBUTTON | TPM_NONOTIFY | TPM_RETURNCMD, pt.x, pt.y, 0, p_list->get_wnd(), nullptr);
+        DestroyMenu(menu);
+
+        switch (cmd) {
+        case ID_DROP:
+            break;
+        case ID_NEW_PLAYLIST:
+            send_new_playlist = true;
+            break;
+        default:
+            return S_OK;
+        }
+    }
+
+    metadb_handle_list data;
+    const auto incoming_api = playlist_incoming_item_filter::get();
+    incoming_api->process_dropped_files(pDataObj, data, true, p_list->get_wnd());
+
+    POINT pttab = pti;
+
+    size_t newPlaylistIndex = pfc_infinite;
+    size_t target_index = playlist_api->get_active_playlist();
+
+    if (p_list->wnd_tabs && wnd == p_list->wnd_tabs) {
+        RECT tabs;
+
+        GetWindowRect(p_list->wnd_tabs, &tabs);
+        if (ScreenToClient(p_list->wnd_tabs, &pttab)) {
+            TCHITTESTINFO hittest;
+            hittest.pt.x = pttab.x;
+            hittest.pt.y = pttab.y;
+            int idx = TabCtrl_HitTest(p_list->wnd_tabs, &hittest);
+
+            if (send_new_playlist || idx < 0 || isAltDown) {
+                send_new_playlist = true;
+                if (idx >= 0)
+                    newPlaylistIndex = idx;
+            } else
+                target_index = idx;
+        }
+    }
+
+    if (send_new_playlist) {
+        pfc::string8 playlist_name("Untitled");
+
+        bool named = false;
+
+        FORMATETC fe{};
+        STGMEDIUM sm{};
+        HRESULT hr = E_FAIL;
+
+        fe.cfFormat = CF_HDROP;
+        fe.ptd = nullptr;
+        fe.dwAspect = DVASPECT_CONTENT;
+        fe.lindex = -1;
+        fe.tymed = TYMED_HGLOBAL;
+
+        // User has dropped on us. Get the data from drag source
+        hr = pDataObj->GetData(&fe, &sm);
+        if (SUCCEEDED(hr)) {
+            // Display the data and release it.
+            pfc::string8 temp;
+
+            unsigned int /*n,*/ t = uDragQueryFileCount((HDROP)sm.hGlobal);
+            if (t == 1) {
+                uDragQueryFile((HDROP)sm.hGlobal, 0, temp);
+                if (uGetFileAttributes(temp) & FILE_ATTRIBUTE_DIRECTORY) {
+                    playlist_name.set_string(string_filename_ext(temp));
+                    named = true;
+                } else {
+                    playlist_name.set_string(string_filename(temp));
+                    named = true;
                 }
             }
+
+            ReleaseStgMedium(&sm);
         }
 
-        if (process) {
-            metadb_handle_list data;
-            const auto incoming_api = playlist_incoming_item_filter::get();
-            incoming_api->process_dropped_files(pDataObj, data, true, p_list->get_wnd());
+        size_t new_idx;
+        if (newPlaylistIndex == pfc_infinite)
+            newPlaylistIndex = playlist_api->get_playlist_count();
 
-            POINT pttab = pti;
+        if (named && cfg_replace_drop_underscores)
+            playlist_name.replace_char('_', ' ');
+        if (!named && cfg_pgen_tf)
+            new_idx = playlist_api->create_playlist(
+                StringFormatCommonTrackTitle(data, cfg_pgenstring), pfc_infinite, newPlaylistIndex);
 
-            size_t newPlaylistIndex = pfc_infinite;
-            size_t target_index = playlist_api->get_active_playlist();
+        else
+            new_idx = playlist_api->create_playlist(playlist_name, pfc_infinite, newPlaylistIndex);
 
-            if (p_list->wnd_tabs && wnd == p_list->wnd_tabs) {
-                RECT tabs;
+        playlist_api->playlist_add_items(new_idx, data, bit_array_false());
+        if (main_window::config_get_activate_target_playlist_on_dropped_items())
+            playlist_api->set_active_playlist(new_idx);
 
-                GetWindowRect(p_list->wnd_tabs, &tabs);
-                if (ScreenToClient(p_list->wnd_tabs, &pttab)) {
-                    TCHITTESTINFO hittest;
-                    hittest.pt.x = pttab.x;
-                    hittest.pt.y = pttab.y;
-                    int idx = TabCtrl_HitTest(p_list->wnd_tabs, &hittest);
+    } else {
+        playlist_api->playlist_clear_selection(target_index);
 
-                    if (send_new_playlist || idx < 0 || isAltDown) {
-                        send_new_playlist = true;
-                        if (idx >= 0)
-                            newPlaylistIndex = idx;
-                    } else
-                        target_index = idx;
-                }
-            }
+        const auto index = fbh::as_optional(
+            playlist_api->playlist_insert_items(target_index, fbh::max_size_t, data, bit_array_true()));
 
-            if (send_new_playlist) {
-                pfc::string8 playlist_name("Untitled");
+        if (index) {
+            playlist_api->playlist_set_focus_item(target_index, *index);
 
-                bool named = false;
-
-                if (true || true) {
-                    FORMATETC fe;
-                    STGMEDIUM sm;
-                    HRESULT hr = E_FAIL;
-
-                    //                    memset(&sm, 0, sizeof(0));
-
-                    fe.cfFormat = CF_HDROP;
-                    fe.ptd = nullptr;
-                    fe.dwAspect = DVASPECT_CONTENT;
-                    fe.lindex = -1;
-                    fe.tymed = TYMED_HGLOBAL;
-
-                    // User has dropped on us. Get the data from drag source
-                    hr = pDataObj->GetData(&fe, &sm);
-                    if (SUCCEEDED(hr)) {
-                        // Display the data and release it.
-                        pfc::string8 temp;
-
-                        unsigned int /*n,*/ t = uDragQueryFileCount((HDROP)sm.hGlobal);
-                        if (t == 1) {
-                            {
-                                uDragQueryFile((HDROP)sm.hGlobal, 0, temp);
-                                if (uGetFileAttributes(temp) & FILE_ATTRIBUTE_DIRECTORY) {
-                                    playlist_name.set_string(string_filename_ext(temp));
-                                    named = true;
-                                } else {
-                                    playlist_name.set_string(string_filename(temp));
-                                    named = true;
-#if 0
-                                    pfc::string_extension ext(temp);
-
-                                    service_enum_t<playlist_loader> e;
-                                    service_ptr_t<playlist_loader> l;
-                                    if (e.first(l))
-                                        do
-                                        {
-                                            if (!strcmp(l->get_extension(), ext))
-                                            {
-                                                playlist_name.set_string(pfc::string_filename(temp));
-                                                named = true;
-                                                l.release();
-                                                break;
-                                            }
-                                            l.release();
-                                        } while (e.next(l));
-#endif
-                                }
-                            }
-                        }
-
-                        ReleaseStgMedium(&sm);
-                    }
-                }
-
-                size_t new_idx;
-                if (newPlaylistIndex == pfc_infinite)
-                    newPlaylistIndex = playlist_api->get_playlist_count();
-
-                if (named && cfg_replace_drop_underscores)
-                    playlist_name.replace_char('_', ' ');
-                if (!named && cfg_pgen_tf)
-                    new_idx = playlist_api->create_playlist(
-                        StringFormatCommonTrackTitle(data, cfg_pgenstring), pfc_infinite, newPlaylistIndex);
-
-                else
-                    new_idx = playlist_api->create_playlist(playlist_name, pfc_infinite, newPlaylistIndex);
-
-                playlist_api->playlist_add_items(new_idx, data, bit_array_false());
-                if (main_window::config_get_activate_target_playlist_on_dropped_items())
-                    playlist_api->set_active_playlist(new_idx);
-
-            } else {
-                playlist_api->playlist_clear_selection(target_index);
-
-                const auto index = fbh::as_optional(
-                    playlist_api->playlist_insert_items(target_index, fbh::max_size_t, data, bit_array_true()));
-
-                if (index) {
-                    playlist_api->playlist_set_focus_item(target_index, *index);
-
-                    if (main_window::config_get_activate_target_playlist_on_dropped_items())
-                        playlist_api->set_active_playlist(target_index);
-                }
-            }
+            if (main_window::config_get_activate_target_playlist_on_dropped_items())
+                playlist_api->set_active_playlist(target_index);
         }
     }
 


### PR DESCRIPTION
This should fix a rare drag-and-drop crash when dropping items on certain parts of the main window (and probably also the playlist tabs on reviewing the code).

This was related to some incorrect usage of `m_DataObject` in the `IDropTarget::Drop` implementation in a `uih::ole::set_drop_description()` call (and somehow `m_DataObject` being empty at the same time).

I could not recall a reason for removing the drop description in the `IDropTarget::Drop` implementation. It was not being done consistently, so I've stopped doing it everywhere. (Additionally, there was an incorrect call to `IDropTargetHelper::DragLeave()`...

The second commit also makes an attempt to tidy up some of the IDropTarget implementations (mainly by returning early and reducing indentation everywhere...)