### PR TITLE
Allow disabling anti-aliasing for DirectWrite rendered text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Development version
 
+### Features
+
+- A ‘No anti-aliasing’ DirectWrite text rendering mode was added.
+  [[#1100](https://github.com/reupen/columns_ui/pull/1100)]
+
+  Additionally, the previous ‘Automatic’ mode has been renamed ‘Automatic
+  anti-aliasing’, and a new ‘Default’ mode has been added that selects
+  ‘Automatic anti-aliasing’ or ‘No anti-aliasing’ based on the system ‘Smooth
+  edges of screen fonts’ setting.
+
 ## 3.0.0-alpha.4
 
 - A bug where DirectWrite-rendered text did not use the correct font family on

--- a/foo_ui_columns/font_manager_data.cpp
+++ b/foo_ui_columns/font_manager_data.cpp
@@ -484,6 +484,12 @@ fbh::ConfigBool force_greyscale_antialiasing(
 
 DWRITE_RENDERING_MODE get_rendering_mode()
 {
+    if (rendering_mode.get() == WI_EnumValue(RenderingMode::Automatic)) {
+        BOOL font_smoothing_enabled{true};
+        SystemParametersInfo(SPI_GETFONTSMOOTHING, 0, &font_smoothing_enabled, 0);
+        return font_smoothing_enabled ? DWRITE_RENDERING_MODE_DEFAULT : DWRITE_RENDERING_MODE_ALIASED;
+    }
+
     return static_cast<DWRITE_RENDERING_MODE>(rendering_mode.get());
 }
 

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -11,9 +11,11 @@ enum class FontMode {
 };
 
 enum class RenderingMode : int32_t {
-    Automatic = DWRITE_RENDERING_MODE_DEFAULT,
+    Automatic = 99,
+    NaturalAutomatic = DWRITE_RENDERING_MODE_DEFAULT,
     Natural = DWRITE_RENDERING_MODE_NATURAL,
     NaturalSymmetric = DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+    Aliased = DWRITE_RENDERING_MODE_ALIASED,
     GdiClassic = DWRITE_RENDERING_MODE_GDI_CLASSIC,
     GdiNatural = DWRITE_RENDERING_MODE_GDI_NATURAL,
 };

--- a/foo_ui_columns/font_manager_v3.cpp
+++ b/foo_ui_columns/font_manager_v3.cpp
@@ -141,7 +141,7 @@ public:
         auto axis_values = uih::direct_write::axis_values_to_vector(font_description.axis_values);
 
         return fb2k::service_new<Font>(log_font, wss, font_description.typographic_family_name, std::move(axis_values),
-            size, static_cast<DWRITE_RENDERING_MODE>(rendering_mode.get()), force_greyscale_antialiasing.get());
+            size, get_rendering_mode(), force_greyscale_antialiasing.get());
     }
 
     void set_font_size(GUID id, float size) override

--- a/foo_ui_columns/tab_text_rendering.cpp
+++ b/foo_ui_columns/tab_text_rendering.cpp
@@ -9,9 +9,11 @@ namespace cui::prefs {
 namespace {
 
 constexpr auto rendering_modes = {
-    std::make_tuple(fonts::RenderingMode::Automatic, L"Automatic"),
+    std::make_tuple(fonts::RenderingMode::Automatic, L"Default"),
+    std::make_tuple(fonts::RenderingMode::NaturalAutomatic, L"Automatic anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::Natural, L"Horizontal anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::NaturalSymmetric, L"Symmetric anti-aliasing"),
+    std::make_tuple(fonts::RenderingMode::Aliased, L"No anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::GdiClassic, L"GDI-compatible, classic"),
     std::make_tuple(fonts::RenderingMode::GdiNatural, L"GDI-compatible, natural"),
 };


### PR DESCRIPTION
This:

- adds a new ’No anti-aliasing’ text rendering mode
- renames the previous ‘Automatic’ mode to ‘Automatic anti-aliasing’
- adds a new ‘Default’ mode that disables anti-aliasing automatically based on the system font smoothing setting