### PR TITLE
Migrate Artwork view to Direct2D and decode images asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Change log
 
-## Development version
+## 3.0.0-beta.3
 
 ### Features
 
 - The rendering performance of built-in list views, including the playlist view,
   was improved. [[#1212](https://github.com/reupen/columns_ui/pull/1212)]
+
+- The Artwork view now decodes images in a background thread and renders and
+  resizes images using Direct2D.
+  [[#1221](https://github.com/reupen/columns_ui/pull/1221)]
+
+  These changes are intended to improve UI responsiveness when loading large
+  images and images that are otherwise slow to decode.
 
 ### Bug fixes
 

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -86,6 +86,14 @@ void ArtworkPanel::get_menu_items(ui_extension::menu_hook_t& p_hook)
     p_hook.add_node(uie::menu_node_ptr(new MenuNodeOptions()));
 }
 
+void ArtworkPanel::request_artwork(const metadb_handle_ptr& track, bool is_from_playback)
+{
+    const auto handle_artwork_read
+        = [self{service_ptr_t{this}}](bool artwork_changed) { self->on_artwork_loaded(artwork_changed); };
+
+    m_artwork_loader->request(track, std::move(handle_artwork_read), is_from_playback);
+}
+
 ArtworkPanel::ArtworkPanel() : m_track_mode(cfg_track_mode), m_preserve_aspect_ratio(cfg_preserve_aspect_ratio) {}
 
 uie::container_window_v3_config ArtworkPanel::get_window_config()
@@ -263,7 +271,7 @@ void ArtworkPanel::on_selection_changed(const pfc::list_base_const_t<metadb_hand
         if (g_track_mode_includes_selection(m_track_mode)
             && (!g_track_mode_includes_auto(m_track_mode) || !play_control::get()->is_playing())) {
             if (m_selection_handles.get_count()) {
-                m_artwork_loader->request(m_selection_handles[0], new service_impl_t<CompletionNotifyForwarder>(this));
+                request_artwork(m_selection_handles[0]);
             } else {
                 flush_image();
                 if (m_artwork_loader)
@@ -288,7 +296,7 @@ void ArtworkPanel::on_playback_stop(play_control::t_stop_reason p_reason) noexce
         }
 
         if (handles.get_count()) {
-            m_artwork_loader->request(handles[0], new service_impl_t<CompletionNotifyForwarder>(this));
+            request_artwork(handles[0]);
             b_set = true;
         }
 
@@ -306,7 +314,7 @@ void ArtworkPanel::on_playback_new_track(metadb_handle_ptr p_track) noexcept
     if (g_track_mode_includes_now_playing(m_track_mode) && m_artwork_loader) {
         const auto data = now_playing_album_art_notify_manager::get()->current();
 
-        m_artwork_loader->request(p_track, new service_impl_t<CompletionNotifyForwarder>(this), true);
+        request_artwork(p_track, true);
     }
 }
 
@@ -329,7 +337,7 @@ void ArtworkPanel::force_reload_artwork()
     }
 
     if (handle.is_valid()) {
-        m_artwork_loader->request(handle, new service_impl_t<CompletionNotifyForwarder>(this), is_from_playback);
+        request_artwork(handle, is_from_playback);
     } else {
         flush_image();
         if (m_artwork_loader)
@@ -392,7 +400,7 @@ void ArtworkPanel::on_playlist_switch() noexcept
         metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
         playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
         if (handles.get_count()) {
-            m_artwork_loader->request(handles[0], new service_impl_t<CompletionNotifyForwarder>(this));
+            request_artwork(handles[0]);
         } else {
             flush_image();
             if (m_artwork_loader)
@@ -408,7 +416,7 @@ void ArtworkPanel::on_items_selection_change(const bit_array& p_affected, const 
         metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
         playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
         if (handles.get_count()) {
-            m_artwork_loader->request(handles[0], new service_impl_t<CompletionNotifyForwarder>(this));
+            request_artwork(handles[0]);
         } else {
             flush_image();
             if (m_artwork_loader)
@@ -417,13 +425,12 @@ void ArtworkPanel::on_items_selection_change(const bit_array& p_affected, const 
     }
 }
 
-void ArtworkPanel::on_completion(unsigned p_code)
+void ArtworkPanel::on_artwork_loaded(bool artwork_changed)
 {
     if (!get_wnd())
         return;
 
     const auto is_dynamic_artwork_pending = m_dynamic_artwork_pending && m_selected_artwork_type_index == 0;
-    const auto artwork_changed = p_code == 1;
 
     if (m_image && !is_dynamic_artwork_pending && !artwork_changed)
         return;
@@ -634,13 +641,6 @@ public:
 
 namespace {
 colours::client::factory<ArtworkColoursClient> g_appearance_client_impl;
-}
-
-ArtworkPanel::CompletionNotifyForwarder::CompletionNotifyForwarder(ArtworkPanel* p_this) : m_this(p_this) {}
-
-void ArtworkPanel::CompletionNotifyForwarder::on_completion(unsigned p_code) noexcept
-{
-    m_this->on_completion(p_code);
 }
 
 void ArtworkPanel::set_config(stream_reader* p_reader, size_t size, abort_callback& p_abort)

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -6,6 +6,65 @@
 
 namespace cui::artwork_panel {
 
+namespace {
+
+wil::unique_hbitmap scale_image(Gdiplus::Bitmap& bitmap, const int client_width, const int client_height,
+    const bool preserve_aspect_ratio, const COLORREF background_colour)
+{
+    if (bitmap.GetWidth() < 2 || bitmap.GetHeight() < 2)
+        return {};
+
+    const double image_aspect_ratio
+        = gsl::narrow_cast<double>(bitmap.GetWidth()) / gsl::narrow_cast<double>(bitmap.GetHeight());
+    const double client_aspect_ratio = gsl::narrow_cast<double>(client_width) / gsl::narrow_cast<double>(client_height);
+
+    int scaled_width = client_width;
+    int scaled_height = client_height;
+
+    if (preserve_aspect_ratio) {
+        if (client_aspect_ratio < image_aspect_ratio)
+            scaled_height
+                = gsl::narrow_cast<unsigned>(floor(gsl::narrow_cast<double>(client_width) / image_aspect_ratio));
+        else if (client_aspect_ratio > image_aspect_ratio)
+            scaled_width
+                = gsl::narrow_cast<unsigned>(floor(gsl::narrow_cast<double>(client_height) * image_aspect_ratio));
+    }
+
+    if (((client_height - scaled_height) % 2) != 0)
+        ++scaled_height;
+
+    if (((client_width - scaled_width) % 2) != 0)
+        ++scaled_width;
+
+    const auto dc = wil::GetDC(nullptr);
+    const wil::unique_hdc memory_dc(CreateCompatibleDC(dc.get()));
+
+    wil::unique_hbitmap scaled_bitmap(CreateCompatibleBitmap(dc.get(), client_width, client_height));
+
+    auto _ = wil::SelectObject(memory_dc.get(), scaled_bitmap.get());
+
+    Gdiplus::Graphics graphics(memory_dc.get());
+    graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHighQuality);
+    graphics.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
+
+    Gdiplus::SolidBrush brush(
+        Gdiplus::Color(GetRValue(background_colour), GetGValue(background_colour), GetBValue(background_colour)));
+    graphics.FillRectangle(&brush, 0, 0, client_width, client_height);
+
+    Gdiplus::Rect dest_rect(
+        (client_width - scaled_width) / 2, (client_height - scaled_height) / 2, scaled_width, scaled_height);
+    graphics.SetClip(dest_rect);
+    Gdiplus::ImageAttributes image_attributes;
+    image_attributes.SetWrapMode(Gdiplus::WrapModeTileFlipXY);
+
+    graphics.DrawImage(
+        &bitmap, dest_rect, 0, 0, bitmap.GetWidth(), bitmap.GetHeight(), Gdiplus::UnitPixel, &image_attributes);
+
+    return scaled_bitmap;
+}
+
+} // namespace
+
 // {005C7B29-3915-4b83-A283-C01A4EDC4F3A}
 const GUID g_guid_track_mode = {0x5c7b29, 0x3915, 0x4b83, {0xa2, 0x83, 0xc0, 0x1a, 0x4e, 0xdc, 0x4f, 0x3a}};
 
@@ -61,7 +120,7 @@ void ArtworkPanel::get_config(stream_writer* p_writer, abort_callback& p_abort) 
     p_writer->write_lendian_t(m_track_mode, p_abort);
     p_writer->write_lendian_t(static_cast<uint32_t>(current_stream_version), p_abort);
     p_writer->write_lendian_t(m_preserve_aspect_ratio, p_abort);
-    p_writer->write_lendian_t(m_lock_type, p_abort);
+    p_writer->write_lendian_t(m_artwork_type_locked, p_abort);
     p_writer->write_lendian_t(gsl::narrow<uint32_t>(m_selected_artwork_type_index), p_abort);
 }
 
@@ -91,7 +150,7 @@ void ArtworkPanel::request_artwork(const metadb_handle_ptr& track, bool is_from_
     const auto handle_artwork_read
         = [self{service_ptr_t{this}}](bool artwork_changed) { self->on_artwork_loaded(artwork_changed); };
 
-    m_artwork_loader->request(track, std::move(handle_artwork_read), is_from_playback);
+    m_artwork_reader->request(track, std::move(handle_artwork_read), is_from_playback);
 }
 
 ArtworkPanel::ArtworkPanel() : m_track_mode(cfg_track_mode), m_preserve_aspect_ratio(cfg_preserve_aspect_ratio) {}
@@ -135,7 +194,7 @@ void ArtworkPanel::g_on_edge_style_change()
  */
 void ArtworkPanel::on_album_art(album_art_data::ptr data) noexcept
 {
-    if (!m_artwork_loader || !m_artwork_loader->is_ready()) {
+    if (!m_artwork_reader || !m_artwork_reader->is_ready()) {
         m_dynamic_artwork_pending = true;
         return;
     }
@@ -174,9 +233,9 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_CREATE: {
         Gdiplus::GdiplusStartupInput gdiplusStartupInput;
         m_gdiplus_initialised = (Gdiplus::Ok == GdiplusStartup(&m_gdiplus_instance, &gdiplusStartupInput, nullptr));
-        m_artwork_loader = std::make_shared<ArtworkReaderManager>();
+        m_artwork_reader = std::make_shared<ArtworkReaderManager>();
         now_playing_album_art_notify_manager::get()->add(this);
-        m_artwork_loader->set_types(g_artwork_types);
+        m_artwork_reader->set_types(g_artwork_types);
         play_callback_manager::get()->register_callback(
             this, flag_on_playback_new_track | flag_on_playback_stop | flag_on_playback_edited, false);
         playlist_manager_v3::get()->register_callback(this, playlist_callback_flags);
@@ -191,14 +250,14 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         play_callback_manager::get()->unregister_callback(this);
         now_playing_album_art_notify_manager::get()->remove(this);
         m_selection_handles.remove_all();
-        m_image.reset();
+        m_artwork_decoder.shut_down();
         m_bitmap.reset();
         if (m_gdiplus_initialised)
             Gdiplus::GdiplusShutdown(m_gdiplus_instance);
         m_gdiplus_initialised = false;
-        if (m_artwork_loader)
-            m_artwork_loader->deinitialise();
-        m_artwork_loader.reset();
+        if (m_artwork_reader)
+            m_artwork_reader->deinitialise();
+        m_artwork_reader.reset();
         break;
     case WM_ERASEBKGND:
         return FALSE;
@@ -243,8 +302,8 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             }
         }
         EndPaint(wnd, &ps);
-    }
         return 0;
+    }
     }
     return DefWindowProc(wnd, msg, wp, lp);
 }
@@ -274,8 +333,8 @@ void ArtworkPanel::on_selection_changed(const pfc::list_base_const_t<metadb_hand
                 request_artwork(m_selection_handles[0]);
             } else {
                 flush_image();
-                if (m_artwork_loader)
-                    m_artwork_loader->reset();
+                if (m_artwork_reader)
+                    m_artwork_reader->reset();
             }
         }
     }
@@ -302,8 +361,8 @@ void ArtworkPanel::on_playback_stop(play_control::t_stop_reason p_reason) noexce
 
         if (!b_set) {
             flush_image();
-            if (m_artwork_loader)
-                m_artwork_loader->reset();
+            if (m_artwork_reader)
+                m_artwork_reader->reset();
         }
     }
 }
