### PR TITLE
Work around stolen keyboard focus during main window creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@
 ### Features
 
 - The performance of the playlist view was improved when reordering items.
-  [[#1238](https://github.com/reupen/columns_ui/pull/1238)]
+  [[#1239](https://github.com/reupen/columns_ui/pull/1239)]
 
-  This is mainly only for playlists that do not use grouping.
+  This mainly applies to playlists that do not use grouping.
+
+- A workaround was added to ensure a playlist view is focused when foobar2000
+  starts if a misbehaving panel steals the keyboard focus on creation.
+  [[#1240](https://github.com/reupen/columns_ui/pull/1240)]
+
+  A warning is logged in the console if this happens.
 
 ## 3.0.0-beta.4
 

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -144,6 +144,19 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         create_child_windows();
 
+        if (HWND focused_wnd = GetFocus(); focused_wnd && IsChild(wnd, focused_wnd)) {
+            std::array<wchar_t, 256> class_name{};
+            GetClassName(focused_wnd, class_name.data(), gsl::narrow<int>(class_name.size()));
+
+            console::print(fmt::format(
+                L"Columns UI – window with class name ‘{}’ was unexpectedly focused during layout creation. "
+                L"The keyboard focus will be reset to a playlist view.",
+                class_name.data())
+                    .c_str());
+
+            g_layout_window.set_focus();
+        }
+
         g_get_msg_hook.register_hook();
 
         if (config_object::g_get_data_bool_simple(standard_config_objects::bool_ui_always_on_top, false))


### PR DESCRIPTION
This adds detection of the keyboard focus being stolen by a panel when the main window first initialises. If that is detected, a playlist view is focused and a console message is emitted.