### PR TITLE
Fix bug adding buttons or changing button commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.0.0-alpha.3
+
+### Bug fixes
+
+- A bug where it wasn’t possible to add new buttons or change existing button
+  commands in the Buttons toolbar was fixed.
+  [[#1087](https://github.com/reupen/columns_ui/pull/1087)]
+
 ## 3.0.0-alpha.2
 
 ### Bug fixes

--- a/foo_ui_columns/buttons_command_picker.cpp
+++ b/foo_ui_columns/buttons_command_picker.cpp
@@ -9,8 +9,9 @@ std::tuple<bool, CommandPickerData> CommandPickerDialog::open_modal(HWND wnd)
     dark::DialogDarkModeConfig dark_mode_config{
         .button_ids = {IDOK, IDCANCEL}, .list_box_ids = {IDC_GROUP, IDC_ITEM, IDC_COMMAND}};
 
-    const auto dialog_result = modal_dialog_box(IDD_BUTTON_COMMAND_PICKER, dark_mode_config, wnd,
-        [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
+    const auto dialog_result = modal_dialog_box(
+        IDD_BUTTON_COMMAND_PICKER, dark_mode_config, wnd,
+        [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); }, false);
 
     return {dialog_result > 0, m_data};
 }

--- a/foo_ui_columns/dark_mode_dialog.cpp
+++ b/foo_ui_columns/dark_mode_dialog.cpp
@@ -286,16 +286,18 @@ void DialogDarkModeHelper::on_dark_mode_change()
 } // namespace
 
 INT_PTR modal_dialog_box(UINT resource_id, DialogDarkModeConfig dark_mode_config, HWND parent_window,
-    std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message)
+    std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message, bool poke)
 {
-    return fbh::modal_dialog_box(resource_id, parent_window,
+    return fbh::modal_dialog_box(
+        resource_id, parent_window,
         [helper = std::make_shared<DialogDarkModeHelper>(std::move(dark_mode_config)),
             on_message{std::move(on_message)}](HWND wnd, UINT msg, WPARAM wp, LPARAM lp) {
             if (const auto result = helper->handle_message(wnd, msg, wp, lp))
                 return *result;
 
             return on_message(wnd, msg, wp, lp);
-        });
+        },
+        poke);
 }
 
 HWND modeless_dialog_box(UINT resource_id, DialogDarkModeConfig dark_mode_config, HWND parent_window,

--- a/foo_ui_columns/dark_mode_dialog.h
+++ b/foo_ui_columns/dark_mode_dialog.h
@@ -17,7 +17,7 @@ struct DialogDarkModeConfig {
 };
 
 INT_PTR modal_dialog_box(UINT resource_id, DialogDarkModeConfig dark_mode_config, HWND parent_window,
-    std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);
+    std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message, bool poke = true);
 
 HWND modeless_dialog_box(UINT resource_id, DialogDarkModeConfig dark_mode_config, HWND parent_window,
     std::function<INT_PTR(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)> on_message);


### PR DESCRIPTION
This fixes a bug where neither the ‘Change command...’ nor the ‘Add’ buttons worked in the Options dialogue for the Buttons toolbar.