### PR TITLE
Fix dark mode handling on Fonts preferences tab on foobar2000 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   until another event caused a content update was fixed.
   [[#1120](https://github.com/reupen/columns_ui/pull/1120)]
 
+- A bug where the font family and font style drop-down controls on the Fonts
+  preferences tab did not have the expected appearance on foobar2000 1.x when
+  dark mode is enabled was fixed.
+  [[#1129](https://github.com/reupen/columns_ui/pull/1129)]
+
 ## 3.0.0-alpha.5
 
 ### Features

--- a/foo_ui_columns/font_picker.cpp
+++ b/foo_ui_columns/font_picker.cpp
@@ -25,14 +25,14 @@ public:
         ConfigureAxesDialog dialog(
             std::move(font_family), std::move(font), std::move(axis_values), std::move(on_values_change));
 
-        const cui::dark::DialogDarkModeConfig dark_mode_config{
+        const dark::DialogDarkModeConfig dark_mode_config{
             .button_ids = {IDOK, IDCANCEL},
             .combo_box_ids = {IDC_AXIS},
             .edit_ids = {IDC_AXIS_VALUE},
             .spin_ids = {IDC_AXIS_VALUE_SPIN},
         };
 
-        return cui::dark::modal_dialog_box(IDD_FONT_AXES, dark_mode_config, wnd,
+        return dark::modal_dialog_box(IDD_FONT_AXES, dark_mode_config, wnd,
                    [&dialog](auto wnd, auto msg, auto wp, auto lp) { return dialog.handle_message(wnd, msg, wp, lp); })
             != 0;
     }
@@ -179,7 +179,7 @@ private:
                     break;
 
                 const auto new_value_text = uih::get_window_text(m_axis_value_edit);
-                const auto new_value_float = cui::string::safe_stof(new_value_text);
+                const auto new_value_float = string::safe_stof(new_value_text);
 
                 if (!new_value_float)
                     break;
@@ -443,7 +443,7 @@ std::optional<INT_PTR> DirectWriteFontPicker::handle_wm_command(WPARAM wp, LPARA
         const auto previous_size = m_font_description->point_size_tenths;
         const auto font_size_text = uih::get_window_text(m_font_size_edit);
 
-        const auto font_size_float = cui::string::safe_stof(font_size_text);
+        const auto font_size_float = string::safe_stof(font_size_text);
 
         if (!font_size_float)
             break;
@@ -516,12 +516,12 @@ std::optional<INT_PTR> DirectWriteFontPicker::handle_wm_draw_item(LPDRAWITEMSTRU
     const auto is_edit_box = (dis->itemState & ODS_COMBOBOXEDIT) != 0;
     const auto is_selected = (dis->itemState & ODS_SELECTED) != 0;
     const auto index = dis->itemID;
-    const auto is_dark = cui::dark::is_active_ui_dark();
+    const auto is_dark = dark::is_active_ui_dark(m_allow_cui_dark_mode_fallback);
     const auto hide_focus = (SendMessage(dis->hwndItem, WM_QUERYUISTATE, NULL, NULL) & UISF_HIDEFOCUS) != 0;
 
     const auto background_colour = [&dis, is_dark, is_edit_box, is_selected] {
         if (is_edit_box && is_dark)
-            return cui::dark::get_dark_colour(cui::dark::ColourID::ComboBoxEditBackground);
+            return dark::get_dark_colour(dark::ColourID::ComboBoxEditBackground);
 
         if (is_selected)
             return GetSysColor(COLOR_HIGHLIGHT);
@@ -545,7 +545,7 @@ std::optional<INT_PTR> DirectWriteFontPicker::handle_wm_draw_item(LPDRAWITEMSTRU
 
     const auto text_colour = [&dis, is_dark, is_edit_box, is_selected] {
         if (is_edit_box && is_dark)
-            return cui::dark::get_dark_colour(cui::dark::ColourID::ComboBoxEditText);
+            return dark::get_dark_colour(dark::ColourID::ComboBoxEditText);
 
         if (is_selected)
             return GetSysColor(COLOR_HIGHLIGHTTEXT);

--- a/foo_ui_columns/font_picker.h
+++ b/foo_ui_columns/font_picker.h
@@ -5,6 +5,11 @@ namespace cui::utils {
 
 class DirectWriteFontPicker {
 public:
+    DirectWriteFontPicker(bool allow_cui_dark_mode_fallback = true)
+        : m_allow_cui_dark_mode_fallback(allow_cui_dark_mode_fallback)
+    {
+    }
+
     std::optional<INT_PTR> handle_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     void on_font_changed(std::function<void(const fonts::FontDescription&)> on_font_changed);
     void set_font_description(fonts::FontDescription font_description);
@@ -33,6 +38,7 @@ private:
     void update_font_size_spin() const;
 
     bool m_is_updating_font_size_edit{};
+    bool m_allow_cui_dark_mode_fallback{};
     HWND m_wnd{};
     HWND m_configure_axes_button{};
     HWND m_font_family_combobox{};

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -49,7 +49,7 @@ INT_PTR TabFonts::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         update_mode_combobox();
 
-        m_direct_write_font_picker = cui::utils::DirectWriteFontPicker();
+        m_direct_write_font_picker = cui::utils::DirectWriteFontPicker(false);
         m_direct_write_font_picker->on_font_changed([this](auto& font_description) {
             m_element_ptr->font_description = font_description;
             on_font_changed();


### PR DESCRIPTION
This fixes a minor bug where the owner drawn combo boxes on the Fonts tab of the Colours and fonts preferences page incorrectly had a dark appearance in some cases on on foobar2000 1.x (which does not support dark mode for Preferences). This happened when Columns UI was the active UI and had dark mode enabled.