### PR TITLE
Reload artwork when the source track is modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Development version
+## 3.1.0-beta.1
 
 ### Features
 
@@ -22,6 +22,10 @@
   [[#1363](https://github.com/reupen/columns_ui/pull/1363)]
 
 ### Bug fixes
+
+- The Artwork view now reloads artwork if the panel is showing selection or
+  non-front-cover playing track artwork, and the track the artwork was loaded
+  from is modified. [[#1364](https://github.com/reupen/columns_ui/pull/1364)]
 
 - The playlist view now reloads the artwork for a group if the first track in
   the group is modified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@
   filters edit box when playlist filters are enabled for that column.
   [[#1363](https://github.com/reupen/columns_ui/pull/1363)]
 
+### Bug fixes
+
+- The playlist view now reloads the artwork for a group if the first track in
+  the group is modified.
+  [[#1364](https://github.com/reupen/columns_ui/pull/1364)]
+
 ## 3.1.0-alpha.3
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@
 
 ### Bug fixes
 
-- The Artwork view now reloads artwork if the panel is showing selection or
-  non-front-cover playing track artwork, and the track the artwork was loaded
-  from is modified. [[#1364](https://github.com/reupen/columns_ui/pull/1364)]
+- The Artwork view now always reloads artwork if the track it’s currently
+  showing artwork for is modified.
+  [[#1364](https://github.com/reupen/columns_ui/pull/1364)]
 
 - The playlist view now reloads the artwork for a group if the first track in
   the group is modified.

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -282,15 +282,19 @@ void ArtworkPanel::g_on_edge_style_change()
  */
 void ArtworkPanel::on_album_art(album_art_data::ptr data) noexcept
 {
+    if (!g_track_mode_includes_now_playing(m_track_mode))
+        return;
+
     if (!m_artwork_reader || !m_artwork_reader->is_ready()) {
         m_dynamic_artwork_pending = true;
         return;
     }
 
-    if (m_selected_artwork_type_index == 0) {
+    if (m_selected_artwork_type_index == 0 && data.is_valid())
         m_artwork_type_override_index.reset();
+
+    if (get_displayed_artwork_type_index() == 0)
         refresh_image();
-    }
 }
 
 const GUID& ArtworkPanel::get_extension_guid() const
@@ -914,11 +918,8 @@ void ArtworkPanel::on_playback_stop(play_control::t_stop_reason p_reason) noexce
 void ArtworkPanel::on_playback_new_track(metadb_handle_ptr p_track) noexcept
 {
     m_dynamic_artwork_pending = false;
-    if (g_track_mode_includes_now_playing(m_track_mode) && m_artwork_reader) {
-        const auto data = now_playing_album_art_notify_manager::get()->current();
-
+    if (g_track_mode_includes_now_playing(m_track_mode) && m_artwork_reader)
         request_artwork(p_track, true);
-    }
 }
 
 void ArtworkPanel::force_reload_artwork()

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -4,6 +4,7 @@
 #include "config.h"
 #include "d2d_utils.h"
 #include "d3d_utils.h"
+#include "fb2k_callbacks.h"
 #include "imaging.h"
 #include "tab_setup.h"
 
@@ -232,6 +233,8 @@ void ArtworkPanel::get_menu_items(ui_extension::menu_hook_t& p_hook)
 
 void ArtworkPanel::request_artwork(const metadb_handle_ptr& track, bool is_from_playback)
 {
+    m_current_track = track;
+
     const auto handle_artwork_read
         = [self{service_ptr_t{this}}](bool artwork_changed) { self->on_artwork_loaded(artwork_changed); };
 
@@ -333,10 +336,23 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             reset_d2d_device_resources();
             refresh_image();
         });
+
+        m_metadb_io_change_token = fb2k_utils::add_metadb_io_callback(
+            [this, self{service_ptr_t{this}}](metadb_handle_list_cref tracks, bool from_hook) {
+                if (from_hook || m_current_track.is_empty())
+                    return;
+
+                if (size_t index{};
+                    !tracks.bsearch_t(pfc::compare_t<metadb_handle_ptr, metadb_handle_ptr>, m_current_track, index))
+                    return;
+
+                soft_reload_selection_artwork();
+            });
         break;
     }
     case WM_DESTROY:
         std::erase(g_windows, this);
+        m_metadb_io_change_token.reset();
         m_use_hardware_acceleration_change_token.reset();
         m_display_change_token.reset();
         ui_selection_manager::get()->unregister_callback(this);
@@ -344,6 +360,7 @@ LRESULT ArtworkPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         play_callback_manager::get()->unregister_callback(this);
         now_playing_album_art_notify_manager::get()->remove(this);
         m_selection_handles.remove_all();
+        m_current_track.reset();
         m_show_in_explorer_thread.reset();
         m_artwork_decoder.shut_down();
         if (m_artwork_reader)
@@ -931,6 +948,19 @@ void ArtworkPanel::force_reload_artwork()
     }
 }
 
+void ArtworkPanel::soft_reload_selection_artwork()
+{
+    if (!m_current_track.is_valid())
+        return;
+
+    const auto is_from_playback = g_track_mode_includes_now_playing(m_track_mode) && play_control::get()->is_playing();
+
+    if (is_from_playback && get_displayed_artwork_type_index() == 0)
+        return;
+
+    request_artwork(m_current_track, is_from_playback);
+}
+
 bool ArtworkPanel::is_core_image_viewer_available() const
 {
     if (fb2k::imageViewer::ptr api; !fb2k::imageViewer::tryGet(api)) {
@@ -1220,6 +1250,8 @@ void ArtworkPanel::refresh_image()
 
 void ArtworkPanel::clear_image()
 {
+    m_current_track.reset();
+
     reset_effects();
     m_artwork_decoder.reset();
 

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -85,6 +85,7 @@ public:
     static void s_on_use_advanced_colour_change();
 
     void force_reload_artwork();
+    void soft_reload_selection_artwork();
     bool is_core_image_viewer_available() const;
     void open_core_image_viewer() const;
     bool is_show_in_file_explorer_available() const;
@@ -166,6 +167,7 @@ private:
 
     EventToken::Ptr m_use_hardware_acceleration_change_token;
     EventToken::Ptr m_display_change_token;
+    EventToken::Ptr m_metadb_io_change_token;
     std::shared_ptr<ArtworkReaderManager> m_artwork_reader;
     ArtworkDecoder m_artwork_decoder;
     std::optional<std::jthread> m_show_in_explorer_thread;
@@ -178,6 +180,7 @@ private:
     bool m_using_flip_model_swap_chain{};
     bool m_scale_effect_needs_updating{};
     metadb_handle_list m_selection_handles;
+    metadb_handle_ptr m_current_track;
 
     static std::vector<ArtworkPanel*> g_windows;
 };

--- a/foo_ui_columns/artwork_reader.h
+++ b/foo_ui_columns/artwork_reader.h
@@ -79,8 +79,8 @@ public:
     void reset();
     void abort_current_task();
 
-    album_art_data_ptr get_image(const GUID& p_what) const;
-    bool has_image(GUID artwork_type_id) const { return get_image(artwork_type_id).is_valid(); }
+    album_art_data_ptr get_image(const GUID& p_what, bool is_checking_existence_only = false) const;
+    bool has_image(GUID artwork_type_id) const { return get_image(artwork_type_id, true).is_valid(); }
     album_art_path_list::ptr get_paths(GUID artwork_type_id) const;
     album_art_data_ptr get_stub_image(GUID artwork_type_id);
 

--- a/foo_ui_columns/fb2k_callbacks.cpp
+++ b/foo_ui_columns/fb2k_callbacks.cpp
@@ -1,0 +1,39 @@
+#include "pch.h"
+
+#include "fb2k_callbacks.h"
+
+namespace cui::fb2k_utils {
+
+namespace {
+
+class MetadbIoCallbackImpl : public metadb_io_callback_dynamic_impl_base {
+public:
+    explicit MetadbIoCallbackImpl(MetadbIoCallbackFunc callback) : m_callback(std::move(callback)) {}
+    void on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) noexcept override
+    {
+        m_callback(p_items_sorted, p_fromhook);
+    }
+
+private:
+    MetadbIoCallbackFunc m_callback;
+};
+
+class MetadbIoCallbackToken : public EventToken {
+public:
+    explicit MetadbIoCallbackToken(MetadbIoCallbackFunc callback)
+        : m_callback_wrapper(std::make_unique<MetadbIoCallbackImpl>(std::move(callback)))
+    {
+    }
+
+private:
+    std::unique_ptr<MetadbIoCallbackImpl> m_callback_wrapper;
+};
+
+} // namespace
+
+EventToken::Ptr add_metadb_io_callback(MetadbIoCallbackFunc callback)
+{
+    return std::make_unique<MetadbIoCallbackToken>(std::move(callback));
+}
+
+} // namespace cui::fb2k_utils

--- a/foo_ui_columns/fb2k_callbacks.h
+++ b/foo_ui_columns/fb2k_callbacks.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "event_token.h"
+
+namespace cui::fb2k_utils {
+
+using MetadbIoCallbackFunc = std::function<void(metadb_handle_list_cref, bool)>;
+
+EventToken::Ptr add_metadb_io_callback(MetadbIoCallbackFunc callback);
+
+} // namespace cui::fb2k_utils

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -269,6 +269,7 @@
     <ClCompile Include="dark_mode_active_ui.cpp" />
     <ClCompile Include="dark_mode_dialog.cpp" />
     <ClCompile Include="dark_mode_spin.cpp" />
+    <ClCompile Include="fb2k_callbacks.cpp" />
     <ClCompile Include="file_info_utils.cpp" />
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="font_manager_v3.cpp" />
@@ -454,6 +455,7 @@
     <ClInclude Include="dark_mode_active_ui.h" />
     <ClInclude Include="dark_mode_spin.h" />
     <ClInclude Include="event_token.h" />
+    <ClInclude Include="fb2k_callbacks.h" />
     <ClInclude Include="file_info_utils.h" />
     <ClInclude Include="font_manager_data.h" />
     <ClInclude Include="font_picker.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -647,6 +647,9 @@
     <ClCompile Include="tab_setup.cpp">
       <Filter>Config UI</Filter>
     </ClCompile>
+    <ClCompile Include="fb2k_callbacks.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -967,6 +970,9 @@
       <Filter>Config UI</Filter>
     </ClInclude>
     <ClInclude Include="panel_utils.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="fb2k_callbacks.h">
       <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -331,7 +331,7 @@ wil::shared_hbitmap PlaylistView::request_group_artwork(size_t index_item, HMONI
             metadb_handle_ptr handle;
             m_playlist_api->activeplaylist_get_item_handle(handle, index_item);
 
-            m_artwork_manager->request(handle, monitor, cx, cy, cfg_artwork_reflection,
+            m_artwork_manager->request(group, handle, monitor, cx, cy, cfg_artwork_reflection,
                 [this, self{ptr{this}}, group{PlaylistViewGroup::ptr{group}}](
                     const ArtworkReader* reader) { on_artwork_read_complete(group, reader); });
         }
@@ -583,6 +583,24 @@ void PlaylistView::s_destroy_message_window()
 {
     s_message_window->destroy();
     s_message_window.reset();
+}
+
+void PlaylistView::invalidate_artwork_images(size_t start, size_t count)
+{
+    const auto group_count = get_group_count();
+
+    if (group_count == 0 || !get_show_group_info_area())
+        return;
+
+    for (const auto index : std::views::iota(start, start + count)) {
+        const auto group = get_item(index)->get_leaf_group();
+        const auto is_new_group = index == 0 || group != get_item(index - 1)->get_leaf_group();
+
+        if (!is_new_group)
+            continue;
+
+        group->reset_artwork();
+    }
 }
 
 int g_compare_wchar(const pfc::array_t<WCHAR>& a, const pfc::array_t<WCHAR>& b)

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -88,7 +88,9 @@ void PlaylistView::on_items_modified(size_t playlist, const bit_array& p_mask) n
         if (i > start) {
             InsertItemsContainer items;
             get_insert_items(start, i - start, items);
+            // If grouping is enabled, the entire client area is invalidated
             replace_items(start, items);
+            invalidate_artwork_images(start, i - start);
         }
     }
 }

--- a/foo_ui_columns/ng_playlist/ng_playlist_groups.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist_groups.h
@@ -1,8 +1,29 @@
 #pragma once
 
 #include "common.h"
+#include "ng_playlist_style.h"
 
 namespace cui::panels::playlist_view {
+
+class PlaylistViewGroup : public uih::ListView::Group {
+public:
+    using self_t = PlaylistViewGroup;
+    using ptr = pfc::refcounted_object_ptr_t<self_t>;
+    SharedCellStyleData::ptr m_style_data;
+
+    bool m_artwork_load_attempted{false};
+    bool m_artwork_load_succeeded{false};
+    wil::shared_hbitmap m_artwork_bitmap;
+
+    void reset_artwork()
+    {
+        m_artwork_bitmap.reset();
+        m_artwork_load_attempted = false;
+        m_artwork_load_succeeded = false;
+    }
+
+    PlaylistViewGroup() = default;
+};
 
 class Group {
 public:
@@ -74,5 +95,7 @@ private:
     }
     pfc::list_t<Group> m_groups;
 };
+
 extern ConfigGroups g_groups;
+
 } // namespace cui::panels::playlist_view


### PR DESCRIPTION
This:

- updates the playlist view to invalidate artwork for a group if the first track in the group is modified
- updates the Artwork view reload artwork if it’s showing art for a selection and the first track in that selection is modified
- fixes a bug where the Artwork view didn't update if it was showing artwork obtained via `now_playing_album_art_notify_manager`, and then that artwork was removed (e.g. an embedded front cover was removed from the track)

For the first two changes, it is only the first track (of the group or the selection) that is considered, because that is the track that artwork is shown for.

These changes help to make changes to embedded artwork immediately visible, and also to update shown artwork where changes to metadata affect the external artwork search (without affecting grouping, in the case of the playlist view).