### PR TITLE
Fix playlist view artwork recovery from Direct3D device loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bug fixes
 
+- Playlist view artwork now properly recovers from a graphics card reset when
+  Direct2D hardware acceleration is enabled.
+  [[#1374](https://github.com/reupen/columns_ui/pull/1374)]
+
 - Missing support for Ctrl+Backspace, and Ctrl+A on older versions of Windows,
   was added to Filter search and two edit controls in Preferences where support
   was missing. [[#1372](https://github.com/reupen/columns_ui/pull/1372)]

--- a/foo_ui_columns/d2d_utils.h
+++ b/foo_ui_columns/d2d_utils.h
@@ -2,6 +2,11 @@
 
 namespace cui::d2d {
 
+constexpr bool is_device_reset_error(const HRESULT hr)
+{
+    return hr == D2DERR_RECREATE_TARGET || hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET;
+}
+
 wil::com_ptr<ID2D1Factory1> create_factory(D2D1_FACTORY_TYPE factory_type);
 
 using MainThreadD2D1Factory = std::shared_ptr<wil::com_ptr<ID2D1Factory1>>;


### PR DESCRIPTION
This fixes a few problems that were preventing artwork from rendering following a Direct3D device loss or reset (when hardware acceleration is enabled).

(The recovery logic was already there, but some exceptions were being swallowed preventing it from working.)

(`DXCap.exe -forcetdr` is an easy way to simulate this without having to e.g. reinstall the graphics card driver.)