### PR TITLE
Handle DXGI occlusion status correctly in Artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 3.1.4
+
+- A bug where the Artwork view sometimes did not update in some scenarios, such
+  as the display being in sleep mode, was fixed.
+  [[#1408](https://github.com/reupen/columns_ui/pull/1408)]
+
 ## 3.1.3
 
 ### Bug fixes

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -141,6 +141,8 @@ private:
     void update_dxgi_output_desc();
     void create_d2d_device_resources();
     void reset_d2d_device_resources(bool keep_devices = false);
+    void register_occlusion_event();
+    void deregister_occlusion_event();
     void create_effects();
     void refresh_image();
     void clear_image();
@@ -164,6 +166,8 @@ private:
     std::optional<DXGI_OUTPUT_DESC1> m_dxgi_output_desc;
     wil::com_ptr<ID2D1Effect> m_scale_effect;
     wil::com_ptr<ID2D1Effect> m_output_effect;
+    std::optional<DWORD> m_occlusion_status_event_cookie;
+    bool m_is_occlusion_status_timer_active{};
 
     EventToken::Ptr m_use_hardware_acceleration_change_token;
     EventToken::Ptr m_display_change_token;


### PR DESCRIPTION
This adds missing handling for the `DXGI_STATUS_OCCLUDED` return value of `IDXGISwapChain::Present()`.

This status occurred when the monitor was in sleep mode or off, the desktop was locked, or a UAC prompt was active. Sometimes, this would result in the Artwork view showing an old image when the window became visible again.

On Windows 8 and newer, `IDXGIFactory2::RegisterOcclusionStatusWindow()` is used to receive a notification when the window is no longer occluded.

Unfortunately, that method is not supported on Windows 7, so it falls back to using a timer there.