### PR TITLE
Fix wrong system tray icon tooltip after minimising to the system tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   no horizontal or vertical scroll bar was fixed.
   [[#1120](https://github.com/reupen/columns_ui/pull/1120)]
 
+- A bug where the system tray icon did not always have the correct tooltip text
+  immediately after minimising the main window when ‘Always show icon’ is turned
+  off and ‘Minimise to icon’ is turned on was fixed.
+  [[#1151](https://github.com/reupen/columns_ui/pull/1151)]
+
 - A bug where the `%default_font_size%` and the deprecated `%default_font_face%`
   title formatting fields did not update in Item details after a font change
   until another event caused a content update was fixed.

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -91,7 +91,7 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook)
 
     m_hook_proc = hook;
 
-    create_icon_handle();
+    systray::create_icon_handle();
 
     WNDCLASS wc{};
     wc.lpfnWndProc = s_on_message;

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -67,8 +67,8 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     if (m_wm_taskbarcreated && msg == m_wm_taskbarcreated) {
         if (g_icon_created) {
             g_icon_created = false;
-            create_systray_icon();
-            update_systray();
+            systray::create_icon();
+            systray::update_icon_tooltip();
         }
     }
 
@@ -137,7 +137,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         set_title(core_version_info_v2::get()->get_name());
         if (cfg_show_systray)
-            create_systray_icon();
+            systray::create_icon();
 
         wil::com_ptr<MainWindowDropTarget> drop_handler = new MainWindowDropTarget;
         RegisterDragDrop(m_wnd, drop_handler.get());
@@ -162,7 +162,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         status_bar::destroy_window();
         m_taskbar_list.reset();
         RevokeDragDrop(m_wnd);
-        destroy_systray_icon();
+        systray::remove_icon();
         on_destroy();
         m_is_destroying = false;
         break;
@@ -512,7 +512,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             if (styles & WS_MINIMIZE) {
                 cfg_go_to_tray = cfg_go_to_tray || cfg_minimise_to_tray;
                 if (!g_icon_created && cfg_go_to_tray)
-                    create_systray_icon();
+                    systray::create_icon();
                 if (g_icon_created && cfg_go_to_tray)
                     ShowWindow(wnd, SW_HIDE);
             } else {

--- a/foo_ui_columns/system_tray.cpp
+++ b/foo_ui_columns/system_tray.cpp
@@ -8,76 +8,87 @@ extern HWND g_status;
 extern HICON g_icon;
 extern bool g_icon_created;
 
-void update_systray(bool balloon, int btitle, bool force_balloon)
-{
-    if (g_icon_created) {
-        metadb_handle_ptr track;
-        const auto play_api = play_control::get();
-        play_api->get_now_playing(track);
-        pfc::string8 escaped_title;
-        pfc::string8 title;
+namespace cui::systray {
 
-        if (track.is_valid()) {
-            service_ptr_t<titleformat_object> to_systray;
-            titleformat_compiler::get()->compile_safe(to_systray, main_window::config_system_tray_icon_script.get());
-            play_api->playback_format_title_ex(
-                track, nullptr, title, to_systray, nullptr, play_control::display_level_titles);
+namespace {
 
-            track.release();
+const std::unordered_map<systray::BalloonTipTitle, const char*> balloon_tip_title_map = {
+    {systray::BalloonTipTitle::NowPlaying, "Now playing:"},
+    {systray::BalloonTipTitle::Unpaused, "Unpaused:"},
+    {systray::BalloonTipTitle::Paused, "Paused:"},
+};
 
-        } else {
-            title = core_version_info_v2::get()->get_name();
-        }
-
-        if (cui::win32::is_windows_11_rtm_or_newer())
-            escaped_title = title;
-        else
-            uFixAmpersandChars(title, escaped_title);
-
-        if (balloon && (cfg_balloon || force_balloon)) {
-            uShellNotifyIconEx(
-                NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title, "", "");
-            uShellNotifyIconEx(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title,
-                (btitle == 0 ? "Now playing:" : (btitle == 1 ? "Unpaused:" : "Paused:")), title);
-        } else
-            uShellNotifyIcon(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title);
-    }
 }
 
-void destroy_systray_icon()
+void update_icon_tooltip(std::optional<BalloonTipTitle> balloon_tip_title, bool force_balloon)
+{
+    if (!g_icon_created)
+        return;
+
+    metadb_handle_ptr track;
+    const auto play_api = play_control::get();
+    play_api->get_now_playing(track);
+    pfc::string8 escaped_title;
+    pfc::string8 title;
+
+    if (track.is_valid()) {
+        service_ptr_t<titleformat_object> to_systray;
+        titleformat_compiler::get()->compile_safe(to_systray, main_window::config_system_tray_icon_script.get());
+        play_api->playback_format_title_ex(
+            track, nullptr, title, to_systray, nullptr, play_control::display_level_titles);
+
+        track.release();
+
+    } else {
+        title = core_version_info_v2::get()->get_name();
+    }
+
+    if (win32::is_windows_11_rtm_or_newer())
+        escaped_title = title;
+    else
+        uFixAmpersandChars(title, escaped_title);
+
+    if (balloon_tip_title && (cfg_balloon || force_balloon)) {
+        uShellNotifyIconEx(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title, "", "");
+        uShellNotifyIconEx(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title,
+            balloon_tip_title_map.at(*balloon_tip_title), title);
+    } else
+        uShellNotifyIcon(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title);
+}
+
+void remove_icon()
 {
     if (g_icon_created) {
-        uShellNotifyIcon(NIM_DELETE, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, nullptr, nullptr);
+        uShellNotifyIcon(NIM_DELETE, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, nullptr, nullptr);
         g_icon_created = false;
     }
 }
 
-void on_show_system_tray_icon_change()
+void on_show_icon_change()
 {
-    if (!cui::main_window.get_wnd())
+    if (!main_window.get_wnd())
         return;
 
-    const auto is_iconic = IsIconic(cui::main_window.get_wnd()) != 0;
-    const auto close_to_icon = cui::config::advbool_close_to_system_tray_icon.get();
+    const auto is_iconic = IsIconic(main_window.get_wnd()) != 0;
+    const auto close_to_icon = config::advbool_close_to_system_tray_icon.get();
     if (cfg_show_systray && !g_icon_created) {
-        create_systray_icon();
+        create_icon();
     } else if (!cfg_show_systray && g_icon_created && (!is_iconic || !(cfg_minimise_to_tray || close_to_icon))) {
-        destroy_systray_icon();
+        remove_icon();
         if (is_iconic)
             standard_commands::main_activate();
     }
     if (g_status)
-        update_systray();
+        update_icon_tooltip();
 }
 
-void create_systray_icon()
+void create_icon()
 {
-    uShellNotifyIcon(g_icon_created ? NIM_MODIFY : NIM_ADD, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon,
+    uShellNotifyIcon(g_icon_created ? NIM_MODIFY : NIM_ADD, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon,
         core_version_info_v2::get()->get_name());
-    /* There was some misbehaviour with the newer messages. So we don't use them. */
-    //    if (!g_icon_created)
-    //        uih::shell_notify_icon(NIM_SETVERSION, cui::main_window.get_wnd(), 1, NOTIFYICON_VERSION,
-    //        MSG_NOTICATION_ICON, g_icon, "foobar2000"/*core_version_info::g_get_version_string()*/);
+
+    // NIM_SETVERSION is not used as caused some undesirable behaviour with some mouse clicks.
+
     g_icon_created = true;
 }
 
@@ -85,13 +96,18 @@ void create_icon_handle()
 {
     const unsigned cx = GetSystemMetrics(SM_CXSMICON);
     const unsigned cy = GetSystemMetrics(SM_CYSMICON);
+
     if (g_icon) {
         DestroyIcon(g_icon);
         g_icon = nullptr;
     }
+
     if (cfg_custom_icon)
         g_icon
             = (HICON)uLoadImage(core_api::get_my_instance(), cfg_tray_icon_path, IMAGE_ICON, cx, cy, LR_LOADFROMFILE);
+
     if (!g_icon)
         g_icon = ui_control::get()->load_main_icon(cx, cy);
 }
+
+} // namespace cui::systray

--- a/foo_ui_columns/system_tray.cpp
+++ b/foo_ui_columns/system_tray.cpp
@@ -4,7 +4,6 @@
 #include "main_window.h"
 #include "win32.h"
 
-extern HWND g_status;
 extern HICON g_icon;
 extern bool g_icon_created;
 
@@ -14,46 +13,63 @@ namespace {
 
 const std::unordered_map<systray::BalloonTipTitle, const char*> balloon_tip_title_map = {
     {systray::BalloonTipTitle::NowPlaying, "Now playing:"},
-    {systray::BalloonTipTitle::Unpaused, "Unpaused:"},
     {systray::BalloonTipTitle::Paused, "Paused:"},
+    {systray::BalloonTipTitle::Unpaused, "Unpaused:"},
 };
 
+std::string get_tooltip_text()
+{
+    const auto playback_api = playback_control::get();
+
+    metadb_handle_ptr track;
+    playback_api->get_now_playing(track);
+    std::string title;
+
+    if (track.is_valid()) {
+        service_ptr_t<titleformat_object> to_systray;
+        titleformat_compiler::get()->compile_safe(to_systray, main_window::config_system_tray_icon_script.get());
+
+        mmh::StringAdaptor adapted_string(title);
+        playback_api->playback_format_title_ex(
+            track, nullptr, adapted_string, to_systray, nullptr, play_control::display_level_titles);
+
+        track.release();
+    } else {
+        title = core_version_info_v2::get()->get_name();
+    }
+
+    return title;
 }
+
+std::string escape_tooltip_text(std::string text)
+{
+    if (win32::is_windows_11_rtm_or_newer())
+        return text;
+
+    std::string escaped_text;
+    mmh::StringAdaptor adapted_escaped_text(escaped_text);
+    uFixAmpersandChars(text.c_str(), adapted_escaped_text);
+
+    return escaped_text;
+}
+
+} // namespace
 
 void update_icon_tooltip(std::optional<BalloonTipTitle> balloon_tip_title, bool force_balloon)
 {
     if (!g_icon_created)
         return;
 
-    metadb_handle_ptr track;
-    const auto play_api = play_control::get();
-    play_api->get_now_playing(track);
-    pfc::string8 escaped_title;
-    pfc::string8 title;
-
-    if (track.is_valid()) {
-        service_ptr_t<titleformat_object> to_systray;
-        titleformat_compiler::get()->compile_safe(to_systray, main_window::config_system_tray_icon_script.get());
-        play_api->playback_format_title_ex(
-            track, nullptr, title, to_systray, nullptr, play_control::display_level_titles);
-
-        track.release();
-
-    } else {
-        title = core_version_info_v2::get()->get_name();
-    }
-
-    if (win32::is_windows_11_rtm_or_newer())
-        escaped_title = title;
-    else
-        uFixAmpersandChars(title, escaped_title);
+    const auto title = get_tooltip_text();
+    const auto escaped_title = escape_tooltip_text(title);
 
     if (balloon_tip_title && (cfg_balloon || force_balloon)) {
-        uShellNotifyIconEx(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title, "", "");
-        uShellNotifyIconEx(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title,
-            balloon_tip_title_map.at(*balloon_tip_title), title);
+        uShellNotifyIconEx(
+            NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title.c_str(), "", "");
+        uShellNotifyIconEx(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title.c_str(),
+            balloon_tip_title_map.at(*balloon_tip_title), title.c_str());
     } else
-        uShellNotifyIcon(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title);
+        uShellNotifyIcon(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title.c_str());
 }
 
 void remove_icon()
@@ -71,6 +87,7 @@ void on_show_icon_change()
 
     const auto is_iconic = IsIconic(main_window.get_wnd()) != 0;
     const auto close_to_icon = config::advbool_close_to_system_tray_icon.get();
+
     if (cfg_show_systray && !g_icon_created) {
         create_icon();
     } else if (!cfg_show_systray && g_icon_created && (!is_iconic || !(cfg_minimise_to_tray || close_to_icon))) {
@@ -78,14 +95,13 @@ void on_show_icon_change()
         if (is_iconic)
             standard_commands::main_activate();
     }
-    if (g_status)
-        update_icon_tooltip();
 }
 
 void create_icon()
 {
+    const auto tooltip_text = escape_tooltip_text(get_tooltip_text());
     uShellNotifyIcon(g_icon_created ? NIM_MODIFY : NIM_ADD, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon,
-        core_version_info_v2::get()->get_name());
+        tooltip_text.c_str());
 
     // NIM_SETVERSION is not used as caused some undesirable behaviour with some mouse clicks.
 

--- a/foo_ui_columns/system_tray.h
+++ b/foo_ui_columns/system_tray.h
@@ -1,7 +1,17 @@
 #pragma once
 
+namespace cui::systray {
+
+enum class BalloonTipTitle {
+    NowPlaying,
+    Unpaused,
+    Paused
+};
+
 void create_icon_handle();
-void create_systray_icon();
-void update_systray(bool balloon = false, int btitle = 0, bool force_balloon = false);
-void destroy_systray_icon();
-void on_show_system_tray_icon_change();
+void create_icon();
+void update_icon_tooltip(std::optional<BalloonTipTitle> balloon_tip_title = {}, bool force_balloon = false);
+void remove_icon();
+void on_show_icon_change();
+
+} // namespace cui::systray

--- a/foo_ui_columns/system_tray.h
+++ b/foo_ui_columns/system_tray.h
@@ -4,8 +4,8 @@ namespace cui::systray {
 
 enum class BalloonTipTitle {
     NowPlaying,
+    Paused,
     Unpaused,
-    Paused
 };
 
 void create_icon_handle();

--- a/foo_ui_columns/system_tray_callbacks.cpp
+++ b/foo_ui_columns/system_tray_callbacks.cpp
@@ -5,26 +5,39 @@
 extern HICON g_icon;
 extern bool g_icon_created;
 
+namespace cui::systray {
+
+namespace {
+
 class SystemTrayPlayCallback : public play_callback_static {
 public:
     unsigned get_flags() override { return flags; }
     void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
-    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override { update_systray(true); }
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override
+    {
+        update_icon_tooltip(BalloonTipTitle::NowPlaying);
+    }
 
     void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override
     {
         if (g_icon_created && p_reason != play_control::stop_reason_shutting_down) {
-            uShellNotifyIcon(NIM_MODIFY, cui::main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon,
+            uShellNotifyIcon(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon,
                 core_version_info_v2::get()->get_name());
         }
     }
     void on_playback_seek(double p_time) override {}
-    void on_playback_pause(bool b_state) noexcept override { update_systray(true, b_state ? 2 : 1); }
+    void on_playback_pause(bool b_state) noexcept override
+    {
+        update_icon_tooltip(b_state ? BalloonTipTitle::Paused : BalloonTipTitle::Unpaused);
+    }
 
     void on_playback_edited(metadb_handle_ptr p_track) override {}
 
     void on_playback_dynamic_info(const file_info& p_info) override {}
-    void on_playback_dynamic_info_track(const file_info& p_info) noexcept override { update_systray(true); }
+    void on_playback_dynamic_info_track(const file_info& p_info) noexcept override
+    {
+        update_icon_tooltip(BalloonTipTitle::NowPlaying);
+    }
     void on_playback_time(double p_time) override {}
     void on_volume_change(float p_new_val) override {}
 
@@ -33,4 +46,8 @@ private:
         | flag_on_playback_dynamic_info_track;
 };
 
-static play_callback_static_factory_t<SystemTrayPlayCallback> _system_tray_play_callback;
+play_callback_static_factory_t<SystemTrayPlayCallback> _system_tray_play_callback;
+
+} // namespace
+
+} // namespace cui::systray

--- a/foo_ui_columns/tab_system_tray.cpp
+++ b/foo_ui_columns/tab_system_tray.cpp
@@ -45,8 +45,8 @@ public:
             case IDC_USE_CUSTOM_ICON: {
                 cfg_custom_icon = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
                 EnableWindow(GetDlgItem(wnd, IDC_BROWSE_ICON), cfg_custom_icon);
-                create_icon_handle();
-                create_systray_icon();
+                cui::systray::create_icon_handle();
+                cui::systray::create_icon();
             } break;
             case IDC_BROWSE_ICON: {
                 pfc::string8 path = cfg_tray_icon_path;
@@ -54,8 +54,8 @@ public:
                         nullptr, path, FALSE)) {
                     cfg_tray_icon_path = path;
                     if (cfg_custom_icon) {
-                        create_icon_handle();
-                        create_systray_icon();
+                        cui::systray::create_icon_handle();
+                        cui::systray::create_icon();
                     }
                 }
             } break;
@@ -66,7 +66,7 @@ public:
             case IDC_SHOW_SYSTRAY: {
                 cfg_show_systray = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
                 //                EnableWindow(GetDlgItem(wnd, IDC_MINIMISE_TO_SYSTRAY), cfg_show_systray);
-                on_show_system_tray_icon_change();
+                cui::systray::on_show_icon_change();
             } break;
             case IDC_BALLOON: {
                 cfg_balloon = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;

--- a/foo_ui_columns/user_interface_impl.cpp
+++ b/foo_ui_columns/user_interface_impl.cpp
@@ -163,7 +163,8 @@ public:
     void show_now_playing() override
     {
         auto play_api = play_control::get();
-        update_systray(true, play_api->is_paused() ? 2 : 0, true);
+        systray::update_icon_tooltip(
+            play_api->is_paused() ? systray::BalloonTipTitle::Paused : systray::BalloonTipTitle::NowPlaying, true);
     }
     void shutdown() override
     {
@@ -176,7 +177,7 @@ public:
         if (main_window.get_wnd()) {
             cfg_go_to_tray = false;
             if (g_icon_created && !cfg_show_systray)
-                destroy_systray_icon();
+                systray::remove_icon();
 
             if (!is_visible()) {
                 ShowWindow(main_window.get_wnd(), SW_RESTORE);


### PR DESCRIPTION
This fixes a bug where the system tray icon did not have the correct title after minimising the main window if ‘Always show icon’ is turned off and ‘Minimise to icon’ is turned on.