### PR TITLE
Monitor per-monitor ClearType settings for changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   Text Tuner did not immediately take effect after clicking the final ‘Finish’
   button was fixed. [[#1248](https://github.com/reupen/columns_ui/pull/1248)]
 
+### Internal changes
+
+- Thread descriptions were set for some worker threads on Windows 10 and newer
+  for debugging purposes.
+  [[#1248](https://github.com/reupen/columns_ui/pull/1248)]
+
 ## 3.0.0-beta.5
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.0.0-rc-1
+
+### Bug fixes
+
+- A problem where DirectWrite-specific changes made in the Windows ClearType
+  Text Tuner did not immediately take effect after clicking the final ‘Finish’
+  button was fixed. [[#1248](https://github.com/reupen/columns_ui/pull/1248)]
+
 ## 3.0.0-beta.5
 
 ### Features

--- a/foo_ui_columns/artwork_reader.cpp
+++ b/foo_ui_columns/artwork_reader.cpp
@@ -40,6 +40,7 @@ void ArtworkReader::start(ArtworkReaderArgs args)
     m_thread = std::jthread([this, args{std::move(args)}] {
         TRACK_CALL_TEXT("cui::artwork_panel::ArtworkReader::thread");
         SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
+        (void)mmh::set_thread_description(GetCurrentThread(), L"[Columns UI] Artwork view reader");
 
         bool artwork_changed{};
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -97,6 +97,7 @@ public:
 DWORD ArtworkReader::on_thread()
 {
     TRACK_CALL_TEXT("artwork_reader_ng_t::on_thread");
+    (void)mmh::set_thread_description(GetCurrentThread(), L"[Columns UI] Playlist view artwork reader");
 
     bool b_aborted = false;
     DWORD ret = -1;

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -67,6 +67,7 @@
 
 #include <wil/cppwinrt.h>
 #include <wil/com.h>
+#include <wil/registry.h>
 #include <wil/resource.h>
 #include <wil/win32_helpers.h>
 


### PR DESCRIPTION
Previously, changes to per-monitor ClearType settings made using the ClearType Text Tuner usually didn’t take effect until restarting foobar2000, or after changing Columns UI font settings.

Unfortunately, there is no official way to subscribe for notifications about changes to these settings. However, monitoring the relevant registry keys works. This adds a simple registry monitoring solution that works well enough.

Additionally, this sets thread descriptions for the Artwork view and playlist view artwork reader worker threads using the `SetThreadDescription()` function available on recent versions of Windows.

(`mmh::set_thread_description()` is used here, though `pfc::setCurrentThreadDescription()` is also available…)