### PR TITLE
Pin C++/WinRT headers to last version compatible with Windows 7

### DIFF
--- a/vcpkg-ports/LICENCE
+++ b/vcpkg-ports/LICENCE
@@ -1,0 +1,23 @@
+The files in this directory are based on the original ports from the vcpkg
+repo (https://github.com/microsoft/vcpkg), for which the following licence applies.
+
+MIT License
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be included in all copies
+or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vcpkg-ports/cppwinrt/cppwinrt-config.cmake.in
+++ b/vcpkg-ports/cppwinrt/cppwinrt-config.cmake.in
@@ -1,0 +1,24 @@
+get_filename_component(_cppwinrt_root "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_cppwinrt_root "${_cppwinrt_root}" PATH)
+
+set(_cppwinrt_exe "${_cppwinrt_root}/@tool_path@")
+if (EXISTS "${_cppwinrt_exe}")
+
+   add_library(Microsoft::CppWinRT INTERFACE IMPORTED)
+   set_target_properties(Microsoft::CppWinRT PROPERTIES
+      INTERFACE_COMPILE_FEATURES cxx_std_17
+      INTERFACE_INCLUDE_DIRECTORIES "${_cppwinrt_root}/include"
+      INTERFACE_LINK_LIBRARIES "${_cppwinrt_root}/lib/@lib_name@"
+   )
+
+   set(cppwinrt_FOUND TRUE)
+   set(CPPWINRT_TOOL ${_cppwinrt_exe})
+
+else()
+
+    set(cppwinrt_FOUND FALSE)
+
+endif()
+
+unset(_cppwinrt_root)
+unset(_cppwinrt_exe)

--- a/vcpkg-ports/cppwinrt/portfile.cmake
+++ b/vcpkg-ports/cppwinrt/portfile.cmake
@@ -1,0 +1,72 @@
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.Windows.CppWinRT/${VERSION}"
+    FILENAME "cppwinrt.${VERSION}.zip"
+    SHA512 6331c70ea7adfdc7d0e493dc49a30b2fc39ca342c067f7f70076572023842047ec4e7dd77ec6d309181753959d191742c667db8f95749ca7299d8357c4f792ce
+)
+
+vcpkg_extract_source_archive(
+    src
+    ARCHIVE "${ARCHIVE}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(CPPWINRT_ARCH win32)
+else()
+    set(CPPWINRT_ARCH ${VCPKG_TARGET_ARCHITECTURE})
+endif()
+
+set(CPPWINRT_TOOL "${src}/bin/cppwinrt.exe")
+
+#--- Find Windows SDK Version
+if (NOT EXISTS "$ENV{WindowsSDKDir}/Lib/$ENV{WindowsSDKVersion}.")
+    message(FATAL_ERROR "ERROR: Cannot locate the Windows SDK. Please define %WindowsSDKDir% and %WindowsSDKVersion%.
+(Expected file to exist: $ENV{WindowsSDKDir}/Lib/$ENV{WindowsSDKVersion})")
+endif()
+if (NOT EXISTS "$ENV{WindowsSDKDir}References/$ENV{WindowsSDKVersion}Windows.Foundation.FoundationContract")
+    message(FATAL_ERROR "ERROR: The Windows SDK is too old (needs 14393 or later, found $ENV{WindowsSDKVersion}).")
+endif()
+
+file(TO_CMAKE_PATH "$ENV{WindowsSDKDir}References/$ENV{WindowsSDKVersion}" winsdk)
+
+file(GLOB winmds "${winsdk}/*/*/*.winmd")
+
+#--- Create response file
+set(args "")
+foreach(winmd IN LISTS winmds)
+    string(APPEND args "-input \"${winmd}\"\n")
+endforeach()
+
+file(REMOVE_RECURSE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}")
+file(MAKE_DIRECTORY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}")
+file(WRITE "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}/cppwinrt.rsp" "${args}")
+
+#--- Generate headers
+string(REGEX MATCH "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" SDKVersion $ENV{WindowsSDKVersion})
+message(STATUS "Generating headers for Windows SDK ${SDKVersion}")
+vcpkg_execute_required_process(
+    COMMAND "${CPPWINRT_TOOL}"
+        "@${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}/cppwinrt.rsp"
+        -output "${CURRENT_PACKAGES_DIR}/include"
+        -verbose
+    WORKING_DIRECTORY "${CURRENT_PACKAGES_DIR}"
+    LOGNAME "cppwinrt-generate-${TARGET_TRIPLET}"
+)
+
+set(CPPWINRT_LIB "${src}/build/native/lib/${CPPWINRT_ARCH}/cppwinrt_fast_forwarder.lib")
+file(INSTALL "${CPPWINRT_LIB}" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+if(NOT DEFINED VCPKG_BUILD_TYPE)
+    file(INSTALL "${CPPWINRT_LIB}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+endif()
+file(INSTALL "${CPPWINRT_TOOL}" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/cppwinrt")
+
+set(tool_path "tools/cppwinrt/cppwinrt.exe")
+set(lib_name "cppwinrt_fast_forwarder.lib")
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/cppwinrt-config.cmake.in"
+  "${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake"
+  @ONLY)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${src}/LICENSE")

--- a/vcpkg-ports/cppwinrt/usage
+++ b/vcpkg-ports/cppwinrt/usage
@@ -1,0 +1,6 @@
+The C++/WinRT package provides CMake targets:
+
+    find_package(cppwinrt CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE Microsoft::CppWinRT)
+
+The CMake variable CPPWINRT_TOOL is also set to point to the .winmd to header command-line tool.

--- a/vcpkg-ports/cppwinrt/vcpkg.json
+++ b/vcpkg-ports/cppwinrt/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "name": "cppwinrt",
+  "version": "2.0.230706.1",
+  "description": "C++/WinRT is a standard C++ language projection for the Windows Runtime.",
+  "homepage": "https://github.com/microsoft/cppwinrt",
+  "documentation": "https://docs.microsoft.com/windows/uwp/cpp-and-winrt-apis/",
+  "license": "MIT",
+  "supports": "windows"
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,14 @@
   "name": "columns-ui",
   "version-string": "git",
   "builtin-baseline": "6062c8fe02d38b10d5291411bc235ae4d02cfe6c",
-  "dependencies": ["fmt", "foonathan-lexy", "ms-gsl", "range-v3", "wil"],
+  "dependencies": [
+    "cppwinrt",
+    "fmt",
+    "foonathan-lexy",
+    "ms-gsl",
+    "range-v3",
+    "wil"
+  ],
   "overrides": [
     {
       "name": "fmt",


### PR DESCRIPTION
Resolves #1226

The May Windows SDK update (version 10.0.26100.4188) includes an update to the `cppwinrt` headers that breaks compatibility with Windows 7 (and also stops Columns UI from building as it tries to link against those functions not available on Windows 7).

This switches to installing `cppwinrt` via vcpkg and pinning it to version 2.0.230706.1, the last one compatible with Windows 7. This version was not available via vcpkg, so an overlay port had to be used.