### PR TITLE
Fix crash when Artwork view is destroyed while reading artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.0.1
+
+### Bug fixes
+
+- A crash that occurred when closing the Artwork view or foobar2000 while the
+  Artwork view was reading artwork was fixed.
+  [[#1264](https://github.com/reupen/columns_ui/pull/1264)]
+
 ## 3.0.0
 
 - There were no changes from version 3.0.0-rc.1.

--- a/foo_ui_columns/artwork_reader.cpp
+++ b/foo_ui_columns/artwork_reader.cpp
@@ -112,8 +112,10 @@ void ArtworkReaderManager::deinitialise()
     for (auto iter = m_aborting_readers.begin(); iter != m_aborting_readers.end();)
         iter = m_aborting_readers.erase(iter);
 
-    if (m_current_reader)
+    if (m_current_reader) {
+        m_current_reader->abort();
         m_current_reader.reset();
+    }
 
     m_stub_images.clear();
 }
@@ -271,7 +273,7 @@ bool ArtworkReader::read_artwork(const ArtworkReaderArgs& args, abort_callback& 
                 m_stub_images.insert_or_assign(artwork_id, data);
         }
 
-        if (m_stub_images.find(album_art_ids::cover_front) == m_stub_images.end()) {
+        if (!m_stub_images.contains(album_art_ids::cover_front)) {
             album_art_data_ptr data;
             panels::playlist_view::g_get_default_nocover_bitmap_data(data, p_abort);
 

--- a/foo_ui_columns/artwork_reader.h
+++ b/foo_ui_columns/artwork_reader.h
@@ -38,6 +38,14 @@ public:
     {
     }
 
+    ~ArtworkReader()
+    {
+        if (m_thread) {
+            m_abort.abort();
+            m_thread.reset();
+        }
+    }
+
     void notify_panel(bool artwork_changed);
 
     void start(ArtworkReaderArgs args);
@@ -47,7 +55,6 @@ public:
 private:
     bool read_artwork(const ArtworkReaderArgs& args, abort_callback& p_abort);
 
-    std::optional<std::jthread> m_thread;
     std::vector<GUID> m_artwork_type_ids;
     std::unordered_map<GUID, album_art_data_ptr> m_previous_artwork_data;
     std::unordered_map<GUID, album_art_data_ptr> m_artwork_data;
@@ -56,6 +63,7 @@ private:
     bool m_is_from_playback{};
     OnArtworkLoadedCallback m_on_artwork_loaded;
     abort_callback_impl m_abort;
+    std::optional<std::jthread> m_thread;
 };
 
 class ArtworkReaderManager : public std::enable_shared_from_this<ArtworkReaderManager> {


### PR DESCRIPTION
This fixes a crash that happened when the Artwork view was closed while it was reading artwork.

This occurred because the destruction order of `ArtworkReader` members meant some members the background thread depended on were destructed before the thread was joined.