### PR TITLE
Don’t retry using display profiles if D2D rejects them

### DIFF
--- a/foo_ui_columns/artwork_decoder.cpp
+++ b/foo_ui_columns/artwork_decoder.cpp
@@ -2,6 +2,7 @@
 
 #include "artwork_decoder.h"
 
+#include "imaging.h"
 #include "wcs.h"
 #include "wic.h"
 #include "win32.h"
@@ -178,11 +179,9 @@ void ArtworkDecoder::decode(wil::com_ptr<ID2D1DeviceContext> d2d_render_target, 
             if (monitor) {
                 const auto display_device_key = win32::get_display_device_key(monitor);
                 const auto display_profile_name = wcs::get_display_colour_profile_name(display_device_key.c_str());
-                const auto profile = wcs::get_display_colour_profile(display_profile_name);
 
-                if (!profile.empty())
-                    LOG_IF_FAILED(d2d_render_target->CreateColorContext(D2D1_COLOR_SPACE_CUSTOM, profile.data(),
-                        gsl::narrow<uint32_t>(profile.size()), &d2d_display_colour_context));
+                d2d_display_colour_context
+                    = utils::create_d2d_colour_context_for_display_profile(d2d_render_target, display_profile_name);
 
                 if (!d2d_display_colour_context) {
                     LOG_IF_FAILED(d2d_render_target->CreateColorContext(

--- a/foo_ui_columns/imaging.cpp
+++ b/foo_ui_columns/imaging.cpp
@@ -1,5 +1,8 @@
 #include "pch.h"
 
+#include "d2d_utils.h"
+#include "wcs.h"
+
 namespace cui::utils {
 
 std::tuple<int, int> calculate_scaled_image_size(int image_width, int image_height, int target_width, int target_height,
@@ -29,6 +32,35 @@ std::tuple<int, int> calculate_scaled_image_size(int image_width, int image_heig
     }
 
     return {scaled_width, scaled_height};
+}
+
+wil::com_ptr<ID2D1ColorContext> create_d2d_colour_context_for_display_profile(
+    const wil::com_ptr<ID2D1DeviceContext>& d2d_device_context, const std::wstring& display_profile_name)
+{
+    wil::com_ptr<ID2D1ColorContext> d2d_colour_context;
+
+    const auto profile = wcs::get_display_colour_profile(display_profile_name);
+
+    if (profile.empty())
+        return {};
+
+    try {
+        THROW_IF_FAILED(d2d_device_context->CreateColorContext(
+            D2D1_COLOR_SPACE_CUSTOM, profile.data(), gsl::narrow<uint32_t>(profile.size()), &d2d_colour_context));
+    } catch (const wil::ResultException& ex) {
+        if (d2d::is_device_reset_error(ex.GetErrorCode()))
+            throw;
+
+        wcs::mark_display_colour_profile_as_bad(display_profile_name);
+
+        const auto error_message = mmh::to_utf8(mmh::win32::format_error(ex.GetErrorCode()));
+        const auto log_message = fmt::format("Columns UI – failed to create colour context from display colour profile "
+                                             "\"{}\": {}. This display profile will not be used.",
+            mmh::to_utf8(display_profile_name), error_message);
+        console::print(log_message.c_str());
+    }
+
+    return d2d_colour_context;
 }
 
 } // namespace cui::utils

--- a/foo_ui_columns/imaging.h
+++ b/foo_ui_columns/imaging.h
@@ -5,4 +5,7 @@ namespace cui::utils {
 std::tuple<int, int> calculate_scaled_image_size(int image_width, int image_height, int target_width, int target_height,
     bool preserve_aspect_ratio, bool ensure_even_margins);
 
+wil::com_ptr<ID2D1ColorContext> create_d2d_colour_context_for_display_profile(
+    const wil::com_ptr<ID2D1DeviceContext>& d2d_device_context, const std::wstring& display_profile_name);
+
 } // namespace cui::utils

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -168,11 +168,8 @@ namespace {
         return d2d_colour_context;
     }
 
-    const auto colour_profile = wcs::get_display_colour_profile(display_profile_name);
-
-    if (!colour_profile.empty())
-        LOG_IF_FAILED(context->d2d_device_context->CreateColorContext(D2D1_COLOR_SPACE_CUSTOM, colour_profile.data(),
-            gsl::narrow<uint32_t>(colour_profile.size()), &d2d_colour_context));
+    d2d_colour_context
+        = utils::create_d2d_colour_context_for_display_profile(context->d2d_device_context, display_profile_name);
 
     if (!d2d_colour_context) {
         // ID2D1DeviceContext::CreateColorContext() isn't implemented on Wine

--- a/foo_ui_columns/wcs.h
+++ b/foo_ui_columns/wcs.h
@@ -4,6 +4,7 @@ namespace cui::wcs {
 
 std::wstring get_display_colour_profile_name(const wchar_t* device_key);
 std::vector<uint8_t> get_display_colour_profile(const std::wstring& filename);
+void mark_display_colour_profile_as_bad(std::wstring_view filename);
 void reset_colour_profiles();
 
 } // namespace cui::wcs


### PR DESCRIPTION
#1389

This makes the Artwork view and playlist view not try to use a display colour profile again if creating a Direct2D colour context from it fails.

Additionally, a more user-friendly error message is now logged when creating a colour context from the display profile fails.