### PR TITLE
Correct Item details maximum $set_format() font weight in docs

### DIFF
--- a/docs/source/item-details/title-formatting.md
+++ b/docs/source/item-details/title-formatting.md
@@ -26,7 +26,7 @@ $set_format(
 | ----------------- | ---------------------------------------------- |
 | `font-family`     | \<font family name> \| `initial`               |
 | `font-size`       | \<font size in points> \| `initial`            |
-| `font-weight`     | \<1–900> \| `initial`                          |
+| `font-weight`     | \<1–999> \| `initial`                          |
 | `font-stretch`    | \<1–9> \| <percentage> \| `initial`            |
 | `font-style`      | `normal` \| `italic` \| `oblique` \| `initial` |
 | `text-decoration` | `none` \| `underline` \| `initial`             |


### PR DESCRIPTION
This corrects the maximum `font-weight` value from 900 to 999 in the docs for the Item details `$set_format()` title formatting function.