### PR TITLE
Add separator to Artwork view context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
   [[#1307](https://github.com/reupen/columns_ui/pull/1307)]
 
 - A ‘Copy path’ command was added to the Artwork view context menu.
-  [[#1313](https://github.com/reupen/columns_ui/pull/1313)]
+  [[#1313](https://github.com/reupen/columns_ui/pull/1313),
+  [#1314](https://github.com/reupen/columns_ui/pull/1314)]
 
 - When right-clicking in the Artwork view, a dedicated context menu is now shown
   (rather than the parent splitter’s context menu with Artwork view items

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -532,6 +532,9 @@ void ArtworkPanel::handle_wm_contextmenu(HWND wnd, POINT pt)
     if (is_copy_image_path_to_clipboard_available())
         menu.append_command(ID_COPY_PATH, L"Copy path");
 
+    if (menu.size() > 0)
+        menu.append_separator();
+
     menu.append_command(ID_RELOAD_ARTWORK, L"Reload artwork");
     menu.append_separator();
     menu.append_submenu(std::move(artwork_type_submenu), L"Artwork type");


### PR DESCRIPTION
This adds a separator before ‘Reload artwork’ in the main context menu only.