### PR TITLE
Fix wrong image showing through in non-square artwork in playlist view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@
 
 - The use of hardware acceleration for built-in panels that use Direct2D can now
   be turned off or on in Preferences.
-  [[#1308](https://github.com/reupen/columns_ui/pull/1308)]
+  [[#1308](https://github.com/reupen/columns_ui/pull/1308),
+  [#1317](https://github.com/reupen/columns_ui/pull/1317)]
 
   Hardware acceleration is now disabled by default due to inconsistent
   performance for different hardware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@
   playlist view. [[#1281](https://github.com/reupen/columns_ui/pull/1281),
   [#1289](https://github.com/reupen/columns_ui/pull/1289),
   [#1292](https://github.com/reupen/columns_ui/pull/1292),
-  [#1299](https://github.com/reupen/columns_ui/pull/1299)]
+  [#1299](https://github.com/reupen/columns_ui/pull/1299),
+  [#1317](https://github.com/reupen/columns_ui/pull/1317)]
 
 #### Buttons toolbar
 

--- a/foo_ui_columns/tab_setup.cpp
+++ b/foo_ui_columns/tab_setup.cpp
@@ -19,6 +19,9 @@ public:
             uih::enhance_edit_control(wnd, IDC_STRING);
             SendDlgItemMessage(wnd, IDC_TRANSPARENCY_SPIN, UDM_SETRANGE32, 0, 255);
 
+            if (config::use_hardware_acceleration)
+                Button_SetCheck(GetDlgItem(wnd, IDC_HARDWARE_ACCELERATION), BST_CHECKED);
+
             if (!main_window.get_wnd())
                 EnableWindow(GetDlgItem(wnd, IDC_QUICKSETUP), FALSE);
 


### PR DESCRIPTION
Resolves #1316

This fixes a bug where, when rendering a non-square image, the prerendered bitmap created was too large, and another previously rendered image showed through in the extra space.

A problem where the ‘Allow Direct2D hardware acceleration in built-in panels’ checkbox in Preferences wasn’t initialised with the current value of the setting has also been fixed.