### PR TITLE
Add support for legacy colour management to artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,26 @@
 
 ### Features
 
-- The Artwork view now supports Windows 10 and 11 advanced colour management,
-  with improved support for HDR images, images with an embedded colour profile
-  and images with more than eight bits per channel.
-  [[#1275](https://github.com/reupen/columns_ui/pull/1275),
+- The Artwork view now supports colour management. This improves support for
+  images with an embedded colour profile and makes image colours more consistent
+  with web browsers. [[#1275](https://github.com/reupen/columns_ui/pull/1275),
   [#1284](https://github.com/reupen/columns_ui/pull/1284),
-  [#1289](https://github.com/reupen/columns_ui/pull/1289)]
+  [#1289](https://github.com/reupen/columns_ui/pull/1289),
+  [#1290](https://github.com/reupen/columns_ui/pull/1290)]
+
+  Additionally, support for Windows Advanced Colour can be enabled in
+  Preferences on Windows 10 version 1809 and newer. This improves support for
+  HDR and high bit-depth images but is recommended only if HDR is enabled in
+  Windows.
+
+- The playlist view now supports colour management for artwork images. This
+  improves support for images with an embedded colour profile and makes image
+  colours more consistent with web browsers.
+  [[#1286](https://github.com/reupen/columns_ui/pull/1286)]
 
 - Direct2D is now used to scale artwork and create artwork reflections in the
   playlist view. [[#1281](https://github.com/reupen/columns_ui/pull/1281),
   [#1289](https://github.com/reupen/columns_ui/pull/1289)]
-
-- The playlist view now supports basic (legacy) per-monitor colour management
-  for artwork images. [[#1286](https://github.com/reupen/columns_ui/pull/1286)]
 
 ### Bug fixes
 

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -588,14 +588,17 @@ void ArtworkPanel::create_d2d_device_resources()
 
 void ArtworkPanel::reset_d2d_device_resources(bool keep_devices)
 {
+    m_artwork_decoder.abort();
+
     reset_effects();
 
-    m_artwork_decoder.reset();
     m_d2d_device_context.reset();
     m_sdr_white_level.reset();
     m_dxgi_output_desc.reset();
     m_dxgi_swap_chain.reset();
     m_swap_chain_format.reset();
+
+    m_artwork_decoder.shut_down();
 
     if (m_d3d_device_context) {
         m_d3d_device_context->ClearState();

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -2,6 +2,7 @@
 
 #include "artwork.h"
 #include "config.h"
+#include "d2d_utils.h"
 #include "d3d_utils.h"
 #include "imaging.h"
 
@@ -131,6 +132,9 @@ cfg_uint cfg_edge_style(g_guid_edge_style, 0);
 
 fbh::ConfigInt32 click_action({0x01b0f35f, 0xcdca, 0x49ba, {0xac, 0x39, 0x0a, 0x91, 0x81, 0xa1, 0x6f, 0xc1}},
     WI_EnumValue(ClickAction::show_next_artwork_type));
+
+fbh::ConfigInt32 colour_management_mode({0xb1551e5b, 0x51d7, 0x4702, {0xbe, 0x3f, 0x78, 0x26, 0x13, 0x4d, 0xc3, 0xf2}},
+    WI_EnumValue(ColourManagementMode::Legacy));
 
 // {E32DCBA9-A2BF-4901-AB43-228628071410}
 static const GUID g_guid_colour_client = {0xe32dcba9, 0xa2bf, 0x4901, {0xab, 0x43, 0x22, 0x86, 0x28, 0x7, 0x14, 0x10}};
@@ -355,7 +359,7 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
             const auto d2d_background_colour = [&] {
                 const auto d2d_colour = uih::d2d::colorref_to_d2d_color(background_colour);
-                if (m_dxgi_output_desc) {
+                if (is_advanced_colour_active()) {
                     const auto white_level_adjustment
                         = m_sdr_white_level && is_hdr_display ? *m_sdr_white_level / 1000.f : 1.f;
                     return srgb_to_linear(d2d_colour, white_level_adjustment);
@@ -364,36 +368,24 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 return d2d_colour;
             }();
 
+            auto image_rect = D2D1::RectF();
+
+            if (m_image_effect)
+                THROW_IF_FAILED(context->GetImageLocalBounds(m_image_effect.query<ID2D1Image>().get(), &image_rect));
+
             m_d2d_device_context->BeginDraw();
             m_d2d_device_context->Clear(d2d_background_colour);
 
             const auto& bitmap = m_artwork_decoder.get_image();
 
-            if (bitmap) {
-                auto [bitmap_width, bitmap_height] = bitmap->GetPixelSize();
-                auto [render_target_width, render_target_height] = m_d2d_device_context->GetPixelSize();
+            if (m_image_effect) {
+                auto [render_target_width, render_target_height] = m_d2d_device_context->GetSize();
 
-                float dpi_x{};
-                float dpi_y{};
-                m_d2d_device_context->GetDpi(&dpi_x, &dpi_y);
+                const auto left = (render_target_width - image_rect.right) * .5f;
+                const auto top = (render_target_height - image_rect.bottom) * .5f;
 
-                const auto [scaled_width, scaled_height]
-                    = cui::utils::calculate_scaled_image_size(gsl::narrow<int>(bitmap_width),
-                        gsl::narrow<int>(bitmap_height), gsl::narrow<int>(render_target_width),
-                        gsl::narrow<int>(render_target_height), m_preserve_aspect_ratio, true);
-
-                const auto left = (render_target_width - scaled_width) * .5f * 96.0f / dpi_x;
-                const auto top = (render_target_height - scaled_height) * .5f * 96.0f / dpi_x;
-
-                if (m_image_effect) {
-                    const auto offset = D2D1::Point2F(left, top);
-                    context->DrawImage(
-                        m_image_effect.get(), &offset, nullptr, D2D1_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC);
-                } else {
-                    const auto rect = D2D1::RectF(
-                        left, top, left + scaled_width * 96.0f / dpi_x, top + scaled_height * 96.0f / dpi_y);
-                    context->DrawBitmap(bitmap.get(), &rect, 1.f, D2D1_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC);
-                }
+                const auto offset = D2D1::Point2F(left, top);
+                context->DrawImage(m_image_effect.get(), &offset, nullptr, D2D1_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC);
             }
 
             auto result = m_d2d_device_context->EndDraw();
@@ -484,10 +476,11 @@ void ArtworkPanel::create_d2d_device_resources()
                 = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0};
 
             try {
-                THROW_IF_FAILED(
-                    d3d::create_d3d_device(D3D_DRIVER_TYPE_HARDWARE, feature_levels, &m_d3d_device, nullptr));
+                THROW_IF_FAILED(d3d::create_d3d_device(
+                    D3D_DRIVER_TYPE_HARDWARE, feature_levels, &m_d3d_device, &m_d3d_device_context));
             } catch (const wil::ResultException&) {
-                THROW_IF_FAILED(d3d::create_d3d_device(D3D_DRIVER_TYPE_WARP, feature_levels, &m_d3d_device, nullptr));
+                THROW_IF_FAILED(
+                    d3d::create_d3d_device(D3D_DRIVER_TYPE_WARP, feature_levels, &m_d3d_device, &m_d3d_device_context));
                 console::print(
                     "Artwork view – failed to create a hardware renderer, using a software (WARP) renderer instead");
             }
@@ -517,28 +510,36 @@ void ArtworkPanel::create_d2d_device_resources()
             THROW_IF_FAILED(dxgi_adapter->GetParent(__uuidof(IDXGIFactory2), m_dxgi_factory.put_void()));
 
             const auto dxgi_factory_6 = m_dxgi_factory.try_query<IDXGIFactory6>();
+            const auto use_advanced_colour
+                = colour_management_mode == WI_EnumValue(ColourManagementMode::Advanced) && dxgi_factory_6;
 
             DXGI_SWAP_CHAIN_DESC1 swap_chain_desc{};
             swap_chain_desc.Width = 0;
             swap_chain_desc.Height = 0;
-            swap_chain_desc.Format = dxgi_factory_6 ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_R8G8B8A8_UNORM;
+            swap_chain_desc.Format = use_advanced_colour ? DXGI_FORMAT_R16G16B16A16_FLOAT : DXGI_FORMAT_R8G8B8A8_UNORM;
             swap_chain_desc.Stereo = false;
             swap_chain_desc.SampleDesc.Count = 1;
             swap_chain_desc.SampleDesc.Quality = 0;
             swap_chain_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
             swap_chain_desc.BufferCount = 2;
             swap_chain_desc.Scaling = DXGI_SCALING_STRETCH;
-            swap_chain_desc.SwapEffect
-                = mmh::is_windows_10_or_newer() ? DXGI_SWAP_EFFECT_FLIP_DISCARD : DXGI_SWAP_EFFECT_DISCARD;
+            // Once a window has had a flip-model swap chain, replacing it with a non-flip model
+            // swap chain doesn't work at all (it just displays the old contents)
+            swap_chain_desc.SwapEffect = use_advanced_colour || m_using_flip_model_swap_chain
+                ? DXGI_SWAP_EFFECT_FLIP_DISCARD
+                : DXGI_SWAP_EFFECT_DISCARD;
             swap_chain_desc.Flags = 0;
             swap_chain_desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 
             THROW_IF_FAILED(m_dxgi_factory->CreateSwapChainForHwnd(
                 m_d3d_device.get(), get_wnd(), &swap_chain_desc, nullptr, nullptr, &m_dxgi_swap_chain));
 
+            if (use_advanced_colour)
+                m_using_flip_model_swap_chain = true;
+
             m_swap_chain_format = swap_chain_desc.Format;
 
-            if (dxgi_factory_6) {
+            if (use_advanced_colour) {
                 const auto swap_chain_3 = m_dxgi_swap_chain.query<IDXGISwapChain3>();
                 THROW_IF_FAILED(swap_chain_3->SetColorSpace1(DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709));
             }
@@ -584,16 +585,27 @@ void ArtworkPanel::create_d2d_device_resources()
     }
 }
 
-void ArtworkPanel::reset_d2d_device_resources()
+void ArtworkPanel::reset_d2d_device_resources(bool keep_devices)
 {
     m_artwork_decoder.reset();
-    m_sdr_white_level.reset();
     m_image_effect.reset();
-    m_dxgi_output_desc.reset();
     m_d2d_device_context.reset();
-    m_d2d_device.reset();
-    m_d3d_device.reset();
+    m_sdr_white_level.reset();
+    m_dxgi_output_desc.reset();
     m_dxgi_swap_chain.reset();
+    m_swap_chain_format.reset();
+
+    if (m_d3d_device_context) {
+        m_d3d_device_context->ClearState();
+        m_d3d_device_context->Flush();
+    }
+
+    m_d3d_device_context.reset();
+
+    if (!keep_devices) {
+        m_d2d_device.reset();
+        m_d3d_device.reset();
+    }
 }
 
 void ArtworkPanel::create_image_colour_processing_effect()
@@ -609,56 +621,14 @@ void ArtworkPanel::create_image_colour_processing_effect()
     }
 
     const auto& bitmap = m_artwork_decoder.get_image();
-    const auto& colour_context = m_artwork_decoder.get_colour_context();
+    const auto& image_colour_context = m_artwork_decoder.get_image_colour_context();
 
-    if (!m_d2d_device_context || !bitmap || !colour_context || !m_dxgi_output_desc)
+    if (!m_d2d_device_context || !bitmap)
         return;
 
-    const auto is_hdr_display = m_dxgi_output_desc->ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
-    const auto device_context_5 = m_d2d_device_context.query<ID2D1DeviceContext5>();
-
-    wil::com_ptr<ID2D1Effect> colour_management_effect;
-    THROW_IF_FAILED(m_d2d_device_context->CreateEffect(CLSID_D2D1ColorManagement, &colour_management_effect));
-
-    THROW_IF_FAILED(
-        colour_management_effect->SetValue(D2D1_COLORMANAGEMENT_PROP_QUALITY, D2D1_COLORMANAGEMENT_QUALITY_BEST));
-    THROW_IF_FAILED(
-        colour_management_effect->SetValue(D2D1_COLORMANAGEMENT_PROP_SOURCE_COLOR_CONTEXT, colour_context.get()));
-
-    wil::com_ptr<ID2D1ColorContext1> dest_colour_context;
-    THROW_IF_FAILED(device_context_5->CreateColorContextFromDxgiColorSpace(
-        DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709, &dest_colour_context));
-    THROW_IF_FAILED(colour_management_effect->SetValue(
-        D2D1_COLORMANAGEMENT_PROP_DESTINATION_COLOR_CONTEXT, dest_colour_context.get()));
-
-    wil::com_ptr<ID2D1Effect> white_level_adjustment_effect;
-    THROW_IF_FAILED(m_d2d_device_context->CreateEffect(CLSID_D2D1WhiteLevelAdjustment, &white_level_adjustment_effect));
-
-    const auto is_hdr_image = m_artwork_decoder.is_float();
-
-    std::optional<float> input_level{};
-    std::optional<float> output_level{};
-
-    if (m_sdr_white_level && is_hdr_display && !is_hdr_image) {
-        input_level = gsl::narrow_cast<float>(*m_sdr_white_level) / 1000.f * D2D1_SCENE_REFERRED_SDR_WHITE_LEVEL;
-        output_level = D2D1_SCENE_REFERRED_SDR_WHITE_LEVEL;
-    } else if (is_hdr_image && !is_hdr_display) {
-        input_level = D2D1_SCENE_REFERRED_SDR_WHITE_LEVEL;
-        output_level = m_dxgi_output_desc->MaxLuminance;
-    }
-
-    if (input_level)
-        THROW_IF_FAILED(
-            white_level_adjustment_effect->SetValue(D2D1_WHITELEVELADJUSTMENT_PROP_INPUT_WHITE_LEVEL, *input_level));
-
-    if (output_level)
-        THROW_IF_FAILED(
-            white_level_adjustment_effect->SetValue(D2D1_WHITELEVELADJUSTMENT_PROP_OUTPUT_WHITE_LEVEL, *output_level));
-
-    colour_management_effect->SetInput(0, bitmap.get());
-
-    wil::com_ptr<ID2D1Effect> scale_effect;
-    THROW_IF_FAILED(m_d2d_device_context->CreateEffect(CLSID_D2D1Scale, scale_effect.put()));
+    const auto is_hdr_display
+        = m_dxgi_output_desc && m_dxgi_output_desc->ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
+    const auto is_advanced_colour = is_advanced_colour_active();
 
     auto [bitmap_width, bitmap_height] = bitmap->GetPixelSize();
     auto [render_target_width, render_target_height] = m_d2d_device_context->GetPixelSize();
@@ -671,17 +641,76 @@ void ArtworkPanel::create_image_colour_processing_effect()
         gsl::narrow<int>(bitmap_height), gsl::narrow<int>(render_target_width), gsl::narrow<int>(render_target_height),
         m_preserve_aspect_ratio, true);
 
+    wil::com_ptr<ID2D1Effect> scale_effect;
+    THROW_IF_FAILED(m_d2d_device_context->CreateEffect(CLSID_D2D1Scale, scale_effect.put()));
+
     THROW_IF_FAILED(
         scale_effect->SetValue(D2D1_SCALE_PROP_INTERPOLATION_MODE, D2D1_SCALE_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC));
     THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD));
+
     THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_SCALE,
         D2D1::Vector2F(scaled_width / gsl::narrow_cast<float>(bitmap_width),
             scaled_height / gsl::narrow_cast<float>(bitmap_height))));
-    scale_effect->SetInputEffect(0, colour_management_effect.get());
 
-    white_level_adjustment_effect->SetInputEffect(0, scale_effect.get());
+    scale_effect->SetInput(0, bitmap.get());
 
-    m_image_effect = white_level_adjustment_effect;
+    wil::com_ptr<ID2D1Effect> white_level_adjustment_effect;
+    wil::com_ptr<ID2D1ColorContext> working_colour_context;
+
+    if (is_advanced_colour) {
+        THROW_IF_FAILED(
+            m_d2d_device_context->CreateColorContext(D2D1_COLOR_SPACE_SCRGB, nullptr, 0, &working_colour_context));
+
+        const auto working_colour_management_effect
+            = d2d::create_colour_management_effect(m_d2d_device_context, image_colour_context, working_colour_context);
+        working_colour_management_effect->SetInputEffect(0, scale_effect.get());
+
+        THROW_IF_FAILED(
+            m_d2d_device_context->CreateEffect(CLSID_D2D1WhiteLevelAdjustment, &white_level_adjustment_effect));
+
+        const auto is_hdr_image = m_artwork_decoder.is_float();
+
+        std::optional<float> input_level{};
+        std::optional<float> output_level{};
+
+        if (m_sdr_white_level && is_hdr_display && !is_hdr_image) {
+            input_level = gsl::narrow_cast<float>(*m_sdr_white_level) / 1000.f * D2D1_SCENE_REFERRED_SDR_WHITE_LEVEL;
+            output_level = D2D1_SCENE_REFERRED_SDR_WHITE_LEVEL;
+        } else if (is_hdr_image && !is_hdr_display) {
+            input_level = D2D1_SCENE_REFERRED_SDR_WHITE_LEVEL;
+            output_level = m_dxgi_output_desc ? m_dxgi_output_desc->MaxLuminance : D2D1_SCENE_REFERRED_SDR_WHITE_LEVEL;
+        }
+
+        if (input_level)
+            THROW_IF_FAILED(white_level_adjustment_effect->SetValue(
+                D2D1_WHITELEVELADJUSTMENT_PROP_INPUT_WHITE_LEVEL, *input_level));
+
+        if (output_level)
+            THROW_IF_FAILED(white_level_adjustment_effect->SetValue(
+                D2D1_WHITELEVELADJUSTMENT_PROP_OUTPUT_WHITE_LEVEL, *output_level));
+
+        white_level_adjustment_effect->SetInputEffect(0, working_colour_management_effect.get());
+    }
+
+    wil::com_ptr<ID2D1ColorContext> dest_colour_context;
+
+    if (is_advanced_colour) {
+        const auto device_context_5 = m_d2d_device_context.query<ID2D1DeviceContext5>();
+        wil::com_ptr<ID2D1ColorContext1> dest_colour_context_1;
+        THROW_IF_FAILED(device_context_5->CreateColorContextFromDxgiColorSpace(
+            DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709, &dest_colour_context_1));
+        dest_colour_context = dest_colour_context_1;
+    } else {
+        dest_colour_context = m_artwork_decoder.get_display_colour_context();
+    }
+
+    const auto colour_management_effect = d2d::create_colour_management_effect(m_d2d_device_context,
+        working_colour_context ? working_colour_context : image_colour_context, dest_colour_context);
+
+    colour_management_effect->SetInputEffect(
+        0, white_level_adjustment_effect ? white_level_adjustment_effect.get() : scale_effect.get());
+
+    m_image_effect = colour_management_effect;
 }
 
 bool g_check_process_on_selection_changed()
@@ -929,8 +958,7 @@ void ArtworkPanel::show_stub_image()
     }
     CATCH_LOG()
 
-    if (m_d2d_device_context)
-        m_artwork_decoder.decode(m_d2d_device_context, data, [this, self{ptr{this}}] { invalidate_window(); });
+    queue_decode(data);
 }
 
 void ArtworkPanel::refresh_image()
@@ -954,8 +982,7 @@ void ArtworkPanel::refresh_image()
 
     m_image_effect.reset();
 
-    if (m_d2d_device_context)
-        m_artwork_decoder.decode(m_d2d_device_context, data, [this, self{ptr{this}}] { invalidate_window(); });
+    queue_decode(data);
 }
 
 void ArtworkPanel::clear_image()
@@ -969,6 +996,17 @@ void ArtworkPanel::clear_image()
     invalidate_window();
 }
 
+void ArtworkPanel::queue_decode(const album_art_data::ptr& data)
+{
+    if (!m_d2d_device_context)
+        return;
+
+    const auto monitor = is_advanced_colour_active() ? nullptr : MonitorFromWindow(get_wnd(), MONITOR_DEFAULTTONEAREST);
+
+    m_artwork_decoder.decode(m_d2d_device_context, is_advanced_colour_active(), monitor, data,
+        [this, self{ptr{this}}] { invalidate_window(); });
+}
+
 void ArtworkPanel::invalidate_window() const
 {
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE);
@@ -977,6 +1015,11 @@ void ArtworkPanel::invalidate_window() const
 size_t ArtworkPanel::get_displayed_artwork_type_index() const
 {
     return m_artwork_type_override_index.value_or(m_selected_artwork_type_index);
+}
+
+bool ArtworkPanel::is_advanced_colour_active() const
+{
+    return m_swap_chain_format && *m_swap_chain_format == DXGI_FORMAT_R16G16B16A16_FLOAT;
 }
 
 void ArtworkPanel::g_on_colours_change()
@@ -996,6 +1039,17 @@ void ArtworkPanel::s_on_dark_mode_status_change()
             continue;
 
         window->invalidate_window();
+    }
+}
+
+void ArtworkPanel::s_on_use_advanced_colour_change()
+{
+    for (auto&& window : g_windows) {
+        if (!window->get_wnd())
+            continue;
+
+        window->reset_d2d_device_resources(true);
+        window->refresh_image();
     }
 }
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -11,7 +11,13 @@ enum class ClickAction : int32_t {
     show_next_artwork_type,
 };
 
+enum class ColourManagementMode : int32_t {
+    Legacy,
+    Advanced,
+};
+
 extern fbh::ConfigInt32 click_action;
+extern fbh::ConfigInt32 colour_management_mode;
 
 class ArtworkPanel
     : public uie::container_uie_window_v3
@@ -75,6 +81,7 @@ public:
 
     static void g_on_colours_change();
     static void s_on_dark_mode_status_change();
+    static void s_on_use_advanced_colour_change();
 
     void force_reload_artwork();
     bool is_core_image_viewer_available() const;
@@ -169,18 +176,21 @@ private:
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
     void update_dxgi_output_desc();
     void create_d2d_device_resources();
-    void reset_d2d_device_resources();
+    void reset_d2d_device_resources(bool keep_devices = false);
     void create_image_colour_processing_effect();
     void refresh_image();
     void clear_image();
+    void queue_decode(const album_art_data::ptr& data);
     void show_stub_image();
     void invalidate_window() const;
     size_t get_displayed_artwork_type_index() const;
+    bool is_advanced_colour_active() const;
 
     wil::com_ptr<ID2D1Factory1> m_d2d_factory;
     wil::com_ptr<ID2D1Device> m_d2d_device;
     wil::com_ptr<ID2D1DeviceContext> m_d2d_device_context;
     wil::com_ptr<ID3D11Device> m_d3d_device;
+    wil::com_ptr<ID3D11DeviceContext> m_d3d_device_context;
     wil::com_ptr<IDXGIFactory2> m_dxgi_factory;
     wil::com_ptr<IDXGISwapChain1> m_dxgi_swap_chain;
     std::optional<DXGI_FORMAT> m_swap_chain_format;
@@ -197,6 +207,7 @@ private:
     bool m_preserve_aspect_ratio{true};
     bool m_artwork_type_locked{false};
     bool m_dynamic_artwork_pending{};
+    bool m_using_flip_model_swap_chain{};
     metadb_handle_list m_selection_handles;
 
     static std::vector<ArtworkPanel*> g_windows;

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -180,6 +180,8 @@ private:
     void create_image_colour_processing_effect();
     void refresh_image();
     void clear_image();
+    void reset_effects();
+    void set_scale_effect_scale(const wil::com_ptr<ID2D1Effect>& scale_effect) const;
     void queue_decode(const album_art_data::ptr& data);
     void show_stub_image();
     void invalidate_window() const;
@@ -196,7 +198,8 @@ private:
     std::optional<DXGI_FORMAT> m_swap_chain_format;
     std::optional<unsigned> m_sdr_white_level;
     std::optional<DXGI_OUTPUT_DESC1> m_dxgi_output_desc;
-    wil::com_ptr<ID2D1Effect> m_image_effect;
+    wil::com_ptr<ID2D1Effect> m_scale_effect;
+    wil::com_ptr<ID2D1Effect> m_output_effect;
 
     std::unique_ptr<EventToken> m_display_change_token;
     std::shared_ptr<ArtworkReaderManager> m_artwork_reader;

--- a/foo_ui_columns/artwork_decoder.cpp
+++ b/foo_ui_columns/artwork_decoder.cpp
@@ -2,15 +2,18 @@
 
 #include "artwork_decoder.h"
 
+#include "wcs.h"
+#include "win32.h"
+
 namespace cui::artwork_panel {
 
 namespace {
 
-auto get_bitmap_source_pixel_format_info(const wil::com_ptr<IWICImagingFactory>& imaging_factory,
-    const wil::com_ptr<IWICBitmapFrameDecode>& bitmap_frame_decode)
+auto get_bitmap_source_pixel_format_info(
+    const wil::com_ptr<IWICImagingFactory>& imaging_factory, const wil::com_ptr<IWICBitmapSource>& bitmap_source)
 {
     WICPixelFormatGUID source_pixel_format{};
-    THROW_IF_FAILED(bitmap_frame_decode->GetPixelFormat(&source_pixel_format));
+    THROW_IF_FAILED(bitmap_source->GetPixelFormat(&source_pixel_format));
 
     wil::com_ptr<IWICComponentInfo> wic_component_info;
     THROW_IF_FAILED(imaging_factory->CreateComponentInfo(source_pixel_format, &wic_component_info));
@@ -20,19 +23,21 @@ auto get_bitmap_source_pixel_format_info(const wil::com_ptr<IWICImagingFactory>&
 
 } // namespace
 
-void ArtworkDecoder::decode(
-    wil::com_ptr<ID2D1DeviceContext> d2d_render_target, album_art_data_ptr data, std::function<void()> on_complete)
+void ArtworkDecoder::decode(wil::com_ptr<ID2D1DeviceContext> d2d_render_target, bool use_advanced_colour,
+    HMONITOR monitor, album_art_data_ptr data, std::function<void()> on_complete)
 {
     reset();
     m_current_task = std::make_shared<ArtworkDecoderTask>(std::move(on_complete));
 
     m_current_task->future = std::async(std::launch::async,
-        [this, data, d2d_render_target{std::move(d2d_render_target)},
-            stop_token{m_current_task->stop_source.get_token()}, task{std::weak_ptr{m_current_task}}]() noexcept {
+        [this, data, d2d_render_target{std::move(d2d_render_target)}, monitor,
+            stop_token{m_current_task->stop_source.get_token()}, task{std::weak_ptr{m_current_task}},
+            use_advanced_colour]() noexcept {
             TRACK_CALL_TEXT("cui::artwork_panel::ArtworkDecoder::async_task");
 
             wil::com_ptr<ID2D1Bitmap> d2d_bitmap;
-            wil::com_ptr<ID2D1ColorContext> d2d_colour_context;
+            wil::com_ptr<ID2D1ColorContext> d2d_image_colour_context;
+            wil::com_ptr<ID2D1ColorContext> d2d_display_colour_context;
             bool is_float{};
 
             try {
@@ -49,8 +54,6 @@ void ArtworkDecoder::decode(
                 wil::com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
                 THROW_IF_FAILED(decoder->GetFrame(0, &bitmap_frame_decode));
 
-                const auto wic_colour_context
-                    = wic::get_bitmap_source_colour_context(imaging_factory, bitmap_frame_decode);
                 const auto pixel_format_info
                     = get_bitmap_source_pixel_format_info(imaging_factory, bitmap_frame_decode);
 
@@ -60,11 +63,13 @@ void ArtworkDecoder::decode(
                 unsigned bpp{};
                 THROW_IF_FAILED(pixel_format_info->GetBitsPerPixel(&bpp));
 
+                const auto wic_colour_context
+                    = wic::get_bitmap_source_colour_context(imaging_factory, bitmap_frame_decode);
                 is_float = pixel_format_numeric_representation == WICPixelFormatNumericRepresentationFloat;
 
                 const auto target_pixel_format = [&] {
                     if (is_float)
-                        return GUID_WICPixelFormat64bppPRGBAHalf;
+                        return use_advanced_colour ? GUID_WICPixelFormat64bppPRGBAHalf : GUID_WICPixelFormat32bppPRGBA;
 
                     if (bpp > 32)
                         return GUID_WICPixelFormat64bppPRGBA;
@@ -110,10 +115,11 @@ void ArtworkDecoder::decode(
                 // Not implemented on Wine
                 if (wic_colour_context) {
                     LOG_IF_FAILED(d2d_render_target->CreateColorContextFromWicColorContext(
-                        wic_colour_context.get(), &d2d_colour_context));
+                        wic_colour_context.get(), &d2d_image_colour_context));
                 } else {
                     LOG_IF_FAILED(d2d_render_target->CreateColorContext(
-                        is_float ? D2D1_COLOR_SPACE_SCRGB : D2D1_COLOR_SPACE_SRGB, nullptr, 0, &d2d_colour_context));
+                        is_float && use_advanced_colour ? D2D1_COLOR_SPACE_SCRGB : D2D1_COLOR_SPACE_SRGB, nullptr, 0,
+                        &d2d_image_colour_context));
                 }
 
                 hr = d2d_render_target->CreateBitmapFromWicBitmap(wic_bitmap.get(), nullptr, &d2d_bitmap);
@@ -138,30 +144,50 @@ void ArtworkDecoder::decode(
 
                 if (stop_token.stop_requested())
                     return;
+
+                if (monitor) {
+                    const auto display_device_key = win32::get_display_device_key(monitor);
+                    const auto display_profile_name = wcs::get_display_colour_profile_name(display_device_key.c_str());
+                    const auto profile = wcs::get_display_colour_profile(display_profile_name);
+
+                    if (!profile.empty())
+                        LOG_IF_FAILED(d2d_render_target->CreateColorContext(D2D1_COLOR_SPACE_CUSTOM, profile.data(),
+                            gsl::narrow<uint32_t>(profile.size()), &d2d_display_colour_context));
+
+                    if (!d2d_display_colour_context) {
+                        LOG_IF_FAILED(d2d_render_target->CreateColorContext(
+                            D2D1_COLOR_SPACE_SRGB, nullptr, 0, &d2d_display_colour_context));
+                    }
+                }
+
+                if (stop_token.stop_requested())
+                    return;
             } catch (const std::exception& ex) {
                 console::print("Artwork panel – loading image failed: ", ex.what());
             }
 
-            fb2k::inMainThread(
-                [this, d2d_bitmap{std::move(d2d_bitmap)}, d2d_colour_context{std::move(d2d_colour_context)}, is_float,
-                    stop_token{std::move(stop_token)}, task{std::move(task)}]() {
-                    const auto locked_task = task.lock();
+            fb2k::inMainThread([this, d2d_bitmap{std::move(d2d_bitmap)},
+                                   d2d_display_colour_context{std::move(d2d_display_colour_context)},
+                                   d2d_image_colour_context{std::move(d2d_image_colour_context)}, is_float,
+                                   stop_token{std::move(stop_token)}, task{std::move(task)}]() {
+                const auto locked_task = task.lock();
 
-                    if (stop_token.stop_requested()) {
-                        if (locked_task)
-                            std::erase(m_aborting_tasks, locked_task);
-                        return;
-                    }
-
-                    assert(m_current_task == locked_task);
-                    m_current_task.reset();
-                    m_decoded_image = std::move(d2d_bitmap);
-                    m_colour_context = std::move(d2d_colour_context);
-                    m_is_float = is_float;
-
+                if (stop_token.stop_requested()) {
                     if (locked_task)
-                        locked_task->on_complete();
-                });
+                        std::erase(m_aborting_tasks, locked_task);
+                    return;
+                }
+
+                assert(m_current_task == locked_task);
+                m_current_task.reset();
+                m_decoded_image = std::move(d2d_bitmap);
+                m_display_colour_context = std::move(d2d_display_colour_context);
+                m_image_colour_context = std::move(d2d_image_colour_context);
+                m_is_float = is_float;
+
+                if (locked_task)
+                    locked_task->on_complete();
+            });
         });
 }
 

--- a/foo_ui_columns/artwork_decoder.h
+++ b/foo_ui_columns/artwork_decoder.h
@@ -15,8 +15,8 @@ class ArtworkDecoder {
 public:
     ~ArtworkDecoder() { abort(); }
 
-    void decode(
-        wil::com_ptr<ID2D1DeviceContext> d2d_render_target, album_art_data_ptr data, std::function<void()> on_complete);
+    void decode(wil::com_ptr<ID2D1DeviceContext> d2d_render_target, bool use_advanced_colour, HMONITOR monitor,
+        album_art_data_ptr data, std::function<void()> on_complete);
 
     void abort()
     {
@@ -30,7 +30,8 @@ public:
     {
         abort();
         m_decoded_image.reset();
-        m_colour_context.reset();
+        m_display_colour_context.reset();
+        m_image_colour_context.reset();
         m_is_float.reset();
     }
 
@@ -43,13 +44,15 @@ public:
     bool has_image() const { return static_cast<bool>(m_decoded_image); }
 
     wil::com_ptr<ID2D1Bitmap> get_image() { return m_decoded_image; }
-    wil::com_ptr<ID2D1ColorContext> get_colour_context() { return m_colour_context; }
+    wil::com_ptr<ID2D1ColorContext> get_image_colour_context() { return m_image_colour_context; }
+    wil::com_ptr<ID2D1ColorContext> get_display_colour_context() { return m_display_colour_context; }
     bool is_float() const { return m_is_float.value_or(false); }
 
     ArtworkDecoderTask::Ptr m_current_task;
     std::vector<ArtworkDecoderTask::Ptr> m_aborting_tasks;
     wil::com_ptr<ID2D1Bitmap> m_decoded_image;
-    wil::com_ptr<ID2D1ColorContext> m_colour_context;
+    wil::com_ptr<ID2D1ColorContext> m_display_colour_context;
+    wil::com_ptr<ID2D1ColorContext> m_image_colour_context;
     std::optional<bool> m_is_float{};
 };
 

--- a/foo_ui_columns/artwork_decoder.h
+++ b/foo_ui_columns/artwork_decoder.h
@@ -13,7 +13,7 @@ public:
 
 class ArtworkDecoder {
 public:
-    ~ArtworkDecoder() { abort(); }
+    ~ArtworkDecoder() { shut_down(); }
 
     void decode(wil::com_ptr<ID2D1DeviceContext> d2d_render_target, bool use_advanced_colour, HMONITOR monitor,
         album_art_data_ptr data, std::function<void()> on_complete);

--- a/foo_ui_columns/d2d_utils.cpp
+++ b/foo_ui_columns/d2d_utils.cpp
@@ -1,0 +1,30 @@
+#include "pch.h"
+
+namespace cui::d2d {
+
+wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
+    const wil::com_ptr<ID2D1ColorContext>& source_color_context,
+    const wil::com_ptr<ID2D1ColorContext>& dest_color_context)
+{
+    wil::com_ptr<ID2D1Effect> colour_management_effect;
+    THROW_IF_FAILED(device_context->CreateEffect(CLSID_D2D1ColorManagement, &colour_management_effect));
+
+    if (device_context->IsBufferPrecisionSupported(D2D1_BUFFER_PRECISION_32BPC_FLOAT)) {
+        THROW_IF_FAILED(
+            colour_management_effect->SetValue(D2D1_COLORMANAGEMENT_PROP_QUALITY, D2D1_COLORMANAGEMENT_QUALITY_BEST));
+    }
+
+    if (source_color_context) {
+        THROW_IF_FAILED(colour_management_effect->SetValue(
+            D2D1_COLORMANAGEMENT_PROP_SOURCE_COLOR_CONTEXT, source_color_context.get()));
+    }
+
+    if (dest_color_context) {
+        THROW_IF_FAILED(colour_management_effect->SetValue(
+            D2D1_COLORMANAGEMENT_PROP_DESTINATION_COLOR_CONTEXT, dest_color_context.get()));
+    }
+
+    return colour_management_effect;
+}
+
+} // namespace cui::d2d

--- a/foo_ui_columns/d2d_utils.h
+++ b/foo_ui_columns/d2d_utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace cui::d2d {
+
+wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
+    const wil::com_ptr<ID2D1ColorContext>& source_color_context,
+    const wil::com_ptr<ID2D1ColorContext>& dest_color_context);
+
+} // namespace cui::d2d

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -505,16 +505,18 @@ EXSTYLE WS_EX_CONTROLPARENT
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     LTEXT           "Artwork view panel",IDC_TITLE2,7,4,252,16
-    LTEXT           "Action to perform on click",IDC_STATIC,7,28,87,8
-    COMBOBOX        IDC_CLICK_ACTION,7,39,140,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Panel edge style",IDC_STATIC,7,63,55,8
-    COMBOBOX        IDC_EDGESTYLE,7,74,40,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Artwork sources",IDC_TITLE1,7,115,252,16
-    LTEXT           "Artwork sources are now configured on the Display preferences page. Columns UI no longer has separate artwork source settings.",IDC_STATIC,7,140,312,23
-    PUSHBUTTON      "Go to Display preferences",IDC_OPEN_DISPLAY_PREFERENCES,7,171,148,14
-    LTEXT           "You previously had artwork sources configured in Columns UI. If artwork is no longer displaying correctly, manually copy your previous configuration to Display preferences.",IDC_VIEW_OLD_ARTWORK_SOURCES_TEXT,7,167,312,22
-    PUSHBUTTON      "View previously configured artwork sources",IDC_VIEW_OLD_ARTWORK_SOURCES,7,196,178,14
-    PUSHBUTTON      "Go to Display preferences",IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES,7,219,179,14
+    LTEXT           "Action to perform on click",IDC_STATIC,7,53,87,8
+    COMBOBOX        IDC_CLICK_ACTION,7,64,140,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Panel edge style",IDC_STATIC,7,88,55,8
+    COMBOBOX        IDC_EDGESTYLE,7,99,40,65,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Artwork sources",IDC_TITLE1,7,135,252,16
+    LTEXT           "Artwork sources are now configured on the Display preferences page. Columns UI no longer has separate artwork source settings.",IDC_STATIC,7,160,312,23
+    PUSHBUTTON      "Go to Display preferences",IDC_OPEN_DISPLAY_PREFERENCES,7,191,148,14
+    LTEXT           "You previously had artwork sources configured in Columns UI. If artwork is no longer displaying correctly, manually copy your previous configuration to Display preferences.",IDC_VIEW_OLD_ARTWORK_SOURCES_TEXT,7,187,312,22
+    PUSHBUTTON      "View previously configured artwork sources",IDC_VIEW_OLD_ARTWORK_SOURCES,7,216,178,14
+    PUSHBUTTON      "Go to Display preferences",IDC_PREVIOUS_OPEN_DISPLAY_PREFERENCES,7,239,179,14
+    CONTROL         "Use Advanced Colour (recommended only if HDR is enabled in Windows)",IDC_USE_ADVANCED_COLOUR,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,30,312,10
 END
 
 IDD_ITEM_PROPS_OPTIONS DIALOGEX 0, 0, 268, 385

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -264,6 +264,7 @@
     <ClCompile Include="columns_v2.cpp" />
     <ClCompile Include="colour_manager.cpp" />
     <ClCompile Include="core_dark_list_view.cpp" />
+    <ClCompile Include="d2d_utils.cpp" />
     <ClCompile Include="d3d_utils.cpp" />
     <ClCompile Include="dark_mode_active_ui.cpp" />
     <ClCompile Include="dark_mode_dialog.cpp" />
@@ -447,6 +448,7 @@
     <ClInclude Include="config_items.h" />
     <ClInclude Include="core_dark_list_view.h" />
     <ClInclude Include="core_drop_down_list_toolbar.h" />
+    <ClInclude Include="d2d_utils.h" />
     <ClInclude Include="d3d_utils.h" />
     <ClInclude Include="dark_mode_dialog.h" />
     <ClInclude Include="dark_mode_active_ui.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -644,6 +644,9 @@
     <ClCompile Include="wcs.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="d2d_utils.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -955,6 +958,9 @@
       <Filter>Utilities</Filter>
     </ClInclude>
     <ClInclude Include="wcs.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="d2d_utils.h">
       <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -306,6 +306,7 @@
 #define IDC_AXIS_RANGE                  1202
 #define IDC_SET_FORMAT_SNIPPET          1203
 #define IDC_TEXT_RENDERING_NOTES        1204
+#define IDC_USE_ADVANCED_COLOUR         1205
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -315,7 +316,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        198
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1205
+#define _APS_NEXT_CONTROL_VALUE         1206
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
#1216

This adds support for basic (legacy) colour management to the artwork view.

This is now the default, as it works on all supported versions of Windows, and Advanced Colour requires the flip model for the DXGI swap chain which causes artefacts when resizing the artwork view.

Advanced Colour can be enabled in Preferences on Windows 10 1809 and newer. Note that, when enabled, colours can render differently for SDR displays. It probably shouldn't be used unless HDR is enabled in Windows. Legacy colour management renders colours identically to Chrome, Edge and Firefox (with [full colour management enabled in Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/3.5/ICC_color_correction_in_Firefox#configuring_color_correction)) for the SDR images I checked.