### PR TITLE
Add edit control enhancements to Filter search and some edit controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+- Missing support for Ctrl+Backspace, and Ctrl+A on older versions of Windows,
+  was added to Filter search and two edit controls in Preferences where support
+  was missing. [[#1372](https://github.com/reupen/columns_ui/pull/1372)]
+
 ## 3.1.0-beta.1
 
 ### Features

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -531,6 +531,7 @@ void FilterSearchToolbar::create_edit()
 
     SetWindowLongPtr(m_search_editbox, GWLP_USERDATA, (LPARAM)(this));
     SetWindowLongPtr(cbi.hwndItem, GWLP_USERDATA, (LPARAM)(this));
+    uih::enhance_edit_control(cbi.hwndItem);
     m_proc_search_edit = (WNDPROC)SetWindowLongPtr(cbi.hwndItem, GWLP_WNDPROC, (LPARAM)(g_on_search_edit_message));
     Edit_SetCueBannerText(cbi.hwndItem, L"Search Filters");
 

--- a/foo_ui_columns/font_picker.cpp
+++ b/foo_ui_columns/font_picker.cpp
@@ -143,6 +143,8 @@ private:
             m_axis_value_edit = GetDlgItem(m_wnd, IDC_AXIS_VALUE);
             m_axis_value_spin = GetDlgItem(m_wnd, IDC_AXIS_VALUE_SPIN);
 
+            uih::enhance_edit_control(m_axis_value_edit);
+
             for (auto&& axis : m_font_family.axes) {
                 const wchar_t name[5] = {narrow_to_wchar_t(axis.tag), narrow_to_wchar_t(axis.tag >> 8),
                     narrow_to_wchar_t(axis.tag >> 16), narrow_to_wchar_t(axis.tag >> 24), 0};

--- a/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
@@ -97,6 +97,8 @@ BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         Button_SetCheck(GetDlgItem(wnd, IDC_USE_CUSTOM_INDENTATION),
             cfg_use_custom_group_indentation_amount ? BST_CHECKED : BST_UNCHECKED);
 
+        uih::enhance_edit_control(wnd, IDC_INDENTATION_AMOUNT);
+
         SendDlgItemMessage(wnd, IDC_INDENTATION_AMOUNT_SPIN, UDM_SETRANGE32, 0, 256);
         SendDlgItemMessage(wnd, IDC_INDENTATION_AMOUNT_SPIN, UDM_SETPOS32, NULL, cfg_custom_group_indentation_amount);
 


### PR DESCRIPTION
Resolves #1368

This adds edit control enhancements that add support for Ctrl+Backspace, and support for Ctrl+A on old versions of Windows, to Filter search, and a couple of edit controls in Preferences that had previously been missed.