### PR TITLE
Fix crash after unexpected exception reading artwork in Artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## 3.0.0-rc.1
+## 3.0.0-beta.4
 
 ### Features
 
@@ -16,12 +16,16 @@
 
 ### Bug fixes
 
+- A crash that may have occurred in the Artwork view after there was an
+  unexpected error reading artwork was fixed.
+  [[#1237](https://github.com/reupen/columns_ui/pull/1237)]
+
 - A bug where the previously displayed image remained in the Artwork view when
   an image failed to decode was fixed.
   [[#1232](https://github.com/reupen/columns_ui/pull/1232)]
 
-  If an image fails to decode, the panel will now display no image. Decoding
-  errors are logged in the console.
+  If an image fails to decode, the panel will now be blank. Decoding errors are
+  logged in the console.
 
 ### Internal changes
 

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -555,8 +555,18 @@ void ArtworkPanel::show_stub_image()
     if (!m_artwork_reader || !m_artwork_reader->is_ready())
         return;
 
-    const auto artwork_type_id = g_artwork_types[get_displayed_artwork_type_index()];
-    const album_art_data_ptr data = m_artwork_reader->get_stub_image(artwork_type_id);
+    album_art_data_ptr data;
+
+    if (m_artwork_reader->status() != ArtworkReaderStatus::Failed) {
+        const auto artwork_type_id = g_artwork_types[get_displayed_artwork_type_index()];
+        data = m_artwork_reader->get_stub_image(artwork_type_id);
+    }
+
+    if (!data.is_valid()) {
+        m_artwork_decoder.reset();
+        invalidate_window();
+        return;
+    }
 
     try {
         create_d2d_render_target();

--- a/foo_ui_columns/artwork_reader.cpp
+++ b/foo_ui_columns/artwork_reader.cpp
@@ -51,8 +51,9 @@ void ArtworkReader::start(ArtworkReaderArgs args)
             artwork_changed = false;
             m_status = ArtworkReaderStatus::Aborted;
         } catch (const std::exception& e) {
-            console::print("Artwork view – unhandled error reading artwork: ", e.what());
+            console::print("Artwork view – unexpected error reading artwork: ", e.what());
             m_status = ArtworkReaderStatus::Failed;
+            artwork_changed = true;
         }
 
         if (m_status != ArtworkReaderStatus::Succeeded)
@@ -176,6 +177,14 @@ bool ArtworkReaderManager::is_ready() const
     return m_current_reader && !m_current_reader->is_running();
 }
 
+ArtworkReaderStatus ArtworkReaderManager::status() const
+{
+    if (!is_ready())
+        return ArtworkReaderStatus::Pending;
+
+    return m_current_reader->status();
+}
+
 void ArtworkReaderManager::reset()
 {
     abort_current_task();
@@ -225,9 +234,9 @@ album_art_data_ptr query_artwork_data(
             return data;
     } catch (const exception_aborted&) {
         throw;
-    } catch (exception_album_art_not_found const&) {
-    } catch (exception_io const& ex) {
-        fbh::print_to_console("Artwork view – error loading artwork: ", ex.what());
+    } catch (const exception_album_art_not_found&) {
+    } catch (const exception_io& ex) {
+        fbh::print_to_console("Artwork view – I/O error reading artwork: ", ex.what());
     }
 
     return {};

--- a/foo_ui_columns/artwork_reader.h
+++ b/foo_ui_columns/artwork_reader.h
@@ -65,6 +65,7 @@ public:
     void request(
         const metadb_handle_ptr& handle, OnArtworkLoadedCallback on_artwork_loaded, bool is_from_playback = false);
     bool is_ready() const;
+    ArtworkReaderStatus status() const;
     void reset();
     void abort_current_task();
 


### PR DESCRIPTION
Some input components throw unusual exceptions which are then exposed through `album_art_manager_v2` methods.

In this scenario, previously reading the stub image was skipped, but the component still tried to display it and ended up crashing if it hadn’t been read in the past.

This updates the logic to avoid that. Also, the panel now displays nothing rather than a stub image when such an error occurs.