### PR TITLE
Fix handling of duplicate single-instance panels in built-in splitters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
   artwork type’ straight away.
   [[#1312](https://github.com/reupen/columns_ui/pull/1312)]
 
+- A bug where inserting a single-instance panel into the same splitter twice
+  during live editing would crash was fixed for built-in splitters.
+  [[#1315](https://github.com/reupen/columns_ui/pull/1315)]
+
+- Removing the active tab in a Tab stack during live editing now switches to
+  another tab (rather than leaving no tab active).
+  [[#1315](https://github.com/reupen/columns_ui/pull/1315)]
+
 ### Internal changes
 
 - Some code was refactored.

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -384,7 +384,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 uie::window_ptr p_ext;
 
                 if (idx_hit >= 0 && gsl::narrow_cast<unsigned>(idx_hit) < rebar::g_rebar_window->get_bands().size())
-                    p_ext = rebar::g_rebar_window->get_bands()[idx_hit].m_window;
+                    p_ext = rebar::g_rebar_window->get_bands()[idx_hit]->m_window;
 
                 pfc::refcounted_object_ptr_t<ui_extension::menu_hook_impl> extension_menu_nodes
                     = new ui_extension::menu_hook_impl;

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -34,14 +34,11 @@ HFONT PlaylistTabs::g_font = nullptr;
 void PlaylistTabs::get_supported_panels(
     const pfc::list_base_const_t<window::ptr>& p_windows, bit_array_var& p_mask_unsupported)
 {
-    service_ptr_t<service_base> temp;
-    g_tab_host.instance_create(temp);
-    uie::window_host_ptr ptr;
-    if (temp->service_query_t(ptr))
-        (static_cast<WindowHost*>(ptr.get_ptr()))->set_this(this);
-    size_t count = p_windows.get_count();
+    const uie::window_host::ptr host = m_host.is_valid() ? m_host : fb2k::service_new<WindowHost>(this);
+    const size_t count = p_windows.get_count();
+
     for (size_t i = 0; i < count; i++)
-        p_mask_unsupported.set(i, !p_windows[i]->is_available(ptr));
+        p_mask_unsupported.set(i, !p_windows[i]->is_available(host));
 }
 
 bool PlaylistTabs::is_point_ours(HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<window::ptr>& p_hierarchy)
@@ -815,11 +812,6 @@ public:
 };
 
 PlaylistTabsFontClient::factory<PlaylistTabsFontClient> g_font_client_switcher_tabs;
-
-void PlaylistTabs::WindowHost::set_this(PlaylistTabs* ptr)
-{
-    m_this = ptr;
-}
 
 void PlaylistTabs::WindowHost::relinquish_ownership(HWND wnd)
 {

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -818,7 +818,10 @@ void PlaylistTabs::WindowHost::relinquish_ownership(HWND wnd)
     m_this->m_child_wnd = nullptr;
     m_this->m_host.release();
     m_this->m_child.release();
+    m_this->m_child_guid = pfc::guid_null;
+    m_this->m_child_data.set_size(0);
     m_this->reset_size_limits();
+    m_this->get_host()->on_size_limit_change(m_this->get_wnd(), uie::size_limit_all);
 }
 
 bool PlaylistTabs::WindowHost::override_status_text_create(service_ptr_t<ui_status_text_override>& p_out)

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -20,6 +20,9 @@ public:
     };
     class WindowHost : public ui_extension::window_host {
     public:
+        WindowHost() {}
+        explicit WindowHost(PlaylistTabs* window_instance) : m_this(window_instance) {}
+
         unsigned is_resize_supported(HWND wnd) const override;
 
         bool request_resize(HWND wnd, unsigned flags, unsigned width, unsigned height) override;
@@ -38,8 +41,6 @@ public:
         bool override_status_text_create(service_ptr_t<ui_status_text_override>& p_out) override;
 
         void relinquish_ownership(HWND wnd) override;
-
-        void set_this(PlaylistTabs* ptr);
 
     private:
         service_ptr_t<PlaylistTabs> m_this;

--- a/foo_ui_columns/playlist_tabs_wndproc.cpp
+++ b/foo_ui_columns/playlist_tabs_wndproc.cpp
@@ -40,16 +40,9 @@ LRESULT PlaylistTabs::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         create_tabs();
 
-        service_ptr_t<service_base> p_temp;
+        m_host = fb2k::service_new<WindowHost>(this);
+        create_child();
 
-        g_tab_host.instance_create(p_temp);
-
-        // Well simple reinterpret_cast without this mess should work fine but this is "correct"
-        m_host = static_cast<WindowHost*>(p_temp.get_ptr());
-        if (m_host.is_valid()) {
-            m_host->set_this(this);
-            create_child();
-        }
         playlist_manager::get()->register_callback(this, flag_all);
         m_dark_mode_notifier
             = std::make_unique<colours::dark_mode_notifier>([this, self = ptr{this}, wnd, wnd_tabs = wnd_tabs] {

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -88,7 +88,7 @@ public:
     HWND init();
 
     void refresh_band_configs();
-    const std::vector<RebarBand>& get_bands() const { return m_bands; }
+    const std::vector<RebarBand::Ptr>& get_bands() const { return m_bands; }
 
     [[nodiscard]] std::vector<RebarBandState> get_band_states() const;
 
@@ -124,7 +124,7 @@ public:
 
     auto find_band_by_hwnd(HWND wnd)
     {
-        return std::ranges::find_if(m_bands, [&wnd](auto&& item) { return item.m_wnd == wnd; });
+        return std::ranges::find_if(m_bands, [&wnd](auto&& item) { return item->m_wnd == wnd; });
     }
 
 private:
@@ -140,7 +140,7 @@ private:
     void fix_z_order();
 
     WNDPROC m_rebar_wnd_proc{nullptr};
-    std::vector<RebarBand> m_bands;
+    std::vector<RebarBand::Ptr> m_bands;
     std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
 
     friend class RebarWindowHost;

--- a/foo_ui_columns/rebar.h
+++ b/foo_ui_columns/rebar.h
@@ -139,6 +139,7 @@ private:
      */
     void fix_z_order();
 
+    bool m_refresh_children_in_progress{};
     WNDPROC m_rebar_wnd_proc{nullptr};
     std::vector<RebarBand::Ptr> m_bands;
     std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;

--- a/foo_ui_columns/rebar_band.h
+++ b/foo_ui_columns/rebar_band.h
@@ -19,6 +19,8 @@ struct RebarBandState {
 };
 
 struct RebarBand {
+    using Ptr = std::shared_ptr<RebarBand>;
+
     RebarBandState m_state;
     ui_extension::window_ptr m_window{};
     HWND m_wnd{};

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -198,6 +198,7 @@ private:
     std::vector<Panel::Ptr> m_panels;
     HWND m_wnd{nullptr};
 
+    bool m_refresh_children_in_progress{};
     int m_last_position{};
     size_t m_panel_dragging{};
     bool m_panel_dragging_valid{false};

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -41,9 +41,10 @@ public:
     bool set_config_item(size_t index, const GUID& p_type, stream_reader* p_source, abort_callback& p_abort) override;
 
     class FlatSplitterPanelHost : public ui_extension::window_host_ex {
-        service_ptr_t<FlatSplitterPanel> m_this;
-
     public:
+        FlatSplitterPanelHost() {}
+        explicit FlatSplitterPanelHost(FlatSplitterPanel* window_instance) : m_this(window_instance) {}
+
         const GUID& get_host_guid() const override;
 
         bool get_keyboard_shortcuts_enabled() const override;
@@ -65,9 +66,10 @@ public:
         bool is_visibility_modifiable(HWND wnd, bool desired_visibility) const override;
         bool set_window_visibility(HWND wnd, bool visibility) override;
 
-        void set_window_ptr(FlatSplitterPanel* p_ptr);
-
         void relinquish_ownership(HWND wnd) override;
+
+    private:
+        service_ptr_t<FlatSplitterPanel> m_this;
     };
 
     bool is_point_ours(HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<window::ptr>& p_hierarchy) override;
@@ -140,8 +142,6 @@ private:
         bool m_use_custom_title{false};
         pfc::string8 m_custom_title;
 
-        service_ptr_t<class FlatSplitterPanelHost> m_interface;
-
         uih::IntegerAndDpi<uint32_t> m_size{150};
 
         uie::splitter_item_full_v2_t* create_splitter_item(bool b_set_ptr = true);
@@ -195,6 +195,7 @@ private:
     std::vector<Panel::Ptr>::iterator find_panel_by_container_wnd(HWND wnd);
     std::vector<Panel::Ptr>::iterator find_panel_by_panel_wnd(HWND wnd);
 
+    service_ptr_t<FlatSplitterPanelHost> m_window_host;
     std::vector<Panel::Ptr> m_panels;
     HWND m_wnd{nullptr};
 

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -29,7 +29,7 @@ public:
     {
         const auto iter = m_this->find_active_panel_by_wnd(wnd);
 
-        if (iter == m_this->m_panels.end())
+        if (iter == m_this->m_active_panels.end())
             return;
 
         const auto p_ext = *iter;
@@ -77,7 +77,7 @@ public:
 
         const auto iter = m_this->find_active_panel_by_wnd(wnd);
 
-        if (iter == m_this->m_panels.end())
+        if (iter == m_this->m_active_panels.end())
             return false;
 
         if (m_this->get_host()->is_visible(m_this->get_wnd()))
@@ -98,7 +98,7 @@ public:
 
         const auto iter = m_this->find_active_panel_by_wnd(wnd);
 
-        if (iter == m_this->m_panels.end())
+        if (iter == m_this->m_active_panels.end())
             return false;
 
         TabCtrl_SetCurSel(m_this->m_wnd_tabs, std::distance(m_this->m_active_panels.begin(), iter));
@@ -112,7 +112,7 @@ public:
     {
         const auto iter = m_this->find_active_panel_by_wnd(wnd);
 
-        if (iter == m_this->m_panels.end())
+        if (iter == m_this->m_active_panels.end())
             return;
 
         const auto p_ext = *iter;

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -104,8 +104,6 @@ public:
         void write(stream_writer* out, abort_callback& p_abort);
         void _export(stream_writer* out, abort_callback& p_abort);
         void import(stream_reader* t, abort_callback& p_abort);
-
-        service_ptr_t<class TabStackSplitterHost> m_interface;
     };
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
@@ -140,6 +138,7 @@ public:
 
 private:
     bool m_refresh_children_in_progress{};
+    service_ptr_t<TabStackSplitterHost> m_window_host;
     std::vector<Panel::Ptr> m_panels;
     std::vector<Panel::Ptr> m_active_panels;
     HWND m_wnd_tabs{};

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -16,7 +16,7 @@ public:
     unsigned get_type() const override;
 
     void insert_panel(size_t index, const uie::splitter_item_t* p_item) override;
-    void remove_panel(size_t index) override;
+    void remove_panel(size_t index) noexcept override;
     void replace_panel(size_t index, const uie::splitter_item_t* p_item) override;
 
     bool is_point_ours(HWND wnd_point, const POINT& pt_screen, pfc::list_base_t<window::ptr>& p_hierarchy) override
@@ -128,19 +128,25 @@ public:
     void on_size_changed(unsigned width, unsigned height);
     void on_size_changed();
     void on_active_tab_changed(int index_to, bool from_interaction = false);
+    std::optional<size_t> get_active_tab_index() const;
+    std::optional<size_t> get_active_panel_index() const;
+    Panel::Ptr get_active_panel() const;
+    std::optional<size_t> get_saved_active_panel_index() const;
 
     std::vector<Panel::Ptr>::iterator find_active_panel_by_wnd(HWND wnd);
+    void remove_panel(std::vector<Panel::Ptr>::iterator active_panels_iter, bool should_destroy) noexcept;
 
     TabStackPanel() = default;
 
 private:
+    bool m_refresh_children_in_progress{};
     std::vector<Panel::Ptr> m_panels;
     std::vector<Panel::Ptr> m_active_panels;
     HWND m_wnd_tabs{};
     WNDPROC m_tab_proc{};
     HWND m_up_down_control_wnd{};
     HWND m_active_child_wnd{};
-    std::optional<size_t> m_active_tab;
+    std::optional<size_t> m_saved_active_panel_index;
     static std::vector<service_ptr_t<t_self>> g_windows;
     uie::size_limit_t m_size_limits;
     int32_t m_mousewheel_delta{NULL};

--- a/foo_ui_columns/splitter_window_wndproc.cpp
+++ b/foo_ui_columns/splitter_window_wndproc.cpp
@@ -11,6 +11,7 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_NCCREATE:
         m_wnd = wnd;
         g_instances.add_item(this);
+        m_window_host = fb2k::service_new<FlatSplitterPanelHost>(this);
         break;
     case WM_CREATE:
         if (!g_count++) {
@@ -30,6 +31,7 @@ LRESULT FlatSplitterPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
         break;
     case WM_NCDESTROY:
+        m_window_host.reset();
         g_instances.remove_item(this);
         m_wnd = nullptr;
         break;


### PR DESCRIPTION
This fixes a long-standing bug where, if a single-instance panel was inserted in a built-in splitter twice, a crash would tend to occur.

Normally inserting a single-instance panel in the same splitter twice is not allowed, but it was (and potentially still is) possible via live editing. (Some improvements to live editing will also follow separately.)

These changes also improve handling of removing the active tab in a Tab stack panel during live editing. It now switches to another tab (if there is one), rather than leaving the Tab stack in a state where no tab is active. Internal logic for tracking the active tab was also changed to support these changes.