### PR TITLE
Rename ‘Splitters’ panel category and flat splitter panel names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,10 +77,10 @@
   [#1332](https://github.com/reupen/columns_ui/pull/1332)]
 
 - A ‘Paste/Before’ command was added to the live editing context menu.
-  [[#1335](https://github.com/reupen/columns_ui/pull/1335)]
+  [[#1336](https://github.com/reupen/columns_ui/pull/1336)]
 
 - An ‘Edit parent’ command was added to the live editing context menu.
-  [[#1335](https://github.com/reupen/columns_ui/pull/1335)]
+  [[#1336](https://github.com/reupen/columns_ui/pull/1336)]
 
   This closes the menu for the current panel and shows the live editing menu for
   the parent splitter.
@@ -88,7 +88,7 @@
 - The ‘Add sibling’ (previously ‘Add panel’ underneath the name of the parent
   splitter) command in the live editing context menu now adds the new panel
   directly after the panel the menu is being shown for.
-  [[#1335](https://github.com/reupen/columns_ui/pull/1335)]
+  [[#1336](https://github.com/reupen/columns_ui/pull/1336)]
 
 - Commands to cut, copy or paste panels now all operate on an internal clipboard
   in addition to the Windows clipboard, to protect against accidentally
@@ -101,6 +101,12 @@
 - Unknown panels (such as uninstalled panels) are now preserved when copied and
   pasted in the Layout tree in Preferences.
   [[#1302](https://github.com/reupen/columns_ui/pull/1302)]
+
+- The ‘Splitters’ panel category was renamed ‘Containers’.
+  [[#1337](https://github.com/reupen/columns_ui/pull/1337)]
+
+- ‘Horizontal splitter’ and ‘Vertical splitter’ were renamed ‘Row’ and ‘Column’
+  respectively. [[#1337](https://github.com/reupen/columns_ui/pull/1337)]
 
 #### Other
 

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -615,7 +615,7 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 EXSTYLE WS_EX_CONTROLPARENT
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    LTEXT           "Horizontal and vertical splitters",IDC_TITLE1,7,4,313,16
+    LTEXT           "Rows and columns",IDC_TITLE1,7,4,313,16
     CONTROL         "Allow resizing of locked panels",IDC_ALLOW_LOCKED_PANEL_RESIZING,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,30,116,10
     LTEXT           "Divider width",-1,7,50,47,8

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -60,8 +60,8 @@ std::optional<pfc::array_t<uint8_t>> convert_splitter_and_get_config(
 
     const auto panel_count = old_splitter->get_panel_count();
     if (panel_count > new_splitter->get_maximum_panel_count()
-        && !cui::dark::modal_info_box(wnd, "Change splitter type",
-            "The number of child items will not fit in the selected splitter type. Do you want to "
+        && !cui::dark::modal_info_box(wnd, "Change container type",
+            "The number of child items will not fit in the selected container type. Do you want to "
             "continue?",
             uih::InfoBoxType::Warning, uih::InfoBoxModalType::YesNo))
         return {};
@@ -78,7 +78,7 @@ std::optional<pfc::array_t<uint8_t>> convert_splitter_and_get_config(
     try {
         new_splitter->get_config(&conf, fb2k::noAbort);
     } catch (const std::exception& ex) {
-        console::print("Columns UI – error changing splitter type: ", ex.what());
+        console::print("Columns UI – error changing container type: ", ex.what());
         return {};
     }
 
@@ -852,7 +852,7 @@ void LayoutWindow::run_live_edit_base(LiveEditData p_data)
             };
 
             menu.append_submenu(
-                create_splitters_menu(parent_supported_panels, leaf_id, commands, handle_command), L"Splitter type");
+                create_splitters_menu(parent_supported_panels, leaf_id, commands, handle_command), L"Container type");
         }
     }
 
@@ -872,7 +872,7 @@ void LayoutWindow::run_live_edit_base(LiveEditData p_data)
 
             menu.append_submenu(
                 create_splitters_menu(parent_supported_panels, leaf_id, commands, handle_change_root_splitter),
-                L"Splitter type");
+                L"Container type");
 
             menu.append_separator();
         }

--- a/foo_ui_columns/panel_utils.h
+++ b/foo_ui_columns/panel_utils.h
@@ -8,6 +8,7 @@ public:
     std::wstring name;
     std::wstring category;
     bool is_single_instance{};
+    bool prefers_multiple_instances{};
     uint32_t type{};
 };
 
@@ -24,11 +25,11 @@ std::vector<PanelInfo> get_panel_info(const WindowIterable& windows = uie::windo
         window->get_name(name);
         info.name = mmh::to_utf16(name.c_str());
 
-        pfc::string8 category;
-        window->get_category(category);
+        const auto category = uie::utils::get_remapped_category(window);
         info.category = mmh::to_utf16(category.c_str());
 
         info.is_single_instance = window->get_is_single_instance();
+        info.prefers_multiple_instances = window->get_prefer_multiple_instances();
         info.type = window->get_type();
 
         panels.emplace_back(std::move(info));

--- a/foo_ui_columns/splitter.cpp
+++ b/foo_ui_columns/splitter.cpp
@@ -10,7 +10,7 @@ class HorizontalSplitterPanel : public FlatSplitterPanel {
     {
         return {L"{72FACC90-BB7E-4733-8449-D7537232AD26}", true, CS_DBLCLKS};
     }
-    void get_name(pfc::string_base& p_out) const override { p_out = "Horizontal splitter"; }
+    void get_name(pfc::string_base& p_out) const override { p_out = "Row"; }
     const GUID& get_extension_guid() const override
     {
         // {8FA0BC24-882A-4fff-8A3B-215EA7FBD07F}
@@ -25,7 +25,7 @@ class VerticalSplitterPanel : public FlatSplitterPanel {
     {
         return {L"{77653A44-66D1-49e0-9A7A-1C71898C0441}", true, CS_DBLCLKS};
     }
-    void get_name(pfc::string_base& p_out) const override { p_out = "Vertical splitter"; }
+    void get_name(pfc::string_base& p_out) const override { p_out = "Column"; }
     const GUID& get_extension_guid() const override
     {
         // {77653A44-66D1-49e0-9A7A-1C71898C0441}

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -364,8 +364,8 @@ void LayoutTab::switch_splitter(HWND wnd, HTREEITEM ti, const GUID& p_guid)
     if (uie::window::create_by_guid(p_guid, window) && window->service_query_t(splitter)) {
         const auto count = std::min(old_node->m_children.size(), splitter->get_maximum_panel_count());
         if (count == old_node->m_children.size()
-            || dark::modal_info_box(wnd, "Change splitter type",
-                "The number of child items will not fit in the selected splitter type. Do you want to continue?",
+            || dark::modal_info_box(wnd, "Change container type",
+                "The number of child items will not fit in the selected container type. Do you want to continue?",
                 uih::InfoBoxType::Warning, uih::InfoBoxModalType::YesNo)) {
             for (unsigned n = 0; n < count; n++)
                 splitter->add_panel(old_node->m_children[n]->m_item->get_ptr());
@@ -845,7 +845,7 @@ bool LayoutTab::handle_wm_contextmenu(HWND wnd, HWND contextmenu_wnd, POINT pt)
                 }
             }
 
-            menu.append_submenu(std::move(change_splitter_menu), L"Splitter type");
+            menu.append_submenu(std::move(change_splitter_menu), L"Container type");
         }
 
         if (!ti.hItem) {


### PR DESCRIPTION
Resolves #358

This:

- rename ‘Splitters’ panel category to ‘Containers’, to better reflect the types of panels that sit in the category
- renames ‘Horizontal splitter’ and ‘Vertical splitter’ to ‘Row’ and ‘Column’ respectively, to get rid of the confusion associated with the previous names