### PR TITLE
Use /utf-8 compiler option and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@
 
   (Note that other third-party components can still affect the behaviour.)
 
+### Internal changes
+
+- Various dependencies were updated.
+  [[#1227](https://github.com/reupen/columns_ui/pull/1227),
+  [#1229](https://github.com/reupen/columns_ui/pull/1229)]
+
+- The
+  [`/utf-8` compiler option](https://learn.microsoft.com/en-gb/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170)
+  is now used instead of `/source-charset:utf-8`.
+
 ## 3.0.0-beta.3
 
 ### Features

--- a/foo_ui_columns/artwork_decoder.cpp
+++ b/foo_ui_columns/artwork_decoder.cpp
@@ -49,10 +49,10 @@ void ArtworkDecoder::decode(
                     const auto new_height = std::min(max_bitmap_size,
                         gsl::narrow_cast<uint32_t>(gsl::narrow_cast<float>(height) * scaling_factor + .5f));
 
-                    const auto message = fmt::format(u8"Artwork panel – image with size {0}×{1} exceeds maximum "
-                                                     u8"size of {2}×{2}, image will be pre-scaled to {3}×{4}",
+                    const auto message = fmt::format("Artwork panel – image with size {0}×{1} exceeds maximum "
+                                                     "size of {2}×{2}, image will be pre-scaled to {3}×{4}",
                         width, height, max_bitmap_size, new_width, new_height);
-                    console::print(reinterpret_cast<const char*>(message.c_str()));
+                    console::print(message.c_str());
 
                     wic_bitmap = wic::resize_bitmap_source(wic_bitmap, new_width, new_height, imaging_factory);
 
@@ -84,7 +84,7 @@ void ArtworkDecoder::decode(
                     return;
 
             } catch (const std::exception& ex) {
-                console::print(u8"Artwork panel – loading image failed: "_pcc, ex.what());
+                console::print("Artwork panel – loading image failed: ", ex.what());
                 return;
             }
 

--- a/foo_ui_columns/artwork_reader.cpp
+++ b/foo_ui_columns/artwork_reader.cpp
@@ -51,7 +51,7 @@ void ArtworkReader::start(ArtworkReaderArgs args)
             artwork_changed = false;
             m_status = ArtworkReaderStatus::Aborted;
         } catch (const std::exception& e) {
-            console::print(u8"Artwork view – unhandled error reading artwork: "_pcc, e.what());
+            console::print("Artwork view – unhandled error reading artwork: ", e.what());
             m_status = ArtworkReaderStatus::Failed;
         }
 
@@ -227,7 +227,7 @@ album_art_data_ptr query_artwork_data(
         throw;
     } catch (exception_album_art_not_found const&) {
     } catch (exception_io const& ex) {
-        fbh::print_to_console(u8"Artwork view – error loading artwork: "_pcc, ex.what());
+        fbh::print_to_console("Artwork view – error loading artwork: ", ex.what());
     }
 
     return {};

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -190,14 +190,14 @@ void ButtonsToolbar::create_toolbar()
         }
 
         if (any_images_resized)
-            console::print(reinterpret_cast<const char*>(fmt::format(
-                u8"Buttons toolbar – resized some custom non-hover icons to {} x {}px", button_width, button_height)
-                    .c_str()));
+            console::print(fmt::format(
+                "Buttons toolbar – resized some custom non-hover icons to {} x {}px", button_width, button_height)
+                    .c_str());
 
         if (any_hot_images_resized)
-            console::print(reinterpret_cast<const char*>(fmt::format(
-                u8"Buttons toolbar – resized some custom hover icons to {} x {}px", button_width, button_height)
-                    .c_str()));
+            console::print(fmt::format(
+                "Buttons toolbar – resized some custom hover icons to {} x {}px", button_width, button_height)
+                    .c_str());
 
         m_standard_images.reset(
             ImageList_Create(button_width, button_height, ILC_COLOR32 | ILC_MASK, gsl::narrow<int>(image_count), 0));

--- a/foo_ui_columns/buttons_button_image.cpp
+++ b/foo_ui_columns/buttons_button_image.cpp
@@ -29,7 +29,7 @@ void ButtonsToolbar::ButtonImage::preload(const Button::CustomImage& p_image)
         wic::check_hresult(m_bitmap_source->GetSize(&width, &height));
         m_bitmap_source_size = std::make_tuple(gsl::narrow<int>(width), gsl::narrow<int>(height));
     } catch (const std::exception& ex) {
-        fbh::print_to_console(u8"Buttons toolbar – loading image failed: "_pcc, ex.what());
+        fbh::print_to_console("Buttons toolbar – loading image failed: ", ex.what());
     }
 }
 
@@ -43,7 +43,7 @@ bool ButtonsToolbar::ButtonImage::load_custom_image(const Button::CustomImage& c
             uLoadImage(wil::GetModuleInstanceHandle(), full_path, IMAGE_ICON, width, height, LR_LOADFROMFILE)));
 
         if (!m_icon)
-            fbh::print_to_console(u8"Buttons toolbar – loading icon failed. Path: "_pcc, full_path.get_ptr());
+            fbh::print_to_console("Buttons toolbar – loading icon failed. Path: ", full_path.get_ptr());
         return false;
     }
 
