### PR TITLE
Fix documentation link-related Setup preferences tab problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
   (Previous 3.1.0 versions triggered a bug check crash.)
 
 - A link to the Columns UI documentation site was added to the Setup tab in
-  preferences. [[#1363](https://github.com/reupen/columns_ui/pull/1363)]
+  preferences. [[#1363](https://github.com/reupen/columns_ui/pull/1363),
+  [#1366](https://github.com/reupen/columns_ui/pull/1366)]
 
   Additionally, all links to the archived Columns UI wiki were replaced with
   links to the current documentation site.

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -781,7 +781,7 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,141,313,10
     LTEXT           "This option affects only the artwork view, artwork in the playlist view, and Item details.",IDC_STATIC,7,157,313,15
     CONTROL         "<a href=""https://columns-ui.readthedocs.io"">Columns UI documentation site</a>",IDC_DOCUMENTATION_LINK,
-                    "SysLink",WS_TABSTOP,7,206,123,13
+                    "SysLink",WS_TABSTOP,7,210,123,13
     LTEXT           "Documentation",IDC_TITLE3,7,185,313,14
 END
 

--- a/foo_ui_columns/tab_setup.cpp
+++ b/foo_ui_columns/tab_setup.cpp
@@ -36,10 +36,10 @@ public:
             if (!main_window.get_wnd())
                 EnableWindow(GetDlgItem(wnd, IDC_QUICKSETUP), FALSE);
 
-            uih::subclass_window(
-                wnd, [documentation_link_wnd](auto _, auto wnd, auto msg, auto wp, auto lp) -> std::optional<LRESULT> {
+            uih::subclass_window(wnd,
+                [documentation_link_wnd](auto wndproc, auto wnd, auto msg, auto wp, auto lp) -> std::optional<LRESULT> {
                     if (msg == WM_CTLCOLORSTATIC && reinterpret_cast<HWND>(lp) == documentation_link_wnd) {
-                        auto result = DefWindowProc(wnd, msg, wp, lp);
+                        const auto result = CallWindowProc(wndproc, wnd, msg, wp, lp);
                         const auto colour
                             = dark::get_colour(dark::ColourID::HyperlinkText, ui_config_manager::g_is_dark_mode());
                         SetTextColor(reinterpret_cast<HDC>(wp), colour);
@@ -70,6 +70,7 @@ public:
 
                 break;
             }
+            break;
         case WM_NOTIFY: {
             const auto nmhdr = reinterpret_cast<LPNMHDR>(lp);
 


### PR DESCRIPTION
The solution for changing the dark mode link colour wasn’t working on foobar2000 2.24. This fixes that by updating `fbh` to make the subclassing happen earlier. The link was also moved down further from the heading above it.

This also fixes a bug where other controls on the tab triggered a crash, due to a missing `break` under `WM_COMMAND`.