### PR TITLE
Tweak Direct2D image handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   with web browsers. [[#1275](https://github.com/reupen/columns_ui/pull/1275),
   [#1284](https://github.com/reupen/columns_ui/pull/1284),
   [#1289](https://github.com/reupen/columns_ui/pull/1289),
-  [#1290](https://github.com/reupen/columns_ui/pull/1290)]
+  [#1290](https://github.com/reupen/columns_ui/pull/1290),
+  [#1292](https://github.com/reupen/columns_ui/pull/1292)]
 
   Additionally, support for Windows Advanced Colour can be enabled in
   Preferences on Windows 10 version 1809 and newer. This improves support for
@@ -23,7 +24,8 @@
 
 - Direct2D is now used to scale artwork and create artwork reflections in the
   playlist view. [[#1281](https://github.com/reupen/columns_ui/pull/1281),
-  [#1289](https://github.com/reupen/columns_ui/pull/1289)]
+  [#1289](https://github.com/reupen/columns_ui/pull/1289),
+  [#1292](https://github.com/reupen/columns_ui/pull/1292)]
 
 ### Bug fixes
 

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -553,10 +553,9 @@ void ArtworkPanel::create_d2d_device_resources()
             m_d2d_device_context->GetTarget(&target);
 
             if (!target) {
-                const auto dpi = gsl::narrow_cast<float>(uih::get_system_dpi_cached().cx);
                 D2D1_BITMAP_PROPERTIES1 bitmap_properties
                     = D2D1::BitmapProperties1(D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
-                        D2D1::PixelFormat(*m_swap_chain_format, D2D1_ALPHA_MODE_IGNORE), dpi, dpi);
+                        D2D1::PixelFormat(*m_swap_chain_format, D2D1_ALPHA_MODE_IGNORE));
 
                 wil::com_ptr<IDXGISurface> dxgi_back_buffer;
                 THROW_IF_FAILED(m_dxgi_swap_chain->GetBuffer(0, __uuidof(IDXGISurface), dxgi_back_buffer.put_void()));
@@ -977,10 +976,6 @@ D2D1_VECTOR_2F ArtworkPanel::calculate_scaling_factor(const wil::com_ptr<ID2D1Im
 
     auto [bitmap_width, bitmap_height] = bitmap->GetPixelSize();
     auto [render_target_width, render_target_height] = m_d2d_device_context->GetPixelSize();
-
-    float dpi_x{};
-    float dpi_y{};
-    m_d2d_device_context->GetDpi(&dpi_x, &dpi_y);
 
     const auto [scaled_width, scaled_height] = cui::utils::calculate_scaled_image_size(gsl::narrow<int>(bitmap_width),
         gsl::narrow<int>(bitmap_height), gsl::narrow<int>(render_target_width), gsl::narrow<int>(render_target_height),

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -487,16 +487,8 @@ void ArtworkPanel::create_d2d_device_resources()
             }
         }
 
-        if (!m_d2d_factory) {
-            D2D1_FACTORY_OPTIONS options{};
-
-#ifdef _DEBUG
-            options.debugLevel = IsDebuggerPresent() ? D2D1_DEBUG_LEVEL_INFORMATION : D2D1_DEBUG_LEVEL_NONE;
-#endif
-
-            THROW_IF_FAILED(D2D1CreateFactory(
-                D2D1_FACTORY_TYPE_MULTI_THREADED, __uuidof(ID2D1Factory1), &options, m_d2d_factory.put_void()));
-        }
+        if (!m_d2d_factory)
+            m_d2d_factory = d2d::create_factory(D2D1_FACTORY_TYPE_MULTI_THREADED);
 
         const auto dxgi_device = m_d3d_device.query<IDXGIDevice1>();
 

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -649,9 +649,6 @@ void ArtworkPanel::create_image_colour_processing_effect()
             = d2d::create_colour_management_effect(m_d2d_device_context, image_colour_context, working_colour_context);
         working_colour_management_effect->SetInputEffect(0, scale_effect.get());
 
-        THROW_IF_FAILED(
-            m_d2d_device_context->CreateEffect(CLSID_D2D1WhiteLevelAdjustment, &white_level_adjustment_effect));
-
         const auto is_hdr_image = m_artwork_decoder.is_float();
 
         std::optional<float> input_level{};
@@ -665,14 +662,8 @@ void ArtworkPanel::create_image_colour_processing_effect()
             output_level = m_dxgi_output_desc ? m_dxgi_output_desc->MaxLuminance : D2D1_SCENE_REFERRED_SDR_WHITE_LEVEL;
         }
 
-        if (input_level)
-            THROW_IF_FAILED(white_level_adjustment_effect->SetValue(
-                D2D1_WHITELEVELADJUSTMENT_PROP_INPUT_WHITE_LEVEL, *input_level));
-
-        if (output_level)
-            THROW_IF_FAILED(white_level_adjustment_effect->SetValue(
-                D2D1_WHITELEVELADJUSTMENT_PROP_OUTPUT_WHITE_LEVEL, *output_level));
-
+        white_level_adjustment_effect
+            = d2d::create_white_level_adjustment_effect(m_d2d_device_context, input_level, output_level);
         white_level_adjustment_effect->SetInputEffect(0, working_colour_management_effect.get());
     }
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -181,7 +181,8 @@ private:
     void refresh_image();
     void clear_image();
     void reset_effects();
-    void set_scale_effect_scale(const wil::com_ptr<ID2D1Effect>& scale_effect) const;
+    D2D1_VECTOR_2F calculate_scaling_factor(const wil::com_ptr<ID2D1Image>& image) const;
+    void update_scale_effect() const;
     void queue_decode(const album_art_data::ptr& data);
     void show_stub_image();
     void invalidate_window() const;

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -177,7 +177,7 @@ private:
     void update_dxgi_output_desc();
     void create_d2d_device_resources();
     void reset_d2d_device_resources(bool keep_devices = false);
-    void create_image_colour_processing_effect();
+    void create_effects();
     void refresh_image();
     void clear_image();
     void reset_effects();

--- a/foo_ui_columns/d2d_utils.cpp
+++ b/foo_ui_columns/d2d_utils.cpp
@@ -2,6 +2,20 @@
 
 namespace cui::d2d {
 
+wil::com_ptr<ID2D1Factory1> create_factory(D2D1_FACTORY_TYPE factory_type)
+{
+    wil::com_ptr<ID2D1Factory1> factory;
+    D2D1_FACTORY_OPTIONS options{};
+
+#if CUI_ENABLE_D3D_D2D_DEBUG_LAYER == 1
+    options.debugLevel = IsDebuggerPresent() ? D2D1_DEBUG_LEVEL_INFORMATION : D2D1_DEBUG_LEVEL_NONE;
+#endif
+
+    THROW_IF_FAILED(D2D1CreateFactory(factory_type, __uuidof(ID2D1Factory1), &options, factory.put_void()));
+
+    return factory;
+}
+
 wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
     const wil::com_ptr<ID2D1ColorContext>& source_color_context,
     const wil::com_ptr<ID2D1ColorContext>& dest_color_context)

--- a/foo_ui_columns/d2d_utils.cpp
+++ b/foo_ui_columns/d2d_utils.cpp
@@ -27,4 +27,17 @@ wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2
     return colour_management_effect;
 }
 
+wil::com_ptr<ID2D1Effect> create_scale_effect(
+    const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_VECTOR_2F scale)
+{
+    wil::com_ptr<ID2D1Effect> scale_effect;
+    THROW_IF_FAILED(device_context->CreateEffect(CLSID_D2D1Scale, &scale_effect));
+    THROW_IF_FAILED(
+        scale_effect->SetValue(D2D1_SCALE_PROP_INTERPOLATION_MODE, D2D1_SCALE_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC));
+    THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD));
+    THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_SCALE, scale));
+
+    return scale_effect;
+}
+
 } // namespace cui::d2d

--- a/foo_ui_columns/d2d_utils.cpp
+++ b/foo_ui_columns/d2d_utils.cpp
@@ -40,4 +40,21 @@ wil::com_ptr<ID2D1Effect> create_scale_effect(
     return scale_effect;
 }
 
+wil::com_ptr<ID2D1Effect> create_white_level_adjustment_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
+    std::optional<float> input_white_level, std::optional<float> output_white_level)
+{
+    wil::com_ptr<ID2D1Effect> white_level_adjustment_effect;
+    THROW_IF_FAILED(device_context->CreateEffect(CLSID_D2D1WhiteLevelAdjustment, &white_level_adjustment_effect));
+
+    if (input_white_level)
+        THROW_IF_FAILED(white_level_adjustment_effect->SetValue(
+            D2D1_WHITELEVELADJUSTMENT_PROP_INPUT_WHITE_LEVEL, *input_white_level));
+
+    if (output_white_level)
+        THROW_IF_FAILED(white_level_adjustment_effect->SetValue(
+            D2D1_WHITELEVELADJUSTMENT_PROP_OUTPUT_WHITE_LEVEL, *output_white_level));
+
+    return white_level_adjustment_effect;
+}
+
 } // namespace cui::d2d

--- a/foo_ui_columns/d2d_utils.h
+++ b/foo_ui_columns/d2d_utils.h
@@ -2,6 +2,8 @@
 
 namespace cui::d2d {
 
+wil::com_ptr<ID2D1Factory1> create_factory(D2D1_FACTORY_TYPE factory_type);
+
 wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
     const wil::com_ptr<ID2D1ColorContext>& source_color_context,
     const wil::com_ptr<ID2D1ColorContext>& dest_color_context);

--- a/foo_ui_columns/d2d_utils.h
+++ b/foo_ui_columns/d2d_utils.h
@@ -6,4 +6,7 @@ wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2
     const wil::com_ptr<ID2D1ColorContext>& source_color_context,
     const wil::com_ptr<ID2D1ColorContext>& dest_color_context);
 
+wil::com_ptr<ID2D1Effect> create_scale_effect(
+    const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_VECTOR_2F scale);
+
 } // namespace cui::d2d

