### PR TITLE
Adjust artwork view rendering intent when Advanced Colour is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
   [#1292](https://github.com/reupen/columns_ui/pull/1292),
   [#1296](https://github.com/reupen/columns_ui/pull/1296),
   [#1300](https://github.com/reupen/columns_ui/pull/1300),
-  [#1301](https://github.com/reupen/columns_ui/pull/1301)]
+  [#1301](https://github.com/reupen/columns_ui/pull/1301),
+  [#1340](https://github.com/reupen/columns_ui/pull/1340)]
 
   Additionally, support for Windows Advanced Colour can be enabled in
   Preferences on Windows 10 version 1809 and newer. This improves support for

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -792,12 +792,16 @@ void ArtworkPanel::create_effects()
     wil::com_ptr<ID2D1Effect> white_level_adjustment_effect;
     wil::com_ptr<ID2D1ColorContext> working_colour_context;
 
+    const auto rendering_intent = is_advanced_colour
+        ? std::make_optional(D2D1_COLORMANAGEMENT_RENDERING_INTENT_RELATIVE_COLORIMETRIC)
+        : std::nullopt;
+
     if (is_advanced_colour) {
         THROW_IF_FAILED(
             m_d2d_device_context->CreateColorContext(D2D1_COLOR_SPACE_SCRGB, nullptr, 0, &working_colour_context));
 
-        const auto working_colour_management_effect
-            = d2d::create_colour_management_effect(m_d2d_device_context, image_colour_context, working_colour_context);
+        const auto working_colour_management_effect = d2d::create_colour_management_effect(
+            m_d2d_device_context, image_colour_context, working_colour_context, rendering_intent, rendering_intent);
         working_colour_management_effect->SetInputEffect(0, scale_effect.get());
 
         const auto is_hdr_image = m_artwork_decoder.is_float();
@@ -831,7 +835,8 @@ void ArtworkPanel::create_effects()
     }
 
     const auto colour_management_effect = d2d::create_colour_management_effect(m_d2d_device_context,
-        working_colour_context ? working_colour_context : image_colour_context, dest_colour_context);
+        working_colour_context ? working_colour_context : image_colour_context, dest_colour_context, rendering_intent,
+        rendering_intent);
 
     colour_management_effect->SetInputEffect(
         0, white_level_adjustment_effect ? white_level_adjustment_effect.get() : scale_effect.get());

--- a/foo_ui_columns/d2d_utils.cpp
+++ b/foo_ui_columns/d2d_utils.cpp
@@ -37,7 +37,9 @@ MainThreadD2D1Factory create_main_thread_factory()
 
 wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
     const wil::com_ptr<ID2D1ColorContext>& source_color_context,
-    const wil::com_ptr<ID2D1ColorContext>& dest_color_context)
+    const wil::com_ptr<ID2D1ColorContext>& dest_color_context,
+    std::optional<D2D1_COLORMANAGEMENT_RENDERING_INTENT> source_rendering_intent,
+    std::optional<D2D1_COLORMANAGEMENT_RENDERING_INTENT> dest_rendering_intent)
 {
     wil::com_ptr<ID2D1Effect> colour_management_effect;
     THROW_IF_FAILED(device_context->CreateEffect(CLSID_D2D1ColorManagement, &colour_management_effect));
@@ -55,6 +57,16 @@ wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2
     if (dest_color_context) {
         THROW_IF_FAILED(colour_management_effect->SetValue(
             D2D1_COLORMANAGEMENT_PROP_DESTINATION_COLOR_CONTEXT, dest_color_context.get()));
+    }
+
+    if (source_rendering_intent) {
+        THROW_IF_FAILED(colour_management_effect->SetValue(
+            D2D1_COLORMANAGEMENT_PROP_SOURCE_RENDERING_INTENT, *source_rendering_intent));
+    }
+
+    if (dest_rendering_intent) {
+        THROW_IF_FAILED(colour_management_effect->SetValue(
+            D2D1_COLORMANAGEMENT_PROP_DESTINATION_RENDERING_INTENT, *dest_rendering_intent));
     }
 
     return colour_management_effect;

--- a/foo_ui_columns/d2d_utils.h
+++ b/foo_ui_columns/d2d_utils.h
@@ -9,7 +9,9 @@ MainThreadD2D1Factory create_main_thread_factory();
 
 wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
     const wil::com_ptr<ID2D1ColorContext>& source_color_context,
-    const wil::com_ptr<ID2D1ColorContext>& dest_color_context);
+    const wil::com_ptr<ID2D1ColorContext>& dest_color_context,
+    std::optional<D2D1_COLORMANAGEMENT_RENDERING_INTENT> source_rendering_intent = {},
+    std::optional<D2D1_COLORMANAGEMENT_RENDERING_INTENT> dest_rendering_intent = {});
 
 wil::com_ptr<ID2D1Effect> create_scale_effect(
     const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_VECTOR_2F scale);


### PR DESCRIPTION
[Microsoft documentation](https://learn.microsoft.com/en-gb/windows/win32/wcs/advanced-color-icc-profiles#perform-gamut-mapping-to-constrain-to-the-displays-gamut) states:

> When you're in an advanced color workflow, we generally don't recommend using the perceptual rendering intent, neither for source or destination, since it was designed for SDR sources and destinations that have smaller color gamuts than the ones used for HDR and some WCG displays; so using them can result in unexpected behavior.

Helpfully, it doesn’t explain what to actually do.

Relative colorimetric seems to get correct results on an HDR display, or when [auto colour management](https://support.microsoft.com/en-gb/windows/change-display-brightness-and-color-in-windows-3f67a2f2-5c65-ceca-778b-5858fc007041#bkmk_color_profile) is enabled in Windows, so this switches to that (when Advanced Colour is enabled in Artwork view).

