### PR TITLE
Migrate to new text rendering mode config variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Change log
 
-## Development version
+## 3.0.0-alpha.5
 
 ### Features
 
 - A ‘GDI-compatible, no anti-aliasing’ DirectWrite text rendering mode was
   added. [[#1102](https://github.com/reupen/columns_ui/pull/1102),
   [#1103](https://github.com/reupen/columns_ui/pull/1103),
-  [#1104](https://github.com/reupen/columns_ui/pull/1104)]
+  [#1104](https://github.com/reupen/columns_ui/pull/1104),
+  [#1112](https://github.com/reupen/columns_ui/pull/1112)]
 
   Additionally, the previous ‘Automatic’ mode has been renamed ‘Automatic
   anti-aliasing’, and a new ‘Default’ mode has been added that selects

--- a/foo_ui_columns/font_manager_data.cpp
+++ b/foo_ui_columns/font_manager_data.cpp
@@ -480,7 +480,7 @@ void FontManagerData::Entry::write_extra_data_v2(stream_writer* stream, abort_ca
 
 namespace cui::fonts {
 
-fbh::ConfigInt32 rendering_mode({0x3168bfe2, 0x5c40, 0x4d5b, {0x96, 0xe7, 0xd3, 0x95, 0xa7, 0xf0, 0x4d, 0x67}},
+fbh::ConfigInt32 rendering_mode({0x91fdd234, 0x05f9, 0x420c, {0x9c, 0x0c, 0x3d, 0xb9, 0x2f, 0xba, 0x25, 0x06}},
     WI_EnumValue(RenderingMode::Automatic));
 
 fbh::ConfigBool force_greyscale_antialiasing(
@@ -488,13 +488,26 @@ fbh::ConfigBool force_greyscale_antialiasing(
 
 DWRITE_RENDERING_MODE get_rendering_mode()
 {
-    if (rendering_mode.get() == WI_EnumValue(RenderingMode::Automatic)) {
+    switch (static_cast<RenderingMode>(rendering_mode.get())) {
+    default:
+    case RenderingMode::Automatic: {
         BOOL font_smoothing_enabled{true};
         SystemParametersInfo(SPI_GETFONTSMOOTHING, 0, &font_smoothing_enabled, 0);
         return font_smoothing_enabled ? DWRITE_RENDERING_MODE_DEFAULT : DWRITE_RENDERING_MODE_ALIASED;
     }
-
-    return static_cast<DWRITE_RENDERING_MODE>(rendering_mode.get());
+    case RenderingMode::DirectWriteAutomatic:
+        return DWRITE_RENDERING_MODE_DEFAULT;
+    case RenderingMode::Natural:
+        return DWRITE_RENDERING_MODE_NATURAL;
+    case RenderingMode::NaturalSymmetric:
+        return DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC;
+    case RenderingMode::GdiClassic:
+        return DWRITE_RENDERING_MODE_GDI_CLASSIC;
+    case RenderingMode::GdiNatural:
+        return DWRITE_RENDERING_MODE_GDI_NATURAL;
+    case RenderingMode::GdiAliased:
+        return DWRITE_RENDERING_MODE_ALIASED;
+    }
 }
 
 } // namespace cui::fonts

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -11,13 +11,13 @@ enum class FontMode {
 };
 
 enum class RenderingMode : int32_t {
-    Automatic = 99,
-    NaturalAutomatic = DWRITE_RENDERING_MODE_DEFAULT,
-    Natural = DWRITE_RENDERING_MODE_NATURAL,
-    NaturalSymmetric = DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
-    Aliased = DWRITE_RENDERING_MODE_ALIASED,
-    GdiClassic = DWRITE_RENDERING_MODE_GDI_CLASSIC,
-    GdiNatural = DWRITE_RENDERING_MODE_GDI_NATURAL,
+    Automatic,
+    DirectWriteAutomatic,
+    Natural,
+    NaturalSymmetric,
+    GdiClassic,
+    GdiNatural,
+    GdiAliased,
 };
 
 extern fbh::ConfigInt32 rendering_mode;

--- a/foo_ui_columns/tab_text_rendering.cpp
+++ b/foo_ui_columns/tab_text_rendering.cpp
@@ -11,12 +11,12 @@ namespace {
 
 constexpr auto rendering_modes = {
     std::make_tuple(fonts::RenderingMode::Automatic, L"Default"),
-    std::make_tuple(fonts::RenderingMode::NaturalAutomatic, L"Automatic anti-aliasing"),
+    std::make_tuple(fonts::RenderingMode::DirectWriteAutomatic, L"Automatic anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::Natural, L"Horizontal anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::NaturalSymmetric, L"Symmetric anti-aliasing"),
     std::make_tuple(fonts::RenderingMode::GdiClassic, L"GDI-compatible, classic"),
     std::make_tuple(fonts::RenderingMode::GdiNatural, L"GDI-compatible, natural"),
-    std::make_tuple(fonts::RenderingMode::Aliased, L"GDI-compatible, no anti-aliasing"),
+    std::make_tuple(fonts::RenderingMode::GdiAliased, L"GDI-compatible, no anti-aliasing"),
 };
 
 class TextRenderingTab : public PreferencesTab {


### PR DESCRIPTION
The way the previous `cui::fonts::rendering_mode` variable was handled caused problems when downgrading Columns UI.

This switches to a new variable and makes things more robust.

The value stored in the old variable is automatically copied to the new variable on upgrade.