### PR TITLE
Add debug show image metadata Artwork view command

### DIFF
--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -4,6 +4,10 @@
 #include "artwork_reader.h"
 #include "system_appearance_manager.h"
 
+#ifdef _DEBUG
+#define ENABLE_METADATA_VIEWER
+#endif
+
 namespace cui::artwork_panel {
 
 enum class ClickAction : int32_t {
@@ -88,6 +92,10 @@ public:
     void soft_reload_selection_artwork();
     bool is_core_image_viewer_available() const;
     void open_core_image_viewer() const;
+#ifdef ENABLE_METADATA_VIEWER
+    bool is_show_metadata_available() const;
+    void show_metadata() const;
+#endif
     bool is_show_in_file_explorer_available() const;
     void show_in_file_explorer();
     bool is_copy_image_path_to_clipboard_available() const;

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -39,4 +39,8 @@ BitmapData decode_image_data(const void* data, size_t size);
 
 std::optional<uint32_t> get_icc_colour_space_signature(const wil::com_ptr<IWICColorContext>& colour_context);
 
+using MetadataValue = std::variant<std::wstring, int64_t, uint64_t>;
+using MetadataCollection = std::vector<std::tuple<std::wstring, MetadataValue>>;
+MetadataCollection get_image_metadata(const wil::com_ptr<IWICBitmapFrameDecode>& bitmap_frame_decode);
+
 } // namespace cui::wic


### PR DESCRIPTION
This adds a command to Artwork view for showing image metadata in a pop-up window.

The output is very raw (EXIF tags are referenced by number, for example) so the command is only enabled for debug builds.