### PR TITLE
Add ‘Copy path’ command to Artwork view context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   action that shows the file containing the displayed image in File Explorer.
   [[#1307](https://github.com/reupen/columns_ui/pull/1307)]
 
+- A ‘Copy path’ command was added to the Artwork view context menu.
+  [[#1313](https://github.com/reupen/columns_ui/pull/1313)]
+
 - When right-clicking in the Artwork view, a dedicated context menu is now shown
   (rather than the parent splitter’s context menu with Artwork view items
   appended). [[#1312](https://github.com/reupen/columns_ui/pull/1312)]

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -89,6 +89,8 @@ public:
     void open_core_image_viewer() const;
     bool is_show_in_file_explorer_available() const;
     void show_in_file_explorer();
+    bool is_copy_image_path_to_clipboard_available() const;
+    void copy_image_path_to_clipboard() const;
     void show_next_artwork_type();
     void set_artwork_type_index(uint32_t index);
     void set_tracking_mode(uint32_t new_tracking_mode);


### PR DESCRIPTION
This adds a ‘Copy path’ command to the context menu of the Artwork view.

This aims to copy the path (or URL for streams) of the shown image in the native format (i.e. not file:// URLs etc).