@@ -52,7 +52,7 @@ bool ButtonsToolbar::ButtonImage::load_custom_image(const Button::CustomImage& c
             load_custom_svg_image(full_path, width, height);
         } catch (const std::exception& ex) {
             fbh::print_to_console(
-                u8"Buttons toolbar – loading SVG file failed. Path: "_pcc, full_path.get_ptr(), " Error: ", ex.what());
+                "Buttons toolbar – loading SVG file failed. Path: ", full_path.get_ptr(), " Error: ", ex.what());
         }
 
         return false;
@@ -69,7 +69,7 @@ bool ButtonsToolbar::ButtonImage::load_custom_image(const Button::CustomImage& c
             return resized;
         } catch (const std::exception& ex) {
             fbh::print_to_console(
-                u8"Buttons toolbar – loading image failed. Path: "_pcc, full_path.get_ptr(), " Error: ", ex.what());
+                "Buttons toolbar – loading image failed. Path: ", full_path.get_ptr(), " Error: ", ex.what());
         }
         m_bitmap_source.reset();
     }
@@ -124,7 +124,7 @@ void ButtonsToolbar::ButtonImage::load_default_image(
     try {
         m_bm = wic::resize_hbitmap(bitmap.get(), width, height);
     } catch (const std::exception& ex) {
-        fbh::print_to_console(u8"Buttons toolbar – error resizing default image: "_pcc, ex.what());
+        fbh::print_to_console("Buttons toolbar – error resizing default image: ", ex.what());
     }
 }
 

--- a/foo_ui_columns/command_line.cpp
+++ b/foo_ui_columns/command_line.cpp
@@ -3,13 +3,13 @@
 #include "dark_mode_dialog.h"
 #include "fcl.h"
 
-static const char8_t* g_help_text
-    = u8"Available commands:\n\n"
-      u8"/columnsui:help, /columnsui:?\t\tdisplay this command-line help\n"
-      u8"/columnsui:import <fcl path>\t\timport a Columns UI configuration\n"
-      u8"/columnsui:import-quiet <fcl path>\timport a Columns UI configuration without confirming first\n"
-      u8"/columnsui:export <fcl path>\t\texport selected parts of the current Columns UI configuration\n"
-      u8"/columnsui:export-quiet <fcl path>\texport all parts of the current Columns UI configuration";
+static const char* g_help_text
+    = "Available commands:\n\n"
+      "/columnsui:help, /columnsui:?\t\tdisplay this command-line help\n"
+      "/columnsui:import <fcl path>\t\timport a Columns UI configuration\n"
+      "/columnsui:import-quiet <fcl path>\timport a Columns UI configuration without confirming first\n"
+      "/columnsui:export <fcl path>\t\texport selected parts of the current Columns UI configuration\n"
+      "/columnsui:export-quiet <fcl path>\texport all parts of the current Columns UI configuration";
 
 class HelpCommandLineHandler : public commandline_handler {
 public:
@@ -25,8 +25,8 @@ public:
     {
         HWND parent = core_api::get_main_window();
         ui_control::get()->activate();
-        cui::dark::modeless_info_box(parent, "Columns UI command-line help", reinterpret_cast<const char*>(g_help_text),
-            uih::InfoBoxType::Neutral, true);
+        cui::dark::modeless_info_box(
+            parent, "Columns UI command-line help", g_help_text, uih::InfoBoxType::Neutral, true);
     }
 };
 
@@ -70,7 +70,7 @@ public:
     CommandLineSingleFileHelper m_single_file_helper;
 
     ImportCommandLineHandler()
