### PR TITLE
Link windowsapp.lib when compiling with Clang

### DIFF
--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -86,6 +86,8 @@
 #pragma clang diagnostic warning "-Winconsistent-missing-override"
 #pragma clang diagnostic warning "-Woverloaded-virtual"
 #pragma clang diagnostic warning "-Wreorder-ctor"
+
+#pragma comment(lib, "windowsapp.lib")
 #endif
 
 #include "../foobar2000/SDK/foobar2000.h"


### PR DESCRIPTION
Unfortunately, the fix for #1226 is not working with Clang, as it still seems to using the C++/WinRT headers from the Windows SDK, rather than the ones installed via vcpkg.

This change links `windowsapp.lib` when compiling with Clang to at least fix the linker errors.