### PR TITLE
Fix crash when destroying playlist view while artwork still loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.1.0-alpha.2
+
+### Bug fixes
+
+- A crash when a playlist view was destroyed (for example, when closing
+  foobar2000) while artwork was loading was fixed.
+  [[#1349](https://github.com/reupen/columns_ui/pull/1349)]
+
 ## 3.1.0-alpha.1
 
 ### Features

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -406,7 +406,8 @@ void ArtworkReader::start(ArtworkRenderingContext::Ptr context)
         if (m_status != ArtworkReaderStatus::Succeeded)
             m_bitmaps.clear();
 
-        fb2k::inMainThread([this, context{std::move(context)}] { m_manager->on_reader_done(context, this); });
+        fb2k::inMainThread(
+            [this, manager{m_manager}, context{std::move(context)}] { manager->on_reader_done(context, this); });
     });
 }
 


### PR DESCRIPTION
This fixes a crash that occured if playlist view artwork was being loaded when a playlist view was destroyed (e.g. when closing foobar2000 or editing the layout).