--- a/foo_ui_columns/d2d_utils.h
+++ b/foo_ui_columns/d2d_utils.h
@@ -9,4 +9,7 @@ wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2
 wil::com_ptr<ID2D1Effect> create_scale_effect(
     const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_VECTOR_2F scale);
 
+wil::com_ptr<ID2D1Effect> create_white_level_adjustment_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
+    std::optional<float> input_white_level, std::optional<float> output_white_level);
+
 } // namespace cui::d2d

--- a/foo_ui_columns/d3d_utils.cpp
+++ b/foo_ui_columns/d3d_utils.cpp
@@ -5,7 +5,7 @@ namespace cui::d3d {
 HRESULT create_d3d_device(D3D_DRIVER_TYPE driver_type, std::span<const D3D_FEATURE_LEVEL> feature_levels,
     ID3D11Device** device, ID3D11DeviceContext** device_context)
 {
-#ifdef _DEBUG
+#if CUI_ENABLE_D3D_D2D_DEBUG_LAYER == 1
     const auto hr = D3D11CreateDevice(nullptr, driver_type, nullptr,
         D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_DEBUG, feature_levels.data(),
         gsl::narrow<uint32_t>(std::size(feature_levels)), D3D11_SDK_VERSION, device, nullptr, device_context);

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -320,10 +320,7 @@ ArtworkRenderingContext::Ptr ArtworkRenderingContext::s_create(unsigned width, u
             "Playlist view artwork – failed to create a software (WARP) renderer, using a hardware renderer instead");
     }
 
-    wil::com_ptr<ID2D1Factory1> d2d_factory;
-    THROW_IF_FAILED(
-        D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, __uuidof(ID2D1Factory1), d2d_factory.put_void()));
-
+    const auto d2d_factory = d2d::create_factory(D2D1_FACTORY_TYPE_SINGLE_THREADED);
     const auto dxgi_device = d3d_device.query<IDXGIDevice1>();
 
     wil::com_ptr<ID2D1Device> d2d_device;

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "ng_playlist_artwork.h"
 
