### PR TITLE
Update all documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 
   (Previous 3.1.0 versions triggered a bug check crash.)
 
+- A link to the Columns UI documentation site was added to the Setup tab in
+  preferences. [[#1363](https://github.com/reupen/columns_ui/pull/1363)]
+
+  Additionally, all links to the archived Columns UI wiki were replaced with
+  links to the current documentation site.
+
+- On the Columns tab on the Playlist view preferences page, ‘Size weight’ was
+  renamed ‘Auto-size weight’ and some hint text was added under the playlist
+  filters edit box when playlist filters are enabled for that column.
+  [[#1363](https://github.com/reupen/columns_ui/pull/1363)]
+
 ## 3.1.0-alpha.3
 
 ### Bug fixes

--- a/foo_ui_columns/config_artwork.cpp
+++ b/foo_ui_columns/config_artwork.cpp
@@ -134,7 +134,7 @@ public:
     const char* get_name() override { return "Artwork"; }
     bool get_help_url(pfc::string_base& p_out) override
     {
-        p_out = "http://yuo.be/wiki/columns_ui:config:artwork";
+        p_out = "https://columns-ui.readthedocs.io/page/other/artwork.html";
         return true;
     }
 

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -68,8 +68,9 @@ public:
         EnableWindow(GetDlgItem(wnd, IDC_PARTS), show);
         EnableWindow(GetDlgItem(wnd, IDC_SHOW_COLUMN), show);
         EnableWindow(GetDlgItem(wnd, IDC_ALIGNMENT), show);
-        EnableWindow(
-            GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), show && m_column && m_column->filter_type != FILTER_NONE);
+        const auto enable_filter_pattern_controls = show && m_column && m_column->filter_type != FILTER_NONE;
+        EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), enable_filter_pattern_controls);
+        ShowWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_HINT), enable_filter_pattern_controls ? SW_SHOW : SW_HIDE);
         EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_TYPE), show);
         EnableWindow(GetDlgItem(wnd, IDC_EDITFIELD), show);
     }
@@ -142,7 +143,10 @@ public:
             case (CBN_SELCHANGE << 16) | IDC_PLAYLIST_FILTER_TYPE: {
                 if (!initialising && m_column) {
                     m_column->filter_type = ((PlaylistFilterType)SendMessage((HWND)lp, CB_GETCURSEL, 0, 0));
-                    EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), m_column->filter_type != FILTER_NONE);
+                    const auto enable_filter_pattern_controls = m_column->filter_type != FILTER_NONE;
+                    EnableWindow(GetDlgItem(wnd, IDC_PLAYLIST_FILTER_STRING), enable_filter_pattern_controls);
+                    ShowWindow(
+                        GetDlgItem(wnd, IDC_PLAYLIST_FILTER_HINT), enable_filter_pattern_controls ? SW_SHOW : SW_HIDE);
                 }
             } break;
             case IDC_SHOW_COLUMN: {

--- a/foo_ui_columns/config_columns_v2.h
+++ b/foo_ui_columns/config_columns_v2.h
@@ -34,11 +34,6 @@ public:
     void show_column(size_t index);
 
     const char* get_name() override { return "Columns"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:playlist_view:columns";
-        return true;
-    }
 
 private:
     class ColumnsListView : public cui::helpers::CoreDarkListView {

--- a/foo_ui_columns/config_filter.cpp
+++ b/foo_ui_columns/config_filter.cpp
@@ -216,11 +216,6 @@ public:
             [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Fields"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:filter";
-        return true;
-    }
 
 private:
     cui::prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}};
@@ -294,11 +289,6 @@ public:
             [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Appearance"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:filter";
-        return true;
-    }
 
 private:
     cui::prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}};
@@ -404,11 +394,6 @@ public:
             [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Behaviour"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:filter";
-        return true;
-    }
 
 private:
     cui::prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}};

