### PR TITLE
Fix incorrect image size after resizing artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
   [#1284](https://github.com/reupen/columns_ui/pull/1284),
   [#1289](https://github.com/reupen/columns_ui/pull/1289),
   [#1290](https://github.com/reupen/columns_ui/pull/1290),
-  [#1292](https://github.com/reupen/columns_ui/pull/1292)]
+  [#1292](https://github.com/reupen/columns_ui/pull/1292),
+  [#1296](https://github.com/reupen/columns_ui/pull/1296)]
 
   Additionally, support for Windows Advanced Colour can be enabled in
   Preferences on Windows 10 version 1809 and newer. This improves support for

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -182,7 +182,7 @@ private:
     void clear_image();
     void reset_effects();
     D2D1_VECTOR_2F calculate_scaling_factor(const wil::com_ptr<ID2D1Image>& image) const;
-    void update_scale_effect() const;
+    void update_scale_effect();
     void queue_decode(const album_art_data::ptr& data);
     void show_stub_image();
     void invalidate_window() const;
@@ -212,6 +212,7 @@ private:
     bool m_artwork_type_locked{false};
     bool m_dynamic_artwork_pending{};
     bool m_using_flip_model_swap_chain{};
+    bool m_scale_effect_needs_updating{};
     metadb_handle_list m_selection_handles;
 
     static std::vector<ArtworkPanel*> g_windows;


### PR DESCRIPTION
Fixes #1295

The scale effect was being updated before the Direct2D device context size was updated, so the updated scale was being based on the old render target size.

This delays updating the scale effect under rendering to avoid the problem.