-        : m_single_file_helper{u8"Import configuration – Columns UI"_pcc, "No file to import specified.",
+        : m_single_file_helper{"Import configuration – Columns UI", "No file to import specified.",
               "Too many files to import specified. You can only import one file at a time, "
               "and should use double quotes around paths containing spaces."}
     {
@@ -122,7 +122,7 @@ public:
     CommandLineSingleFileHelper m_single_file_helper;
 
     ExportCommandLineHandler()
-        : m_single_file_helper{u8"Export configuration – Columns UI"_pcc, "No file to export to specified.",
+        : m_single_file_helper{"Export configuration – Columns UI", "No file to export to specified.",
               "Too many destination files specified. You must specify only one destination path, "
               "and should use double quotes around paths containing spaces."}
     {

--- a/foo_ui_columns/config_vars.cpp
+++ b/foo_ui_columns/config_vars.cpp
@@ -142,11 +142,11 @@ cfg_string cfg_colour(
 ConfigMenuItem cfg_playlist_double(GUID{0xffc47d9d, 0xb43d, 0x8fad, {0x8f, 0xb3, 0x42, 0x84, 0xbf, 0x9a, 0x22, 0x2a}});
 cfg_string cfg_playlist_switcher_tagz(
     GUID{0x13f4b9ae, 0x5db5, 0xb083, {0x15, 0x36, 0x08, 0x4d, 0x55, 0xe3, 0xb5, 0x64}},
-    reinterpret_cast<const char*>(u8"%title%\r\n"
-                                  u8"\r\n"
-                                  u8"$tab()\r\n"
-                                  u8"\r\n"
-                                  u8"$if(%is_playing%,🔉)"));
+    "%title%\r\n"
+    "\r\n"
+    "$tab()\r\n"
+    "\r\n"
+    "$if(%is_playing%,🔉)");
 
 // {F006EC50-7F52-4037-9D48-7447BBF742AA}
 static const GUID guid_columns = {0xf006ec50, 0x7f52, 0x4037, {0x9d, 0x48, 0x74, 0x47, 0xbb, 0xf7, 0x42, 0xaa}};

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -105,7 +105,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -145,7 +145,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -180,7 +180,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalOptions>/Zm125 /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm125 /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -215,7 +215,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalOptions>/Zm125 /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm125 /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -1282,7 +1282,7 @@ bool ItemDetails::s_track_mode_includes_playlist(size_t mode)
 
 uie::container_window_v3_config ItemDetails::get_window_config()
 {
-    uie::container_window_v3_config config(L"columns_ui_item_details_E0D8v091EU8", false);
+    uie::container_window_v3_config config(L"columns_ui_item_details_E0D8v091E", false);
 
     if (m_edge_style == 1)
         config.extended_window_styles |= WS_EX_CLIENTEDGE;

--- a/foo_ui_columns/item_details_text.cpp
+++ b/foo_ui_columns/item_details_text.cpp
@@ -100,10 +100,9 @@ std::optional<FormatProperties> parse_font_code(
         return FormatProperties{std::move(family_name), *size_points, weight, stretch, style, text_decoration};
     } catch (...) {
         if (wil::ResultFromCaughtException() == DWRITE_E_NOFONT) {
-            console::print(reinterpret_cast<const char*>(
-                fmt::format(u8"Item details – $set_font() error: font family \"{}\" not found",
-                    reinterpret_cast<const char8_t*>(mmh::to_utf8(lf.lfFaceName).c_str()))
-                    .c_str()));
+            console::print(fmt::format(
+                "Item details – $set_font() error: font family \"{}\" not found", mmh::to_utf8(lf.lfFaceName).c_str())
+                    .c_str());
             return {};
         }
 

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -526,7 +526,7 @@ void ItemProperties::refresh_contents()
         }
 
         if (aggregator.m_truncated)
-            temp << u8"; …"_pcc;
+            temp << "; …";
         else if (count_values > 0 && aggregator.m_some_values_missing)
             temp << "; (not set)";
 
@@ -801,11 +801,11 @@ bool ItemProperties::notify_create_inline_edit(const pfc::list_base_const_t<size
     const auto joined = mmh::join(aggregator.m_values, "; "s);
 
     if (aggregator.m_mixed_values) {
-        p_text = u8"«mixed values» "_pcc;
+        p_text = "«mixed values» ";
         p_text += joined.c_str();
 
         if (aggregator.m_truncated)
-            p_text += u8"; …"_pcc;
+            p_text += "; …";
     } else {
         p_text = joined.c_str();
     }

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -52,7 +52,7 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook, bool is_hidden
     fbh::enable_wil_console_logging();
 
     if (!IsWindows7SP1OrGreater()) {
-        dark::modal_info_box(nullptr, u8"Unsupported operating system – Columns UI"_pcc, unsupported_os_message,
+        dark::modal_info_box(nullptr, "Unsupported operating system – Columns UI", unsupported_os_message,
             uih::InfoBoxType::Error, uih::InfoBoxModalType::OK);
         return nullptr;
     }
@@ -65,8 +65,8 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook, bool is_hidden
         pfc::string8 message = "Unknown COM initialisation error";
         uFormatMessage(ex.GetFailureInfo().hr, message);
 
-        dark::modal_info_box(nullptr, u8"Failed to initialise COM – Columns UI"_pcc, message.c_str(),
-            uih::InfoBoxType::Error, uih::InfoBoxModalType::OK);
+        dark::modal_info_box(nullptr, "Failed to initialise COM – Columns UI", message.c_str(), uih::InfoBoxType::Error,
+            uih::InfoBoxModalType::OK);
         return nullptr;
     }
 
@@ -81,8 +81,8 @@ HWND cui::MainWindow::initialise(user_interface::HookProc_t hook, bool is_hidden
         const auto message
             = IsWindows8OrGreater() ? error_message.get_ptr() : "The Platform Update for Windows 7 is required.";
 
-        dark::modal_info_box(nullptr, u8"Failed to initialise DirectWrite – Columns UI"_pcc, message,
-            uih::InfoBoxType::Error, uih::InfoBoxModalType::OK);
+        dark::modal_info_box(nullptr, "Failed to initialise DirectWrite – Columns UI", message, uih::InfoBoxType::Error,
+            uih::InfoBoxModalType::OK);
         return nullptr;
     }
 

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -636,7 +636,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                             }
                             if (title2.length() > 25) {
                                 title2.truncate(24);
-                                title2 += "\xe2\x80\xa6";
+                                title2 += "…";
                             }
 
                             title.prealloc(14 + 25);

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -111,7 +111,7 @@ DWORD ArtworkReader::on_thread()
     } catch (pfc::exception const& e) {
         m_bitmaps.clear();
         console::formatter formatter;
-        formatter << u8"Playlist view – unhandled error loading artwork: "_pcc << e.what();
+        formatter << "Playlist view – unhandled error loading artwork: " << e.what();
         ret = -1;
     }
     // send this first so thread gets closed first
@@ -147,7 +147,7 @@ unsigned ArtworkReader::read_artwork(abort_callback& p_abort)
     } catch (exception_io_not_found const&) {
     } catch (pfc::exception const& e) {
         console::formatter formatter;
-        formatter << u8"Playlist view – error loading artwork: "_pcc << e.what();
+        formatter << "Playlist view – error loading artwork: " << e.what();
     }
 
     // Warning: Broken input components can intitialise COM as apartment-threaded. Hence, COM intialisation
@@ -280,7 +280,7 @@ wil::unique_hbitmap g_create_hbitmap_from_data(
         const auto bitmap_data = wic::decode_image_data(data->get_ptr(), data->get_size());
         bitmap = gdip::create_bitmap_from_wic_data(bitmap_data);
     } catch (const std::exception& ex) {
-        fbh::print_to_console(u8"Playlist view – loading image failed: "_pcc, ex.what());
+        fbh::print_to_console("Playlist view – loading image failed: ", ex.what());
         return nullptr;
     }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
@@ -38,11 +38,11 @@ bool PlaylistView::notify_create_inline_edit(const pfc::list_base_const_t<size_t
     const auto joined = mmh::join(aggregator.m_values, "; "s);
 
     if (aggregator.m_mixed_values) {
-        p_text = u8"«mixed values» "_pcc;
+        p_text = "«mixed values» ";
         p_text += joined.c_str();
 
         if (aggregator.m_truncated)
-            p_text += u8"; …"_pcc;
+            p_text += "; …";
     } else {
         p_text = joined.c_str();
     }

--- a/foo_ui_columns/splitter_utils.cpp
+++ b/foo_ui_columns/splitter_utils.cpp
@@ -163,7 +163,7 @@ std::unique_ptr<uie::splitter_item_full_v3_impl_t> get_splitter_item_from_clipbo
     try {
         return get_splitter_item_from_clipboard();
     } catch (const exception_io& ex) {
-        dark::modeless_info_box(wnd, u8"Error – Paste panel"_pcc, ex.what(), uih::InfoBoxType::Error);
+        dark::modeless_info_box(wnd, "Error – Paste panel", ex.what(), uih::InfoBoxType::Error);
     }
     return {};
 }

--- a/foo_ui_columns/splitter_utils.h
+++ b/foo_ui_columns/splitter_utils.h
@@ -28,7 +28,7 @@ void copy_splitter_item_to_clipboard_safe(HWND wnd, const SplitterItem* item)
     try {
         copy_splitter_item_to_clipboard(item);
     } catch (const exception_io& ex) {
-        dark::modeless_info_box(wnd, u8"Error – Copy panel"_pcc, ex.what(), uih::InfoBoxType::Error);
+        dark::modeless_info_box(wnd, "Error – Copy panel", ex.what(), uih::InfoBoxType::Error);
     }
 }
 

--- a/foo_ui_columns/status_pane.cpp
+++ b/foo_ui_columns/status_pane.cpp
@@ -13,11 +13,11 @@ namespace cui::status_pane {
 namespace {
 
 const auto* default_status_pane_script
-    = u8"// This is the default script for the content of the main status pane section during playback.\r\n"
-      u8"\r\n"
-      u8"%artist% – %title%\r\n"
-      u8"$crlf()\r\n"
-      u8"%codec% | %bitrate% kbps | %samplerate% Hz | $caps(%channels%) | %playback_time%[ / %length%]"_pcc;
+    = "// This is the default script for the content of the main status pane section during playback.\r\n"
+      "\r\n"
+      "%artist% – %title%\r\n"
+      "$crlf()\r\n"
+      "%codec% | %bitrate% kbps | %samplerate% Hz | $caps(%channels%) | %playback_time%[ / %length%]";
 
 }
 

--- a/foo_ui_columns/system_appearance_manager.cpp
+++ b/foo_ui_columns/system_appearance_manager.cpp
@@ -23,12 +23,11 @@ COLORREF winrt_color_to_colorref(const winrt::Windows::UI::Color& colour)
     return RGB(colour.R, colour.G, colour.B);
 }
 
-void log_winrt_error(std::basic_string_view<char8_t> main_message, const winrt::hresult_error& ex)
+void log_winrt_error(std::string_view main_message, const winrt::hresult_error& ex)
 {
     const pfc::stringcvt::string_utf8_from_wide error_message(ex.message().c_str());
-    const auto message
-        = fmt::format(u8"Columns UI – {}: {}", main_message, reinterpret_cast<const char8_t*>(error_message.get_ptr()));
-    console::warning(reinterpret_cast<const char*>(message.c_str()));
+    const auto message = fmt::format("Columns UI – {}: {}", main_message, error_message.get_ptr());
+    console::warning(message.c_str());
 }
 
 std::optional<ModernColours> fetch_modern_colours()
@@ -42,7 +41,7 @@ std::optional<ModernColours> fetch_modern_colours()
 
         return ModernColours{background, foreground, accent, light_accent};
     } catch (const winrt::hresult_error& ex) {
-        log_winrt_error(u8"Error retrieving UISettings colours"sv, ex);
+        log_winrt_error("Error retrieving UISettings colours"sv, ex);
         return {};
     }
 }
