### PR TITLE
Fix crash when changing playlist while artwork loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 3.1.0-alpha.3
+
+### Bug fixes
+
+- A crash when switching playlist while artwork was loading was fixed.
+  [[#1353](https://github.com/reupen/columns_ui/pull/1353)]
+
 ## 3.1.0-alpha.2
 
 ### Bug fixes

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -332,7 +332,7 @@ wil::shared_hbitmap PlaylistView::request_group_artwork(size_t index_item, HMONI
             m_playlist_api->activeplaylist_get_item_handle(handle, index_item);
 
             m_artwork_manager->request(handle, monitor, cx, cy, cfg_artwork_reflection,
-                [this, self{ptr{this}}, group](
+                [this, self{ptr{this}}, group{PlaylistViewGroup::ptr{group}}](
                     const ArtworkReader* reader) { on_artwork_read_complete(group, reader); });
         }
 


### PR DESCRIPTION
This fixes a crash that occurred if a playlist group was removed (e.g. due to switching playlist) while artwork was still being loaded for the group.