### PR TITLE
Fix playlist view artwork relections for narrow images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@
   [#1292](https://github.com/reupen/columns_ui/pull/1292),
   [#1299](https://github.com/reupen/columns_ui/pull/1299),
   [#1317](https://github.com/reupen/columns_ui/pull/1317),
-  [#1344](https://github.com/reupen/columns_ui/pull/1344)]
+  [#1344](https://github.com/reupen/columns_ui/pull/1344),
+  [#1345](https://github.com/reupen/columns_ui/pull/1345)]
 
 #### Buttons toolbar
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -21,15 +21,16 @@ namespace {
     const auto bitmap_pixel_size = d2d_bitmap->GetPixelSize();
     const auto bitmap_size = d2d_bitmap->GetSize();
 
+    const auto reflection_height_px = show_reflection ? (target_width * 3) / 11 : 0;
+    const auto reflection_height_dip = static_cast<float>(reflection_height_px);
+    const auto target_height_without_reflection = std::max(0, target_height - reflection_height_px);
+
     const auto [render_width_px, render_height_px]
         = cui::utils::calculate_scaled_image_size(static_cast<int>(bitmap_pixel_size.width),
-            static_cast<int>(bitmap_pixel_size.height), target_width, target_height, true, false);
+            static_cast<int>(bitmap_pixel_size.height), target_width, target_height_without_reflection, true, false);
 
     const auto render_width_dip = static_cast<float>(render_width_px);
     const auto render_height_dip = static_cast<float>(render_height_px);
-
-    const auto reflection_height_px = show_reflection ? (target_width * 3) / 11 : 0;
-    const auto reflection_height_dip = static_cast<float>(reflection_height_px);
 
     const auto scale_effect = d2d::create_scale_effect(context->d2d_device_context,
         D2D1::Vector2F(render_width_dip / bitmap_size.width, render_height_dip / bitmap_size.height));

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -43,7 +43,7 @@ void PlaylistViewRenderer::render_group_info(uih::lv::RendererContext context, s
     blend_function.AlphaFormat = AC_SRC_ALPHA;
 
     GdiAlphaBlend(context.dc, rc_bitmap.left, rc_bitmap.top, wil::rect_width(rc_bitmap), wil::rect_height(rc_bitmap),
-        bitmap_dc.get(), 0, 0, bitmap_info.bmWidth, bitmap_info.bmHeight, blend_function);
+        bitmap_dc.get(), 0, 0, wil::rect_width(rc_bitmap), wil::rect_height(rc_bitmap), blend_function);
 }
 
 void PlaylistViewRenderer::render_item(uih::lv::RendererContext context, size_t index,


### PR DESCRIPTION
Enabling artwork relections in the playlist view caused narrow images to render incorrectly, because it was scaling the image too large as it wasn't correctly accounting for the additional height of the reflection.