### PR TITLE
Adjust Direct3D/2D threading options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
   [#1290](https://github.com/reupen/columns_ui/pull/1290),
   [#1292](https://github.com/reupen/columns_ui/pull/1292),
   [#1296](https://github.com/reupen/columns_ui/pull/1296),
-  [#1300](https://github.com/reupen/columns_ui/pull/1300)]
+  [#1300](https://github.com/reupen/columns_ui/pull/1300),
+  [#1301](https://github.com/reupen/columns_ui/pull/1301)]
 
   Additionally, support for Windows Advanced Colour can be enabled in
   Preferences on Windows 10 version 1809 and newer. This improves support for

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -385,8 +385,6 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             m_d2d_device_context->BeginDraw();
             m_d2d_device_context->Clear(d2d_background_colour);
 
-            const auto& bitmap = m_artwork_decoder.get_image();
-
             if (m_output_effect) {
                 auto [render_target_width, render_target_height] = m_d2d_device_context->GetSize();
 
@@ -547,8 +545,7 @@ void ArtworkPanel::create_d2d_device_resources()
         }
 
         if (!m_d2d_device_context) {
-            THROW_IF_FAILED(m_d2d_device->CreateDeviceContext(
-                D2D1_DEVICE_CONTEXT_OPTIONS_ENABLE_MULTITHREADED_OPTIMIZATIONS, &m_d2d_device_context));
+            THROW_IF_FAILED(m_d2d_device->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &m_d2d_device_context));
         }
 
         if (m_d2d_device_context && m_dxgi_swap_chain) {

--- a/foo_ui_columns/d2d_utils.cpp
+++ b/foo_ui_columns/d2d_utils.cpp
@@ -11,7 +11,7 @@ wil::com_ptr<ID2D1Factory1> create_factory(D2D1_FACTORY_TYPE factory_type)
     options.debugLevel = IsDebuggerPresent() ? D2D1_DEBUG_LEVEL_INFORMATION : D2D1_DEBUG_LEVEL_NONE;
 #endif
 
-    THROW_IF_FAILED(D2D1CreateFactory(factory_type, __uuidof(ID2D1Factory1), &options, factory.put_void()));
+    THROW_IF_FAILED(D2D1CreateFactory(factory_type, options, &factory));
 
     return factory;
 }

--- a/foo_ui_columns/d3d_utils.cpp
+++ b/foo_ui_columns/d3d_utils.cpp
@@ -5,10 +5,12 @@ namespace cui::d3d {
 HRESULT create_d3d_device(D3D_DRIVER_TYPE driver_type, std::span<const D3D_FEATURE_LEVEL> feature_levels,
     ID3D11Device** device, ID3D11DeviceContext** device_context)
 {
+    const auto base_flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT
+        | (driver_type == D3D_DRIVER_TYPE_HARDWARE ? D3D11_CREATE_DEVICE_PREVENT_INTERNAL_THREADING_OPTIMIZATIONS : 0);
 #if CUI_ENABLE_D3D_D2D_DEBUG_LAYER == 1
-    const auto hr = D3D11CreateDevice(nullptr, driver_type, nullptr,
-        D3D11_CREATE_DEVICE_BGRA_SUPPORT | D3D11_CREATE_DEVICE_DEBUG, feature_levels.data(),
-        gsl::narrow<uint32_t>(std::size(feature_levels)), D3D11_SDK_VERSION, device, nullptr, device_context);
+    const auto hr = D3D11CreateDevice(nullptr, driver_type, nullptr, base_flags | D3D11_CREATE_DEVICE_DEBUG,
+        feature_levels.data(), gsl::narrow<uint32_t>(std::size(feature_levels)), D3D11_SDK_VERSION, device, nullptr,
+        device_context);
 
     if (SUCCEEDED(hr) || (hr != DXGI_ERROR_SDK_COMPONENT_MISSING && hr != E_FAIL))
         return hr;
@@ -16,7 +18,7 @@ HRESULT create_d3d_device(D3D_DRIVER_TYPE driver_type, std::span<const D3D_FEATU
     console::print("Columns UI – Direct3D debug layer not installed");
 #endif
 
-    return D3D11CreateDevice(nullptr, driver_type, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT, feature_levels.data(),
+    return D3D11CreateDevice(nullptr, driver_type, nullptr, base_flags, feature_levels.data(),
         gsl::narrow<uint32_t>(std::size(feature_levels)), D3D11_SDK_VERSION, device, nullptr, device_context);
 }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -327,8 +327,7 @@ ArtworkRenderingContext::Ptr ArtworkRenderingContext::s_create(unsigned width, u
     THROW_IF_FAILED(d2d_factory->CreateDevice(dxgi_device.get(), &d2d_device));
 
     wil::com_ptr<ID2D1DeviceContext> d2d_device_context;
-    THROW_IF_FAILED(d2d_device->CreateDeviceContext(
-        D2D1_DEVICE_CONTEXT_OPTIONS_ENABLE_MULTITHREADED_OPTIMIZATIONS, &d2d_device_context));
+    THROW_IF_FAILED(d2d_device->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &d2d_device_context));
 
     const auto bitmap_properties = D2D1::BitmapProperties1(D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
         D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED));


### PR DESCRIPTION
I noticed on my system that the switch from `ID2D1HwndRenderTarget` to `ID3D11Device` and `ID2D1Device` was causing increased power consumption.

This was difficult to observe with monitoring software, but was easily seen with a plug-in energy monitor.

Even with `ID2D1HwndRenderTarget`, though, the higher power consumption level (around 7 to 8 watts higher) started once an image was rendered in the artwork view (and until foobar2000 was minimised). This seemed to be related to the CPU spending less time in low power states.

As it turned out, the root cause of these problems was that I had a global frame rate limit configured in the NVIDIA app, and it somehow triggers this higher power consumption. Removing that limit gets rid of the problem. Renaming `foobar2000.exe` to `explorer.exe` (which requires a binary edit as `foobar2000.exe` validates the process name) also solved the problem (alas, not a viable solution...)

The other difference in behaviour (the higher power consumption before an image is rendered, though still with the frame rate limit on) I traced to `ID2D1HwndRenderTarget` setting the `D3D11_CREATE_DEVICE_PREVENT_INTERNAL_THREADING_OPTIMIZATIONS` Direct3D flag for hardware devices only (not WARP devices). The first clue about this was in the Windows Terminal source code: https://github.com/microsoft/terminal/blob/a5d916f5d30d4b80faf278a1233b8ec1918c9d10/src/renderer/atlas/AtlasEngine.r.cpp#L176-L180

This therefore sets that flag for hardware devices here, and also makes a few other tweaks to other threading options.

(I may also add a setting for whether to prefer hardware or software rendering, and possibly change the default to software (WARP).)