### PR TITLE
Fix crash following failure to list fonts on Fonts preferences tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 
   (Previously, this resulted in a crash.)
 
+- A crash following a failure to list available fonts on the Fonts preferences
+  page was fixed. [[#1116](https://github.com/reupen/columns_ui/pull/1116)]
+
 - A problem where some panels were notified of font changes multiple times when
   the text rendering mode is changed, or after importing an FCL file, was fixed.
   [[#1105](https://github.com/reupen/columns_ui/pull/1105)]

--- a/foo_ui_columns/font_picker.cpp
+++ b/foo_ui_columns/font_picker.cpp
@@ -308,6 +308,8 @@ void DirectWriteFontPicker::set_font_description(fonts::FontDescription font_des
         typographic_family_name.c_str(), wss->weight, wss->stretch, wss->style, m_font_description->axis_values);
 
     if (!resolved_names) {
+        ComboBox_SetCurSel(m_font_family_combobox, -1);
+        handle_family_change();
         return;
     }
 
@@ -325,7 +327,9 @@ void DirectWriteFontPicker::set_font_description(fonts::FontDescription font_des
     if (!face_name.empty()) {
         const auto face_iter
             = ranges::find_if(m_font_faces, [&face_name](auto&& face) { return face.localised_name == face_name; });
-        face_index = std::distance(m_font_faces.begin(), face_iter);
+
+        if (face_iter != m_font_faces.end())
+            face_index = std::distance(m_font_faces.begin(), face_iter);
     }
 
     if (face_index) {


### PR DESCRIPTION
This fixes a crash following an error listing available fonts on the Font tab of the Colour and fonts preferences page.