@@ -62,7 +61,7 @@ bool fetch_dark_mode_available()
         if (AccessibilitySettings().HighContrast())
             return false;
     } catch (const winrt::hresult_error& ex) {
-        log_winrt_error(u8"Error retrieving HighContrast setting"sv, ex);
+        log_winrt_error("Error retrieving HighContrast setting"sv, ex);
     }
 
     return true;
@@ -141,7 +140,7 @@ private:
                 m_colours_changed_token = m_ui_settings->ColorValuesChanged(
                     [](auto&&, auto&&) { fb2k::inMainThread([] { handle_modern_colours_changed(); }); });
             } catch (const winrt::hresult_error& ex) {
-                log_winrt_error(u8"Error registering UISettings ColorValuesChanged event handler"sv, ex);
+                log_winrt_error("Error registering UISettings ColorValuesChanged event handler"sv, ex);
             }
             break;
         case WM_FONTCHANGE:

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -631,11 +631,9 @@ INT_PTR LayoutTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 cfg_layout.get_preset_name(m_active_preset, preset_name);
 
                 const auto confirmation_message
-                    = fmt::format(u8"Are you sure that you want to delete the layout preset ‘{}’?",
-                        reinterpret_cast<const char8_t*>(preset_name.c_str()));
+                    = fmt::format("Are you sure that you want to delete the layout preset ‘{}’?", preset_name.c_str());
 