@@ -311,7 +370,7 @@ void ArtworkPanel::on_playback_stop(play_control::t_stop_reason p_reason) noexce
 void ArtworkPanel::on_playback_new_track(metadb_handle_ptr p_track) noexcept
 {
     m_dynamic_artwork_pending = false;
-    if (g_track_mode_includes_now_playing(m_track_mode) && m_artwork_loader) {
+    if (g_track_mode_includes_now_playing(m_track_mode) && m_artwork_reader) {
         const auto data = now_playing_album_art_notify_manager::get()->current();
 
         request_artwork(p_track, true);
@@ -340,8 +399,8 @@ void ArtworkPanel::force_reload_artwork()
         request_artwork(handle, is_from_playback);
     } else {
         flush_image();
-        if (m_artwork_loader)
-            m_artwork_loader->reset();
+        if (m_artwork_reader)
+            m_artwork_reader->reset();
     }
 }
 
@@ -352,7 +411,7 @@ bool ArtworkPanel::is_core_image_viewer_available() const
     }
 
     const auto artwork_type_id = g_artwork_types[get_displayed_artwork_type_index()];
-    const album_art_data_ptr data = m_artwork_loader->get_image(artwork_type_id);
+    const album_art_data_ptr data = m_artwork_reader->get_image(artwork_type_id);
 
     return data.is_valid();
 }
@@ -360,7 +419,7 @@ bool ArtworkPanel::is_core_image_viewer_available() const
 void ArtworkPanel::open_core_image_viewer() const
 {
     const auto artwork_type_id = g_artwork_types[get_displayed_artwork_type_index()];
-    const album_art_data_ptr data = m_artwork_loader->get_image(artwork_type_id);
+    const album_art_data_ptr data = m_artwork_reader->get_image(artwork_type_id);
 
     if (!data.is_valid())
         return;
@@ -372,25 +431,44 @@ void ArtworkPanel::open_core_image_viewer() const
 
 void ArtworkPanel::show_next_artwork_type()
 {
+    if (!m_artwork_reader || !m_artwork_reader->is_ready())
+        return;
+
     const auto start_artwork_type_index = get_displayed_artwork_type_index();
     auto artwork_type_index = start_artwork_type_index;
     const size_t count = g_artwork_types.size();
 
-    for (size_t i = 0; i < count; i++) {
+    for (size_t i = 0; i + 1 < count; i++) {
         artwork_type_index = (artwork_type_index + 1) % count;
+        const auto artwork_type_id = g_artwork_types[artwork_type_index];
+        const auto data = m_artwork_reader->get_image(artwork_type_id);
 
-        if (!refresh_image(artwork_type_index))
-            continue;
-
-        if (artwork_type_index != start_artwork_type_index) {
+        if (data.is_valid()) {
             m_artwork_type_override_index.reset();
             m_selected_artwork_type_index = artwork_type_index;
+            refresh_image();
+            break;
         }
+    }
+}
+
+void ArtworkPanel::set_artwork_type_index(size_t index)
+{
+    m_selected_artwork_type_index = index;
+    m_artwork_type_override_index.reset();
+
+    if (!m_artwork_reader || !m_artwork_reader->is_ready())
+        return;
+
+    const auto artwork_type_id = g_artwork_types[m_selected_artwork_type_index];
+    const auto data = m_artwork_reader->get_image(artwork_type_id);
+
+    if (!data.is_valid()) {
+        show_stub_image();
         return;
     }
 
-    m_artwork_type_override_index.reset();
-    show_stub_image();
+    refresh_image();
 }
 
 void ArtworkPanel::on_playlist_switch() noexcept
@@ -403,8 +481,8 @@ void ArtworkPanel::on_playlist_switch() noexcept
             request_artwork(handles[0]);
         } else {
             flush_image();
-            if (m_artwork_loader)
-                m_artwork_loader->reset();
+            if (m_artwork_reader)
+                m_artwork_reader->reset();
         }
     }
 }
@@ -419,8 +497,8 @@ void ArtworkPanel::on_items_selection_change(const bit_array& p_affected, const 
             request_artwork(handles[0]);
         } else {
             flush_image();
-            if (m_artwork_loader)
-                m_artwork_loader->reset();
+            if (m_artwork_reader)
+                m_artwork_reader->reset();
         }
     }
 }
@@ -432,7 +510,7 @@ void ArtworkPanel::on_artwork_loaded(bool artwork_changed)
 
     const auto is_dynamic_artwork_pending = m_dynamic_artwork_pending && m_selected_artwork_type_index == 0;
 
-    if (m_image && !is_dynamic_artwork_pending && !artwork_changed)
+    if (m_artwork_decoder.has_image() && !is_dynamic_artwork_pending && !artwork_changed)
         return;
 
     m_dynamic_artwork_pending = false;
@@ -440,13 +518,21 @@ void ArtworkPanel::on_artwork_loaded(bool artwork_changed)
 
     bool b_found = false;
     size_t count = g_artwork_types.size();
-    if (m_lock_type)
+
+    if (m_artwork_type_locked)
         count = std::min(size_t{1}, count);
