### PR TITLE
Fix loading of display ICC profiles with embedded WCS profile

### DIFF
--- a/foo_ui_columns/wcs.cpp
+++ b/foo_ui_columns/wcs.cpp
@@ -48,8 +48,8 @@ std::vector<uint8_t> read_display_colour_profile(const std::wstring& filename)
     profile_desc.dwType = PROFILE_FILENAME;
     profile_desc.pProfileData = const_cast<wchar_t*>(filename.data());
 
-    const auto profile
-        = WcsOpenColorProfile(&profile_desc, nullptr, nullptr, PROFILE_READ, FILE_SHARE_READ, OPEN_EXISTING, 0);
+    const auto profile = WcsOpenColorProfile(
+        &profile_desc, nullptr, nullptr, PROFILE_READ, FILE_SHARE_READ, OPEN_EXISTING, DONT_USE_EMBEDDED_WCS_PROFILES);
 
     if (!profile) {
 #if _DEBUG


### PR DESCRIPTION
Resolves #1389

It turns out that there are ICC profiles that contain embedded Windows Color System (WCS) profiles. An example of these is profiles created by the built-in calibration tool in Windows. `WcsOpenColorProfile` returns the WCS profile in these cases unless a flag is set, and so this sets that flag to get the ICC profile, and fix the onward conversion of these profiles into Direct2D colour contexts.

It seems Windows these WCS profiles can also exist in [a standalone format with the .cdmp file extension](https://learn.microsoft.com/en-gb/windows/win32/wcs/wcs-color-device-model-profile-schema-and-algorithms). These should be ignored as the call to `WcsGetDefaultColorProfile()` requests an ICC profile (though this needs testing).