### PR TITLE
Migrate Item details to Direct2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   This includes support for SVG font glyphs on recent versions of Windows,
   including Windows 11 emojis.
 
+### Bug fixes
+
+- A bug where left and/or top padding was missing in Item details when there was
+  no horizontal or vertical scroll bar was fixed.
+  [[#1120](https://github.com/reupen/columns_ui/pull/1120)]
+
 ## 3.0.0-alpha.5
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   no horizontal or vertical scroll bar was fixed.
   [[#1120](https://github.com/reupen/columns_ui/pull/1120)]
 
+- A bug where the `%default_font_size%` and the deprecated `%default_font_face%`
+  title formatting fields did not update in Item details after a font change
+  until another event caused a content update was fixed.
+  [[#1120](https://github.com/reupen/columns_ui/pull/1120)]
+
 ## 3.0.0-alpha.5
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+## Development version
+
+### Features
+
+- Item details now uses Direct2D for rendering.
+  [[#1120](https://github.com/reupen/columns_ui/pull/1120)]
+
+  This includes support for SVG font glyphs on recent versions of Windows,
+  including Windows 11 emojis.
+
 ## 3.0.0-alpha.5
 
 ### Features

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -120,7 +120,7 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;uxtheme.lib;Dwmapi.lib;usp10.lib;Windowscodecs.lib;Dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;uxtheme.lib;Dwmapi.lib;usp10.lib;Windowscodecs.lib;D2d1.lib;Dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -160,7 +160,7 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;uxtheme.lib;Dwmapi.lib;usp10.lib;Windowscodecs.lib;Dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;uxtheme.lib;Dwmapi.lib;usp10.lib;Windowscodecs.lib;D2d1.lib;Dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -198,7 +198,7 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;uxtheme.lib;Dwmapi.lib;usp10.lib;Windowscodecs.lib;Dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;uxtheme.lib;Dwmapi.lib;usp10.lib;Windowscodecs.lib;D2d1.lib;Dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>Debug</GenerateDebugInformation>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
@@ -233,7 +233,7 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;uxtheme.lib;Dwmapi.lib;usp10.lib;Windowscodecs.lib;Dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;uxtheme.lib;Dwmapi.lib;usp10.lib;Windowscodecs.lib;D2d1.lib;Dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>Debug</GenerateDebugInformation>
       <DataExecutionPrevention>
       </DataExecutionPrevention>

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -434,9 +434,9 @@ void ItemDetails::update_display_info()
         scale_max(layout_height + overhang_metrics.bottom),
     };
 
-    m_text_rect = {std::min(text_rect.left, overhang_rect.left) - padding,
-        std::min(text_rect.top, overhang_rect.top) - padding, std::max(text_rect.right, overhang_rect.right) + padding,
-        std::max(text_rect.bottom, overhang_rect.bottom) + padding};
+    m_text_rect = {std::min(text_rect.left, overhang_rect.left), std::min(text_rect.top, overhang_rect.top),
+        std::max(text_rect.right, overhang_rect.right) + padding * 2,
+        std::max(text_rect.bottom, overhang_rect.bottom) + padding * 2};
 }
 
 void ItemDetails::reset_display_info()
@@ -879,10 +879,11 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             const auto is_horizontal_scroll_bar_visible
                 = m_hscroll && !m_word_wrapping && (sih.nMax - sih.nMin - 1) > gsl::narrow_cast<int>(sih.nPage);
             const auto is_vertical_scroll_bar_visible = (siv.nMax - siv.nMin - 1) > gsl::narrow_cast<int>(siv.nPage);
+            const auto padding = gsl::narrow_cast<float>(s_get_padding());
             const auto x_offset = uih::direct_write::px_to_dip(
-                gsl::narrow_cast<float>(is_horizontal_scroll_bar_visible ? -sih.nPos : 0));
-            const auto y_offset
-                = uih::direct_write::px_to_dip(gsl::narrow_cast<float>(is_vertical_scroll_bar_visible ? -siv.nPos : 0));
+                gsl::narrow_cast<float>(is_horizontal_scroll_bar_visible ? -sih.nPos : 0) + padding);
+            const auto y_offset = uih::direct_write::px_to_dip(
+                gsl::narrow_cast<float>(is_vertical_scroll_bar_visible ? -siv.nPos : 0) + padding);
 
             try {
                 create_d2d_render_target();

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -588,6 +588,19 @@ void ItemDetails::update_now()
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_UPDATENOW);
 }
 
+void ItemDetails::create_d2d_render_target()
+{
+    if (!m_d2d_context)
+        m_d2d_context = uih::d2d::Context::s_create();
+
+    if (!m_d2d_render_target)
+        m_d2d_render_target = m_d2d_context->create_hwnd_render_target(get_wnd());
+
+    const auto& rendering_params = m_text_layout->rendering_params();
+    m_d2d_render_target->SetTextRenderingParams(rendering_params->get(get_wnd()).get());
+    m_d2d_render_target->SetTextAntialiasMode(rendering_params->d2d_text_antialiasing_mode());
+}
+
 void ItemDetails::invalidate_all(bool b_update)
 {
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | (b_update ? RDW_UPDATENOW : NULL));
@@ -600,12 +613,19 @@ void ItemDetails::on_size()
     on_size(wil::rect_width(rc), wil::rect_height(rc));
 }
 
-void ItemDetails::on_size(size_t cx, size_t cy)
+void ItemDetails::on_size(int cx, int cy)
 {
+    if (m_d2d_render_target) {
+        try {
+            m_d2d_render_target->Resize({gsl::narrow<unsigned>(cx), gsl::narrow<unsigned>(cy)});
+        }
+        CATCH_LOG();
+    }
+
     if (m_text_layout) {
         const auto padding = s_get_padding();
-        const auto max_width = std::max(0, gsl::narrow<int>(cx) - padding * 2);
-        const auto max_height = std::max(0, gsl::narrow<int>(cy) - padding * 2);
+        const auto max_width = std::max(0, cx - padding * 2);
+        const auto max_height = std::max(0, cy - padding * 2);
 
         try {
             m_text_layout->set_max_width(uih::direct_write::px_to_dip(gsl::narrow_cast<float>(max_width)));
@@ -718,7 +738,12 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_direct_write_context.reset();
         m_last_cx = 0;
         m_last_cy = 0;
-    } break;
+        m_d2d_render_target.reset();
+        m_d2d_text_brush.reset();
+        m_d2d_brush_cache.clear();
+        m_d2d_context.reset();
+        break;
+    }
     case WM_SETFOCUS:
         deregister_callback();
         m_selection_holder = ui_selection_manager::get()->acquire();
@@ -860,8 +885,37 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 = uih::direct_write::px_to_dip(gsl::narrow_cast<float>(is_vertical_scroll_bar_visible ? -siv.nPos : 0));
 
             try {
-                m_text_layout->render_with_solid_background(
-                    wnd, dc.get(), x_offset, y_offset, ps.rcPaint, background_colour, text_colour);
+                create_d2d_render_target();
+
+                const auto context_1 = m_d2d_render_target.try_query<ID2D1DeviceContext1>();
+
+                if (!m_d2d_text_brush) {
+                    const auto d2d_text_colour = uih::d2d::colorref_to_d2d_color(text_colour);
+                    THROW_IF_FAILED(m_d2d_render_target->CreateSolidColorBrush(d2d_text_colour, &m_d2d_text_brush));
+                }
+
+                const auto d2d_background_colour = uih::d2d::colorref_to_d2d_color(background_colour);
+
+                m_d2d_render_target->BeginDraw();
+
+                m_d2d_render_target->Clear(d2d_background_colour);
+
+                m_d2d_render_target->DrawTextLayout({x_offset, y_offset}, m_text_layout->text_layout().get(),
+                    m_d2d_text_brush.get(),
+                    context_1 ? D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT : D2D1_DRAW_TEXT_OPTIONS_NONE);
+
+                const auto result = m_d2d_render_target->EndDraw();
+
+                if (result == D2DERR_RECREATE_TARGET) {
+                    m_d2d_render_target.reset();
+                    m_d2d_text_brush.reset();
+                    m_d2d_brush_cache.clear();
+                    return 0;
+                }
+
+                THROW_IF_FAILED(result);
+
+                ValidateRect(wnd, nullptr);
             }
             CATCH_LOG()
         }
@@ -1059,13 +1113,30 @@ void ItemDetails::create_text_layout()
     if (!m_text_layout)
         return;
 
-    for (auto& [colour, start_character, character_count] : colour_segments) {
-        try {
-            m_text_layout->set_colour(
-                colour, {gsl::narrow<uint32_t>(start_character), gsl::narrow<uint32_t>(character_count)});
+    try {
+        create_d2d_render_target();
+
+        std::unordered_map<COLORREF, wil::com_ptr<ID2D1SolidColorBrush>> old_d2d_brush_cache
+            = std::move(m_d2d_brush_cache);
+
+        for (auto& [colour, start_character, character_count] : colour_segments) {
+            wil::com_ptr<ID2D1SolidColorBrush> brush;
+
+            if (auto iter = m_d2d_brush_cache.find(colour); iter != m_d2d_brush_cache.end()) {
+                brush = iter->second;
+            } else if (auto iter = old_d2d_brush_cache.find(colour); iter != old_d2d_brush_cache.end()) {
+                brush = iter->second;
+                m_d2d_brush_cache.emplace(colour, std::move(iter->second));
+            } else {
+                m_d2d_render_target->CreateSolidColorBrush(uih::d2d::colorref_to_d2d_color(colour), &brush);
+                m_d2d_brush_cache.emplace(colour, brush);
+            }
+
+            m_text_layout->set_effect(
+                brush.get(), {gsl::narrow<uint32_t>(start_character), gsl::narrow<uint32_t>(character_count)});
         }
-        CATCH_LOG()
     }
+    CATCH_LOG()
 
     process_simple_style_property<std::wstring>(font_segments, &FormatProperties::font_family,
         [&](auto&& value, auto&& text_range) { m_text_layout->set_family(value.c_str(), text_range); });
@@ -1094,6 +1165,7 @@ void ItemDetails::on_font_change()
 
 void ItemDetails::on_colours_change()
 {
+    m_d2d_text_brush.reset();
     invalidate_all();
 }
 

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -252,6 +252,7 @@ private:
     void set_window_theme() const;
     void invalidate_all(bool b_update = true);
     void update_now();
+    void create_d2d_render_target();
 
     enum class ScrollbarType {
         vertical = SB_VERT,
@@ -262,7 +263,7 @@ private:
     void update_scrollbars(bool reset_vertical_position, bool reset_horizontal_position);
 
     void on_size();
-    void on_size(size_t cx, size_t cy);
+    void on_size(int cx, int cy);
 
     void recreate_text_format();
     void create_text_layout();
@@ -271,8 +272,8 @@ private:
 
     inline static std::vector<ItemDetails*> s_windows;
 
-    size_t m_last_cx{};
-    size_t m_last_cy{};
+    int m_last_cx{};
+    int m_last_cy{};
     ui_selection_holder::ptr m_selection_holder;
     metadb_handle_list m_handles;
     metadb_handle_list m_selection_handles;
@@ -287,6 +288,10 @@ private:
     uih::direct_write::Context::Ptr m_direct_write_context;
     std::optional<uih::direct_write::TextFormat> m_text_format;
     std::optional<uih::direct_write::TextLayout> m_text_layout;
+    uih::d2d::Context::Ptr m_d2d_context;
+    wil::com_ptr<ID2D1HwndRenderTarget> m_d2d_render_target;
+    wil::com_ptr<ID2D1SolidColorBrush> m_d2d_text_brush;
+    std::unordered_map<COLORREF, wil::com_ptr<ID2D1SolidColorBrush>> m_d2d_brush_cache;
 
     std::optional<RECT> m_text_rect{};
 

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -32,11 +32,11 @@ public:
     bool process_function(titleformat_text_out* p_out, const char* p_name, size_t p_name_length,
         titleformat_hook_function_params* p_params, bool& p_found_flag) override;
 
-    explicit TitleformatHookChangeFont(const LOGFONT& lf);
+    TitleformatHookChangeFont(const LOGFONT& lf, int font_size);
 
 private:
     pfc::string8 m_default_font_face;
-    size_t m_default_font_size;
+    int m_default_font_size;
 };
 
 class ItemDetails
@@ -236,7 +236,8 @@ private:
     void on_app_activate(bool b_activated);
 
     void set_handles(const metadb_handle_list& handles);
-    void refresh_contents(bool reset_vertical_scroll_position = false, bool reset_horizontal_scroll_position = false);
+    void refresh_contents(bool reset_vertical_scroll_position = false, bool reset_horizontal_scroll_position = false,
+        bool force_update = false);
     void request_full_file_info();
     void on_full_file_info_request_completion(std::shared_ptr<helpers::FullFileInfoRequest> request);
     void release_aborted_full_file_info_requests();

--- a/foo_ui_columns/item_details_font.cpp
+++ b/foo_ui_columns/item_details_font.cpp
@@ -5,12 +5,8 @@
 
 namespace cui::panels::item_details {
 
-TitleformatHookChangeFont::TitleformatHookChangeFont(const LOGFONT& lf)
+TitleformatHookChangeFont::TitleformatHookChangeFont(const LOGFONT& lf, int font_size) : m_default_font_size(font_size)
 {
-    HDC dc = GetDC(nullptr);
-    m_default_font_size = -MulDiv(lf.lfHeight, 72, GetDeviceCaps(dc, LOGPIXELSY));
-    ReleaseDC(nullptr, dc);
-
     m_default_font_face = pfc::stringcvt::string_utf8_from_wide(lf.lfFaceName, std::size(lf.lfFaceName));
 }
 

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -63,6 +63,7 @@
 #include <wincodec.h>
 #include <strsafe.h>
 #include <strstream>
+#include <d2d1_3.h>
 
 #include <wil/cppwinrt.h>
 #include <wil/com.h>
@@ -99,6 +100,7 @@
 #include "../svg-services/api/api.h"
 #include "../columns_ui-sdk/ui_extension.h"
 #include "../ui_helpers/stdafx.h"
+#include "../ui_helpers/direct_2d.h"
 #include "../ui_helpers/direct_write.h"
 #include "../ui_helpers/direct_write_text_out.h"
 #include "../ui_helpers/list_view/list_view.h"


### PR DESCRIPTION
#954 

This migrates Item details from GDI to Direct2D. Text rendering appears to be identical in all modes.

This also adds support for SVG glyphs, in theory from later Windows 10 versions onwards (but I'm only aware of Windows 11 actually having SVG glyphs in Segoe UI Emoji).

Additionally, a couple of small bugs with padding and font-related title formatting fields were fixed.