### PR TITLE
Use GdiAlphaBlend() instead of AlphaBlend()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@
   [#1289](https://github.com/reupen/columns_ui/pull/1289),
   [#1292](https://github.com/reupen/columns_ui/pull/1292),
   [#1299](https://github.com/reupen/columns_ui/pull/1299),
-  [#1317](https://github.com/reupen/columns_ui/pull/1317)]
+  [#1317](https://github.com/reupen/columns_ui/pull/1317),
+  [#1344](https://github.com/reupen/columns_ui/pull/1344)]
 
 #### Buttons toolbar
 

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -120,7 +120,7 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;uxtheme.lib;Dwmapi.lib;usp10.lib;mscms.lib;Msimg32.lib;Windowscodecs.lib;dxgi.lib;d3d11.lib;d2d1.lib;dwrite.lib;dxguid.lib;../foobar2000/shared/shared-$(Platform).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;uxtheme.lib;Dwmapi.lib;usp10.lib;mscms.lib;Windowscodecs.lib;dxgi.lib;d3d11.lib;d2d1.lib;dwrite.lib;dxguid.lib;../foobar2000/shared/shared-$(Platform).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -160,7 +160,7 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;uxtheme.lib;Dwmapi.lib;usp10.lib;mscms.lib;Msimg32.lib;Windowscodecs.lib;dxgi.lib;d3d11.lib;d2d1.lib;dwrite.lib;dxguid.lib;../foobar2000/shared/shared-$(Platform).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;uxtheme.lib;Dwmapi.lib;usp10.lib;mscms.lib;Windowscodecs.lib;dxgi.lib;d3d11.lib;d2d1.lib;dwrite.lib;dxguid.lib;../foobar2000/shared/shared-$(Platform).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -198,7 +198,7 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;uxtheme.lib;Dwmapi.lib;usp10.lib;mscms.lib;Msimg32.lib;Windowscodecs.lib;dxgi.lib;d3d11.lib;d2d1.lib;dwrite.lib;dxguid.lib;../foobar2000/shared/shared-$(Platform).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;uxtheme.lib;Dwmapi.lib;usp10.lib;mscms.lib;Windowscodecs.lib;dxgi.lib;d3d11.lib;d2d1.lib;dwrite.lib;dxguid.lib;../foobar2000/shared/shared-$(Platform).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>Debug</GenerateDebugInformation>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
@@ -233,7 +233,7 @@
       <Culture>0x0809</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;uxtheme.lib;Dwmapi.lib;usp10.lib;mscms.lib;Msimg32.lib;Windowscodecs.lib;dxgi.lib;d3d11.lib;d2d1.lib;dwrite.lib;dxguid.lib;../foobar2000/shared/shared-$(Platform).lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Urlmon.lib;comctl32.lib;shell32.lib;shlwapi.lib;Winmm.lib;gdiplus.lib;uxtheme.lib;Dwmapi.lib;usp10.lib;mscms.lib;Windowscodecs.lib;dxgi.lib;d3d11.lib;d2d1.lib;dwrite.lib;dxguid.lib;../foobar2000/shared/shared-$(Platform).lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>Debug</GenerateDebugInformation>
       <DataExecutionPrevention>
       </DataExecutionPrevention>

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 
-#include "font_manager_data.h"
 #include "ng_playlist.h"
 
 namespace cui::panels::playlist_view {
@@ -43,7 +42,7 @@ void PlaylistViewRenderer::render_group_info(uih::lv::RendererContext context, s
     blend_function.SourceConstantAlpha = 255;
     blend_function.AlphaFormat = AC_SRC_ALPHA;
 
-    AlphaBlend(context.dc, rc_bitmap.left, rc_bitmap.top, wil::rect_width(rc_bitmap), wil::rect_height(rc_bitmap),
+    GdiAlphaBlend(context.dc, rc_bitmap.left, rc_bitmap.top, wil::rect_width(rc_bitmap), wil::rect_height(rc_bitmap),
         bitmap_dc.get(), 0, 0, bitmap_info.bmWidth, bitmap_info.bmHeight, blend_function);
 }
 


### PR DESCRIPTION
`GdiAlphaBlend()` was previously being used in the status bar, while `AlphaBlend()` was being used in the playlist view.

The functions are meant to be equivalent (on further investigation, `AlphaBlend()` seems to just call `GdiAlphaBlend()` after performing some checks).

Additionally, `AlphaBlend()` is exported by `msimg32.dll`, and using it requires linking `msimg32.lib`.

This therefore standardises on using `GdiAlphaBlend()`.