### PR TITLE
Fix text encoding of resource file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+- A bug causing incorrect characters to appear in the the Item details format
+  code generator dialogue box title was fixed.
+  [[#1076](https://github.com/reupen/columns_ui/pull/1076)]
+
 ## 3.0.0-alpha.1
 
 ### Features

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -1,5 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
+#pragma code_page(65001)
+
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
@@ -19,7 +21,6 @@
 
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENG)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
-#pragma code_page(1252)
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
@@ -747,7 +748,7 @@ END
 
 IDD_ITEM_DETAILS_PICK_FONT DIALOGEX 0, 0, 200, 227
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
-CAPTION "Format code generator � Item details"
+CAPTION "Format code generator – Item details"
 FONT 8, "Segoe UI", 400, 0, 0x0
 BEGIN
     LTEXT           "Font family",-1,14,7,47,8


### PR DESCRIPTION
Fixes #1073

This stops Visual Studio getting confused about the text encoding of `foo_ui_columns.rc` (and makes it consistently save it as UTF-8).

The solution is from https://developercommunity.visualstudio.com/t/visualstudio-v1590-resource-editor-using-utf-8-bom/384705#T-N796658.