+
     for (size_t i = 0; i < count; i++) {
-        if (refresh_image()) {
+        const auto artwork_type_index = get_displayed_artwork_type_index();
+        const auto artwork_type_id = g_artwork_types[artwork_type_index];
+        const auto data = m_artwork_reader->get_image(artwork_type_id);
+
+        if (data.is_valid()) {
+            refresh_image();
             b_found = true;
             break;
         }
+
         m_artwork_type_override_index = (*m_artwork_type_override_index + 1) % g_artwork_types.size();
     }
 
@@ -459,56 +545,33 @@ void ArtworkPanel::on_artwork_loaded(bool artwork_changed)
 void ArtworkPanel::show_stub_image()
 {
     flush_image(false);
-    // Needs to be delayed until after WIC calls are made (otherwise painting
-    // may happen prematurely).
-    auto _ = gsl::finally([this] { invalidate_window(); });
 
-    if (!m_artwork_loader || !m_artwork_loader->is_ready())
+    if (!m_artwork_reader || !m_artwork_reader->is_ready())
         return;
 
     const auto artwork_type_id = g_artwork_types[get_displayed_artwork_type_index()];
-    const album_art_data_ptr data = m_artwork_loader->get_stub_image(artwork_type_id);
+    const album_art_data_ptr data = m_artwork_reader->get_stub_image(artwork_type_id);
 
-    if (data.is_empty()) {
-        return;
-    }
-
-    try {
-        const auto bitmap_data = wic::decode_image_data(data->get_ptr(), data->get_size());
-        m_image = gdip::create_bitmap_from_wic_data(bitmap_data);
-    } catch (const std::exception& ex) {
-        fbh::print_to_console(u8"Artwork panel – loading stub image failed: "_pcc, ex.what());
-    }
+    m_artwork_decoder.decode(data, [this, self{ptr{this}}] { invalidate_window(); });
 }
 
-bool ArtworkPanel::refresh_image(std::optional<size_t> artwork_type_index_override)
+void ArtworkPanel::refresh_image()
 {
     TRACK_CALL_TEXT("cui::ArtworkPanel::refresh_image");
 
     flush_image(false);
-    // Needs to be delayed until after WIC calls are made (otherwise painting
-    // may happen prematurely).
-    auto _ = gsl::finally([this] { invalidate_window(); });
 
-    if (!m_artwork_loader || !m_artwork_loader->is_ready())
-        return false;
+    if (!m_artwork_reader || !m_artwork_reader->is_ready())
+        return;
 
-    const auto artwork_type_index = artwork_type_index_override.value_or(get_displayed_artwork_type_index());
+    const auto artwork_type_index = get_displayed_artwork_type_index();
     const auto artwork_type_id = g_artwork_types[artwork_type_index];
-    const auto data = m_artwork_loader->get_image(artwork_type_id);
+    const auto data = m_artwork_reader->get_image(artwork_type_id);
 
     if (data.is_empty())
-        return false;
+        return;
 
-    try {
-        const auto bitmap_data = wic::decode_image_data(data->get_ptr(), data->get_size());
-        m_image = gdip::create_bitmap_from_wic_data(bitmap_data);
-    } catch (const std::exception& ex) {
-        fbh::print_to_console(u8"Artwork panel – loading image failed: "_pcc, ex.what());
-        return false;
-    }
-
-    return static_cast<bool>(m_image);
+    m_artwork_decoder.decode(data, [this, self{ptr{this}}] { invalidate_window(); });
 }
 
 void ArtworkPanel::flush_cached_bitmap()
@@ -518,7 +581,7 @@ void ArtworkPanel::flush_cached_bitmap()
 
 void ArtworkPanel::flush_image(bool invalidate)
 {
-    m_image.reset();
+    m_artwork_decoder.reset();
     flush_cached_bitmap();
     if (invalidate)
         invalidate_window();
@@ -536,59 +599,20 @@ size_t ArtworkPanel::get_displayed_artwork_type_index() const
 
 void ArtworkPanel::refresh_cached_bitmap()
 {
-    RECT rc;
+    RECT rc{};
     GetClientRect(get_wnd(), &rc);
-    if (wil::rect_width(rc) && wil::rect_height(rc) && m_image) {
-        HDC dc = nullptr;
-        HDC dcc = nullptr;
-        dc = GetDC(get_wnd());
-        dcc = CreateCompatibleDC(dc);
+    const auto width = static_cast<int>(wil::rect_width(rc));
+    const auto height = static_cast<int>(wil::rect_height(rc));
 
-        m_bitmap.reset(CreateCompatibleBitmap(dc, wil::rect_width(rc), wil::rect_height(rc)));
-
-        HBITMAP bm_old = SelectBitmap(dcc, m_bitmap.get());
-
-        Gdiplus::Graphics graphics(dcc);
-
-        double ar_source = (double)m_image->GetWidth() / (double)m_image->GetHeight();
-        double ar_dest = (double)wil::rect_width(rc) / (double)wil::rect_height(rc);
-        unsigned cx = wil::rect_width(rc);
-        unsigned cy = wil::rect_height(rc);
-
-        graphics.SetPixelOffsetMode(Gdiplus::PixelOffsetModeHighQuality);
-        graphics.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
-
-        COLORREF cr = colours::helper(g_guid_colour_client).get_colour(colours::colour_background);
-        Gdiplus::SolidBrush br(Gdiplus::Color(LOBYTE(LOWORD(cr)), HIBYTE(LOWORD(cr)), LOBYTE(HIWORD(cr))));
-        graphics.FillRectangle(&br, 0, 0, cx, cy);
-
-        if (m_preserve_aspect_ratio) {
-            if (ar_dest < ar_source)
-                cy = (unsigned)floor((double)wil::rect_width(rc) / ar_source);
-            else if (ar_dest > ar_source)
-                cx = (unsigned)floor((double)wil::rect_height(rc) * ar_source);
-        }
-        if ((wil::rect_height(rc) - cy) % 2)
-            cy++;
-        if ((wil::rect_width(rc) - cx) % 2)
-            cx++;
-
-        if (m_image->GetWidth() >= 2 && m_image->GetHeight() >= 2) {
-            Gdiplus::Rect destRect(INT((wil::rect_width(rc) - cx) / 2), INT((wil::rect_height(rc) - cy) / 2), cx, cy);
-            graphics.SetClip(destRect);
-            Gdiplus::ImageAttributes imageAttributes;
-            imageAttributes.SetWrapMode(Gdiplus::WrapModeTileFlipXY);
-
-            graphics.DrawImage(&*m_image, destRect, 0, 0, m_image->GetWidth(), m_image->GetHeight(), Gdiplus::UnitPixel,
-                &imageAttributes);
-        }
-
-        SelectBitmap(dcc, bm_old);
-
-        DeleteDC(dcc);
-        ReleaseDC(get_wnd(), dc);
-    } else
+    if (width <= 0 || height <= 0 || !m_artwork_decoder.has_image()) {
         m_bitmap.reset();
+        return;
+    }
+
+    const auto background_colour = colours::helper(g_guid_colour_client).get_colour(colours::colour_background);
+    auto image = m_artwork_decoder.get_image();
+
+    m_bitmap = scale_image(*image, width, height, background_colour, m_preserve_aspect_ratio);
 }
 
 void ArtworkPanel::g_on_colours_change()
@@ -608,8 +632,8 @@ void ArtworkPanel::s_on_dark_mode_status_change()
         if (!window->get_wnd())
             continue;
 
-        if (window->m_artwork_loader)
-            window->m_artwork_loader->reset();
+        if (window->m_artwork_reader)
+            window->m_artwork_reader->reset();
 
         window->flush_image();
         window->force_reload_artwork();
@@ -656,7 +680,7 @@ void ArtworkPanel::set_config(stream_reader* p_reader, size_t size, abort_callba
         if (version <= 3) {
             p_reader->read_lendian_t(m_preserve_aspect_ratio, p_abort);
             if (version >= 2) {
-                p_reader->read_lendian_t(m_lock_type, p_abort);
+                p_reader->read_lendian_t(m_artwork_type_locked, p_abort);
                 if (version >= 3) {
                     m_selected_artwork_type_index = p_reader->read_lendian_t<uint32_t>(p_abort);
                     if (m_selected_artwork_type_index >= g_artwork_types.size()) {
@@ -715,12 +739,7 @@ ArtworkPanel::MenuNodeArtworkType::MenuNodeArtworkType(ArtworkPanel* p_wnd, uint
 
 void ArtworkPanel::MenuNodeArtworkType::execute()
 {
-    p_this->m_selected_artwork_type_index = m_type;
-    p_this->m_artwork_type_override_index.reset();
-
-    if (!p_this->refresh_image()) {
-        p_this->show_stub_image();
-    }
+    p_this->set_artwork_type_index(m_type);
 }
 
 bool ArtworkPanel::MenuNodeArtworkType::get_description(pfc::string_base& p_out) const
@@ -807,6 +826,7 @@ void ArtworkPanel::MenuNodePreserveAspectRatio::execute()
     cfg_preserve_aspect_ratio = p_this->m_preserve_aspect_ratio;
     p_this->flush_cached_bitmap();
     p_this->invalidate_window();
+    p_this->refresh_cached_bitmap();
 }
 
 bool ArtworkPanel::MenuNodePreserveAspectRatio::get_description(pfc::string_base& p_out) const
@@ -843,8 +863,8 @@ ArtworkPanel::MenuNodeLockType::MenuNodeLockType(ArtworkPanel* p_wnd) : p_this(p
 
 void ArtworkPanel::MenuNodeLockType::execute()
 {
-    p_this->m_lock_type = !p_this->m_lock_type;
-    if (p_this->m_lock_type) {
+    p_this->m_artwork_type_locked = !p_this->m_artwork_type_locked;
+    if (p_this->m_artwork_type_locked) {
         p_this->m_selected_artwork_type_index = p_this->get_displayed_artwork_type_index();
         p_this->m_artwork_type_override_index.reset();
     }
@@ -858,7 +878,7 @@ bool ArtworkPanel::MenuNodeLockType::get_description(pfc::string_base& p_out) co
 bool ArtworkPanel::MenuNodeLockType::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
     p_out = "Lock artwork type";
-    p_displayflags = (p_this->m_lock_type) ? state_checked : 0;
+    p_displayflags = (p_this->m_artwork_type_locked) ? state_checked : 0;
     return true;
 }
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -166,20 +166,18 @@ private:
     void get_config(stream_writer* p_writer, abort_callback& p_abort) const override;
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
-    void refresh_cached_bitmap();
-    void flush_cached_bitmap();
+    void create_d2d_render_target();
     void refresh_image();
+    void clear_image();
     void show_stub_image();
-    void flush_image(bool invalidate = true);
     void invalidate_window() const;
     size_t get_displayed_artwork_type_index() const;
 
-    ULONG_PTR m_gdiplus_instance{NULL};
-    bool m_gdiplus_initialised{false};
+    wil::com_ptr<ID2D1Factory> m_d2d_factory;
+    wil::com_ptr<ID2D1HwndRenderTarget> m_d2d_render_target;
 
     std::shared_ptr<ArtworkReaderManager> m_artwork_reader;
     ArtworkDecoder m_artwork_decoder;
-    wil::unique_hbitmap m_bitmap;
     size_t m_selected_artwork_type_index{0};
     std::optional<size_t> m_artwork_type_override_index{};
     uint32_t m_track_mode;

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "artwork_helpers.h"
+#include "artwork_decoder.h"
+#include "artwork_reader.h"
 
 namespace cui::artwork_panel {
 
@@ -78,6 +79,7 @@ public:
     bool is_core_image_viewer_available() const;
     void open_core_image_viewer() const;
     void show_next_artwork_type();
+    void set_artwork_type_index(size_t index);
 
     ArtworkPanel();
 
@@ -166,7 +168,7 @@ private:
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     void refresh_cached_bitmap();
     void flush_cached_bitmap();
-    bool refresh_image(std::optional<size_t> artwork_type_index_override = {});
+    void refresh_image();
     void show_stub_image();
     void flush_image(bool invalidate = true);
     void invalidate_window() const;
@@ -175,14 +177,14 @@ private:
     ULONG_PTR m_gdiplus_instance{NULL};
     bool m_gdiplus_initialised{false};
 
-    std::shared_ptr<ArtworkReaderManager> m_artwork_loader;
-    std::unique_ptr<Gdiplus::Bitmap> m_image;
+    std::shared_ptr<ArtworkReaderManager> m_artwork_reader;
+    ArtworkDecoder m_artwork_decoder;
     wil::unique_hbitmap m_bitmap;
     size_t m_selected_artwork_type_index{0};
     std::optional<size_t> m_artwork_type_override_index{};
     uint32_t m_track_mode;
     bool m_preserve_aspect_ratio{true};
-    bool m_lock_type{false};
+    bool m_artwork_type_locked{false};
     bool m_dynamic_artwork_pending{};
     metadb_handle_list m_selection_handles;
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -18,15 +18,6 @@ class ArtworkPanel
     , public playlist_callback_single
     , public ui_selection_callback {
 public:
-    class CompletionNotifyForwarder : public completion_notify {
-    public:
-        void on_completion(unsigned p_code) noexcept override;
-        explicit CompletionNotifyForwarder(ArtworkPanel* p_this);
-
-    private:
-        service_ptr_t<ArtworkPanel> m_this;
-    };
-
     const GUID& get_extension_guid() const override;
     void get_name(pfc::string_base& out) const override;
     void get_category(pfc::string_base& out) const override;
@@ -78,7 +69,7 @@ public:
 
     void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept override;
 
-    void on_completion(unsigned p_code);
+    void on_artwork_loaded(bool artwork_changed);
 
     static void g_on_colours_change();
     static void s_on_dark_mode_status_change();
@@ -166,6 +157,8 @@ private:
     enum {
         current_stream_version = 3
     };
+
+    void request_artwork(const metadb_handle_ptr& track, bool is_from_playback = false);
 
     void set_config(stream_reader* p_reader, size_t size, abort_callback& p_abort) override;
     void get_config(stream_writer* p_writer, abort_callback& p_abort) const override;

--- a/foo_ui_columns/artwork_decoder.cpp
+++ b/foo_ui_columns/artwork_decoder.cpp
@@ -1,0 +1,56 @@
+#include "pch.h"
+
+#include "artwork_decoder.h"
+
+namespace cui::artwork_panel {
+
+void ArtworkDecoder::decode(album_art_data_ptr data, std::function<void()> on_complete)
+{
+    reset();
+    m_current_task = std::make_shared<ArtworkDecoderTask>(std::move(on_complete));
+
+    m_current_task->future = std::async(std::launch::async,
+        [this, data, stop_token{m_current_task->stop_source.get_token()},
+            task{std::weak_ptr{m_current_task}}]() noexcept {
+            TRACK_CALL_TEXT("cui::artwork_panel::ArtworkDecoder::async_task");
+
+            std::unique_ptr<Gdiplus::Bitmap> bitmap;
+
+            try {
+                auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
+
+                if (stop_token.stop_requested())
+                    return;
+
+                const auto bitmap_data = wic::decode_image_data(data->get_ptr(), data->get_size());
+
+                if (stop_token.stop_requested())
+                    return;
+
+                bitmap = gdip::create_bitmap_from_wic_data(bitmap_data);
+            } catch (const std::exception& ex) {
+                console::print(u8"Artwork panel – loading image failed: "_pcc, ex.what());
+                return;
+            }
+
+            fb2k::inMainThread([this, bitmap{std::shared_ptr{std::move(bitmap)}}, stop_token{std::move(stop_token)},
+                                   task{std::move(task)}]() {
+                const auto locked_task = task.lock();
+
+                if (stop_token.stop_requested()) {
+                    if (locked_task)
+                        std::erase(m_aborting_tasks, locked_task);
+                    return;
+                }
+
+                assert(m_current_task == locked_task);
+                m_current_task.reset();
+                m_decoded_image = std::move(bitmap);
+
+                if (locked_task)
+                    locked_task->on_complete();
+            });
+        });
+}
+
+} // namespace cui::artwork_panel

--- a/foo_ui_columns/artwork_decoder.cpp
+++ b/foo_ui_columns/artwork_decoder.cpp
@@ -4,52 +4,107 @@
 
 namespace cui::artwork_panel {
 
-void ArtworkDecoder::decode(album_art_data_ptr data, std::function<void()> on_complete)
+void ArtworkDecoder::decode(
+    wil::com_ptr<ID2D1HwndRenderTarget> d2d_render_target, album_art_data_ptr data, std::function<void()> on_complete)
 {
     reset();
     m_current_task = std::make_shared<ArtworkDecoderTask>(std::move(on_complete));
 
     m_current_task->future = std::async(std::launch::async,
-        [this, data, stop_token{m_current_task->stop_source.get_token()},
-            task{std::weak_ptr{m_current_task}}]() noexcept {
+        [this, data, d2d_render_target{std::move(d2d_render_target)},
+            stop_token{m_current_task->stop_source.get_token()}, task{std::weak_ptr{m_current_task}}]() noexcept {
             TRACK_CALL_TEXT("cui::artwork_panel::ArtworkDecoder::async_task");
 
-            std::unique_ptr<Gdiplus::Bitmap> bitmap;
+            wil::com_ptr_t<ID2D1Bitmap> d2d_bitmap;
 
             try {
+                if (stop_token.stop_requested())
+                    return;
+
                 auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
+                const auto imaging_factory = wic::create_factory();
+                const auto decoder = wic::create_decoder_from_data(data->get_ptr(), data->get_size(), imaging_factory);
 
                 if (stop_token.stop_requested())
                     return;
 
-                const auto bitmap_data = wic::decode_image_data(data->get_ptr(), data->get_size());
+                auto wic_bitmap = wic::get_image_frame(decoder, GUID_WICPixelFormat32bppPBGRA);
 
                 if (stop_token.stop_requested())
                     return;
 
-                bitmap = gdip::create_bitmap_from_wic_data(bitmap_data);
+                uint32_t width{};
+                uint32_t height{};
+
+                THROW_IF_FAILED(wic_bitmap->GetSize(&width, &height));
+
+                const auto max_bitmap_size = d2d_render_target->GetMaximumBitmapSize();
+                const auto needs_rescaling = width > max_bitmap_size || height > max_bitmap_size;
+
+                if (needs_rescaling) {
+                    const auto scaling_factor
+                        = gsl::narrow_cast<float>(max_bitmap_size) / gsl::narrow_cast<float>(std::max(width, height));
+                    const auto new_width = std::min(max_bitmap_size,
+                        gsl::narrow_cast<uint32_t>(gsl::narrow_cast<float>(width) * scaling_factor + .5f));
+                    const auto new_height = std::min(max_bitmap_size,
+                        gsl::narrow_cast<uint32_t>(gsl::narrow_cast<float>(height) * scaling_factor + .5f));
+
+                    const auto message = fmt::format(u8"Artwork panel – image with size {0}×{1} exceeds maximum "
+                                                     u8"size of {2}×{2}, image will be pre-scaled to {3}×{4}",
+                        width, height, max_bitmap_size, new_width, new_height);
+                    console::print(reinterpret_cast<const char*>(message.c_str()));
+
+                    wic_bitmap = wic::resize_bitmap_source(wic_bitmap, new_width, new_height, imaging_factory);
+
+                    if (stop_token.stop_requested())
+                        return;
+                }
+
+                const auto hr = d2d_render_target->CreateBitmapFromWicBitmap(wic_bitmap.get(), nullptr, &d2d_bitmap);
+
+                if (hr != E_NOTIMPL || needs_rescaling)
+                    THROW_IF_FAILED(hr);
+
+                if (stop_token.stop_requested())
+                    return;
+
+                if (hr == E_NOTIMPL) {
+                    // For lossy images, the Microsoft JXL codec does not support some interface or
+                    // method that D2D expects (but making a copy of the bitmap and trying again works fine).
+                    // (ID2D1DeviceContext2::CreateImageSourceFromWic() doesn't have this problem.)
+                    wil::com_ptr<IWICBitmap> wic_bitmap_copy;
+                    THROW_IF_FAILED(imaging_factory->CreateBitmapFromSource(
+                        wic_bitmap.get(), WICBitmapCacheOnDemand, &wic_bitmap_copy));
+
+                    THROW_IF_FAILED(
+                        d2d_render_target->CreateBitmapFromWicBitmap(wic_bitmap_copy.get(), nullptr, &d2d_bitmap));
+                }
+
+                if (stop_token.stop_requested())
+                    return;
+
             } catch (const std::exception& ex) {
                 console::print(u8"Artwork panel – loading image failed: "_pcc, ex.what());
                 return;
             }
 
-            fb2k::inMainThread([this, bitmap{std::shared_ptr{std::move(bitmap)}}, stop_token{std::move(stop_token)},
-                                   task{std::move(task)}]() {
-                const auto locked_task = task.lock();
+            fb2k::inMainThread(
+                [this, d2d_bitmap{std::move(d2d_bitmap)}, stop_token{std::move(stop_token)}, task{std::move(task)}]() {
+                    const auto locked_task = task.lock();
 
-                if (stop_token.stop_requested()) {
+                    if (stop_token.stop_requested()) {
+                        if (locked_task)
+                            std::erase(m_aborting_tasks, locked_task);
+                        return;
+                    }
+
+                    assert(m_current_task == locked_task);
+                    m_current_task.reset();
+                    m_decoded_image = std::move(d2d_bitmap);
+
                     if (locked_task)
-                        std::erase(m_aborting_tasks, locked_task);
-                    return;
-                }
-
-                assert(m_current_task == locked_task);
-                m_current_task.reset();
-                m_decoded_image = std::move(bitmap);
-
-                if (locked_task)
-                    locked_task->on_complete();
-            });
+                        locked_task->on_complete();
+                });
         });
 }
 

--- a/foo_ui_columns/artwork_decoder.h
+++ b/foo_ui_columns/artwork_decoder.h
@@ -15,7 +15,8 @@ class ArtworkDecoder {
 public:
     ~ArtworkDecoder() { abort(); }
 
-    void decode(album_art_data_ptr data, std::function<void()> on_complete);
+    void decode(wil::com_ptr<ID2D1HwndRenderTarget> d2d_render_target, album_art_data_ptr data,
+        std::function<void()> on_complete);
 
     void abort()
     {
@@ -39,11 +40,11 @@ public:
 
     bool has_image() const { return static_cast<bool>(m_decoded_image); }
 
-    std::shared_ptr<Gdiplus::Bitmap> get_image() { return m_decoded_image; }
+    wil::com_ptr<ID2D1Bitmap> get_image() { return m_decoded_image; }
 
     ArtworkDecoderTask::Ptr m_current_task;
     std::vector<ArtworkDecoderTask::Ptr> m_aborting_tasks;
-    std::shared_ptr<Gdiplus::Bitmap> m_decoded_image;
+    wil::com_ptr<ID2D1Bitmap> m_decoded_image;
 };
 
 } // namespace cui::artwork_panel

--- a/foo_ui_columns/artwork_decoder.h
+++ b/foo_ui_columns/artwork_decoder.h
@@ -1,0 +1,49 @@
+#pragma once
+
+namespace cui::artwork_panel {
+
+class ArtworkDecoderTask {
+public:
+    using Ptr = std::shared_ptr<ArtworkDecoderTask>;
+
+    std::function<void()> on_complete;
+    std::stop_source stop_source;
+    std::future<void> future;
+};
+
+class ArtworkDecoder {
+public:
+    ~ArtworkDecoder() { abort(); }
+
+    void decode(album_art_data_ptr data, std::function<void()> on_complete);
+
+    void abort()
+    {
+        if (m_current_task) {
+            m_current_task->stop_source.request_stop();
+            m_aborting_tasks.emplace_back(std::move(m_current_task));
+        }
+    }
+
+    void reset()
+    {
+        abort();
+        m_decoded_image.reset();
+    }
+
+    void shut_down()
+    {
+        reset();
+        m_aborting_tasks.clear();
+    }
+
+    bool has_image() const { return static_cast<bool>(m_decoded_image); }
+
+    std::shared_ptr<Gdiplus::Bitmap> get_image() { return m_decoded_image; }
+
+    ArtworkDecoderTask::Ptr m_current_task;
+    std::vector<ArtworkDecoderTask::Ptr> m_aborting_tasks;
+    std::shared_ptr<Gdiplus::Bitmap> m_decoded_image;
+};
+
+} // namespace cui::artwork_panel

--- a/foo_ui_columns/artwork_helpers.cpp
+++ b/foo_ui_columns/artwork_helpers.cpp
@@ -4,16 +4,17 @@
 
 namespace cui::artwork_panel {
 
-void ArtworkReader::run_notification_thisthread(DWORD state)
+void ArtworkReader::notify_panel(bool artwork_changed)
 {
-    if (m_notify.is_valid())
-        m_notify->on_completion(state);
-    m_notify.release();
+    if (m_on_artwork_loaded)
+        (*m_on_artwork_loaded)(artwork_changed);
+
+    m_on_artwork_loaded.reset();
 }
 
 void ArtworkReader::initialise(const std::vector<GUID>& artwork_type_ids,
     const std::unordered_map<GUID, album_art_data_ptr>& p_content_previous, bool read_stub_image,
-    const metadb_handle_ptr& p_handle, bool is_from_playback, const completion_notify_ptr& p_notify,
+    const metadb_handle_ptr& p_handle, bool is_from_playback, OnArtworkLoadedCallback on_artwork_loaded,
     std::shared_ptr<class ArtworkReaderManager> p_manager)
 {
     m_artwork_type_ids = artwork_type_ids;
@@ -21,7 +22,7 @@ void ArtworkReader::initialise(const std::vector<GUID>& artwork_type_ids,
     m_read_stub_image = read_stub_image;
     m_handle = p_handle;
     m_is_from_playback = is_from_playback;
-    m_notify = p_notify;
+    m_on_artwork_loaded = std::move(on_artwork_loaded);
     m_manager = std::move(p_manager);
 }
 
@@ -112,7 +113,7 @@ album_art_data_ptr ArtworkReaderManager::get_image(const GUID& p_what)
 }
 
 void ArtworkReaderManager::request(
-    const metadb_handle_ptr& handle, completion_notify_ptr notify, const bool is_from_playback)
+    const metadb_handle_ptr& handle, OnArtworkLoadedCallback on_artwork_loaded, const bool is_from_playback)
 {
     std::shared_ptr<ArtworkReader> ptr_prev = m_current_reader;
     const bool is_prev_valid = ptr_prev && !ptr_prev->is_thread_open() && ptr_prev->did_succeed();
@@ -122,7 +123,7 @@ void ArtworkReaderManager::request(
     m_current_reader = std::make_shared<ArtworkReader>();
     m_current_reader->initialise(m_artwork_type_ids,
         is_prev_valid ? ptr_prev->get_content() : std::unordered_map<GUID, album_art_data_ptr>(), read_stub_images,
-        handle, is_from_playback, notify, shared_from_this());
+        handle, is_from_playback, on_artwork_loaded, shared_from_this());
     m_current_reader->set_priority(THREAD_PRIORITY_BELOW_NORMAL);
     m_current_reader->create_thread();
 }
@@ -155,33 +156,13 @@ void ArtworkReaderManager::set_types(std::vector<GUID> types)
     m_artwork_type_ids = types;
 }
 
-void ArtworkReaderNotification::g_run(
-    std::shared_ptr<ArtworkReaderManager> p_manager, bool p_aborted, DWORD ret, const ArtworkReader* p_reader)
-{
-    service_ptr_t<ArtworkReaderNotification> ptr = new service_impl_t<ArtworkReaderNotification>;
-    ptr->m_aborted = p_aborted;
-    ptr->m_reader = p_reader;
-    ptr->m_manager = std::move(p_manager);
-    ptr->m_ret = ret;
-
-    main_thread_callback_manager::get()->add_callback(ptr.get_ptr());
-}
-
-void ArtworkReaderNotification::callback_run()
-{
-    if (m_aborted)
-        m_manager->on_reader_abort(m_reader);
-    else
-        m_manager->on_reader_completion(m_ret, m_reader);
-}
-
-void ArtworkReaderManager::on_reader_completion(DWORD state, const ArtworkReader* ptr)
+void ArtworkReaderManager::on_reader_completion(bool artwork_changed, const ArtworkReader* ptr)
 {
     if (m_current_reader && ptr == &*m_current_reader) {
         m_current_reader->wait_for_and_release_thread();
         if (!m_current_reader->get_stub_images().empty())
             m_stub_images = m_current_reader->get_stub_images();
-        m_current_reader->run_notification_thisthread(state);
+        m_current_reader->notify_panel(artwork_changed);
     } else {
         auto iter = ranges::find_if(m_aborting_readers, [ptr](auto&& reader) { return &*reader == ptr; });
         if (iter != ranges::end(m_aborting_readers)) {
@@ -189,10 +170,6 @@ void ArtworkReaderManager::on_reader_completion(DWORD state, const ArtworkReader
             m_aborting_readers.erase(iter);
         }
     }
-}
-void ArtworkReaderManager::on_reader_abort(const ArtworkReader* ptr)
-{
-    on_reader_completion(ERROR_PROCESS_ABORTED, ptr);
 }
 
 bool ArtworkReader::are_contents_equal(const std::unordered_map<GUID, album_art_data_ptr>& content1,
@@ -219,24 +196,24 @@ DWORD ArtworkReader::on_thread()
 {
     TRACK_CALL_TEXT("artwork_panel::ArtworkReader::on_thread");
 
-    bool b_aborted = false;
-    DWORD ret = -1;
+    bool artwork_changed{};
+
     try {
-        ret = read_artwork(m_abort);
+        artwork_changed = read_artwork(m_abort);
         m_abort.check();
         m_succeeded = true;
     } catch (const exception_aborted&) {
         m_content.clear();
-        b_aborted = true;
-        ret = ERROR_PROCESS_ABORTED;
-    } catch (pfc::exception const& e) {
+        artwork_changed = false;
+    } catch (const std::exception& e) {
         m_content.clear();
-        console::formatter formatter;
-        formatter << u8"Artwork view – unhandled error reading artwork: "_pcc << e.what();
-        ret = -1;
+        console::print(u8"Artwork view – unhandled error reading artwork: "_pcc, e.what());
     }
-    ArtworkReaderNotification::g_run(m_manager, b_aborted, ret, this);
-    return ret;
+
+    fb2k::inMainThread(
+        [manager = m_manager, artwork_changed, this]() { m_manager->on_reader_completion(artwork_changed, this); });
+
+    return 0;
 }
 
 album_art_data_ptr query_artwork_data(
@@ -257,7 +234,7 @@ album_art_data_ptr query_artwork_data(
     return {};
 }
 
-unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
+bool ArtworkReader::read_artwork(abort_callback& p_abort)
 {
     TRACK_CALL_TEXT("artwork_reader_v2_t::read_artwork");
     std::unordered_map<GUID, album_art_data_ptr> content_previous = m_content;
@@ -296,7 +273,7 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
         }
     }
 
-    return are_contents_equal(m_content, content_previous) ? 0 : 1;
+    return !are_contents_equal(m_content, content_previous);
 }
 
 } // namespace cui::artwork_panel

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -4,44 +4,52 @@ namespace cui::artwork_panel {
 
 using OnArtworkLoadedCallback = std::function<void(bool)>;
 
-class ArtworkReader : public mmh::Thread {
+struct ArtworkReaderArgs {
+    bool read_stub_image{};
+    metadb_handle_ptr track;
+    std::shared_ptr<class ArtworkReaderManager> manager;
+};
+
+class ArtworkReader {
 public:
-    bool is_aborting();
+    bool is_aborting() const;
     bool is_from_playback() const { return m_is_from_playback; }
     void abort();
 
-    // only called when thread closed
-    bool did_succeed();
+    bool succeeded() const;
     const std::unordered_map<GUID, album_art_data_ptr>& get_content() const;
     const std::unordered_map<GUID, album_art_data_ptr>& get_stub_images() const;
     void set_image(GUID artwork_type_id, album_art_data_ptr data);
 
-    ArtworkReader() = default;
+    ArtworkReader(std::vector<GUID> artwork_type_ids, std::unordered_map<GUID, album_art_data_ptr> previous_contents,
+        bool is_from_playback, OnArtworkLoadedCallback on_artwork_loaded)
+        : m_artwork_type_ids(std::move(artwork_type_ids))
+        , m_content{std::move(previous_contents)}
+        , m_is_from_playback(is_from_playback)
+        , m_on_artwork_loaded(std::move(on_artwork_loaded))
+    {
+    }
 
-    void initialise(const std::vector<GUID>& artwork_type_ids,
-        const std::unordered_map<GUID, album_art_data_ptr>& p_content_previous, bool read_stub_image,
-        const metadb_handle_ptr& p_handle, bool is_from_playback, OnArtworkLoadedCallback on_artwork_loaded,
-        std::shared_ptr<class ArtworkReaderManager> p_manager);
     void notify_panel(bool artwork_changed);
 
-protected:
-    DWORD on_thread() override;
+    void start(ArtworkReaderArgs args);
+    void wait();
+    bool is_running() const;
 
 private:
-    bool read_artwork(abort_callback& p_abort);
+    bool read_artwork(const ArtworkReaderArgs& args, abort_callback& p_abort);
     bool are_contents_equal(const std::unordered_map<GUID, album_art_data_ptr>& content1,
-        const std::unordered_map<GUID, album_art_data_ptr>& content2);
+        const std::unordered_map<GUID, album_art_data_ptr>& content2) const;
 
+    std::optional<std::jthread> m_thread;
     std::vector<GUID> m_artwork_type_ids;
     std::unordered_map<GUID, album_art_data_ptr> m_content;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
-    metadb_handle_ptr m_handle;
-    std::optional<OnArtworkLoadedCallback> m_on_artwork_loaded;
+
     bool m_succeeded{false};
-    bool m_read_stub_image{true};
     bool m_is_from_playback{};
+    OnArtworkLoadedCallback m_on_artwork_loaded;
     abort_callback_impl m_abort;
-    std::shared_ptr<class ArtworkReaderManager> m_manager;
 };
 
 class ArtworkReaderManager : public std::enable_shared_from_this<ArtworkReaderManager> {
@@ -50,7 +58,7 @@ public:
 
     void request(
         const metadb_handle_ptr& handle, OnArtworkLoadedCallback on_artwork_loaded, bool is_from_playback = false);
-    bool is_ready();
+    bool is_ready() const;
     void reset();
     void abort_current_task();
 

--- a/foo_ui_columns/artwork_helpers.h
+++ b/foo_ui_columns/artwork_helpers.h
@@ -2,6 +2,8 @@
 
 namespace cui::artwork_panel {
 
+using OnArtworkLoadedCallback = std::function<void(bool)>;
+
 class ArtworkReader : public mmh::Thread {
 public:
     bool is_aborting();
@@ -18,15 +20,15 @@ public:
 
     void initialise(const std::vector<GUID>& artwork_type_ids,
         const std::unordered_map<GUID, album_art_data_ptr>& p_content_previous, bool read_stub_image,
-        const metadb_handle_ptr& p_handle, bool is_from_playback, const completion_notify_ptr& p_notify,
+        const metadb_handle_ptr& p_handle, bool is_from_playback, OnArtworkLoadedCallback on_artwork_loaded,
         std::shared_ptr<class ArtworkReaderManager> p_manager);
-    void run_notification_thisthread(DWORD state);
+    void notify_panel(bool artwork_changed);
 
 protected:
     DWORD on_thread() override;
 
 private:
-    unsigned read_artwork(abort_callback& p_abort);
+    bool read_artwork(abort_callback& p_abort);
     bool are_contents_equal(const std::unordered_map<GUID, album_art_data_ptr>& content1,
         const std::unordered_map<GUID, album_art_data_ptr>& content2);
 
@@ -34,7 +36,7 @@ private:
     std::unordered_map<GUID, album_art_data_ptr> m_content;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
     metadb_handle_ptr m_handle;
-    completion_notify_ptr m_notify;
+    std::optional<OnArtworkLoadedCallback> m_on_artwork_loaded;
     bool m_succeeded{false};
     bool m_read_stub_image{true};
     bool m_is_from_playback{};
@@ -46,7 +48,8 @@ class ArtworkReaderManager : public std::enable_shared_from_this<ArtworkReaderMa
 public:
     void set_types(std::vector<GUID> types);
 
-    void request(const metadb_handle_ptr& handle, completion_notify_ptr notify, bool is_from_playback = false);
+    void request(
+        const metadb_handle_ptr& handle, OnArtworkLoadedCallback on_artwork_loaded, bool is_from_playback = false);
     bool is_ready();
     void reset();
     void abort_current_task();
@@ -56,8 +59,7 @@ public:
 
     void deinitialise();
 
-    void on_reader_completion(DWORD state, const ArtworkReader* ptr);
-    void on_reader_abort(const ArtworkReader* ptr);
+    void on_reader_completion(bool artwork_changed, const ArtworkReader* ptr);
 
 private:
     std::vector<std::shared_ptr<ArtworkReader>> m_aborting_readers;
@@ -66,19 +68,6 @@ private:
     std::vector<GUID> m_artwork_type_ids;
     std::unordered_map<GUID, album_art_data_ptr> m_content;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
-};
-
-class ArtworkReaderNotification : public main_thread_callback {
-public:
-    void callback_run() override;
-
-    static void g_run(
-        std::shared_ptr<ArtworkReaderManager> p_manager, bool p_aborted, DWORD ret, const ArtworkReader* p_reader);
-
-    bool m_aborted;
-    DWORD m_ret;
-    const ArtworkReader* m_reader;
-    std::shared_ptr<ArtworkReaderManager> m_manager;
 };
 
 } // namespace cui::artwork_panel

--- a/foo_ui_columns/artwork_reader.cpp
+++ b/foo_ui_columns/artwork_reader.cpp
@@ -1,6 +1,6 @@
 #include "pch.h"
 #include "ng_playlist/ng_playlist.h"
-#include "artwork_helpers.h"
+#include "artwork_reader.h"
 
 namespace cui::artwork_panel {
 
@@ -25,12 +25,13 @@ void ArtworkReader::start(ArtworkReaderArgs args)
             m_abort.check();
             m_succeeded = true;
         } catch (const exception_aborted&) {
-            m_content.clear();
             artwork_changed = false;
         } catch (const std::exception& e) {
-            m_content.clear();
             console::print(u8"Artwork view – unhandled error reading artwork: "_pcc, e.what());
         }
+
+        if (!m_succeeded)
+            m_artwork_data.clear();
 
         fb2k::inMainThread([manager = args.manager, artwork_changed, this]() {
             manager->on_reader_completion(artwork_changed, this);
@@ -55,12 +56,12 @@ const std::unordered_map<GUID, album_art_data_ptr>& ArtworkReader::get_stub_imag
 
 void ArtworkReader::set_image(GUID artwork_type_id, album_art_data_ptr data)
 {
-    m_content.insert_or_assign(artwork_type_id, data);
+    m_artwork_data.insert_or_assign(artwork_type_id, data);
 }
 
-const std::unordered_map<GUID, album_art_data_ptr>& ArtworkReader::get_content() const
+const std::unordered_map<GUID, album_art_data_ptr>& ArtworkReader::get_artwork_data() const
 {
-    return m_content;
+    return m_artwork_data;
 }
 
 bool ArtworkReader::succeeded() const
@@ -125,9 +126,9 @@ album_art_data_ptr ArtworkReaderManager::get_image(const GUID& p_what)
         }
     }
 
-    auto&& content = m_current_reader->get_content();
-    const auto content_iter = content.find(p_what);
-    if (content_iter != content.end())
+    auto&& artwork_data = m_current_reader->get_artwork_data();
+    const auto content_iter = artwork_data.find(p_what);
+    if (content_iter != artwork_data.end())
         return content_iter->second;
 
     return {};
@@ -142,7 +143,7 @@ void ArtworkReaderManager::request(
     abort_current_task();
 
     m_current_reader = std::make_shared<ArtworkReader>(m_artwork_type_ids,
-        is_prev_valid ? ptr_prev->get_content() : std::unordered_map<GUID, album_art_data_ptr>(), is_from_playback,
+        is_prev_valid ? ptr_prev->get_artwork_data() : std::unordered_map<GUID, album_art_data_ptr>(), is_from_playback,
         on_artwork_loaded);
     m_current_reader->start({read_stub_images, handle, shared_from_this()});
 }
@@ -229,8 +230,8 @@ album_art_data_ptr query_artwork_data(
 bool ArtworkReader::read_artwork(const ArtworkReaderArgs& args, abort_callback& p_abort)
 {
     TRACK_CALL_TEXT("read_artwork");
-    std::unordered_map<GUID, album_art_data_ptr> content_previous = m_content;
-    m_content.clear();
+    std::unordered_map<GUID, album_art_data_ptr> content_previous = m_artwork_data;
+    m_artwork_data.clear();
 
     const auto p_album_art_manager_v2 = album_art_manager_v2::get();
     pfc::list_t<GUID> guids;
@@ -242,7 +243,7 @@ bool ArtworkReader::read_artwork(const ArtworkReaderArgs& args, abort_callback& 
         const auto data = query_artwork_data(artwork_id, artwork_api_v2, p_abort);
 
         if (data.is_valid())
-            m_content.insert_or_assign(artwork_id, data);
+            m_artwork_data.insert_or_assign(artwork_id, data);
     }
 
     if (args.read_stub_image) {
@@ -264,7 +265,7 @@ bool ArtworkReader::read_artwork(const ArtworkReaderArgs& args, abort_callback& 
         }
     }
 
-    return !are_contents_equal(m_content, content_previous);
+    return !are_contents_equal(m_artwork_data, content_previous);
 }
 
 } // namespace cui::artwork_panel

--- a/foo_ui_columns/artwork_reader.h
+++ b/foo_ui_columns/artwork_reader.h
@@ -17,14 +17,15 @@ public:
     void abort();
 
     bool succeeded() const;
-    const std::unordered_map<GUID, album_art_data_ptr>& get_content() const;
+    const std::unordered_map<GUID, album_art_data_ptr>& get_artwork_data() const;
     const std::unordered_map<GUID, album_art_data_ptr>& get_stub_images() const;
     void set_image(GUID artwork_type_id, album_art_data_ptr data);
 
-    ArtworkReader(std::vector<GUID> artwork_type_ids, std::unordered_map<GUID, album_art_data_ptr> previous_contents,
-        bool is_from_playback, OnArtworkLoadedCallback on_artwork_loaded)
+    ArtworkReader(std::vector<GUID> artwork_type_ids,
+        std::unordered_map<GUID, album_art_data_ptr> previous_artwork_data, bool is_from_playback,
+        OnArtworkLoadedCallback on_artwork_loaded)
         : m_artwork_type_ids(std::move(artwork_type_ids))
-        , m_content{std::move(previous_contents)}
+        , m_artwork_data{std::move(previous_artwork_data)}
         , m_is_from_playback(is_from_playback)
         , m_on_artwork_loaded(std::move(on_artwork_loaded))
     {
@@ -43,7 +44,7 @@ private:
 
     std::optional<std::jthread> m_thread;
     std::vector<GUID> m_artwork_type_ids;
-    std::unordered_map<GUID, album_art_data_ptr> m_content;
+    std::unordered_map<GUID, album_art_data_ptr> m_artwork_data;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
 
     bool m_succeeded{false};
@@ -74,7 +75,7 @@ private:
     std::shared_ptr<ArtworkReader> m_current_reader;
 
     std::vector<GUID> m_artwork_type_ids;
-    std::unordered_map<GUID, album_art_data_ptr> m_content;
+    std::unordered_map<GUID, album_art_data_ptr> m_artwork_data;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
 };
 

--- a/foo_ui_columns/artwork_reader.h
+++ b/foo_ui_columns/artwork_reader.h
@@ -10,13 +10,20 @@ struct ArtworkReaderArgs {
     std::shared_ptr<class ArtworkReaderManager> manager;
 };
 
+enum class ArtworkReaderStatus {
+    Pending,
+    Succeeded,
+    Failed,
+    Aborted,
+};
+
 class ArtworkReader {
 public:
     bool is_aborting() const;
     bool is_from_playback() const { return m_is_from_playback; }
     void abort();
 
-    bool succeeded() const;
+    ArtworkReaderStatus status() const;
     const std::unordered_map<GUID, album_art_data_ptr>& get_artwork_data() const;
     const std::unordered_map<GUID, album_art_data_ptr>& get_stub_images() const;
     void set_image(GUID artwork_type_id, album_art_data_ptr data);
@@ -25,7 +32,7 @@ public:
         std::unordered_map<GUID, album_art_data_ptr> previous_artwork_data, bool is_from_playback,
         OnArtworkLoadedCallback on_artwork_loaded)
         : m_artwork_type_ids(std::move(artwork_type_ids))
-        , m_artwork_data{std::move(previous_artwork_data)}
+        , m_previous_artwork_data{std::move(previous_artwork_data)}
         , m_is_from_playback(is_from_playback)
         , m_on_artwork_loaded(std::move(on_artwork_loaded))
     {
@@ -39,15 +46,13 @@ public:
 
 private:
     bool read_artwork(const ArtworkReaderArgs& args, abort_callback& p_abort);
-    bool are_contents_equal(const std::unordered_map<GUID, album_art_data_ptr>& content1,
-        const std::unordered_map<GUID, album_art_data_ptr>& content2) const;
 
     std::optional<std::jthread> m_thread;
     std::vector<GUID> m_artwork_type_ids;
+    std::unordered_map<GUID, album_art_data_ptr> m_previous_artwork_data;
     std::unordered_map<GUID, album_art_data_ptr> m_artwork_data;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
-
-    bool m_succeeded{false};
+    ArtworkReaderStatus m_status{ArtworkReaderStatus::Pending};
     bool m_is_from_playback{};
     OnArtworkLoadedCallback m_on_artwork_loaded;
     abort_callback_impl m_abort;
@@ -63,7 +68,7 @@ public:
     void reset();
     void abort_current_task();
 
-    album_art_data_ptr get_image(const GUID& p_what);
+    album_art_data_ptr get_image(const GUID& p_what) const;
     album_art_data_ptr get_stub_image(GUID artwork_type_id);
 
     void deinitialise();
@@ -75,7 +80,7 @@ private:
     std::shared_ptr<ArtworkReader> m_current_reader;
 
     std::vector<GUID> m_artwork_type_ids;
-    std::unordered_map<GUID, album_art_data_ptr> m_artwork_data;
+    mutable std::unordered_map<GUID, album_art_data_ptr> m_previous_artwork_data;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
 };
 

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -249,7 +249,8 @@
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="artwork_helpers.cpp" />
+    <ClCompile Include="artwork_decoder.cpp" />
+    <ClCompile Include="artwork_reader.cpp" />
     <ClCompile Include="audio_track_toolbar.cpp" />
     <ClCompile Include="buttons_button.cpp" />
     <ClCompile Include="buttons_button_image.cpp" />
@@ -433,7 +434,8 @@
     <ClCompile Include="win32.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="artwork_helpers.h" />
+    <ClInclude Include="artwork_decoder.h" />
+    <ClInclude Include="artwork_reader.h" />
     <ClInclude Include="buttons.h" />
     <ClInclude Include="colour_manager_data.h" />
     <ClInclude Include="colour_utils.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -322,9 +322,6 @@
     <ClCompile Include="artwork.cpp">
       <Filter>Artwork view</Filter>
     </ClCompile>
-    <ClCompile Include="artwork_helpers.cpp">
-      <Filter>Artwork view</Filter>
-    </ClCompile>
     <ClCompile Include="item_properties.cpp">
       <Filter>Item properties</Filter>
     </ClCompile>
@@ -635,6 +632,12 @@
     <ClCompile Include="command_line.cpp">
       <Filter>Command line</Filter>
     </ClCompile>
+    <ClCompile Include="artwork_decoder.cpp">
+      <Filter>Artwork view</Filter>
+    </ClCompile>
+    <ClCompile Include="artwork_reader.cpp">
+      <Filter>Artwork view</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -738,9 +741,6 @@
       <Filter>Item details</Filter>
     </ClInclude>
     <ClInclude Include="artwork.h">
-      <Filter>Artwork view</Filter>
-    </ClInclude>
-    <ClInclude Include="artwork_helpers.h">
       <Filter>Artwork view</Filter>
     </ClInclude>
     <ClInclude Include="item_properties.h">
@@ -935,6 +935,12 @@
     </ClInclude>
     <ClInclude Include="win32.h">
       <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="artwork_decoder.h">
+      <Filter>Artwork view</Filter>
+    </ClInclude>
+    <ClInclude Include="artwork_reader.h">
+      <Filter>Artwork view</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/wic.cpp
+++ b/foo_ui_columns/wic.cpp
@@ -21,20 +21,6 @@ wil::com_ptr<IWICBitmapDecoder> create_decoder_from_path(std::string_view path)
     return bitmap_decoder;
 }
 
-wil::com_ptr<IWICBitmapDecoder> create_decoder_from_data(const void* data, size_t size)
-{
-    const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
-
-    wil::com_ptr<IStream> stream;
-    stream.attach(SHCreateMemStream(static_cast<const BYTE*>(data), gsl::narrow<UINT>(size)));
-
-    wil::com_ptr<IWICBitmapDecoder> bitmap_decoder;
-    check_hresult(imaging_factory->CreateDecoderFromStream(
-        stream.get(), nullptr, WICDecodeMetadataCacheOnDemand, &bitmap_decoder));
-
-    return bitmap_decoder;
-}
-
 wil::com_ptr<IWICBitmap> create_bitmap_from_hbitmap(HBITMAP bitmap)
 {
     const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
@@ -45,18 +31,7 @@ wil::com_ptr<IWICBitmap> create_bitmap_from_hbitmap(HBITMAP bitmap)
     return wic_bitmap;
 }
 
-wil::com_ptr<IWICBitmapSource> get_image_frame(const wil::com_ptr<IWICBitmapDecoder>& bitmap_decoder)
-{
-    wil::com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
-    check_hresult(bitmap_decoder->GetFrame(0, &bitmap_frame_decode));
-
-    wil::com_ptr<IWICBitmapSource> converted_bitmap;
-    check_hresult(WICConvertBitmapSource(GUID_WICPixelFormat32bppBGRA, bitmap_frame_decode.get(), &converted_bitmap));
-
-    return converted_bitmap;
-}
-
-BitmapData decode_image(const wil::com_ptr<IWICBitmapSource>& bitmap_source)
+BitmapData decode_bitmap_source(const wil::com_ptr<IWICBitmapSource>& bitmap_source)
 {
     BitmapData image_data{};
     check_hresult(bitmap_source->GetSize(&image_data.width, &image_data.height));
@@ -81,12 +56,39 @@ void check_hresult(HRESULT hr)
     if (FAILED(hr))
         throw wic_error(message << "WIC error: " << format_win32_error(hr));
 }
-
-wil::com_ptr<IWICBitmapSource> resize_bitmap_source(
-    const wil::com_ptr<IWICBitmapSource>& original_bitmap, int width, int height)
+wil::com_ptr<IWICImagingFactory> create_factory()
 {
-    const auto imaging_factory = wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
+    return wil::CoCreateInstance<IWICImagingFactory>(CLSID_WICImagingFactory);
+}
 
+wil::com_ptr<IWICBitmapDecoder> create_decoder_from_data(
+    const void* data, size_t size, const wil::com_ptr<IWICImagingFactory>& imaging_factory)
+{
+    wil::com_ptr<IStream> stream;
+    stream.attach(SHCreateMemStream(static_cast<const BYTE*>(data), gsl::narrow<UINT>(size)));
+
+    wil::com_ptr<IWICBitmapDecoder> bitmap_decoder;
+    check_hresult(imaging_factory->CreateDecoderFromStream(
+        stream.get(), nullptr, WICDecodeMetadataCacheOnDemand, &bitmap_decoder));
+
+    return bitmap_decoder;
+}
+
+wil::com_ptr<IWICBitmapSource> get_image_frame(
+    const wil::com_ptr<IWICBitmapDecoder>& bitmap_decoder, REFWICPixelFormatGUID pixel_format)
+{
+    wil::com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
+    check_hresult(bitmap_decoder->GetFrame(0, &bitmap_frame_decode));
+
+    wil::com_ptr<IWICBitmapSource> converted_bitmap;
+    check_hresult(WICConvertBitmapSource(pixel_format, bitmap_frame_decode.get(), &converted_bitmap));
+
+    return converted_bitmap;
+}
+
+wil::com_ptr<IWICBitmapSource> resize_bitmap_source(const wil::com_ptr<IWICBitmapSource>& original_bitmap, int width,
+    int height, const wil::com_ptr<IWICImagingFactory>& imaging_factory)
+{
     wil::com_ptr<IWICBitmapScaler> bitmap_scaler;
     check_hresult(imaging_factory->CreateBitmapScaler(&bitmap_scaler));
 
@@ -128,7 +130,7 @@ wil::com_ptr<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const Bitma
 
 wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr<IWICBitmapSource>& source)
 {
-    const auto bitmap_data = decode_image(source);
+    const auto bitmap_data = decode_bitmap_source(source);
 
     return gdi::create_hbitmap_from_32bpp_data(gsl::narrow<int>(bitmap_data.width),
         gsl::narrow<int>(bitmap_data.height), bitmap_data.data.data(), bitmap_data.data.size());
@@ -138,7 +140,7 @@ BitmapData decode_image_data(const void* data, size_t size)
 {
     const auto decoder = create_decoder_from_data(data, size);
     const auto converted_bitmap = get_image_frame(decoder);
-    return decode_image(converted_bitmap);
+    return decode_bitmap_source(converted_bitmap);
 }
 
 } // namespace cui::wic

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -15,11 +15,16 @@ struct BitmapData {
 };
 
 void check_hresult(HRESULT hr);
+wil::com_ptr<IWICImagingFactory> create_factory();
 wil::com_ptr<IWICBitmapSource> create_bitmap_source_from_path(const char* path);
 wil::com_ptr<IWICBitmapSource> create_bitmap_source_from_bitmap_data(const BitmapData& bitmap_data);
 wil::unique_hbitmap create_hbitmap_from_bitmap_source(const wil::com_ptr<IWICBitmapSource>& source);
-wil::com_ptr<IWICBitmapSource> resize_bitmap_source(
-    const wil::com_ptr<IWICBitmapSource>& original_bitmap, int width, int height);
+wil::com_ptr<IWICBitmapDecoder> create_decoder_from_data(
+    const void* data, size_t size, const wil::com_ptr<IWICImagingFactory>& imaging_factory = create_factory());
+wil::com_ptr<IWICBitmapSource> resize_bitmap_source(const wil::com_ptr<IWICBitmapSource>& original_bitmap, int width,
+    int height, const wil::com_ptr<IWICImagingFactory>& imaging_factory = create_factory());
+wil::com_ptr<IWICBitmapSource> get_image_frame(const wil::com_ptr<IWICBitmapDecoder>& bitmap_decoder,
+    REFWICPixelFormatGUID pixel_format = GUID_WICPixelFormat32bppBGRA);
 wil::unique_hbitmap resize_hbitmap(HBITMAP original_bitmap, int width, int height);
 
 BitmapData decode_image_data(const void* data, size_t size);


### PR DESCRIPTION
Resolves #1215 

This:

- tidies up the existing asynchronous artwork reading code
- moves image decoding to a background thread
- migrates to using Direct2D for rendering, including resizing images
- improves handling of rapid tracked track changes

These changes aimed at improving performance and avoiding blocking the UI e.g. when changing selection in the playlist view. Large images, for example, can be slow to decode and previously were able to noticeably block the UI.