--- a/foo_ui_columns/config_host.h
+++ b/foo_ui_columns/config_host.h
@@ -108,7 +108,7 @@ public:
     bool get_help_url(pfc::string_base& p_out) override
     {
         if (!(m_active_tab < (int)m_tabs.size() && m_tabs[m_active_tab]->get_help_url(p_out)))
-            p_out = "http://yuo.be/wiki/columns_ui:manual";
+            p_out = "https://columns-ui.readthedocs.io";
         return true;
     }
 

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -137,6 +137,8 @@ wil::unique_hbrush get_dark_colour_brush(ColourID colour_id)
 int get_light_colour_system_id(ColourID colour_id)
 {
     switch (colour_id) {
+    case ColourID::HyperlinkText:
+        return COLOR_HIGHLIGHT;
     case ColourID::LayoutBackground:
         return COLOR_BTNFACE;
     case ColourID::PanelCaptionText:
@@ -195,6 +197,8 @@ COLORREF get_dark_colour(ColourID colour_id)
         return get_base_dark_colour(DarkColourID::DARK_999);
     case ColourID::EditBackground:
         return get_base_dark_colour(DarkColourID::DARK_200);
+    case ColourID::HyperlinkText:
+        return RGB(50, 155, 250);
     case ColourID::LayoutBackground:
         return get_base_dark_colour(DarkColourID::DARK_200);
     case ColourID::PanelCaptionText:

--- a/foo_ui_columns/dark_mode.h
+++ b/foo_ui_columns/dark_mode.h
@@ -13,6 +13,7 @@ enum class ColourID {
     ComboBoxEditBackground,
     ComboBoxEditText,
     EditBackground,
+    HyperlinkText,
     LayoutBackground,
     PanelCaptionText,
     PanelCaptionBackground,

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -779,6 +779,9 @@ BEGIN
     CONTROL         "Allow Direct2D hardware acceleration in built-in panels",IDC_HARDWARE_ACCELERATION,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,141,313,10
     LTEXT           "This option affects only the artwork view, artwork in the playlist view, and Item details.",IDC_STATIC,7,157,313,15
+    CONTROL         "<a href=""https://columns-ui.readthedocs.io"">Columns UI documentation site</a>",IDC_DOCUMENTATION_LINK,
+                    "SysLink",WS_TABSTOP,7,206,123,13
+    LTEXT           "Documentation",IDC_TITLE3,7,185,313,14
 END
 
 

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -424,7 +424,7 @@ BEGIN
     EDITTEXT        IDC_NAME,7,37,208,13,ES_AUTOHSCROLL
     LTEXT           "Width",-1,7,61,20,8
     EDITTEXT        IDC_WIDTH,7,71,65,13,ES_AUTOHSCROLL | ES_NUMBER
-    LTEXT           "Size weight",-1,78,61,47,8
+    LTEXT           "Auto-size weight",-1,78,61,65,8
     EDITTEXT        IDC_PARTS,78,71,65,13,ES_AUTOHSCROLL | ES_NUMBER
     LTEXT           "Alignment",-1,150,61,45,8
     COMBOBOX        IDC_ALIGNMENT,150,71,65,78,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
@@ -433,6 +433,7 @@ BEGIN
     LTEXT           "Playlist filters",-1,7,130,43,8
     COMBOBOX        IDC_PLAYLIST_FILTER_TYPE,7,140,208,74,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     EDITTEXT        IDC_PLAYLIST_FILTER_STRING,7,157,208,13,ES_AUTOHSCROLL
+    LTEXT           "Case-insensitive. Wildcards (* and ?) allowed. Use a ; to separate multiple patterns.",IDC_PLAYLIST_FILTER_HINT,7,174,208,19
 END
 
 IDD_PREFS_COLUMNS DIALOGEX 0, 0, 327, 272

--- a/foo_ui_columns/help.cpp
+++ b/foo_ui_columns/help.cpp
@@ -7,7 +7,7 @@ namespace cui::help {
 
 void open_colour_script_help(HWND wnd)
 {
-    helpers::open_web_page(wnd, urls::colour_script_help.data());
+    helpers::open_web_page(wnd, urls::style_script_help.data());
 }
 
 void open_global_variables_help(HWND wnd)

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -589,11 +589,6 @@ public:
             [this](auto&&... args) { return ConfigProc(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Grouping"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:playlist_view:grouping";
-        return true;
-    }
 
 private:
     BOOL ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -309,6 +309,7 @@
 #define IDC_USE_ADVANCED_COLOUR         1205
 #define IDC_HARDWARE_ACCELERATION       1207
 #define IDC_DOCUMENTATION_LINK          1208
+#define IDC_PLAYLIST_FILTER_HINT        1209
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -318,7 +319,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        198
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1209
+#define _APS_NEXT_CONTROL_VALUE         1210
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -267,6 +267,7 @@
 #define IDC_COLOUR_CODE                 1166
 #define IDC_TITLE1                      1168
 #define IDC_TITLE2                      1169
+#define IDC_TITLE3                      1170
 #define IDC_DISPLAY_SCRIPT              1173
 #define IDC_SORTING_SCRIPT              1174
 #define IDC_STYLE_SCRIPT                1175
@@ -307,6 +308,7 @@
 #define IDC_SET_FORMAT_SNIPPET          1203
 #define IDC_USE_ADVANCED_COLOUR         1205
 #define IDC_HARDWARE_ACCELERATION       1207
+#define IDC_DOCUMENTATION_LINK          1208
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -316,7 +318,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        198
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1208
+#define _APS_NEXT_CONTROL_VALUE         1209
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/foo_ui_columns/tab_colours.cpp
+++ b/foo_ui_columns/tab_colours.cpp
@@ -15,12 +15,6 @@ bool TabColours::is_active()
     return m_wnd != nullptr;
 }
 
-bool TabColours::get_help_url(pfc::string_base& p_out)
-{
-    p_out = "http://yuo.be/wiki/columns_ui:config:colours_and_fonts:colours";
-    return true;
-}
-
 const char* TabColours::get_name()
 {
     return "Colours";

--- a/foo_ui_columns/tab_colours.h
+++ b/foo_ui_columns/tab_colours.h
@@ -28,7 +28,6 @@ public:
     void apply();
     HWND create(HWND wnd) override;
     const char* get_name() override;
-    bool get_help_url(pfc::string_base& p_out) override;
     bool is_active();
 
 private:

--- a/foo_ui_columns/tab_dark_mode.cpp
+++ b/foo_ui_columns/tab_dark_mode.cpp
@@ -62,11 +62,6 @@ void TabDarkMode::refresh()
         current_mode == cui::colours::DarkModeStatus::UseSystemSetting ? BST_CHECKED : BST_UNCHECKED);
 }
 
-bool TabDarkMode::get_help_url(pfc::string_base& p_out)
-{
-    return false;
-}
-
 const char* TabDarkMode::get_name()
 {
     return "Mode";

--- a/foo_ui_columns/tab_dark_mode.h
+++ b/foo_ui_columns/tab_dark_mode.h
@@ -11,7 +11,6 @@ public:
     void apply() {}
     HWND create(HWND wnd) override;
     const char* get_name() override;
-    bool get_help_url(pfc::string_base& p_out) override;
     bool is_active();
     void refresh();
 

--- a/foo_ui_columns/tab_display2.cpp
+++ b/foo_ui_columns/tab_display2.cpp
@@ -143,11 +143,6 @@ public:
             [this](auto&&... args) { return ConfigProc(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "General"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:playlist_view:general";
-        return true;
-    }
 
 private:
     bool m_initialised{};

--- a/foo_ui_columns/tab_fonts.cpp
+++ b/foo_ui_columns/tab_fonts.cpp
@@ -9,12 +9,6 @@ bool TabFonts::is_active() const
     return m_wnd != nullptr;
 }
 
-bool TabFonts::get_help_url(pfc::string_base& p_out)
-{
-    p_out = "http://yuo.be/wiki/columns_ui:config:colours_and_fonts:fonts";
-    return true;
-}
-
 const char* TabFonts::get_name()
 {
     return "Fonts";

--- a/foo_ui_columns/tab_fonts.h
+++ b/foo_ui_columns/tab_fonts.h
@@ -15,7 +15,6 @@ public:
     INT_PTR on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     HWND create(HWND wnd) override;
     const char* get_name() override;
-    bool get_help_url(pfc::string_base& p_out) override;
     bool is_active() const;
 
 private:

--- a/foo_ui_columns/tab_global.cpp
+++ b/foo_ui_columns/tab_global.cpp
@@ -163,7 +163,7 @@ public:
     const char* get_name() override { return "Globals"; }
     bool get_help_url(pfc::string_base& p_out) override
     {
-        p_out = "http://yuo.be/wiki/columns_ui:config:playlist_view:globals";
+        p_out = "https://columns-ui.readthedocs.io/page/playlist-view/global-variables.html";
         return true;
     }
 

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -1022,10 +1022,4 @@ const char* LayoutTab::get_name()
     return "Layout";
 }
 
-bool LayoutTab::get_help_url(pfc::string_base& p_out)
-{
-    p_out = "http://yuo.be/wiki/columns_ui:config:layout";
-    return true;
-}
-
 } // namespace cui::prefs

--- a/foo_ui_columns/tab_layout.h
+++ b/foo_ui_columns/tab_layout.h
@@ -26,7 +26,6 @@ class LayoutTab : public PreferencesTab {
 public:
     HWND create(HWND wnd) override;
     const char* get_name() override;
-    bool get_help_url(pfc::string_base& p_out) override;
 
 private:
     static HTREEITEM insert_item_in_tree_view(

--- a/foo_ui_columns/tab_layout_misc.cpp
+++ b/foo_ui_columns/tab_layout_misc.cpp
@@ -16,12 +16,6 @@ const char* LayoutMiscTab::get_name()
     return "Misc";
 }
 
-bool LayoutMiscTab::get_help_url(pfc::string_base& p_out)
-{
-    p_out = "http://yuo.be/wiki/columns_ui:config:layout";
-    return true;
-}
-
 INT_PTR LayoutMiscTab::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {

--- a/foo_ui_columns/tab_layout_misc.h
+++ b/foo_ui_columns/tab_layout_misc.h
@@ -7,7 +7,6 @@ class LayoutMiscTab : public PreferencesTab {
 public:
     HWND create(HWND wnd) override;
     const char* get_name() override;
-    bool get_help_url(pfc::string_base& p_out) override;
 
 private:
     INT_PTR on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);

--- a/foo_ui_columns/tab_playlist_dd.cpp
+++ b/foo_ui_columns/tab_playlist_dd.cpp
@@ -84,11 +84,6 @@ public:
             [](auto&&... args) { return ConfigProc(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Drag and drop"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:playlist_switcher:drag_and_drop";
-        return true;
-    }
 
 private:
     PreferencesTabHelper m_helper{{IDC_TITLE1}};

--- a/foo_ui_columns/tab_playlist_swticher.cpp
+++ b/foo_ui_columns/tab_playlist_swticher.cpp
@@ -71,7 +71,7 @@ public:
     const char* get_name() override { return "Playlist switcher"; }
     bool get_help_url(pfc::string_base& p_out) override
     {
-        p_out = "http://yuo.be/wiki/columns_ui:config:playlist_switcher:general";
+        p_out = "https://columns-ui.readthedocs.io/page/playlist-switcher/title-formatting.html";
         return true;
     }
 

--- a/foo_ui_columns/tab_playlist_tabs.cpp
+++ b/foo_ui_columns/tab_playlist_tabs.cpp
@@ -48,11 +48,6 @@ public:
             [this](auto&&... args) { return ConfigProc(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Playlist tabs"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:playlist_switcher:general";
-        return true;
-    }
 
 private:
     PreferencesTabHelper m_helper{{IDC_TITLE1}};

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -57,11 +57,6 @@ public:
             [this](auto&&... args) { return ConfigProc(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Artwork"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:playlist_view:general";
-        return true;
-    }
 
 private:
     bool m_initialised{};

--- a/foo_ui_columns/tab_status_bar.cpp
+++ b/foo_ui_columns/tab_status_bar.cpp
@@ -70,11 +70,6 @@ public:
             [this](auto&&... args) { return ConfigProc(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Status bar"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:status_bar";
-        return true;
-    }
     PreferencesTabHelper m_helper{{IDC_TITLE1}};
 };
 

--- a/foo_ui_columns/tab_status_pane.cpp
+++ b/foo_ui_columns/tab_status_pane.cpp
@@ -50,11 +50,6 @@ public:
             [this](auto&&... args) { return ConfigProc(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "Status pane"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:status_bar";
-        return true;
-    }
     PreferencesTabHelper m_helper{{IDC_TITLE1}};
 };
 

--- a/foo_ui_columns/tab_system_tray.cpp
+++ b/foo_ui_columns/tab_system_tray.cpp
@@ -85,11 +85,6 @@ public:
             [this](auto&&... args) { return ConfigProc(std::forward<decltype(args)>(args)...); });
     }
     const char* get_name() override { return "System tray"; }
-    bool get_help_url(pfc::string_base& p_out) override
-    {
-        p_out = "http://yuo.be/wiki/columns_ui:config:notification_area";
-        return true;
-    }
     cui::prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}};
 };
 

--- a/foo_ui_columns/tab_text_rendering.cpp
+++ b/foo_ui_columns/tab_text_rendering.cpp
@@ -32,7 +32,11 @@ public:
 
     const char* get_name() override { return "Text rendering"; }
 
-    bool get_help_url(pfc::string_base& p_out) override { return false; }
+    bool get_help_url(pfc::string_base& p_out) override
+    {
+        p_out = "https://columns-ui.readthedocs.io/page/other/text-rendering.html";
+        return true;
+    }
 
 private:
     std::optional<ptrdiff_t> find_family_name(std::wstring_view family_name);

--- a/foo_ui_columns/urls.h
+++ b/foo_ui_columns/urls.h
@@ -1,6 +1,10 @@
 #pragma once
 
 namespace cui::urls {
-constexpr std::wstring_view colour_script_help = L"https://wiki.yuo.be/columns_ui:config:colour_string";
-constexpr std::wstring_view global_variables_help = L"https://wiki.yuo.be/columns_ui:config:global_variables";
+
+constexpr std::wstring_view style_script_help
+    = L"https://columns-ui.readthedocs.io/page/playlist-view/style-script.html";
+constexpr std::wstring_view global_variables_help
+    = L"https://columns-ui.readthedocs.io/page/playlist-view/global-variables.html";
+
 } // namespace cui::urls


### PR DESCRIPTION
Resolves #1078

This:

- adds a link to the documentation site on the Setup tab in preferences
- replaces all links to the archived wiki with links to the current documentation site
- renames ‘Size weight’ to ‘Auto-size weight’ on the Playlist view preferences page
- adds some hint text under the playlist filters edit box on the Playlist view preferences page when playlist filters are enabled for that column