### PR TITLE
Correct scaling interpolation mode in artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - The Artwork view now supports Windows 10 and 11 advanced colour management,
   with improved support for HDR images, images with an embedded colour profile
   and images with more than eight bits per channel.
-  [[#1275](https://github.com/reupen/columns_ui/pull/1275)]
+  [[#1275](https://github.com/reupen/columns_ui/pull/1275),
+  [#1284](https://github.com/reupen/columns_ui/pull/1284)]
 
 - Direct2D is now used to scale artwork and create artwork reflections in the
   playlist view. [[#1281](https://github.com/reupen/columns_ui/pull/1281)]

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -671,6 +671,8 @@ void ArtworkPanel::create_image_colour_processing_effect()
         gsl::narrow<int>(bitmap_height), gsl::narrow<int>(render_target_width), gsl::narrow<int>(render_target_height),
         m_preserve_aspect_ratio, true);
 
+    THROW_IF_FAILED(
+        scale_effect->SetValue(D2D1_SCALE_PROP_INTERPOLATION_MODE, D2D1_SCALE_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC));
     THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_SCALE,
         D2D1::Vector2F(scaled_width / gsl::narrow_cast<float>(bitmap_width),
             scaled_height / gsl::narrow_cast<float>(bitmap_height))));


### PR DESCRIPTION
This fixes a regression in #1275 where the interpolation mode for image scaling was not set correctly in the artwork view.