### PR TITLE
Correct light mode colour of documentation site link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
   view, Filter panel and Item properties for very small panel heights was fixed.
   [[#1377](https://github.com/reupen/columns_ui/pull/1377)]
 
+- The colour of the ‘Columns UI documentation site’ hyperlink on the Setup tab
+  in Preferences was corrected on Windows 7.
+  [[#1378](https://github.com/reupen/columns_ui/pull/1378)]
+
 ## 3.1.0-beta.1
 
 ### Features

--- a/foo_ui_columns/dark_mode.cpp
+++ b/foo_ui_columns/dark_mode.cpp
@@ -138,7 +138,7 @@ int get_light_colour_system_id(ColourID colour_id)
 {
     switch (colour_id) {
     case ColourID::HyperlinkText:
-        return COLOR_HIGHLIGHT;
+        return COLOR_HOTLIGHT;
     case ColourID::LayoutBackground:
         return COLOR_BTNFACE;
     case ColourID::PanelCaptionText:


### PR DESCRIPTION
The colour of the ‘Columns UI documentation site’ hyperlink on the Setup tab in Preferences was noticeably wrong on Windows 7. On further investigation, the correct colour to use is `COLOR_HOTLIGHT`. (The colour was slightly off for light mode on Windows 10 and 11 as well, but not noticeably so.)