### PR TITLE
Ignore CMYK ICC profiles embedded in RGB images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.1.3
+
+### Bug fixes
+
+- The Artwork view and playlist view now ignore CMYK colour profiles that have
+  been incorrectly embedded in RGB images.
+  [[#1405](https://github.com/reupen/columns_ui/pull/1405)]
+
 ## 3.1.2
 
 ### Bug fixes

--- a/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_artwork.cpp
@@ -145,9 +145,13 @@ namespace {
         ? wil::com_ptr<IWICColorContext>()
         : wic::get_bitmap_source_colour_context(context->wic_factory, bitmap_frame_decode);
 
+    const auto icc_colour_space
+        = wic_colour_context ? wic::get_icc_colour_space_signature(wic_colour_context) : std::nullopt;
+    const auto has_cmyk_profile = icc_colour_space == wic::icc::cmyk_signature;
+
     wil::com_ptr<ID2D1ColorContext> d2d_colour_context;
 
-    if (wic_colour_context) {
+    if (wic_colour_context && !has_cmyk_profile) {
         LOG_IF_FAILED(context->d2d_device_context->CreateColorContextFromWicColorContext(
             wic_colour_context.get(), &d2d_colour_context));
     } else {

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -2,6 +2,12 @@
 
 namespace cui::wic {
 
+namespace icc {
+
+constexpr auto cmyk_signature = 0x434D594Bu;
+
+}
+
 class wic_error : public std::exception {
 public:
     using std::exception::exception;
@@ -30,5 +36,7 @@ wil::com_ptr<IWICColorContext> get_bitmap_source_colour_context(const wil::com_p
     const wil::com_ptr<IWICBitmapFrameDecode>& bitmap_frame_decode);
 bool is_auto_colour_space_conversion_pixel_format(REFWICPixelFormatGUID pixel_format);
 BitmapData decode_image_data(const void* data, size_t size);
+
+std::optional<uint32_t> get_icc_colour_space_signature(const wil::com_ptr<IWICColorContext>& colour_context);
 
 } // namespace cui::wic


### PR DESCRIPTION
This makes the Artwork view and playlist view ignore CMYK colour profiles embedded in RGB images. This can apparently happen in PNG images that have been badly converted from JPEGs.

Unfortunately, the ICC colour profile signature doesn’t seem to be exposed by WIC, so this reads into the profile bytes to get it. WCS could be used to read the profile instead, though it’s not clear there be much benefit for getting this single value. A full list of signature values can be found in the [ICC specification](https://www.color.org/specification/ICC.1-2022-05.pdf) (page 21 for that version of the spec).