### PR TITLE
Don't show stale image in artwork view on decoding failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 
   (Note that other third-party components can still affect the behaviour.)
 
+### Bug fixes
+
+- A bug where the previously displayed image remained in the Artwork view when
+  an image failed to decode was fixed.
+  [[#1232](https://github.com/reupen/columns_ui/pull/1232)]
+
+  If an image fails to decode, the panel will now display no image. Decoding
+  errors are logged in the console.
+
 ### Internal changes
 
 - Various dependencies were updated.

--- a/foo_ui_columns/artwork_decoder.cpp
+++ b/foo_ui_columns/artwork_decoder.cpp
@@ -85,7 +85,6 @@ void ArtworkDecoder::decode(
 
             } catch (const std::exception& ex) {
                 console::print("Artwork panel – loading image failed: ", ex.what());
-                return;
             }
 
             fb2k::inMainThread(


### PR DESCRIPTION
Resolves #1231

Since #1221, if decoding an image failed for whatever reason, the previous image incorrectly remained in the Artwork view.

This corrects the behaviour and it now removes the previously displayed image (and displays nothing). Decoding errors are logged in the console as before.