### PR TITLE
Rename ‘No anti-aliasing’ text rendering mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Features
 
-- A ‘No anti-aliasing’ DirectWrite text rendering mode was added.
-  [[#1100](https://github.com/reupen/columns_ui/pull/1100)]
+- A ‘GDI-compatible, no anti-aliasing’ DirectWrite text rendering mode was
+  added. [[#1102](https://github.com/reupen/columns_ui/pull/1102),
+  [#1103](https://github.com/reupen/columns_ui/pull/1103),
+  [#1104](https://github.com/reupen/columns_ui/pull/1104)]
 
   Additionally, the previous ‘Automatic’ mode has been renamed ‘Automatic
   anti-aliasing’, and a new ‘Default’ mode has been added that selects
-  ‘Automatic anti-aliasing’ or ‘No anti-aliasing’ based on the system ‘Smooth
-  edges of screen fonts’ setting.
+  ‘Automatic anti-aliasing’ or ‘GDI-compatible, no anti-aliasing’ based on the
+  system ‘Smooth edges of screen fonts’ setting.
 
 ## 3.0.0-alpha.4
 

--- a/foo_ui_columns/tab_text_rendering.cpp
+++ b/foo_ui_columns/tab_text_rendering.cpp
@@ -13,9 +13,9 @@ constexpr auto rendering_modes = {
     std::make_tuple(fonts::RenderingMode::NaturalAutomatic, L"Automatic anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::Natural, L"Horizontal anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::NaturalSymmetric, L"Symmetric anti-aliasing"),
-    std::make_tuple(fonts::RenderingMode::Aliased, L"No anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::GdiClassic, L"GDI-compatible, classic"),
     std::make_tuple(fonts::RenderingMode::GdiNatural, L"GDI-compatible, natural"),
+    std::make_tuple(fonts::RenderingMode::Aliased, L"GDI-compatible, no anti-aliasing"),
 };
 
 class TextRenderingTab : public PreferencesTab {


### PR DESCRIPTION
This renames it to ‘GDI-compatible, no anti-aliasing’, as it now uses a GDI-compatible text layout.