### PR TITLE
Prevent toolbar callbacks from being released during process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change log
 
-## Development version
+## 3.1.0
 
 ### Bug fixes
 
 - Missing support for Ctrl+Backspace, and Ctrl+A on older versions of Windows,
   was added to Filter search and two edit controls in Preferences where support
   was missing. [[#1372](https://github.com/reupen/columns_ui/pull/1372)]
+
+- Some Output device and Output format toolbar clean-up code was prevented from
+  running on certain types of abnormal process exits, reducing crash log noise
+  in rare cases. [[#1373](https://github.com/reupen/columns_ui/pull/1373)]
 
 ## 3.1.0-beta.1
 

--- a/foo_ui_columns/fb2k_misc.h
+++ b/foo_ui_columns/fb2k_misc.h
@@ -1,0 +1,38 @@
+#pragma once
+
+namespace cui::fb2k_utils {
+
+template <class Service = service_base>
+class LeakyServicePtr {
+public:
+    LeakyServicePtr() {}
+    explicit LeakyServicePtr(service_ptr_t<Service> ptr) : m_ptr(std::move(ptr)) {}
+
+    ~LeakyServicePtr()
+    {
+        assert(m_ptr.is_empty());
+        (void)m_ptr.detach();
+    }
+
+    LeakyServicePtr(const LeakyServicePtr&) = delete;
+    LeakyServicePtr& operator=(const LeakyServicePtr&) = delete;
+    LeakyServicePtr(LeakyServicePtr&& other) = delete;
+    LeakyServicePtr& operator=(LeakyServicePtr&& other) = delete;
+
+    LeakyServicePtr& operator=(service_ptr_t<Service> ptr)
+    {
+        m_ptr = std::move(ptr);
+        return *this;
+    }
+
+    operator const service_ptr_t<Service>&() const { return m_ptr; }
+    operator bool() const { return m_ptr.valid(); }
+
+    const service_ptr_t<Service>& get() { return m_ptr; }
+    void reset() { m_ptr.reset(); }
+
+private:
+    service_ptr_t<Service> m_ptr;
+};
+
+} // namespace cui::fb2k_utils

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -456,6 +456,7 @@
     <ClInclude Include="dark_mode_spin.h" />
     <ClInclude Include="event_token.h" />
     <ClInclude Include="fb2k_callbacks.h" />
+    <ClInclude Include="fb2k_misc.h" />
     <ClInclude Include="file_info_utils.h" />
     <ClInclude Include="font_manager_data.h" />
     <ClInclude Include="font_picker.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -975,6 +975,9 @@
     <ClInclude Include="fb2k_callbacks.h">
       <Filter>Utilities</Filter>
     </ClInclude>
+    <ClInclude Include="fb2k_misc.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".clang-format" />

--- a/foo_ui_columns/output_device.cpp
+++ b/foo_ui_columns/output_device.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include "drop_down_list_toolbar.h"
+#include "fb2k_misc.h"
 
 struct OutputDeviceToolbarArgs {
     using ID = std::tuple<GUID, GUID>;
@@ -55,9 +56,10 @@ struct OutputDeviceToolbarArgs {
         callback_handle
             = api->addCallback([] { DropDownListToolbar<OutputDeviceToolbarArgs>::s_refresh_all_items_safe(); });
     }
-    static void on_last_window_destroyed() { callback_handle.release(); }
+    static void on_last_window_destroyed() { callback_handle.reset(); }
     static bool is_available() { return static_api_test_t<output_manager_v2>(); }
-    static service_ptr callback_handle;
+
+    inline static cui::fb2k_utils::LeakyServicePtr<> callback_handle;
     static constexpr bool refresh_on_click = true;
     static constexpr auto no_items_text = ""sv;
     static constexpr const wchar_t* class_name{L"columns_ui_output_device_DQLvIKXzFVY"};
@@ -67,6 +69,4 @@ struct OutputDeviceToolbarArgs {
     static constexpr GUID font_client_id{0x20772a7b, 0xb5b5, 0x48c7, {0xa7, 0xca, 0x98, 0xde, 0x17, 0xff, 0xfc, 0xb4}};
 };
 
-service_ptr OutputDeviceToolbarArgs::callback_handle;
-
-ui_extension::window_factory<DropDownListToolbar<OutputDeviceToolbarArgs>> output_device_toolbar;
+uie::window_factory<DropDownListToolbar<OutputDeviceToolbarArgs>> output_device_toolbar;

--- a/foo_ui_columns/output_format.cpp
+++ b/foo_ui_columns/output_format.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 
 #include "drop_down_list_toolbar.h"
+#include "fb2k_misc.h"
 
 struct OutputFormatToolbarArgs {
     using ID = uint32_t;
@@ -43,9 +44,10 @@ struct OutputFormatToolbarArgs {
         callback_handle
             = api->addCallback([] { DropDownListToolbar<OutputFormatToolbarArgs>::s_refresh_all_items_safe(); });
     }
-    static void on_last_window_destroyed() { callback_handle.release(); }
+    static void on_last_window_destroyed() { callback_handle.reset(); }
     static bool is_available() { return true; }
-    static service_ptr callback_handle;
+
+    inline static cui::fb2k_utils::LeakyServicePtr<> callback_handle;
     static constexpr bool refresh_on_click = false;
     static constexpr auto no_items_text = "Auto"sv;
     static constexpr const wchar_t* class_name{L"columns_ui_output_format_TBWOn9HkOxhkU"};
@@ -55,6 +57,4 @@ struct OutputFormatToolbarArgs {
     static constexpr GUID font_client_id{0x1fb03f29, 0x1a1d, 0x4d11, {0xb5, 0x74, 0xaf, 0x2e, 0xb2, 0x62, 0x48, 0xc2}};
 };
 
-service_ptr OutputFormatToolbarArgs::callback_handle;
-
-ui_extension::window_factory<DropDownListToolbar<OutputFormatToolbarArgs>> output_format_toolbar;
+uie::window_factory<DropDownListToolbar<OutputFormatToolbarArgs>> output_format_toolbar;


### PR DESCRIPTION
In some types of abnormal process exits, apparently destructors for objects with static storage duration get called. If the event that caused the abormal exit was on a non-main thread, this then means those destructors get called on that thread.

In the case of the Output device and Output format toolbars, a single static callback object was created for all instances of the toolbars. In the normal scenario it gets released when the last instance is destroyed. But in the bad scenario, the abnormal process exit is triggered from another thread, and the destructors for those callback objects cause further problems as they are only valid to be called from the main thread.

This simply changes those toolbars to wrap the callback object and not bother releasing it in the destructor to avoid this. (In practice, how much this will help I don’t know, as there must be all kinds of destructors being called in this scenario.)