### PR TITLE
Fix incorrect font family use in DirectWrite panels on Windows 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Development version
 
-### Bug fixes
+### 3.0.0-alpha.4
+
+- A bug where DirectWrite-rendered text did not use the correct font family on
+  Windows 10 and older versions of Windows 11 was fixed.
+  [[#1099](https://github.com/reupen/columns_ui/pull/1099)]
 
 - A bug where typing axis values in the dialogue box opened by the ‘Configure
   variable font axes...’ button on the Fonts preferences tab did not work was

--- a/foo_ui_columns/font_manager_v3.cpp
+++ b/foo_ui_columns/font_manager_v3.cpp
@@ -71,8 +71,8 @@ public:
 
             if (factory_7 && !m_axis_values.empty()) {
                 wil::com_ptr<IDWriteTextFormat3> text_format_3;
-                THROW_IF_FAILED(factory_7->CreateTextFormat(m_typographic_family_name.c_str(), nullptr,
-                    m_axis_values.data(), gsl::narrow<uint32_t>(m_axis_values.size()), size(), L"", &text_format_3));
+                THROW_IF_FAILED(factory_7->CreateTextFormat(family_name(), nullptr, m_axis_values.data(),
+                    gsl::narrow<uint32_t>(m_axis_values.size()), size(), L"", &text_format_3));
                 text_format.attach(text_format_3.detach());
             } else {
                 THROW_IF_FAILED(context->factory()->CreateTextFormat(family_name(), nullptr, weight(), style(),


### PR DESCRIPTION
This corrects an assumption when creating DirectWrite text formats that if axis values are populated then the typographic font family name is also populated.

This assumption was incorrect on most versions of Windows 10 and older versions of Windows 11.

It now falls back to the weight-stretch-style font family name if the typographic font family name is missing and axis values are populated.

Additionally, a few other minor tweaks were made in `ui_helpers` (namely to handle simulated fonts correctly on the same Windows versions as above).