### PR TITLE
Fix crash when using Windows 7 without Platform Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@
   surpressed while foobar2000 is exiting, as that logic is unnecessary at that
   point. [[#1109](https://github.com/reupen/columns_ui/pull/1109)]
 
+- An error message is now shown when trying to use Columns UI on Windows 7 SP1
+  without installing the Platform Update for Windows 7.
+  [[#1115](https://github.com/reupen/columns_ui/pull/1115)]
+
+  (Previously, this resulted in a crash.)
+
 - A problem where some panels were notified of font changes multiple times when
   the text rendering mode is changed, or after importing an FCL file, was fixed.
   [[#1105](https://github.com/reupen/columns_ui/pull/1105)]

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -70,6 +70,22 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook)
         return nullptr;
     }
 
+    uih::direct_write::Context::Ptr direct_write_context;
+
+    try {
+        direct_write_context = uih::direct_write::Context::s_create();
+    } catch (const wil::ResultException& ex) {
+        pfc::string8 error_message = "Unknown DirectWrite initialisation error";
+        uFormatMessage(ex.GetFailureInfo().hr, error_message);
+
+        const auto message
+            = IsWindows8OrGreater() ? error_message.get_ptr() : "The Platform Update for Windows 7 is required.";
+
+        dark::modal_info_box(nullptr, u8"Failed to initialise DirectWrite – Columns UI"_pcc, message,
+            uih::InfoBoxType::Error, uih::InfoBoxModalType::OK);
+        return nullptr;
+    }
+
     migrate::apply_first_run_defaults();
     migrate::migrate_all();
 

--- a/foo_ui_columns/status_pane_msgproc.cpp
+++ b/foo_ui_columns/status_pane_msgproc.cpp
@@ -30,7 +30,11 @@ LRESULT StatusPane::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CREATE: {
         ShowWindow(m_volume_control.create(wnd), SW_SHOWNORMAL);
 
-        m_direct_write_context = uih::direct_write::Context::s_create();
+        try {
+            m_direct_write_context = uih::direct_write::Context::s_create();
+        }
+        CATCH_LOG()
+
         recreate_font();
         m_theme = IsThemeActive() && IsAppThemed() ? OpenThemeData(wnd, L"Window") : nullptr;
         m_dark_mode_notifier = std::make_unique<colours::dark_mode_notifier>(


### PR DESCRIPTION
This change makes an error message appear when on start-up when using Windows 7 SP1 without the Platform Update. (Previously, a crash occurred at a later point.)

The Platform Update is required as it contains an updated version of DirectWrite.