### PR TITLE
Use std::jthread instead of std::async() in Artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@
   after some operations, like a ReplayGain scan, was fixed.
   [[#1293](https://github.com/reupen/columns_ui/pull/1293)]
 
+- A possible problem where artwork stopped loading in the Artwork view until
+  foobar2000 was restarted was fixed.
+  [#1304](https://github.com/reupen/columns_ui/pull/1304)
+
 ### Internal changes
 
 - Some code was refactored.

--- a/foo_ui_columns/artwork_decoder.cpp
+++ b/foo_ui_columns/artwork_decoder.cpp
@@ -28,25 +28,27 @@ void ArtworkDecoder::decode(wil::com_ptr<ID2D1DeviceContext> d2d_render_target, 
     HMONITOR monitor, album_art_data_ptr data, std::function<void()> on_complete)
 {
     reset();
-    m_current_task = std::make_shared<ArtworkDecoderTask>(std::move(on_complete));
+    m_current_task = std::make_shared<ArtworkDecoderTask>();
 
-    m_current_task->future = std::async(std::launch::async,
-        [this, data, d2d_render_target{std::move(d2d_render_target)}, monitor,
-            stop_token{m_current_task->stop_source.get_token()}, task{std::weak_ptr{m_current_task}},
-            use_advanced_colour]() noexcept {
-            TRACK_CALL_TEXT("cui::artwork_panel::ArtworkDecoder::async_task");
+    m_current_task->thread = std::jthread([this, data, d2d_render_target{std::move(d2d_render_target)}, monitor,
+                                              on_complete{std::move(on_complete)}, task{std::weak_ptr{m_current_task}},
+                                              use_advanced_colour](std::stop_token stop_token) noexcept {
+        TRACK_CALL_TEXT("cui::artwork_panel::ArtworkDecoder::thread");
+        SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
+        (void)mmh::set_thread_description(GetCurrentThread(), L"[Columns UI] Artwork view decoder");
 
-            wil::com_ptr<ID2D1Bitmap> d2d_bitmap;
-            wil::com_ptr<ID2D1ColorContext> d2d_image_colour_context;
-            wil::com_ptr<ID2D1ColorContext> d2d_display_colour_context;
-            bool is_float{};
-            std::optional<HRESULT> error_result;
+        wil::com_ptr<ID2D1Bitmap> d2d_bitmap;
+        wil::com_ptr<ID2D1ColorContext> d2d_image_colour_context;
+        wil::com_ptr<ID2D1ColorContext> d2d_display_colour_context;
+        bool is_float{};
+        std::optional<HRESULT> error_result;
 
-            auto _ = wil::scope_exit([&] {
-                fb2k::inMainThread([this, d2d_bitmap{std::move(d2d_bitmap)},
-                                       d2d_display_colour_context{std::move(d2d_display_colour_context)},
-                                       d2d_image_colour_context{std::move(d2d_image_colour_context)}, error_result,
-                                       is_float, stop_token{std::move(stop_token)}, task{std::move(task)}]() {
+        auto _ = wil::scope_exit([&] {
+            fb2k::inMainThread(
+                [this, d2d_bitmap{std::move(d2d_bitmap)},
+                    d2d_display_colour_context{std::move(d2d_display_colour_context)},
+                    d2d_image_colour_context{std::move(d2d_image_colour_context)}, error_result, is_float,
+                    on_complete{std::move(on_complete)}, stop_token{std::move(stop_token)}, task{std::move(task)}]() {
                     const auto locked_task = task.lock();
 
                     if (stop_token.stop_requested()) {
@@ -63,141 +65,138 @@ void ArtworkDecoder::decode(wil::com_ptr<ID2D1DeviceContext> d2d_render_target, 
                     m_is_float = is_float;
                     m_error_result = error_result;
 
-                    if (locked_task)
-                        locked_task->on_complete();
+                    on_complete();
                 });
-            });
-
-            try {
-                if (stop_token.stop_requested())
-                    return;
-
-                auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
-                const auto imaging_factory = wic::create_factory();
-                const auto decoder = wic::create_decoder_from_data(data->get_ptr(), data->get_size(), imaging_factory);
-
-                if (stop_token.stop_requested())
-                    return;
-
-                wil::com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
-                THROW_IF_FAILED(decoder->GetFrame(0, &bitmap_frame_decode));
-
-                const auto pixel_format_info
-                    = get_bitmap_source_pixel_format_info(imaging_factory, bitmap_frame_decode);
-
-                WICPixelFormatNumericRepresentation pixel_format_numeric_representation{};
-                THROW_IF_FAILED(pixel_format_info->GetNumericRepresentation(&pixel_format_numeric_representation));
-
-                unsigned bpp{};
-                THROW_IF_FAILED(pixel_format_info->GetBitsPerPixel(&bpp));
-
-                const auto wic_colour_context
-                    = wic::get_bitmap_source_colour_context(imaging_factory, bitmap_frame_decode);
-                is_float = pixel_format_numeric_representation == WICPixelFormatNumericRepresentationFloat;
-
-                const auto target_pixel_format = [&] {
-                    if (is_float)
-                        return use_advanced_colour ? GUID_WICPixelFormat64bppPRGBAHalf : GUID_WICPixelFormat32bppPRGBA;
-
-                    if (bpp > 32)
-                        return GUID_WICPixelFormat64bppPRGBA;
-
-                    return GUID_WICPixelFormat32bppPRGBA;
-                }();
-
-                wil::com_ptr<IWICBitmapSource> wic_bitmap;
-                THROW_IF_FAILED(WICConvertBitmapSource(target_pixel_format, bitmap_frame_decode.get(), &wic_bitmap));
-
-                if (stop_token.stop_requested())
-                    return;
-
-                uint32_t width{};
-                uint32_t height{};
-
-                THROW_IF_FAILED(wic_bitmap->GetSize(&width, &height));
-
-                const auto max_bitmap_size = d2d_render_target->GetMaximumBitmapSize();
-                const auto needs_rescaling = width > max_bitmap_size || height > max_bitmap_size;
-
-                if (needs_rescaling) {
-                    const auto scaling_factor
-                        = gsl::narrow_cast<float>(max_bitmap_size) / gsl::narrow_cast<float>(std::max(width, height));
-                    const auto new_width = std::min(max_bitmap_size,
-                        gsl::narrow_cast<uint32_t>(gsl::narrow_cast<float>(width) * scaling_factor + .5f));
-                    const auto new_height = std::min(max_bitmap_size,
-                        gsl::narrow_cast<uint32_t>(gsl::narrow_cast<float>(height) * scaling_factor + .5f));
-
-                    const auto message = fmt::format("Artwork panel – image with size {0}×{1} exceeds maximum "
-                                                     "size of {2}×{2}, image will be pre-scaled to {3}×{4}",
-                        width, height, max_bitmap_size, new_width, new_height);
-                    console::print(message.c_str());
-
-                    wic_bitmap = wic::resize_bitmap_source(wic_bitmap, new_width, new_height, imaging_factory);
-
-                    if (stop_token.stop_requested())
-                        return;
-                }
-
-                HRESULT hr{};
-
-                // Not implemented on Wine
-                if (wic_colour_context) {
-                    LOG_IF_FAILED(d2d_render_target->CreateColorContextFromWicColorContext(
-                        wic_colour_context.get(), &d2d_image_colour_context));
-                } else {
-                    LOG_IF_FAILED(d2d_render_target->CreateColorContext(
-                        is_float && use_advanced_colour ? D2D1_COLOR_SPACE_SCRGB : D2D1_COLOR_SPACE_SRGB, nullptr, 0,
-                        &d2d_image_colour_context));
-                }
-
-                hr = d2d_render_target->CreateBitmapFromWicBitmap(wic_bitmap.get(), nullptr, &d2d_bitmap);
-
-                if (hr != E_NOTIMPL || needs_rescaling)
-                    THROW_IF_FAILED(hr);
-
-                if (stop_token.stop_requested())
-                    return;
-
-                if (hr == E_NOTIMPL) {
-                    // For lossy images, the Microsoft JXL codec does not support some interface or
-                    // method that D2D expects (but making a copy of the bitmap and trying again works fine).
-                    // (ID2D1DeviceContext2::CreateImageSourceFromWic() doesn't have this problem.)
-                    wil::com_ptr<IWICBitmap> wic_bitmap_copy;
-                    THROW_IF_FAILED(imaging_factory->CreateBitmapFromSource(
-                        wic_bitmap.get(), WICBitmapCacheOnDemand, &wic_bitmap_copy));
-
-                    THROW_IF_FAILED(
-                        d2d_render_target->CreateBitmapFromWicBitmap(wic_bitmap_copy.get(), nullptr, &d2d_bitmap));
-                }
-
-                if (stop_token.stop_requested())
-                    return;
-
-                if (monitor) {
-                    const auto display_device_key = win32::get_display_device_key(monitor);
-                    const auto display_profile_name = wcs::get_display_colour_profile_name(display_device_key.c_str());
-                    const auto profile = wcs::get_display_colour_profile(display_profile_name);
-
-                    if (!profile.empty())
-                        LOG_IF_FAILED(d2d_render_target->CreateColorContext(D2D1_COLOR_SPACE_CUSTOM, profile.data(),
-                            gsl::narrow<uint32_t>(profile.size()), &d2d_display_colour_context));
-
-                    if (!d2d_display_colour_context) {
-                        LOG_IF_FAILED(d2d_render_target->CreateColorContext(
-                            D2D1_COLOR_SPACE_SRGB, nullptr, 0, &d2d_display_colour_context));
-                    }
-                }
-
-            } catch (const std::exception& ex) {
-                console::print("Artwork panel – loading image failed: ", ex.what());
-
-                d2d_bitmap.reset();
-                d2d_display_colour_context.reset();
-                d2d_image_colour_context.reset();
-                is_float = false;
-                error_result = wil::ResultFromCaughtException();
-            }
         });
+
+        try {
+            if (stop_token.stop_requested())
+                return;
+
+            auto _ = wil::CoInitializeEx(COINIT_MULTITHREADED);
+            const auto imaging_factory = wic::create_factory();
+            const auto decoder = wic::create_decoder_from_data(data->get_ptr(), data->get_size(), imaging_factory);
+
+            if (stop_token.stop_requested())
+                return;
+
+            wil::com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode;
+            THROW_IF_FAILED(decoder->GetFrame(0, &bitmap_frame_decode));
+
+            const auto pixel_format_info = get_bitmap_source_pixel_format_info(imaging_factory, bitmap_frame_decode);
+
+            WICPixelFormatNumericRepresentation pixel_format_numeric_representation{};
+            THROW_IF_FAILED(pixel_format_info->GetNumericRepresentation(&pixel_format_numeric_representation));
+
+            unsigned bpp{};
+            THROW_IF_FAILED(pixel_format_info->GetBitsPerPixel(&bpp));
+
+            const auto wic_colour_context = wic::get_bitmap_source_colour_context(imaging_factory, bitmap_frame_decode);
+            is_float = pixel_format_numeric_representation == WICPixelFormatNumericRepresentationFloat;
+
+            const auto target_pixel_format = [&] {
+                if (is_float)
+                    return use_advanced_colour ? GUID_WICPixelFormat64bppPRGBAHalf : GUID_WICPixelFormat32bppPRGBA;
+
+                if (bpp > 32)
+                    return GUID_WICPixelFormat64bppPRGBA;
+
+                return GUID_WICPixelFormat32bppPRGBA;
+            }();
+
+            wil::com_ptr<IWICBitmapSource> wic_bitmap;
+            THROW_IF_FAILED(WICConvertBitmapSource(target_pixel_format, bitmap_frame_decode.get(), &wic_bitmap));
+
+            if (stop_token.stop_requested())
+                return;
+
+            uint32_t width{};
+            uint32_t height{};
+
+            THROW_IF_FAILED(wic_bitmap->GetSize(&width, &height));
+
+            const auto max_bitmap_size = d2d_render_target->GetMaximumBitmapSize();
+            const auto needs_rescaling = width > max_bitmap_size || height > max_bitmap_size;
+
+            if (needs_rescaling) {
+                const auto scaling_factor
+                    = gsl::narrow_cast<float>(max_bitmap_size) / gsl::narrow_cast<float>(std::max(width, height));
+                const auto new_width = std::min(
+                    max_bitmap_size, gsl::narrow_cast<uint32_t>(gsl::narrow_cast<float>(width) * scaling_factor + .5f));
+                const auto new_height = std::min(max_bitmap_size,
+                    gsl::narrow_cast<uint32_t>(gsl::narrow_cast<float>(height) * scaling_factor + .5f));
+
+                const auto message = fmt::format("Artwork panel – image with size {0}×{1} exceeds maximum "
+                                                 "size of {2}×{2}, image will be pre-scaled to {3}×{4}",
+                    width, height, max_bitmap_size, new_width, new_height);
+                console::print(message.c_str());
+
+                wic_bitmap = wic::resize_bitmap_source(wic_bitmap, new_width, new_height, imaging_factory);
+
+                if (stop_token.stop_requested())
+                    return;
+            }
+
+            HRESULT hr{};
+
+            // Not implemented on Wine
+            if (wic_colour_context) {
+                LOG_IF_FAILED(d2d_render_target->CreateColorContextFromWicColorContext(
+                    wic_colour_context.get(), &d2d_image_colour_context));
+            } else {
+                LOG_IF_FAILED(d2d_render_target->CreateColorContext(
+                    is_float && use_advanced_colour ? D2D1_COLOR_SPACE_SCRGB : D2D1_COLOR_SPACE_SRGB, nullptr, 0,
+                    &d2d_image_colour_context));
+            }
+
+            hr = d2d_render_target->CreateBitmapFromWicBitmap(wic_bitmap.get(), nullptr, &d2d_bitmap);
+
+            if (hr != E_NOTIMPL || needs_rescaling)
+                THROW_IF_FAILED(hr);
+
+            if (stop_token.stop_requested())
+                return;
+
+            if (hr == E_NOTIMPL) {
+                // For lossy images, the Microsoft JXL codec does not support some interface or
+                // method that D2D expects (but making a copy of the bitmap and trying again works fine).
+                // (ID2D1DeviceContext2::CreateImageSourceFromWic() doesn't have this problem.)
+                wil::com_ptr<IWICBitmap> wic_bitmap_copy;
+                THROW_IF_FAILED(imaging_factory->CreateBitmapFromSource(
+                    wic_bitmap.get(), WICBitmapCacheOnDemand, &wic_bitmap_copy));
+
+                THROW_IF_FAILED(
+                    d2d_render_target->CreateBitmapFromWicBitmap(wic_bitmap_copy.get(), nullptr, &d2d_bitmap));
+            }
+
+            if (stop_token.stop_requested())
+                return;
+
+            if (monitor) {
+                const auto display_device_key = win32::get_display_device_key(monitor);
+                const auto display_profile_name = wcs::get_display_colour_profile_name(display_device_key.c_str());
+                const auto profile = wcs::get_display_colour_profile(display_profile_name);
+
+                if (!profile.empty())
+                    LOG_IF_FAILED(d2d_render_target->CreateColorContext(D2D1_COLOR_SPACE_CUSTOM, profile.data(),
+                        gsl::narrow<uint32_t>(profile.size()), &d2d_display_colour_context));
+
+                if (!d2d_display_colour_context) {
+                    LOG_IF_FAILED(d2d_render_target->CreateColorContext(
+                        D2D1_COLOR_SPACE_SRGB, nullptr, 0, &d2d_display_colour_context));
+                }
+            }
+
+        } catch (const std::exception& ex) {
+            console::print("Artwork panel – loading image failed: ", ex.what());
+
+            d2d_bitmap.reset();
+            d2d_display_colour_context.reset();
+            d2d_image_colour_context.reset();
+            is_float = false;
+            error_result = wil::ResultFromCaughtException();
+        }
+    });
 }
 
 } // namespace cui::artwork_panel

--- a/foo_ui_columns/artwork_decoder.h
+++ b/foo_ui_columns/artwork_decoder.h
@@ -6,9 +6,7 @@ class ArtworkDecoderTask {
 public:
     using Ptr = std::shared_ptr<ArtworkDecoderTask>;
 
-    std::function<void()> on_complete;
-    std::stop_source stop_source;
-    std::future<void> future;
+    std::jthread thread;
 };
 
 class ArtworkDecoder {
@@ -21,7 +19,7 @@ public:
     void abort()
     {
         if (m_current_task) {
-            m_current_task->stop_source.request_stop();
+            m_current_task->thread.request_stop();
             m_aborting_tasks.emplace_back(std::move(m_current_task));
         }
     }


### PR DESCRIPTION
In MSVC, `std::async()` uses a thread pool. I’ve encountered (just once...) artwork stop loading due to COM initialisation failing in the async task. Presumably, this was due to something initialising COM as apartment-threaded (while in another `std::async()` task) and not deinitialising COM afterwards, and the thread then returning to thread pool like that.

This switches to using a temporary thread via `std::jthread`, so at least the thread state is always clean and that problem can't happen.

(Additionally, the thread priority is now `THREAD_PRIORITY_BELOW_NORMAL` like other background threads in Columns UI.)