+#include "d2d_utils.h"
 #include "d3d_utils.h"
 #include "gdi.h"
 #include "imaging.h"
@@ -48,14 +49,8 @@ namespace {
     const auto reflection_height_px = show_reflection ? (target_width * 3) / 11 : 0;
     const auto reflection_height_dip = static_cast<float>(reflection_height_px);
 
-    wil::com_ptr<ID2D1Effect> scale_effect;
-    THROW_IF_FAILED(context->d2d_device_context->CreateEffect(CLSID_D2D1Scale, scale_effect.put()));
-
-    THROW_IF_FAILED(
-        scale_effect->SetValue(D2D1_SCALE_PROP_INTERPOLATION_MODE, D2D1_SCALE_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC));
-    THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD));
-    THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_SCALE,
-        D2D1::Vector2F(render_width_dip / bitmap_size.width, render_height_dip / bitmap_size.height)));
+    const auto scale_effect = d2d::create_scale_effect(context->d2d_device_context,
+        D2D1::Vector2F(render_width_dip / bitmap_size.width, render_height_dip / bitmap_size.height));
     scale_effect->SetInputEffect(0, colour_management_effect.get());
 
     wil::com_ptr<ID2D1RectangleGeometry> reflection_rect_geometry;

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -19,6 +19,8 @@
 #include <crtdbg.h>
 #endif
 
+#define CUI_ENABLE_D3D_D2D_DEBUG_LAYER 0
+
 #include <algorithm>
 #include <atomic>
 #include <complex>


### PR DESCRIPTION
Resolves #1216

This makes a few small tweaks to Direct2D usage in the artwork and playlist views. It:

- adds and makes use of a few shared utility functions
- makes the effect pipelines in the playlist view more consistent with the one in the artwork view
- fixes handling of display changes in the artwork view
- stops automatically enabling Direct2D and Direct3D debug layers in debug builds (due to them having unwanted side effects, perhaps because they tend to be older versions than the main binaries)