### PR TITLE
Log nicer error when $set_font() used in Item details with bad font name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   code generator dialogue box title was fixed.
   [[#1076](https://github.com/reupen/columns_ui/pull/1076)]
 
+- A nicer error message is now logged to the console when using $set_font() with
+  a non-existent font family name.
+  [[#1081](https://github.com/reupen/columns_ui/pull/1081)]
+
 ## 3.0.0-alpha.1
 
 ### Features

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -98,10 +98,18 @@ std::optional<FormatProperties> parse_font_code(
         const auto style = direct_write_font->GetStyle();
 
         return FormatProperties{std::move(family_name), *size_points, weight, stretch, style, text_decoration};
-    }
-    CATCH_LOG()
+    } catch (...) {
+        if (wil::ResultFromCaughtException() == DWRITE_E_NOFONT) {
+            console::print(reinterpret_cast<const char*>(
+                fmt::format(u8"Item details – $set_font() error: font family \"{}\" not found",
+                    reinterpret_cast<const char8_t*>(mmh::to_utf8(lf.lfFaceName).c_str()))
+                    .c_str()));
+            return {};
+        }
 
-    return {};
+        LOG_CAUGHT_EXCEPTION();
+        return {};
+    }
 }
 
 std::optional<FormatProperties> parse_font_code(


### PR DESCRIPTION
Resolves #1075

This updates fbh and amends the error handler logic used when parsing a font code in Item details to log a more user-friendly error when `$set_font()` is called with an invalid font family name.