### PR TITLE
Work around Windows 8.1 crash on Fonts preferences tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   Fonts preferences tab were corrected.
   [[#1094](https://github.com/reupen/columns_ui/pull/1094)]
 
+- A Windows bug causing a crash on Windows 8.1 when opening the Fonts tab on the
+  Colours and fonts preferences page was worked around.
+  [[#1098](https://github.com/reupen/columns_ui/pull/1098)]
+
 ## 3.0.0-alpha.3
 
 ### Bug fixes


### PR DESCRIPTION
This updates ui_helpers to pick up this workaround for a Windows bug:

> `IDWriteFont3` inexplicably has the same IID as `IDWriteFont2`, meaning that the `IDWriteFont3` interface can't be reliably queried for.
>
> Equivalent functionality from `IDWriteFontFamily1` is used to work around the problem.