### PR TITLE
Fix Item details handling of graphics card driver reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Item details now uses Direct2D for rendering.
   [[#1120](https://github.com/reupen/columns_ui/pull/1120),
-  [#1153](https://github.com/reupen/columns_ui/pull/1153)]
+  [#1153](https://github.com/reupen/columns_ui/pull/1153),
+  [#1158](https://github.com/reupen/columns_ui/pull/1158)]
 
   This includes support for SVG font glyphs on recent versions of Windows,
   including Windows 11 emojis.

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -888,6 +888,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     m_d2d_render_target.reset();
                     m_d2d_text_brush.reset();
                     m_d2d_brush_cache.clear();
+                    m_text_layout.reset();
                     return 0;
                 }
 


### PR DESCRIPTION
This fixes a problem where the `D2DERR_RECREATE_TARGET` error wasn't quite handled correctly in Items details. As the DirectWrite text layout can contain references to Direct2D brushes as effects, it also needs to be recreated following a `D2DERR_RECREATE_TARGET` error.