### PR TITLE
Fix double-clicking in empty space in Playlist tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+- A regression in version 2.0.0 that stopped double-clicking in empty space in
+  the Playlist tabs from creating a new playlist was fixed.
+  [[#1210](https://github.com/reupen/columns_ui/pull/1210)]
+
 ## 3.0.0-beta.2
 
 ### Bug fixes

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -299,7 +299,8 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             // return 0;
         }
         SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
-    } break;
+        break;
+    }
     case WM_SYSKEYDOWN:
         if (get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
@@ -322,7 +323,8 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 }
             }
         }
-    } break;
+        break;
+    }
     case WM_MOUSEMOVE:
         if (m_dragging && (wp & MK_LBUTTON)) {
             TCHITTESTINFO hittest;
@@ -366,24 +368,24 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     case WM_LBUTTONDBLCLK:
     case WM_MBUTTONUP: {
-        TCHITTESTINFO hittest;
-        hittest.pt.x = GET_X_LPARAM(lp);
-        hittest.pt.y = GET_Y_LPARAM(lp);
-        int idx = TabCtrl_HitTest(wnd_tabs, &hittest);
+        TCHITTESTINFO hittest{};
+        hittest.pt = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+        const auto index = TabCtrl_HitTest(wnd_tabs, &hittest);
         const auto playlist_api = playlist_manager::get();
-        if (idx >= 0) {
+        if (index >= 0) {
             if (config::cfg_playlist_tabs_middle_click && msg == WM_MBUTTONUP) {
-                remove_playlist_helper(idx);
+                remove_playlist_helper(index);
             }
             if (cfg_plm_rename && msg == WM_LBUTTONDBLCLK) {
-                playlist_manager_utils::rename_playlist(idx, get_wnd());
+                playlist_manager_utils::rename_playlist(index, get_wnd());
             }
         } else {
             const auto new_idx = playlist_api->create_playlist(
                 pfc::string8("Untitled"), pfc_infinite, playlist_api->get_playlist_count());
             playlist_api->set_active_playlist(new_idx);
         }
-    } break;
+        break;
+    }
     case WM_MOUSEWHEEL: {
         if ((GetWindowLongPtr(wnd, GWL_STYLE) & TCS_MULTILINE) != 0)
             return 0;

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -157,7 +157,10 @@ public:
     void on_child_position_change();
 
 private:
-    uie::container_window_v3_config get_window_config() override { return {L"{ABB72D0D-DBF0-4bba-8C68-3357EBE07A4D}"}; }
+    uie::container_window_v3_config get_window_config() override
+    {
+        return {L"{ABB72D0D-DBF0-4bba-8C68-3357EBE07A4D}", true, CS_DBLCLKS};
+    }
     void set_up_down_window_theme() const;
 
     static HFONT g_font;

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -76,15 +76,16 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (!(lpwp->flags & SWP_NOSIZE)) {
             on_size(lpwp->cx, lpwp->cy);
         }
-    } break;
+        break;
+    }
     case MSG_RESET_SIZE_LIMITS:
         on_child_position_change();
         break;
     case WM_GETMINMAXINFO: {
         auto lpmmi = LPMINMAXINFO(lp);
         *lpmmi = mmi;
-    }
         return 0;
+    }
     case WM_DESTROY: {
         m_get_message_hook_token.reset();
         m_dark_mode_notifier.reset();
@@ -103,35 +104,34 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             g_font = nullptr;
         }
         initialised = false;
-    } break;
+        break;
+    }
     case WM_NCDESTROY: {
         m_host_wnd = nullptr;
-    } break;
+        break;
+    }
     case WM_LBUTTONDBLCLK:
     case WM_MBUTTONUP: {
-        if (wnd_tabs) {
-            POINT temp;
-            temp.x = GET_X_LPARAM(lp);
-            temp.y = GET_Y_LPARAM(lp);
+        if (!wnd_tabs)
+            break;
 
-            HWND wnd_hit = ChildWindowFromPointEx(wnd, temp, CWP_SKIPINVISIBLE);
+        POINT pt{GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};
+        HWND wnd_hit = ChildWindowFromPointEx(wnd, pt, CWP_SKIPINVISIBLE);
 
-            if (wnd_hit == wnd_tabs) {
-                TCHITTESTINFO hittest;
-                hittest.pt.x = temp.x;
-                hittest.pt.y = temp.y;
-                int idx = TabCtrl_HitTest(wnd_tabs, &hittest);
+        if (wnd_hit != wnd_tabs)
+            break;
 
-                if (idx < 0) {
-                    const auto playlist_api = playlist_manager::get();
-                    const auto new_idx
-                        = playlist_api->create_playlist("Untitled", 12, playlist_api->get_playlist_count());
-                    playlist_api->set_active_playlist(new_idx);
-                    return 0;
-                }
-            }
-        }
-    } break;
+        TCHITTESTINFO hittest{};
+        hittest.pt = pt;
+
+        if (TabCtrl_HitTest(wnd_tabs, &hittest) >= 0)
+            break;
+
+        const auto playlist_api = playlist_manager::get();
+        const auto new_idx = playlist_api->create_playlist("Untitled", 12, playlist_api->get_playlist_count());
+        playlist_api->set_active_playlist(new_idx);
+        return 0;
+    }
     case WM_TIMER:
         if (wp == SWITCH_TIMER_ID) {
             m_switch_timer = false;


### PR DESCRIPTION
This fixes a regression in version 2.0.0 where the `CS_DBLCLKS` class style on the Playlist tabs container window was removed, preventing double-clicking in empty space in the Playlist tabs from working (it previously created a new playlist).

A little bit of tidying up of some Playlist tabs code has also been done.