### PR TITLE
Add support for mainmenu_command_v3 command state in buttons toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@
   [#1289](https://github.com/reupen/columns_ui/pull/1289),
   [#1292](https://github.com/reupen/columns_ui/pull/1292)]
 
+- The buttons toolbar now supports enabled and pressed states for main menu
+  commands that report their command state via the latest foobar2000 API.
+  [[#1297](https://github.com/reupen/columns_ui/pull/1297)]
+
+  This requires main menu commands to implement the `mainmenu_commands_v3`
+  service interface in the foobar2000 SDK.
+
 ### Bug fixes
 
 - The built-in spectrum analyser visualisation now uses the same frequency scale

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -414,8 +414,6 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     switch (msg) {
     case WM_CREATE: {
         wnd_host = wnd;
-        Gdiplus::GdiplusStartupInput gdiplusStartupInput;
-        m_gdiplus_initialised = (Gdiplus::Ok == GdiplusStartup(&m_gdiplus_instance, &gdiplusStartupInput, nullptr));
         initialised = true;
         create_toolbar();
         m_dark_mode_notifier = std::make_unique<colours::dark_mode_notifier>([this, self = ptr{this}] {
@@ -429,10 +427,6 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         destroy_toolbar();
         wnd_host = nullptr;
         initialised = false;
-        if (m_gdiplus_initialised) {
-            Gdiplus::GdiplusShutdown(m_gdiplus_instance);
-            m_gdiplus_initialised = false;
-        }
         break;
     case WM_WINDOWPOSCHANGED: {
         const auto lpwp = reinterpret_cast<LPWINDOWPOS>(lp);

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -104,6 +104,28 @@ public:
         Other,
     };
 
+    class ButtonStateCallback : public uie::button_callback {
+    public:
+        ButtonStateCallback(uie::button::ptr button_instance, HWND toolbar_wnd, int button_id)
+            : m_button_instance(std::move(button_instance))
+            , m_toolbar_wnd(toolbar_wnd)
+            , m_button_id(button_id)
+        {
+            m_button_instance->register_callback(*this);
+        }
+
+        ~ButtonStateCallback() { m_button_instance->deregister_callback(*this); }
+
+    private:
+        void on_button_state_change(unsigned p_new_state) final;
+
+        void on_command_state_change(unsigned p_new_state) final {}
+
+        uie::button::ptr m_button_instance;
+        HWND m_toolbar_wnd{};
+        int m_button_id{};
+    };
+
     class Button {
     public:
         class CustomImage {
@@ -134,24 +156,9 @@ public:
         pfc::string_simple m_text;
         CustomImage m_custom_image;
         CustomImage m_custom_hot_image;
-        service_ptr_t<uie::button> m_interface;
+        uie::button::ptr m_interface;
 
-        class ButtonStateCallback : public uie::button_callback {
-            void on_button_state_change(unsigned p_new_state) override; // see t_button_state
-
-            void on_command_state_change(unsigned p_new_state) override {}
-
-            service_ptr_t<ButtonsToolbar> m_this;
-            int id{};
-
-        public:
-            ButtonStateCallback& operator=(const ButtonStateCallback& p_source);
-            void set_wnd(ButtonsToolbar* p_source);
-            void set_id(int i);
-            ButtonStateCallback() = default;
-        } m_callback;
-
-        void set(const Button& p_source);
+        std::shared_ptr<ButtonStateCallback> m_callback;
 
         void write(stream_writer* out, abort_callback& p_abort) const;
 

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -368,8 +368,7 @@ private:
     static const TCHAR* class_name;
 
     WNDPROC menuproc{nullptr};
-    bool initialised{false}, m_gdiplus_initialised{false};
-    ULONG_PTR m_gdiplus_instance{};
+    bool initialised{false};
     std::vector<Button> m_buttons;
     bool m_text_below{false};
     Appearance m_appearance{APPEARANCE_NORMAL};

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -126,6 +126,29 @@ public:
         int m_button_id{};
     };
 
+    class MainMenuStateCallback : public mainmenu_commands_v3::state_callback {
+    public:
+        MainMenuStateCallback(mainmenu_commands_v3::ptr mainmenu_commands_v3_instance, uint32_t command_index,
+            HWND toolbar_wnd, int button_id)
+            : m_mainmenu_commands_v3(std::move(mainmenu_commands_v3_instance))
+            , m_command_index(command_index)
+            , m_toolbar_wnd(toolbar_wnd)
+            , m_button_id(button_id)
+        {
+            m_mainmenu_commands_v3->add_state_callback(this);
+        }
+
+        ~MainMenuStateCallback() { m_mainmenu_commands_v3->remove_state_callback(this); }
+
+    private:
+        void menu_state_changed(const GUID& main, const GUID& sub) final;
+
+        mainmenu_commands_v3::ptr m_mainmenu_commands_v3;
+        uint32_t m_command_index{};
+        HWND m_toolbar_wnd{};
+        int m_button_id{};
+    };
+
     class Button {
     public:
         class CustomImage {
@@ -156,9 +179,14 @@ public:
         pfc::string_simple m_text;
         CustomImage m_custom_image;
         CustomImage m_custom_hot_image;
-        uie::button::ptr m_interface;
 
-        std::shared_ptr<ButtonStateCallback> m_callback;
+        uie::button::ptr m_interface;
+        mainmenu_commands_v3::ptr m_mainmenu_commands_v3;
+        std::optional<uint32_t> m_mainmenu_commands_index{};
+        std::shared_ptr<ButtonStateCallback> m_button_state_callback;
+        std::shared_ptr<MainMenuStateCallback> m_mainmenu_state_callback;
+
+        void reset_state();
 
         void write(stream_writer* out, abort_callback& p_abort) const;
 

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -3,6 +3,15 @@
 
 namespace cui::toolbars::buttons {
 
+void ButtonsToolbar::Button::reset_state()
+{
+    m_interface.reset();
+    m_mainmenu_commands_v3.reset();
+    m_mainmenu_commands_index.reset();
+    m_button_state_callback.reset();
+    m_mainmenu_state_callback.reset();
+}
+
 void ButtonsToolbar::Button::write(stream_writer* out, abort_callback& p_abort) const
 {
     out->write_lendian_t(m_type, p_abort);

--- a/foo_ui_columns/buttons_button.cpp
+++ b/foo_ui_columns/buttons_button.cpp
@@ -3,52 +3,6 @@
 
 namespace cui::toolbars::buttons {
 
-void ButtonsToolbar::Button::ButtonStateCallback::on_button_state_change(unsigned p_new_state) // see t_button_state
-{
-    auto state = LOWORD(SendMessage(m_this->wnd_toolbar, TB_GETSTATE, id, 0));
-    if (p_new_state & uie::BUTTON_STATE_ENABLED)
-        state |= TBSTATE_ENABLED;
-    else
-        state = state & ~TBSTATE_ENABLED;
-    if (p_new_state & uie::BUTTON_STATE_PRESSED)
-        state |= TBSTATE_PRESSED;
-    else
-        state = state & ~TBSTATE_PRESSED;
-    SendMessage(m_this->wnd_toolbar, TB_SETSTATE, id, MAKELONG(state, 0));
-}
-
-ButtonsToolbar::Button::ButtonStateCallback& ButtonsToolbar::Button::ButtonStateCallback::operator=(
-    const ButtonStateCallback& p_source)
-{
-    m_this = p_source.m_this;
-    return *this;
-}
-void ButtonsToolbar::Button::ButtonStateCallback::set_wnd(ButtonsToolbar* p_source)
-{
-    m_this = p_source;
-}
-void ButtonsToolbar::Button::ButtonStateCallback::set_id(const int i)
-{
-    id = i;
-}
-
-void ButtonsToolbar::Button::set(const Button& p_source)
-{
-    m_guid = p_source.m_guid;
-    m_subcommand = p_source.m_subcommand;
-    m_use_custom = p_source.m_use_custom;
-    m_use_custom_hot = p_source.m_use_custom_hot;
-    m_custom_image = p_source.m_custom_image;
-    m_custom_hot_image = p_source.m_custom_hot_image;
-    m_interface = p_source.m_interface;
-    m_callback = p_source.m_callback;
-    m_type = p_source.m_type;
-    m_filter = p_source.m_filter;
-    m_show = p_source.m_show;
-    m_use_custom_text = p_source.m_use_custom_text;
-    m_text = p_source.m_text;
-}
-
 void ButtonsToolbar::Button::write(stream_writer* out, abort_callback& p_abort) const
 {
     out->write_lendian_t(m_type, p_abort);


### PR DESCRIPTION
Resolves #1283

This adds support for making use of main menu command checked and disabled statuses in the buttons toolbar when the relevant `mainmenu_commands` service has implemented `mainmenu_commands_v3`.

Checked commands are displayed as pressed.

If both `uie::button` and `mainmenu_commands_v3` are implemented, `uie::button` is used in preference to `mainmenu_commands_v3`.

(I haven’t found any built-in commands in foobar2000 where this makes a difference so far, as some were already covered by `uie::button` implementations in Columns UI.)