### PR TITLE
Fix taskbar entry appearing when using hide command while already hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   ‘Automatic anti-aliasing’ or ‘GDI-compatible, no anti-aliasing’ based on the
   system ‘Smooth edges of screen fonts’ setting.
 
+### Bug fixes
+
+- A bug was fixed where foobar2000 incorrectly appeared in the taskbar when
+  using the View/Hide menu command or the /hide command-line argument while
+  foobar2000 was minimised to the system tray.
+  [[#1110](https://github.com/reupen/columns_ui/pull/1110)]
+
 ### Internal changes
 
 - `ui_config_callback::ui_fonts_changed()` is now called once instead of

--- a/foo_ui_columns/user_interface_impl.cpp
+++ b/foo_ui_columns/user_interface_impl.cpp
@@ -187,20 +187,21 @@ public:
             SetForegroundWindow(main_window.get_wnd());
         }
     }
+
     void hide() override
     {
-        if (main_window.get_wnd()) {
+        if (is_visible())
             ShowWindow(main_window.get_wnd(), SW_MINIMIZE);
-        }
     }
+
     bool is_visible() override
     {
-        bool rv = false;
-        if (main_window.get_wnd()) {
-            rv = IsWindowVisible(main_window.get_wnd()) && !IsIconic(main_window.get_wnd());
-        }
-        return rv;
+        if (main_window.get_wnd())
+            return IsWindowVisible(main_window.get_wnd()) && !IsIconic(main_window.get_wnd());
+
+        return false;
     }
+
     void override_statusbar_text(const char* p_text) override
     {
         status_bar::set_menu_item_description(p_text);


### PR DESCRIPTION
This fixes a bug where, when 'Minimise to icon' is enabled, a taskbar entry incorrectly appeared when using the hide command (View/Hide or `/hide` on the command line) while foobar2000 is already hidden.