### PR TITLE
Use greyscale anti-aliasing when ClearType is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Bug fixes
 
+- DirectWrite-rendered text now automatically uses greyscale anti-aliasing if
+  ClearType (but not font smoothing) is disabled globally in Windows.
+  [[#1202](https://github.com/reupen/columns_ui/pull/1202)]
+
 - A workaround for playlist and other list view column titles not rendering on
   Wine was added. [[#1185](https://github.com/reupen/columns_ui/pull/1185)]
 

--- a/foo_ui_columns/font_manager_data.cpp
+++ b/foo_ui_columns/font_manager_data.cpp
@@ -4,6 +4,7 @@
 #include "font_manager_data.h"
 
 #include "config_appearance.h"
+#include "system_appearance_manager.h"
 
 FontManagerData::FontManagerData() : cfg_var(g_cfg_guid)
 {
@@ -536,11 +537,9 @@ DWRITE_RENDERING_MODE get_rendering_mode()
 {
     switch (static_cast<RenderingMode>(rendering_mode.get())) {
     default:
-    case RenderingMode::Automatic: {
-        BOOL font_smoothing_enabled{true};
-        SystemParametersInfo(SPI_GETFONTSMOOTHING, 0, &font_smoothing_enabled, 0);
-        return font_smoothing_enabled ? DWRITE_RENDERING_MODE_DEFAULT : DWRITE_RENDERING_MODE_ALIASED;
-    }
+    case RenderingMode::Automatic:
+        return system_appearance_manager::is_font_smoothing_enabled() ? DWRITE_RENDERING_MODE_DEFAULT
+                                                                      : DWRITE_RENDERING_MODE_ALIASED;
     case RenderingMode::DirectWriteAutomatic:
         return DWRITE_RENDERING_MODE_DEFAULT;
     case RenderingMode::Natural:

--- a/foo_ui_columns/font_manager_v3.cpp
+++ b/foo_ui_columns/font_manager_v3.cpp
@@ -7,6 +7,18 @@
 
 namespace cui::fonts {
 
+namespace {
+
+auto create_rendering_options()
+{
+    const auto resolved_force_greyscale_antialiasing
+        = force_greyscale_antialiasing.get() || !system_appearance_manager::is_cleartype_enabled();
+    return fb2k::service_new<rendering_options_impl>(
+        get_rendering_mode(), resolved_force_greyscale_antialiasing, use_colour_glyphs.get());
+}
+
+} // namespace
+
 class NOVTABLE Font : public font {
 public:
     Font(LOGFONT log_font, uih::direct_write::WeightStretchStyle wss, std::wstring typographic_family_name,
@@ -165,9 +177,7 @@ public:
         auto size = font_description.dip_size;
         auto wss = font_description.get_wss_with_fallback();
         auto axis_values = uih::direct_write::axis_values_to_vector(font_description.axis_values);
-
-        auto rendering_opts = fb2k::service_new<rendering_options_impl>(
-            get_rendering_mode(), force_greyscale_antialiasing.get(), use_colour_glyphs.get());
+        auto rendering_opts = create_rendering_options();
 
         auto emoji_font_selection_config = use_alternative_emoji_font_selection
             ? std::make_optional(uih::direct_write::EmojiFontSelectionConfig{
@@ -228,8 +238,7 @@ public:
     [[nodiscard]] rendering_options::ptr get_default_rendering_options() noexcept override
     {
         system_appearance_manager::initialise();
-        return fb2k::service_new<rendering_options_impl>(
-            get_rendering_mode(), force_greyscale_antialiasing.get(), use_colour_glyphs.get());
+        return create_rendering_options();
     }
 
     [[nodiscard]] pfc::com_ptr_t<IDWriteFontFallback> get_default_font_fallback() noexcept override

--- a/foo_ui_columns/system_appearance_manager.h
+++ b/foo_ui_columns/system_appearance_manager.h
@@ -23,4 +23,7 @@ void initialise();
 [[nodiscard]] std::unique_ptr<EventToken> add_modern_colours_change_handler(ModernColoursChangedHandler event_handler);
 [[nodiscard]] bool is_dark_mode_available();
 [[nodiscard]] bool is_dark_mode_enabled();
+
+[[nodiscard]] bool is_font_smoothing_enabled();
+[[nodiscard]] bool is_cleartype_enabled();
 } // namespace cui::system_appearance_manager


### PR DESCRIPTION
This makes DirectWrite-rendered text switch to greyscale anti-aliasing when Windows indicates that font smoothing is enabled but ClearType is not.