### PR TITLE
Add ‘Show in File Explorer’ command to Artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
   This requires main menu commands to implement the `mainmenu_commands_v3`
   service interface in the foobar2000 SDK.
 
+- The Artwork view now has a ‘Show in File Explorer’ context menu item and click
+  action that shows the file containing the displayed image in File Explorer.
+  [[#1307](https://github.com/reupen/columns_ui/pull/1307)]
+
 - A ‘Cut panel’ command was added to the Layout tree context menu in
   Preferences. [#1302](https://github.com/reupen/columns_ui/pull/1302)
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -9,6 +9,7 @@ namespace cui::artwork_panel {
 enum class ClickAction : int32_t {
     open_image_viewer,
     show_next_artwork_type,
+    show_in_file_explorer,
 };
 
 enum class ColourManagementMode : int32_t {
@@ -86,6 +87,8 @@ public:
     void force_reload_artwork();
     bool is_core_image_viewer_available() const;
     void open_core_image_viewer() const;
+    bool is_show_in_file_explorer_available() const;
+    void show_in_file_explorer();
     void show_next_artwork_type();
     void set_artwork_type_index(size_t index);
 
@@ -205,6 +208,7 @@ private:
     std::unique_ptr<EventToken> m_display_change_token;
     std::shared_ptr<ArtworkReaderManager> m_artwork_reader;
     ArtworkDecoder m_artwork_decoder;
+    std::optional<std::jthread> m_show_in_explorer_thread;
     size_t m_selected_artwork_type_index{0};
     std::optional<size_t> m_artwork_type_override_index{};
     uint32_t m_track_mode;

--- a/foo_ui_columns/artwork_reader.h
+++ b/foo_ui_columns/artwork_reader.h
@@ -25,6 +25,7 @@ public:
 
     ArtworkReaderStatus status() const;
     const std::unordered_map<GUID, album_art_data_ptr>& get_artwork_data() const;
+    const std::unordered_map<GUID, album_art_path_list::ptr>& get_artwork_paths() const;
     const std::unordered_map<GUID, album_art_data_ptr>& get_stub_images() const;
     void set_image(GUID artwork_type_id, album_art_data_ptr data);
 
@@ -58,6 +59,7 @@ private:
     std::vector<GUID> m_artwork_type_ids;
     std::unordered_map<GUID, album_art_data_ptr> m_previous_artwork_data;
     std::unordered_map<GUID, album_art_data_ptr> m_artwork_data;
+    std::unordered_map<GUID, album_art_path_list::ptr> m_artwork_paths;
     std::unordered_map<GUID, album_art_data_ptr> m_stub_images;
     ArtworkReaderStatus m_status{ArtworkReaderStatus::Pending};
     bool m_is_from_playback{};
@@ -78,6 +80,7 @@ public:
     void abort_current_task();
 
     album_art_data_ptr get_image(const GUID& p_what) const;
+    album_art_path_list::ptr get_paths(GUID artwork_type_id) const;
     album_art_data_ptr get_stub_image(GUID artwork_type_id);
 
     void deinitialise();

--- a/foo_ui_columns/config_artwork.cpp
+++ b/foo_ui_columns/config_artwork.cpp
@@ -61,6 +61,9 @@ public:
                 WI_EnumValue(cui::artwork_panel::ClickAction::open_image_viewer));
         }
 
+        uih::combo_box_add_string_data(click_action_wnd, L"Show in File Explorer",
+            WI_EnumValue(cui::artwork_panel::ClickAction::show_in_file_explorer));
+
         uih::combo_box_add_string_data(click_action_wnd, L"Show next available artwork type",
             WI_EnumValue(cui::artwork_panel::ClickAction::show_next_artwork_type));
 


### PR DESCRIPTION
Resolves #1096

This adds a ‘Show in File Explorer’ command to the Artwork view, both in the context menu and as a click action. (The click action is configured in Preferences.)