### PR TITLE
Fix incorrect playlist view header positioning after certain actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 - A workaround for playlist and other list view column titles not rendering on
   Wine was added. [[#1185](https://github.com/reupen/columns_ui/pull/1185)]
 
+- A problem where the playlist view column titles could become incorrectly
+  positioned in some scenarios was fixed.
+  [[#1194](https://github.com/reupen/columns_ui/pull/1194)]
+
+- A problem where the playlist view vertical scroll position was reset in some
+  cases after showing and hiding columns was fixed.
+  [[#1194](https://github.com/reupen/columns_ui/pull/1194)]
+
 ### Internal changes
 
 - An updated font API for panels was implemented for release 8.0.0-beta.1 of the

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -465,11 +465,13 @@ void PlaylistView::g_on_columns_change()
 }
 void PlaylistView::on_columns_change()
 {
-    if (get_wnd()) {
-        clear_all_items();
-        refresh_columns();
-        populate_list();
-    }
+    if (!get_wnd())
+        return;
+
+    const auto saved_scroll_position = save_scroll_position();
+    clear_all_items();
+    refresh_columns();
+    populate_list(saved_scroll_position);
 }
 
 void PlaylistView::s_redraw_all()


### PR DESCRIPTION
This fixes a problem where, in a few scenarios, the playlist view header could be incorrectly positioned.

This happened, for example, when the playlist view was scrolled right and auto-sizing columns was turned on or items were removed from the playlist causing the vertical scroll bar to disappear.

Additionally, a problem where the playlist vertical scroll position was sometimes reset after showing or hiding columns via the header context menu was fixed.
