### PR TITLE
Fix reversed state of Playlist tabs auto-hide setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   the Playlist tabs from creating a new playlist was fixed.
   [[#1210](https://github.com/reupen/columns_ui/pull/1210)]
 
+- A problem where the state of the ‘Hide when a single playlist is open’
+  Playlist tabs option in Preferences was reversed was fixed.
+  [[#1211](https://github.com/reupen/columns_ui/pull/1211)]
+
 ## 3.0.0-beta.2
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   Playlist tabs option in Preferences was reversed was fixed.
   [[#1211](https://github.com/reupen/columns_ui/pull/1211)]
 
+- If the Playlist tabs ‘Hide when a single playlist is open’ option is turned
+  on, a Playlist tabs panel without a child panel now has a maximum height of 0
+  when there is only one playlist.
+  [[#1211](https://github.com/reupen/columns_ui/pull/1211)]
+
 ## 3.0.0-beta.2
 
 ### Bug fixes

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -695,7 +695,7 @@ void PlaylistTabs::reset_size_limits()
             m_mmi.ptMaxTrackSize.x = MAXLONG;
         } else {
             m_mmi.ptMaxTrackSize.x = MAXLONG;
-            m_mmi.ptMaxTrackSize.y = MAXLONG;
+            m_mmi.ptMaxTrackSize.y = 0;
         }
     }
 }

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -649,25 +649,26 @@ void PlaylistTabs::adjust_rect(bool b_larger, RECT* rc)
 void PlaylistTabs::reset_size_limits()
 {
     constexpr auto max_value = static_cast<long>(USHRT_MAX);
-    memset(&mmi, 0, sizeof(mmi));
+    memset(&m_mmi, 0, sizeof(m_mmi));
     if (m_child_wnd) {
-        mmi.ptMinTrackSize.x = 0;
-        mmi.ptMinTrackSize.y = 0;
-        mmi.ptMaxTrackSize.x = max_value;
-        mmi.ptMaxTrackSize.y = max_value;
-        SendMessage(m_child_wnd, WM_GETMINMAXINFO, 0, (LPARAM)&mmi);
-        if (mmi.ptMinTrackSize.x != 0 || mmi.ptMinTrackSize.y != 0 || mmi.ptMaxTrackSize.x < max_value
-            || mmi.ptMaxTrackSize.y < max_value) {
-            RECT rc_min = {0, 0, mmi.ptMinTrackSize.x, mmi.ptMinTrackSize.y};
-            RECT rc_max = {0, 0, std::min(mmi.ptMaxTrackSize.x, max_value), std::min(mmi.ptMaxTrackSize.y, max_value)};
+        m_mmi.ptMinTrackSize.x = 0;
+        m_mmi.ptMinTrackSize.y = 0;
+        m_mmi.ptMaxTrackSize.x = max_value;
+        m_mmi.ptMaxTrackSize.y = max_value;
+        SendMessage(m_child_wnd, WM_GETMINMAXINFO, 0, (LPARAM)&m_mmi);
+        if (m_mmi.ptMinTrackSize.x != 0 || m_mmi.ptMinTrackSize.y != 0 || m_mmi.ptMaxTrackSize.x < max_value
+            || m_mmi.ptMaxTrackSize.y < max_value) {
+            RECT rc_min = {0, 0, m_mmi.ptMinTrackSize.x, m_mmi.ptMinTrackSize.y};
+            RECT rc_max
+                = {0, 0, std::min(m_mmi.ptMaxTrackSize.x, max_value), std::min(m_mmi.ptMaxTrackSize.y, max_value)};
             if (wnd_tabs) {
                 adjust_rect(TRUE, &rc_min);
                 adjust_rect(TRUE, &rc_max);
             }
-            mmi.ptMinTrackSize.x = rc_min.right - rc_min.left;
-            mmi.ptMinTrackSize.y = rc_min.bottom - rc_min.top;
-            mmi.ptMaxTrackSize.x = rc_max.right - rc_max.left;
-            mmi.ptMaxTrackSize.y = rc_max.bottom - rc_max.top;
+            m_mmi.ptMinTrackSize.x = rc_min.right - rc_min.left;
+            m_mmi.ptMinTrackSize.y = rc_min.bottom - rc_min.top;
+            m_mmi.ptMaxTrackSize.x = rc_max.right - rc_max.left;
+            m_mmi.ptMaxTrackSize.y = rc_max.bottom - rc_max.top;
         } else {
             if (wnd_tabs) {
                 RECT rc;
@@ -675,11 +676,11 @@ void PlaylistTabs::reset_size_limits()
                 MapWindowPoints(HWND_DESKTOP, get_wnd(), (LPPOINT)&rc, 2);
                 RECT rc_child = rc;
                 adjust_rect(FALSE, &rc_child);
-                mmi.ptMinTrackSize.x = rc_child.left - rc.left + rc.right - rc_child.right;
-                mmi.ptMinTrackSize.y = rc_child.top - rc.top + rc.bottom - rc_child.bottom;
+                m_mmi.ptMinTrackSize.x = rc_child.left - rc.left + rc.right - rc_child.right;
+                m_mmi.ptMinTrackSize.y = rc_child.top - rc.top + rc.bottom - rc_child.bottom;
             }
-            mmi.ptMaxTrackSize.x = MAXLONG;
-            mmi.ptMaxTrackSize.y = MAXLONG;
+            m_mmi.ptMaxTrackSize.x = MAXLONG;
+            m_mmi.ptMaxTrackSize.y = MAXLONG;
         }
     } else {
         if (wnd_tabs) {
@@ -688,13 +689,13 @@ void PlaylistTabs::reset_size_limits()
             MapWindowPoints(HWND_DESKTOP, get_wnd(), (LPPOINT)&rc_tabs, 2);
             RECT rc_child = rc_tabs;
             adjust_rect(FALSE, &rc_child);
-            mmi.ptMinTrackSize.x = rc_child.left - rc_tabs.left + rc_tabs.right - rc_child.right;
-            mmi.ptMinTrackSize.y = rc_child.top - rc_tabs.top + rc_tabs.bottom - rc_child.bottom;
-            mmi.ptMaxTrackSize.y = mmi.ptMinTrackSize.y;
-            mmi.ptMaxTrackSize.x = MAXLONG;
+            m_mmi.ptMinTrackSize.x = rc_child.left - rc_tabs.left + rc_tabs.right - rc_child.right;
+            m_mmi.ptMinTrackSize.y = rc_child.top - rc_tabs.top + rc_tabs.bottom - rc_child.bottom;
+            m_mmi.ptMaxTrackSize.y = m_mmi.ptMinTrackSize.y;
+            m_mmi.ptMaxTrackSize.x = MAXLONG;
         } else {
-            mmi.ptMaxTrackSize.x = MAXLONG;
-            mmi.ptMaxTrackSize.y = MAXLONG;
+            m_mmi.ptMaxTrackSize.x = MAXLONG;
+            m_mmi.ptMaxTrackSize.y = MAXLONG;
         }
     }
 }

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -193,7 +193,7 @@ private:
 
     unsigned m_child_top{0};
 
-    MINMAXINFO mmi{};
+    MINMAXINFO m_mmi{};
     std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
     std::unique_ptr<uih::EventToken> m_get_message_hook_token;
 };

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -83,7 +83,7 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     case WM_GETMINMAXINFO: {
         auto lpmmi = LPMINMAXINFO(lp);
-        *lpmmi = mmi;
+        *lpmmi = m_mmi;
         return 0;
     }
     case WM_DESTROY: {

--- a/foo_ui_columns/tab_playlist_tabs.cpp
+++ b/foo_ui_columns/tab_playlist_tabs.cpp
@@ -8,18 +8,19 @@ public:
     {
         switch (msg) {
         case WM_INITDIALOG:
-            SendDlgItemMessage(wnd, IDC_MCLICK3, BM_SETCHECK, cfg_plm_rename, 0);
-            SendDlgItemMessage(wnd, IDC_PLDRAG, BM_SETCHECK, cfg_drag_pl, 0);
-            SendDlgItemMessage(wnd, IDC_PLAUTOHIDE, BM_SETCHECK, cfg_pl_autohide == 0, 0);
-            SendDlgItemMessage(
-                wnd, IDC_PLAYLIST_TABS_MCLICK, BM_SETCHECK, cui::config::cfg_playlist_tabs_middle_click, 0);
+            SendDlgItemMessage(wnd, IDC_MCLICK3, BM_SETCHECK, cfg_plm_rename ? BST_CHECKED : BST_UNCHECKED, 0);
+            SendDlgItemMessage(wnd, IDC_PLDRAG, BM_SETCHECK, cfg_drag_pl ? BST_CHECKED : BST_UNCHECKED, 0);
+            SendDlgItemMessage(wnd, IDC_PLAUTOHIDE, BM_SETCHECK, cfg_pl_autohide ? BST_CHECKED : BST_UNCHECKED, 0);
+            SendDlgItemMessage(wnd, IDC_PLAYLIST_TABS_MCLICK, BM_SETCHECK,
+                cui::config::cfg_playlist_tabs_middle_click ? BST_CHECKED : BST_UNCHECKED, 0);
 
-            SendDlgItemMessage(wnd, IDC_TABS_MULTILINE, BM_SETCHECK, cfg_tabs_multiline, 0);
+            SendDlgItemMessage(
+                wnd, IDC_TABS_MULTILINE, BM_SETCHECK, cfg_tabs_multiline ? BST_CHECKED : BST_UNCHECKED, 0);
             break;
         case WM_COMMAND:
             switch (wp) {
             case IDC_PLAUTOHIDE:
-                cfg_pl_autohide = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_UNCHECKED;
+                cfg_pl_autohide = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
                 cui::panels::playlist_tabs::g_on_autohide_tabs_change();
                 break;
             case IDC_PLAYLIST_TABS_MCLICK:


### PR DESCRIPTION
This fixes a problem where the state of the ‘Hide when a single playlist is open’ Playlist tabs option in Preferences was reversed.

It also makes a change to the Playlist tabs size limits so that if ‘Hide when a single playlist is open’ is turned on, a Playlist tabs panel without a child panel has a maximum height of 0 when the tabs are hidden due to there being only one playlist.