### PR TITLE
Fix incorrect system font size on pre-Windows 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@
   [#1039](https://github.com/reupen/columns_ui/pull/1039),
   [#1042](https://github.com/reupen/columns_ui/pull/1042),
   [#1060](https://github.com/reupen/columns_ui/pull/1060),
-  [#1064](https://github.com/reupen/columns_ui/pull/1064)]
+  [#1064](https://github.com/reupen/columns_ui/pull/1064),
+  [#1070](https://github.com/reupen/columns_ui/pull/1070)]
 
   This includes colour font support on Windows 8.1 and newer (allowing the use
   of, for example, colour emojis).

--- a/foo_ui_columns/font_utils.cpp
+++ b/foo_ui_columns/font_utils.cpp
@@ -183,9 +183,11 @@ SystemFont get_icon_font_for_dpi(unsigned dpi)
         uih::dpi::system_parameters_info_for_dpi(SPI_GETICONTITLELOGFONT, sizeof(LOGFONT), &lf, dpi);
     } catch (const uih::dpi::DpiAwareFunctionUnavailableError&) {
         SystemParametersInfo(SPI_GETICONTITLELOGFONT, sizeof(LOGFONT), &lf, 0);
+
+        const auto dip_size = scale_font_size(-lf.lfHeight, dpi);
         lf.lfHeight = MulDiv(lf.lfHeight, dpi, uih::get_system_dpi_cached().cx);
 
-        return {lf, scale_font_size(-lf.lfHeight, dpi)};
+        return {lf, dip_size};
     }
 
     return {lf, gsl::narrow_cast<float>(-lf.lfHeight)};
@@ -199,9 +201,12 @@ SystemFont get_menu_font_for_dpi(unsigned dpi)
         uih::dpi::system_parameters_info_for_dpi(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, dpi);
     } catch (const uih::dpi::DpiAwareFunctionUnavailableError&) {
         SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0);
+
+        const auto dip_size = scale_font_size(-ncm.lfMenuFont.lfHeight, dpi);
         ncm.lfMenuFont.lfHeight = MulDiv(ncm.lfMenuFont.lfHeight, dpi, uih::get_system_dpi_cached().cx);
-        return {ncm.lfMenuFont, scale_font_size(-ncm.lfMenuFont.lfHeight, dpi)};
+        return {ncm.lfMenuFont, dip_size};
     }
+
     return {ncm.lfMenuFont, gsl::narrow_cast<float>(-ncm.lfMenuFont.lfHeight)};
 }
 


### PR DESCRIPTION
This fixes a bug where incorrect font sizes were used in some parts of the UI for system icon and menu fonts on older versions of Windows, when using a system DPI setting of greater than 100%.