### PR TITLE
Add rendering options and font fallback methods to fonts::manager_v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Internal changes
 
 - An updated font API for panels was implemented for release 8.0.0-beta.1 of the
-  Columns UI SDK. [[#1179](https://github.com/reupen/columns_ui/pull/1179)]
+  Columns UI SDK. [[#1179](https://github.com/reupen/columns_ui/pull/1179),
+  [#1183](https://github.com/reupen/columns_ui/pull/1183)]
 
 ## 3.0.0-alpha.6
 

--- a/foo_ui_columns/font_manager.cpp
+++ b/foo_ui_columns/font_manager.cpp
@@ -58,12 +58,12 @@ public:
 
     void register_common_callback(fonts::common_callback* p_callback) override
     {
-        g_font_manager_data.register_common_callback(p_callback);
+        g_font_manager_data.add_common_callback(p_callback);
     }
 
     void deregister_common_callback(fonts::common_callback* p_callback) override
     {
-        g_font_manager_data.deregister_common_callback(p_callback);
+        g_font_manager_data.remove_common_callback(p_callback);
     }
 };
 
@@ -121,12 +121,12 @@ public:
 
     void register_common_callback(fonts::common_callback* p_callback) override
     {
-        g_font_manager_data.register_common_callback(p_callback);
+        g_font_manager_data.add_common_callback(p_callback);
     }
 
     void deregister_common_callback(fonts::common_callback* p_callback) override
     {
-        g_font_manager_data.deregister_common_callback(p_callback);
+        g_font_manager_data.remove_common_callback(p_callback);
     }
 };
 

--- a/foo_ui_columns/font_manager_data.h
+++ b/foo_ui_columns/font_manager_data.h
@@ -78,19 +78,30 @@ public:
     entry_ptr_t find_by_id(GUID id);
     cui::fonts::FontDescription resolve_font_description(const entry_ptr_t& entry);
 
-    void add_callback(GUID id, cui::basic_callback::ptr callback);
-    void remove_callback(GUID id, cui::basic_callback::ptr callback);
-    void dispatch_client_font_changed(cui::fonts::client::ptr client);
+    void add_font_callback(GUID id, cui::basic_callback::ptr callback);
+    void remove_font_callback(GUID id, cui::basic_callback::ptr callback);
+    void dispatch_client_font_changed(cui::fonts::client::ptr client) const;
 
-    void register_common_callback(cui::fonts::common_callback* p_callback);
-    void deregister_common_callback(cui::fonts::common_callback* p_callback);
+    void add_rendering_options_callback(cui::basic_callback::ptr callback);
+    void remove_rendering_options_callback(cui::basic_callback::ptr callback);
+    void dispatch_rendering_options_changed() const;
 
-    void g_on_common_font_changed(uint32_t mask);
-    void dispatch_all_fonts_changed();
+    void add_font_fallback_callback(cui::basic_callback::ptr callback);
+    void remove_font_fallback_callback(cui::basic_callback::ptr callback);
+    void dispatch_font_fallback_changed() const;
 
-    pfc::ptr_list_t<cui::fonts::common_callback> m_callbacks;
-    std::unordered_map<GUID, std::vector<cui::basic_callback::ptr>> m_callback_map;
+    void add_common_callback(cui::fonts::common_callback* p_callback);
+    void remove_common_callback(cui::fonts::common_callback* p_callback);
+    void dispatch_common_font_changed(uint32_t mask) const;
+
+    void dispatch_all_fonts_changed() const;
 
     FontManagerData();
     ~FontManagerData();
+
+private:
+    pfc::ptr_list_t<cui::fonts::common_callback> m_common_font_callbacks;
+    std::unordered_map<GUID, std::vector<cui::basic_callback::ptr>> m_font_callback_map;
+    std::vector<cui::basic_callback::ptr> m_rendering_options_callbacks;
+    std::vector<cui::basic_callback::ptr> m_font_fallback_callbacks;
 };

--- a/foo_ui_columns/system_appearance_manager.cpp
+++ b/foo_ui_columns/system_appearance_manager.cpp
@@ -169,14 +169,14 @@ private:
             switch (wp) {
             case SPI_SETFONTSMOOTHING:
                 if (fonts::rendering_mode.get() == WI_EnumValue(fonts::RenderingMode::Automatic))
-                    g_font_manager_data.dispatch_all_fonts_changed();
+                    g_font_manager_data.dispatch_rendering_options_changed();
                 break;
             case SPI_SETICONTITLELOGFONT:
                 if (!g_font_manager_data.m_common_items_entry
                     || g_font_manager_data.m_common_items_entry->font_mode != fonts::FontMode::System)
                     break;
 
-                g_font_manager_data.g_on_common_font_changed(fonts::font_type_flag_items);
+                g_font_manager_data.dispatch_common_font_changed(fonts::font_type_flag_items);
 
                 for (auto client_ptr : fonts::client::enumerate()) {
                     const auto entry = g_font_manager_data.find_by_id(client_ptr->get_client_guid());
@@ -190,7 +190,7 @@ private:
                     || g_font_manager_data.m_common_labels_entry->font_mode != fonts::FontMode::System)
                     break;
 
-                g_font_manager_data.g_on_common_font_changed(fonts::font_type_flag_labels);
+                g_font_manager_data.dispatch_common_font_changed(fonts::font_type_flag_labels);
 
                 for (auto client_ptr : fonts::client::enumerate()) {
                     const auto entry = g_font_manager_data.find_by_id(client_ptr->get_client_guid());

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -117,7 +117,7 @@ void TabFonts::on_font_changed()
     if (index_element > 1)
         return;
 
-    g_font_manager_data.g_on_common_font_changed(1 << index_element);
+    g_font_manager_data.dispatch_common_font_changed(1 << index_element);
 
     for (auto&& client : m_fonts_client_list) {
         const auto p_data = g_font_manager_data.find_by_id(client.m_guid);

--- a/foo_ui_columns/tab_text_rendering.cpp
+++ b/foo_ui_columns/tab_text_rendering.cpp
@@ -148,7 +148,7 @@ INT_PTR TextRenderingTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 break;
 
             fonts::rendering_mode = gsl::narrow<std::underlying_type_t<fonts::RenderingMode>>(data);
-            g_font_manager_data.dispatch_all_fonts_changed();
+            g_font_manager_data.dispatch_rendering_options_changed();
             break;
         }
         case IDC_COLOUR_EMOJI_FAMILY | (CBN_SELCHANGE << 16): {
@@ -158,7 +158,7 @@ INT_PTR TextRenderingTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 break;
 
             fonts::colour_emoji_font_family = mmh::to_utf8(m_emoji_family_names[index]).c_str();
-            g_font_manager_data.dispatch_all_fonts_changed();
+            g_font_manager_data.dispatch_font_fallback_changed();
             break;
         }
         case IDC_MONOCHROME_EMOJI_FAMILY | (CBN_SELCHANGE << 16): {
@@ -168,25 +168,25 @@ INT_PTR TextRenderingTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 break;
 
             fonts::monochrome_emoji_font_family = mmh::to_utf8(m_emoji_family_names[index]).c_str();
-            g_font_manager_data.dispatch_all_fonts_changed();
+            g_font_manager_data.dispatch_font_fallback_changed();
             break;
         }
         case IDC_FORCE_GREYSCALE_ANTIALIASING: {
             fonts::force_greyscale_antialiasing
                 = Button_GetCheck(m_force_greyscale_antialiasing_checkbox) == BST_CHECKED;
-            g_font_manager_data.dispatch_all_fonts_changed();
+            g_font_manager_data.dispatch_rendering_options_changed();
             break;
         }
         case IDC_USE_COLOUR_GLYPHS: {
             fonts::use_colour_glyphs = Button_GetCheck(m_use_colour_glyphs) == BST_CHECKED;
-            g_font_manager_data.dispatch_all_fonts_changed();
+            g_font_manager_data.dispatch_rendering_options_changed();
             break;
         }
         case IDC_USE_ALT_EMOJI_FONT_SELECTION: {
             fonts::use_alternative_emoji_font_selection
                 = Button_GetCheck(m_use_alternative_emoji_font_selection_checkbox) == BST_CHECKED;
             enable_or_disable_emoji_controls();
-            g_font_manager_data.dispatch_all_fonts_changed();
+            g_font_manager_data.dispatch_font_fallback_changed();
             break;
         }
         }


### PR DESCRIPTION
This implements an updated `cui:fonts::manager_v3` interface, with new methods for retrieving rendering options and the font fallback object, and for registering callbacks relating to those.

It should be uncommon that these are needed, as rendering options and the font fallback object are available via `cui::fonts::font`, but these methods are added for completeness.
