### PR TITLE
Re-enable tab columns in playlist view group titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bug fixes
 
+- The ability to use the tab character in playlist group titles to lay out text
+  in columns was restored.
+  [[#1080](https://github.com/reupen/columns_ui/pull/1080)]
+
 - A bug causing incorrect characters to appear in the the Item details format
   code generator dialogue box title was fixed.
   [[#1076](https://github.com/reupen/columns_ui/pull/1076)]

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -174,7 +174,7 @@ void PlaylistViewRenderer::render_group(uih::lv::RendererContext context, size_t
     const auto border = 3_spx;
 
     const auto text_width = text_out_columns_and_colours(*context.m_group_text_format, context.wnd, context.dc, text,
-        x_offset, border, rc, cr, {.enable_ellipses = cfg_ellipsis != 0, .enable_tab_columns = false});
+        x_offset, border, rc, cr, {.enable_ellipses = cfg_ellipsis != 0});
 
     const auto line_height = 1_spx;
     const auto line_top = rc.top + wil::rect_height(rc) / 2 - line_height / 2;


### PR DESCRIPTION
This re-enables tab-based columns playlist view group titles. (They were probably incorrectly disabled in 4093c516953ac7e9436e582fc255d16d671b40f2.)