### PR TITLE
Fix rendering of some non-RGB images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.1.1
+
+### Bug fixes
+
+- A problem where some non-RGB images (such as CMYK images) did not render
+  correctly in the Artwork view and playlist view was fixed.
+  [[#1383](https://github.com/reupen/columns_ui/pull/1383)]
+
 ## 3.1.0
 
 ### Features

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -136,7 +136,14 @@ namespace {
 [[nodiscard]] wil::com_ptr<ID2D1ColorContext> create_colour_context_for_image(
     const ArtworkRenderingContext::Ptr& context, const wil::com_ptr<IWICBitmapFrameDecode>& bitmap_frame_decode)
 {
-    const auto wic_colour_context = wic::get_bitmap_source_colour_context(context->wic_factory, bitmap_frame_decode);
+    WICPixelFormatGUID source_pixel_format{};
+    THROW_IF_FAILED(bitmap_frame_decode->GetPixelFormat(&source_pixel_format));
+
+    const auto is_auto_colour_space_conversion = wic::is_auto_colour_space_conversion_pixel_format(source_pixel_format);
+
+    const auto wic_colour_context = is_auto_colour_space_conversion
+        ? wil::com_ptr<IWICColorContext>()
+        : wic::get_bitmap_source_colour_context(context->wic_factory, bitmap_frame_decode);
 
     wil::com_ptr<ID2D1ColorContext> d2d_colour_context;
 

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -28,7 +28,7 @@ wil::com_ptr<IWICBitmapSource> get_image_frame(const wil::com_ptr<IWICBitmapDeco
 wil::unique_hbitmap resize_hbitmap(HBITMAP original_bitmap, int width, int height);
 wil::com_ptr<IWICColorContext> get_bitmap_source_colour_context(const wil::com_ptr<IWICImagingFactory>& imaging_factory,
     const wil::com_ptr<IWICBitmapFrameDecode>& bitmap_frame_decode);
-
+bool is_auto_colour_space_conversion_pixel_format(REFWICPixelFormatGUID pixel_format);
 BitmapData decode_image_data(const void* data, size_t size);
 
 } // namespace cui::wic


### PR DESCRIPTION
This resolves a problem were some CMYK and high-bit-depth greyscale images did not render correctly.

It seems like `WICConvertBitmapSource`/`IWICFormatConverter` converts these to sRGB automatically (at least, I was unable to see any noticeable difference from doing a manual conversion).

Doing an explicit conversion to sRGB is also a bit of a pain as it can fail in cases, so this change works on the assumption that `IWICFormatConverter` is doing it.