### PR TITLE
Check and handle Direct2D window occlusion status in Item details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change log
 
+## 3.1.5
+
+### Bug fixes
+
+- A bug where Item details sometimes did not update in some scenarios, such as
+  the display being in sleep mode, was fixed.
+  [[#1413](https://github.com/reupen/columns_ui/pull/1413)]
+
 ## 3.1.4
+
+### Bug fixes
 
 - A bug where the Artwork view sometimes did not update in some scenarios, such
   as the display being in sleep mode, was fixed.

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -257,6 +257,9 @@ private:
     void update_now();
     void create_d2d_render_target();
     void reset_d2d_device_resources();
+    void register_occlusion_event();
+    void deregister_occlusion_event();
+    bool check_occlusion_status();
 
     enum class ScrollbarType {
         vertical = SB_VERT,
@@ -292,11 +295,14 @@ private:
     uih::direct_write::Context::Ptr m_direct_write_context;
     std::optional<uih::direct_write::TextFormat> m_text_format;
     std::optional<uih::direct_write::TextLayout> m_text_layout;
+    wil::com_ptr<IDXGIFactory2> m_dxgi_factory;
     d2d::MainThreadD2D1Factory m_d2d_factory;
     wil::com_ptr<ID2D1HwndRenderTarget> m_d2d_render_target;
     wil::com_ptr<ID2D1SolidColorBrush> m_d2d_text_brush;
     std::unordered_map<COLORREF, wil::com_ptr<ID2D1SolidColorBrush>> m_d2d_brush_cache;
     EventToken::Ptr m_use_hardware_acceleration_change_token;
+    bool m_is_occlusion_status_timer_active{};
+    std::optional<DWORD> m_occlusion_status_event_cookie;
 
     std::optional<RECT> m_text_rect{};
 


### PR DESCRIPTION
Similar to #1408, `ID2D1HwndRenderTarget` reports an occlusion status. It does this indirectly via the [CheckWindowState method](https://learn.microsoft.com/en-gb/windows/win32/api/d2d1/nf-d2d1-id2d1hwndrendertarget-checkwindowstate).

This change checks the occlusion status after rendering, and monitors the occlusion status similarly as in #1408 and re-renders the panel when it’s no longer occluded.

(In this case, `IDXGIFactory` wasn’t being directly used. In theory, an `IDXGIFactory` could be obtained indirectly via [ID2D1Device2::GetDxgiDevice](https://learn.microsoft.com/en-gb/windows/win32/api/d2d1_3/nf-d2d1_3-id2d1device2-getdxgidevice), but it’s far easier just to create a new factory which seems to work fine.)

Additionally, the panel now does not bother drawing anything when it’s occluded (as an optimisation to save resources).