### PR TITLE
Improve focus restoration logic on window activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   foobar2000 was minimised to the system tray.
   [[#1110](https://github.com/reupen/columns_ui/pull/1110)]
 
+- Some logic that normally occurs when main window is activated or focused was
+  surpressed while foobar2000 is exiting, as that logic is unnecessary at that
+  point. [[#1109](https://github.com/reupen/columns_ui/pull/1109)]
+
 ### Internal changes
 
 - `ui_config_callback::ui_fonts_changed()` is now called once instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   foobar2000 was minimised to the system tray.
   [[#1110](https://github.com/reupen/columns_ui/pull/1110)]
 
+- A bug where the keyboard focus changed after minimising and restoring
+  foobar2000 was fixed.
+  [[#1109](https://github.com/reupen/columns_ui/pull/1109)]
+
 - Some logic that normally occurs when main window is activated or focused was
   surpressed while foobar2000 is exiting, as that logic is unnecessary at that
   point. [[#1109](https://github.com/reupen/columns_ui/pull/1109)]

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -248,6 +248,25 @@ void cui::MainWindow::update_taskbar_buttons(bool update) const
     }
 }
 
+void cui::MainWindow::save_focus_state()
+{
+    HWND wnd_focused_before_menu{};
+
+    if (!rebar::g_rebar_window || !rebar::g_rebar_window->get_previous_menu_focus_window(wnd_focused_before_menu))
+        wnd_focused_before_menu = g_layout_window.get_previous_menu_focus_window();
+
+    if (wnd_focused_before_menu) {
+        m_last_focused_wnd = wnd_focused_before_menu;
+        return;
+    }
+
+    HWND wnd_focus = GetFocus();
+    if (wnd_focus && IsChild(m_wnd, wnd_focus))
+        m_last_focused_wnd = wnd_focus;
+    else
+        m_last_focused_wnd = nullptr;
+}
+
 void cui::MainWindow::queue_taskbar_button_update(bool update)
 {
     PostMessage(m_wnd, update ? MSG_UPDATE_TASKBAR_BUTTONS : MSG_CREATE_TASKBAR_BUTTONS, 0, 0);

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -85,12 +85,12 @@ private:
     void set_title(const char* ptr);
     bool update_taskbar_button_images() const;
     void update_taskbar_buttons(bool update) const;
+    void save_focus_state();
 
     pfc::string8 m_window_title;
     wil::com_ptr<ITaskbarList3> m_taskbar_list;
     HWND m_wnd{};
     HWND m_last_focused_wnd{};
-    HWND m_wnd_focused_before_menu{};
     HMONITOR m_monitor{};
     user_interface::HookProc_t m_hook_proc{};
     bool m_should_handle_multimedia_keys{true};

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -89,12 +89,22 @@ private:
     pfc::string8 m_window_title;
     wil::com_ptr<ITaskbarList3> m_taskbar_list;
     HWND m_wnd{};
+    HWND m_last_focused_wnd{};
+    HWND m_wnd_focused_before_menu{};
     HMONITOR m_monitor{};
     user_interface::HookProc_t m_hook_proc{};
     bool m_should_handle_multimedia_keys{true};
     bool m_shell_hook_registered{};
-    ULONG_PTR m_gdiplus_instance{NULL};
-    bool m_gdiplus_initialised{false};
+    bool m_gdiplus_initialised{};
+    bool m_is_destroying{};
+    bool m_last_sysray_r_down{};
+    bool m_last_sysray_x1_down{};
+    bool m_last_sysray_x2_down{};
+    ULONG_PTR m_gdiplus_instance{};
+    UINT m_wm_taskbarcreated{};
+    UINT m_wm_taskbarbuttoncreated{};
+    UINT m_wm_shellhookmessage{};
+
     wil::unique_himagelist m_taskbar_button_images;
 };
 


### PR DESCRIPTION
This:

- fixes a bug where the focus was not restored to the correct window when minimising and restoring the main window
- suppresses focus restoration logic when the window is being destroyed, as it's unneeded at that point and can trigger other side effects
- tidies up a few very old static variables