### PR TITLE
Correct active preset symbol in View/Layout menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,10 @@
   inserted the panel in the wrong position until foobar2000 was restarted was
   fixed. [[#1325](https://github.com/reupen/columns_ui/pull/1325)]
 
+- The symbol used for the active layout preset in the View/Layout menu was
+  corrected to be a filled circle rather than a tick.
+  [[#1326](https://github.com/reupen/columns_ui/pull/1326)]
+
 ### Internal changes
 
 - Some code was refactored.

--- a/foo_ui_columns/menu_items.cpp
+++ b/foo_ui_columns/menu_items.cpp
@@ -196,7 +196,7 @@ class MainMenuLayoutPresets : public mainmenu_commands {
     bool get_display(uint32_t p_index, pfc::string_base& p_text, uint32_t& p_flags) override
     {
         if (g_layout_window.get_wnd()) {
-            p_flags = p_index == cfg_layout.get_active() ? flag_checked : 0;
+            p_flags = p_index == cfg_layout.get_active() ? flag_radiochecked : 0;
             get_name(p_index, p_text);
             return true;
         }


### PR DESCRIPTION
For some reason the the active preset menu item in the View/Layout menu was using `mainmenu_commands::flag_checked` rather than `mainmenu_commands::flag_radiochecked`, and hence the wrong symbol was being shown.

This corrects that.