### PR TITLE
Fix sorting by playlist view column containing colour codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 ### Bug fixes
 
+- A bug where sorting the playlist view by a column containing colour codes did
+  not work as expected on foobar2000 2.0 and newer was fixed.
+  [[#1365](https://github.com/reupen/columns_ui/pull/1365)]
+
 - The Artwork view now always reloads artwork if the track it’s currently
   showing artwork for is modified.
   [[#1364](https://github.com/reupen/columns_ui/pull/1364)]

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -747,12 +747,11 @@ void PlaylistView::sort_by_column_fb2k_v2(size_t column_index, bool b_descending
             track->formatTitle_v2(rec, &tf_hook, adapted_title, m_column_data[column_index].m_sort_script, nullptr);
 
             const char* ptr = title.c_str();
-            if (strchr(ptr, 3)) {
-                pfc::string8_fast_aggressive title_without_colour_codes;
-                title_without_colour_codes.prealloc(title.length());
+            std::string title_without_colour_codes;
 
-                titleformat_compiler::remove_color_marks(ptr, title_without_colour_codes);
-                ptr = title_without_colour_codes;
+            if (strchr(ptr, 3)) {
+                title_without_colour_codes = uih::remove_colour_codes(ptr);
+                ptr = title_without_colour_codes.c_str();
             }
 
             data[index].resize(pfc::stringcvt::estimate_utf8_to_wide_quick(ptr));


### PR DESCRIPTION
This fixes a bug in the foobar2000 2.0 and newer code path for sorting by a column, where it did not handle the stripping of colour codes from strings correctly, causing sorting to behave unexpectedly.