### PR TITLE
Fix empty Tab stack crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,8 @@
 - Various bugs relating to the manipulation of single-instance panels during
   live editing were fixed.
   [[#1315](https://github.com/reupen/columns_ui/pull/1315),
-  [#1322](https://github.com/reupen/columns_ui/pull/1322)]
+  [#1322](https://github.com/reupen/columns_ui/pull/1322),
+  [#1324](https://github.com/reupen/columns_ui/pull/1324)]
 
 - Removing the active tab in a Tab stack during live editing now switches to
   another tab (rather than leaving no tab active).

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -577,10 +577,10 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (!wp || lp != 0)
             break;
 
-        const auto shown_panel = get_active_panel();
+        const auto active_panel = get_active_panel();
 
-        if (shown_panel->m_wnd && !IsWindowVisible(shown_panel->m_wnd))
-            show_tab_window(shown_panel->m_wnd);
+        if (active_panel && active_panel->m_wnd && !IsWindowVisible(active_panel->m_wnd))
+            show_tab_window(active_panel->m_wnd);
         break;
     }
     case WM_CONTEXTMENU: {


### PR DESCRIPTION
This fixes a bug introduced in 55d74529c14a277880de88a8d6788abc6d912527 where an empty Tab stack panel crashed when the Tab stack window was shown.