### PR TITLE
Notify all font clients of font change on change to installed fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
 - A crash following a failure to list available fonts on the Fonts preferences
   page was fixed. [[#1116](https://github.com/reupen/columns_ui/pull/1116)]
 
+- Fonts in use are now refreshed whenever a font is installed or uninstalled in
+  Windows, allowing better recovery if a font in use is deleted or replaced.
+  [[#1117](https://github.com/reupen/columns_ui/pull/1117)]
+
 - A problem where some panels were notified of font changes multiple times when
   the text rendering mode is changed, or after importing an FCL file, was fixed.
   [[#1105](https://github.com/reupen/columns_ui/pull/1105)]

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -7,10 +7,6 @@
 
 namespace cui::panels::filter {
 
-const GUID g_guid_filter_items_font_client{0xd93f1ef3, 0x4aee, 0x4632, {0xb5, 0xbf, 0x2, 0x20, 0xce, 0xc7, 0x6d, 0xed}};
-const GUID g_guid_filter_header_font_client{
-    0xfca8752b, 0xc064, 0x41c4, {0x9b, 0xe3, 0xe1, 0x25, 0xc7, 0xc7, 0xfc, 0x34}};
-
 bool FilterStream::is_visible()
 {
     for (size_t i = 0, count = m_windows.get_count(); i < count; i++)
@@ -193,25 +189,16 @@ void FilterPanel::s_on_dark_mode_status_change()
 
 void FilterPanel::g_on_font_items_change()
 {
-    const auto font = fonts::get_font(g_guid_filter_items_font_client);
-    const auto text_format = fonts::get_text_format(font);
-    const auto log_font = font->log_font();
-
-    for (auto& window : g_windows) {
-        window->set_font(text_format, log_font);
-    }
+    for (auto& window : g_windows)
+        window->recreate_items_text_format();
 }
 
 void FilterPanel::g_on_font_header_change()
 {
-    const auto font = fonts::get_font(g_guid_filter_header_font_client);
-    const auto log_font = font->log_font();
-    const auto text_format = fonts::get_text_format(font);
-
-    for (auto& window : g_windows) {
-        window->set_header_font(text_format, log_font);
-    }
+    for (auto& window : g_windows)
+        window->recreate_header_text_format();
 }
+
 void FilterPanel::g_redraw_all()
 {
     for (auto& window : g_windows)
@@ -796,14 +783,8 @@ void FilterPanel::notify_on_initialisation()
     set_sorting_enabled(cfg_allow_sorting);
     set_show_sort_indicators(cfg_show_sort_indicators);
 
-    const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
-    const auto items_font = font_api->get_font(g_guid_filter_items_font_client);
-    const auto items_text_format = fonts::get_text_format(items_font);
-    const auto items_log_font = items_font->log_font();
-    set_font(items_text_format, items_log_font);
-
-    const auto header_font = font_api->get_font(g_guid_filter_header_font_client);
-    set_header_font(fonts::get_text_format(header_font), header_font->log_font());
+    recreate_items_text_format();
+    recreate_header_text_format();
 
     size_t index = g_windows.size();
     if (index == 0) {
@@ -926,7 +907,7 @@ colours::client::factory<AppearanceClient> g_appearance_client_impl;
 
 class FilterItemFontClient : public fonts::client {
 public:
-    const GUID& get_client_guid() const override { return g_guid_filter_items_font_client; }
+    const GUID& get_client_guid() const override { return items_font_id; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel: Items"; }
 
     fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
@@ -936,7 +917,7 @@ public:
 
 class FilterHeaderFontClient : public fonts::client {
 public:
-    const GUID& get_client_guid() const override { return g_guid_filter_header_font_client; }
+    const GUID& get_client_guid() const override { return header_font_id; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Filter panel: Column titles"; }
 
     fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -4,6 +4,9 @@
 
 namespace cui::panels::filter {
 
+constexpr GUID items_font_id{0xd93f1ef3, 0x4aee, 0x4632, {0xb5, 0xbf, 0x2, 0x20, 0xce, 0xc7, 0x6d, 0xed}};
+constexpr GUID header_font_id{0xfca8752b, 0xc064, 0x41c4, {0x9b, 0xe3, 0xe1, 0x25, 0xc7, 0xc7, 0xfc, 0x34}};
+
 class AppearanceClient : public colours::client {
 public:
     static constexpr GUID id{0x4d6774af, 0xc292, 0x44ac, {0x8a, 0x8f, 0x3b, 0x8, 0x55, 0xdc, 0xbd, 0xf4}};
@@ -81,7 +84,7 @@ public:
 };
 
 class FilterPanel
-    : public ListViewPanelBase<AppearanceClient, uie::window>
+    : public utils::ListViewPanelBase<AppearanceClient::id, items_font_id, header_font_id>
     , fbh::LibraryCallback {
     friend class FilterSearchToolbar;
 

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -15,6 +15,10 @@ struct InfoSection {
 constexpr std::array<InfoSection, 5> g_info_sections{
     {{0, "Location"}, {1, "General"}, {2, "ReplayGain"}, {3, "Playback statistics"}, {4, "All other sections", true}}};
 
+constexpr GUID items_font_id = {0x755fbb3d, 0xa8d4, 0x46f3, {0xb0, 0xba, 0x0, 0x5b, 0xa, 0x10, 0xa0, 0x1a}};
+constexpr GUID header_font_id = {0x7b9df268, 0x4ecc, 0x4e10, {0xa3, 0x8, 0xe1, 0x45, 0xda, 0x96, 0x92, 0xa5}};
+constexpr GUID group_font_id = {0xaf5a96a6, 0x96ed, 0x468f, {0x8b, 0xa1, 0xc2, 0x25, 0x33, 0xc5, 0x34, 0x91}};
+
 class Field {
 public:
     pfc::string8 m_name;
@@ -84,7 +88,7 @@ private:
 };
 
 class ItemProperties
-    : public ListViewPanelBase<ItemPropertiesColoursClient, uie::window>
+    : public utils::ListViewPanelBase<ItemPropertiesColoursClient::id, items_font_id, header_font_id, group_font_id>
     , public ui_selection_callback
     , public play_callback
     , public metadb_io_callback_dynamic {

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -3,7 +3,10 @@
 #include "dark_mode.h"
 #include "font_utils.h"
 
-template <typename t_appearance_client, typename t_window = uie::window>
+namespace cui::utils {
+
+template <GUID ColoursClientId, GUID ItemsFontId, GUID HeaderFontId = GUID{}, GUID GroupFontId = GUID{},
+    typename t_window = uie::window>
 class ListViewPanelBase
     : public uih::ListView
     , public t_window {
@@ -13,7 +16,7 @@ public:
         : ListView(std::move(renderer))
     {
         set_dark_edit_colours(
-            cui::dark::get_dark_system_colour(COLOR_WINDOWTEXT), cui::dark::get_dark_system_colour(COLOR_WINDOW));
+            dark::get_dark_system_colour(COLOR_WINDOWTEXT), dark::get_dark_system_colour(COLOR_WINDOW));
     }
 
     HWND create_or_transfer_window(
@@ -51,21 +54,52 @@ protected:
     bool should_show_drag_text(size_t selection_count) override { return true; }
     void render_get_colour_data(ColourData& p_out) override
     {
-        cui::colours::helper p_helper(t_appearance_client::id);
+        colours::helper p_helper(ColoursClientId);
         p_out.m_themed = p_helper.get_themed();
-        p_out.m_use_custom_active_item_frame = p_helper.get_bool(cui::colours::bool_use_custom_active_item_frame);
-        p_out.m_text = p_helper.get_colour(cui::colours::colour_text);
-        p_out.m_selection_text = p_helper.get_colour(cui::colours::colour_selection_text);
-        p_out.m_background = p_helper.get_colour(cui::colours::colour_background);
-        p_out.m_selection_background = p_helper.get_colour(cui::colours::colour_selection_background);
-        p_out.m_inactive_selection_text = p_helper.get_colour(cui::colours::colour_inactive_selection_text);
-        p_out.m_inactive_selection_background = p_helper.get_colour(cui::colours::colour_inactive_selection_background);
-        p_out.m_active_item_frame = p_helper.get_colour(cui::colours::colour_active_item_frame);
+        p_out.m_use_custom_active_item_frame = p_helper.get_bool(colours::bool_use_custom_active_item_frame);
+        p_out.m_text = p_helper.get_colour(colours::colour_text);
+        p_out.m_selection_text = p_helper.get_colour(colours::colour_selection_text);
+        p_out.m_background = p_helper.get_colour(colours::colour_background);
+        p_out.m_selection_background = p_helper.get_colour(colours::colour_selection_background);
+        p_out.m_inactive_selection_text = p_helper.get_colour(colours::colour_inactive_selection_text);
+        p_out.m_inactive_selection_background = p_helper.get_colour(colours::colour_inactive_selection_background);
+        p_out.m_active_item_frame = p_helper.get_colour(colours::colour_active_item_frame);
         if (!p_out.m_themed || !get_group_text_colour_default(p_out.m_group_text))
             p_out.m_group_text = p_out.m_text;
         p_out.m_group_background = p_out.m_background;
     }
 
+    void recreate_items_text_format()
+    {
+        const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
+        const auto items_font = font_api->get_font(ItemsFontId);
+        const auto items_text_format = fonts::get_text_format(items_font);
+        const auto items_log_font = items_font->log_font();
+        set_font(items_text_format, items_log_font);
+    }
+
+    void recreate_header_text_format()
+    {
+        if (HeaderFontId == GUID{})
+            return;
+
+        const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
+        const auto header_font = font_api->get_font(HeaderFontId);
+        set_header_font(fonts::get_text_format(header_font), header_font->log_font());
+    }
+
+    void recreate_group_text_format()
+    {
+        if (GroupFontId == GUID{})
+            return;
+
+        const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
+        const auto group_font = font_api->get_font(GroupFontId);
+        set_group_font(fonts::get_text_format(group_font));
+    }
+
 private:
     uie::window_host_ptr m_window_host;
 };
+
+} // namespace cui::utils

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -7,7 +7,9 @@
 
 namespace cui::panels::playlist_view {
 
-extern const GUID g_guid_items_font, g_guid_header_font, g_guid_group_header_font;
+constexpr GUID items_font_id = {0x19f8e0b3, 0xe822, 0x4f07, {0xb2, 0x0, 0xd4, 0xa6, 0x7e, 0x48, 0x72, 0xf9}};
+constexpr GUID header_font_id = {0x30fbd64c, 0x2031, 0x4f0b, {0xa9, 0x37, 0xf2, 0x16, 0x71, 0xa2, 0xe1, 0x95}};
+constexpr GUID group_font_id = {0xfb127ffa, 0x1b35, 0x4572, {0x9c, 0x1a, 0x4b, 0x96, 0xa5, 0xc5, 0xd5, 0x37}};
 
 extern cfg_bool cfg_artwork_reflection;
 extern fbh::ConfigUint32DpiAware cfg_artwork_width;
@@ -315,7 +317,8 @@ public:
 };
 
 class PlaylistView
-    : public ListViewPanelBase<ColoursClient, uie::playlist_window>
+    : public utils::ListViewPanelBase<ColoursClient::id, items_font_id, header_font_id, group_font_id,
+          uie::playlist_window>
     , playlist_callback {
     friend class NgTfThread;
     friend class PlaylistViewRenderer;
@@ -345,7 +348,7 @@ public:
     static void s_on_dark_mode_status_change();
     static void g_on_font_change();
     static void g_on_header_font_change();
-    static void g_on_group_header_font_change();
+    static void g_on_group_font_change();
     static void g_on_sorting_enabled_change();
     static void g_on_show_sort_indicators_change();
     static void g_on_edge_style_change();

--- a/foo_ui_columns/playlist_switcher_v2.cpp
+++ b/foo_ui_columns/playlist_switcher_v2.cpp
@@ -112,13 +112,8 @@ void PlaylistSwitcher::g_refresh_all_items()
 
 void PlaylistSwitcher::g_on_font_items_change()
 {
-    const auto font = fonts::get_font(g_guid_font);
-    const auto text_format = fonts::get_text_format(font);
-    const auto log_font = font->log_font();
-
-    for (auto& window : g_windows) {
-        window->set_font(text_format, log_font);
-    }
+    for (auto& window : g_windows)
+        window->recreate_items_text_format();
 }
 
 void PlaylistSwitcher::notify_on_initialisation()
@@ -130,11 +125,9 @@ void PlaylistSwitcher::notify_on_initialisation()
     set_edge_style(cfg_plistframe);
     set_vertical_item_padding(settings::playlist_switcher_item_padding);
 
-    const auto font = fonts::get_font(g_guid_font);
-    const auto text_format = fonts::get_text_format(font);
-    const auto log_font = font->log_font();
-    set_font(text_format, log_font);
+    recreate_items_text_format();
 }
+
 void PlaylistSwitcher::notify_on_create()
 {
     m_playlist_api = standard_api_create_t<playlist_manager_v3>();

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -7,8 +7,10 @@
 
 namespace cui::panels::playlist_switcher {
 
+constexpr GUID items_font_id = {0x70a5c273, 0x67ab, 0x4bb6, {0xb6, 0x1c, 0xf7, 0x97, 0x5a, 0x68, 0x71, 0xfd}};
+
 class PlaylistSwitcher
-    : public ListViewPanelBase<PlaylistSwitcherColoursClient, uie::window>
+    : public utils::ListViewPanelBase<PlaylistSwitcherColoursClient::id, items_font_id>
     , private playlist_callback
     , private play_callback {
     enum {

--- a/foo_ui_columns/system_appearance_manager.cpp
+++ b/foo_ui_columns/system_appearance_manager.cpp
@@ -142,6 +142,9 @@ private:
                 log_winrt_error(u8"Error registering UISettings ColorValuesChanged event handler"sv, ex);
             }
             break;
+        case WM_FONTCHANGE:
+            g_font_manager_data.dispatch_all_fonts_changed();
+            break;
         case WM_SYSCOLORCHANGE: {
             if (colours::is_dark_mode_active())
                 break;


### PR DESCRIPTION
This notifies all font changes of a font change whenever a font is installed or uninstalled in Windows.

This allows the UI to recover if a font in use is deleted or replaced.

Additionally, some list view text format creation logic was refactored.