-                if (!dark::modal_info_box(wnd, "Delete preset",
-                        reinterpret_cast<const char*>(confirmation_message.c_str()), uih::InfoBoxType::Warning,
+                if (!dark::modal_info_box(wnd, "Delete preset", confirmation_message.c_str(), uih::InfoBoxType::Warning,
                         uih::InfoBoxModalType::YesNo))
                     break;
             }

--- a/foo_ui_columns/version.cpp
+++ b/foo_ui_columns/version.cpp
@@ -14,7 +14,7 @@ DECLARE_COMPONENT_VERSION("Columns UI",
     "Columns UI\n"
     "Alternative user interface\n"
     "\n"
-    u8"© musicmusic and contributors "_pcc CUI_COMPILATION_YEAR "\n"
+    "© musicmusic and contributors " CUI_COMPILATION_YEAR "\n"
     "Current version at yuo.be\n"
     "\n"
     "Built on " CUI_COMPILATION_DATE "\n"

--- a/vcpkg-ports/foonathan-lexy/portfile.cmake
+++ b/vcpkg-ports/foonathan-lexy/portfile.cmake
@@ -1,10 +1,10 @@
-vcpkg_minimum_required(VERSION 2022-10-12) # for ${VERSION}
+string(REGEX REPLACE "^([0-9]+)[.]([0-9][.])" "\\1.0\\2" LEXY_VERSION "${VERSION}")
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO foonathan/lexy
-    REF "34d2adf74a2b25b6bdd760a3bbb931f3fd5e60cd"
-    SHA512 f47f932b9a573009a97f9ecfa54614e1087df07c10c8dec5cf1466820ad0f2cfb2d407d302e01b3758a0dc2b434833eb198f1889b643429c927d583e69c6c595
+    REF "v${LEXY_VERSION}"
+    SHA512 04eec38823ab7e6d67fe2017f9d09485ec0e2a2fa60182732e1b7a471944290934f10ded5ad209965efa0931a8f9db8bcf789ca8fb52a371b776d12edd8ca8f5
     HEAD_REF main
 )
 

--- a/vcpkg-ports/foonathan-lexy/vcpkg.json
+++ b/vcpkg-ports/foonathan-lexy/vcpkg.json
@@ -1,10 +1,9 @@
 {
   "name": "foonathan-lexy",
-  "version": "2025-01-13",
+  "version": "2025.5.0",
   "description": "C++ parsing DSL",
   "homepage": "https://github.com/foonathan/lexy",
   "license": "BSL-1.0",
-  "supports": "x86 | x64 | arm64",
   "dependencies": [
     {
       "name": "vcpkg-cmake",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "columns-ui",
   "version-string": "git",
-  "builtin-baseline": "6062c8fe02d38b10d5291411bc235ae4d02cfe6c",
+  "builtin-baseline": "ce613c41372b23b1f51333815feb3edd87ef8a8b",
   "dependencies": [
     "cppwinrt",
     "fmt",
@@ -13,19 +13,19 @@
   "overrides": [
     {
       "name": "fmt",
-      "version": "10.2.1#2"
+      "version": "11.0.2#1"
     },
     {
       "name": "ms-gsl",
-      "version": "4.0.0#1"
+      "version": "4.2.0"
     },
     {
       "name": "range-v3",
-      "version": "0.12.0#2"
+      "version": "0.12.0#4"
     },
     {
       "name": "wil",
-      "version": "2024-01-22"
+      "version": "1.0.250325.1"
     }
   ]
 }


### PR DESCRIPTION
This:

- removes the `/source-charset:utf-8` compiler option and adds `/utf-8` in its place
- updates dependencies installed via vcpkg

`/utf-8` is equivalent to specifying both `/source-charset:utf-8` and `/execution-charset:utf-8`. It’s required by the new version of {fmt}, and is a significant improvement over the previous situation as it means normal (`const char`) string literals are now interpreted as being in UTF-8, and so a lot of the previous faff trying to use `char8_t` literals with incompatible things is no longer required.