### PR TITLE
Fix focus restoration after ReplayGain scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 - A bug where artwork images in the playlist view varied in width by up to two
   pixels was fixed. [[#1281](https://github.com/reupen/columns_ui/pull/1281)]
 
+- A bug where the focus was not restored to the previously focused child window
+  after some operations, like a ReplayGain scan, was fixed.
+  [[#1293](https://github.com/reupen/columns_ui/pull/1293)]
+
 ### Internal changes
 
 - Some code was refactored.

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -290,6 +290,17 @@ void cui::MainWindow::save_focus_state()
         m_last_focused_wnd = nullptr;
 }
 
+void cui::MainWindow::set_or_restore_focus() const
+{
+    if (m_is_destroying)
+        return;
+
+    if (m_last_focused_wnd && IsWindow(m_last_focused_wnd))
+        SetFocus(m_last_focused_wnd);
+    else
+        g_layout_window.set_focus();
+}
+
 void cui::MainWindow::queue_taskbar_button_update(bool update)
 {
     PostMessage(m_wnd, update ? MSG_UPDATE_TASKBAR_BUTTONS : MSG_CREATE_TASKBAR_BUTTONS, 0, 0);

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -86,6 +86,7 @@ private:
     bool update_taskbar_button_images() const;
     void update_taskbar_buttons(bool update) const;
     void save_focus_state();
+    void set_or_restore_focus() const;
 
     pfc::string8 m_window_title;
     wil::com_ptr<ITaskbarList3> m_taskbar_list;

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -256,8 +256,14 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         const auto is_minimised = HIWORD(wp);
         const auto state = LOWORD(wp);
 
-        if (m_is_destroying || state != WA_INACTIVE)
+        if (m_is_destroying)
             return 0;
+
+        if (state != WA_INACTIVE) {
+            if (!GetFocus() && !IsIconic(wnd))
+                set_or_restore_focus();
+            return 0;
+        }
 
         if (!is_minimised)
             save_focus_state();
@@ -273,13 +279,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         return 0;
     }
     case WM_SETFOCUS:
-        if (m_is_destroying)
-            break;
-
-        if (m_last_focused_wnd && IsWindow(m_last_focused_wnd))
-            SetFocus(m_last_focused_wnd);
-        else
-            g_layout_window.set_focus();
+        set_or_restore_focus();
         break;
     case WM_SYSCOMMAND:
         switch (wp) {

--- a/foo_ui_columns/user_interface_impl.cpp
+++ b/foo_ui_columns/user_interface_impl.cpp
@@ -177,18 +177,25 @@ public:
 
     void activate() override
     {
-        if (main_window.get_wnd()) {
-            cfg_main_window_is_hidden = false;
-            if (g_icon_created && !cfg_show_systray)
-                systray::remove_icon();
+        const auto wnd = main_window.get_wnd();
 
-            if (!is_visible()) {
-                ShowWindow(main_window.get_wnd(), SW_RESTORE);
-                if ((GetWindowLong(main_window.get_wnd(), GWL_EXSTYLE) & WS_EX_LAYERED))
-                    RedrawWindow(main_window.get_wnd(), nullptr, nullptr,
-                        RDW_ERASE | RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
-            }
-            SetForegroundWindow(main_window.get_wnd());
+        if (!wnd)
+            return;
+
+        cfg_main_window_is_hidden = false;
+
+        if (g_icon_created && !cfg_show_systray)
+            systray::remove_icon();
+
+        if (GetForegroundWindow() != wnd)
+            SetForegroundWindow(wnd);
+
+        if (!is_visible()) {
+            ShowWindow(wnd, SW_RESTORE);
+
+            if (GetWindowLong(wnd, GWL_EXSTYLE) & WS_EX_LAYERED)
+                RedrawWindow(
+                    wnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
         }
     }
 


### PR DESCRIPTION
Resolves #1280

This resolves a problem where the focus was not restored to the relevant child window after performing a ReplayGain scan and applying changes.