### PR TITLE
Disable captions by default in rows and columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,10 @@
   inserted the panel in the wrong position until foobar2000 was restarted was
   fixed. [[#1325](https://github.com/reupen/columns_ui/pull/1325)]
 
+- Copying panels from a Tab stack and pasting them in a row or column container
+  no longer results in the panel having a zero width or height.
+  [[#1341](https://github.com/reupen/columns_ui/pull/1341)]
+
 - The symbol used for the active layout preset in the View/Layout menu was
   corrected to be a filled circle rather than a tick.
   [[#1326](https://github.com/reupen/columns_ui/pull/1326)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@
 - ‘Horizontal splitter’ and ‘Vertical splitter’ were renamed ‘Row’ and ‘Column’
   respectively. [[#1337](https://github.com/reupen/columns_ui/pull/1337)]
 
+- Captions are no longer enabled by default when adding panels to row and column
+  containers. [[#1341](https://github.com/reupen/columns_ui/pull/1341)]
+
 #### Other
 
 - The Main preferences tab was split into a Setup tab and a Main window tab.

--- a/foo_ui_columns/splitter.h
+++ b/foo_ui_columns/splitter.h
@@ -135,7 +135,7 @@ private:
         bool m_autohide{false};
         HWND m_wnd{nullptr};
         HWND m_wnd_child{nullptr};
-        bool m_show_caption{true};
+        bool m_show_caption{};
         pfc::array_t<uint8_t> m_child_data;
         SizeLimit m_size_limits;
         uie::window_ptr m_child;

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -167,9 +167,9 @@ uie::splitter_item_full_v2_t* TabStackPanel::Panel::create_splitter_item()
     ret->m_locked = false;
     ret->m_hidden = false;
     ret->m_show_toggle_area = false;
-    ret->m_size = 0;
-    ret->m_show_caption = true;
-    ret->m_size_v2 = 0;
+    ret->m_size = 150;
+    ret->m_show_caption = false;
+    ret->m_size_v2 = 150;
     ret->m_size_v2_dpi = USER_DEFAULT_SCREEN_DPI;
     return ret;
 }


### PR DESCRIPTION
This disables captions by default when adding panels to a row or column.

It also changes the Tab stack copy panel behaviour to stop it automatically enabling captions and make it set the panel size to 150 (the default value used in rows and columns), rather than 0.