### PR TITLE
Add support for image orientation metadata to Artwork view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Development version
+
+### Features
+
+- The Artwork view now automatically rotates and/or mirrors images when embedded
+  orientation metadata exists.
+  [[#1425](https://github.com/reupen/columns_ui/pull/1425)]
+
 ## 3.1.5
 
 ### Bug fixes

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -155,8 +155,9 @@ private:
     void refresh_image();
     void clear_image();
     void reset_effects();
-    D2D1_VECTOR_2F calculate_scaling_factor(const wil::com_ptr<ID2D1Image>& image) const;
-    void update_scale_effect();
+    D2D1_VECTOR_2F calculate_scaling_factor(
+        const wil::com_ptr<ID2D1Bitmap>& bitmap, wic::PhotoOrientation orientation) const;
+    void update_transform_effect();
     void queue_decode(const album_art_data::ptr& data);
     void invalidate_window() const;
     uint32_t get_displayed_artwork_type_index() const;
@@ -172,7 +173,8 @@ private:
     std::optional<DXGI_FORMAT> m_swap_chain_format;
     std::optional<unsigned> m_sdr_white_level;
     std::optional<DXGI_OUTPUT_DESC1> m_dxgi_output_desc;
-    wil::com_ptr<ID2D1Effect> m_scale_effect;
+    wil::com_ptr<ID2D1Effect> m_transform_effect;
+    std::optional<wic::PhotoOrientation> m_transform_effect_photo_orientation;
     wil::com_ptr<ID2D1Effect> m_output_effect;
     std::optional<DWORD> m_occlusion_status_event_cookie;
     bool m_is_occlusion_status_timer_active{};
@@ -190,7 +192,7 @@ private:
     bool m_artwork_type_locked{};
     bool m_dynamic_artwork_pending{};
     bool m_using_flip_model_swap_chain{};
-    bool m_scale_effect_needs_updating{};
+    bool m_transform_effect_needs_updating{};
     metadb_handle_list m_selection_handles;
     metadb_handle_ptr m_current_track;
 

--- a/foo_ui_columns/artwork_decoder.h
+++ b/foo_ui_columns/artwork_decoder.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "wic.h"
 
 namespace cui::artwork_panel {
 
@@ -30,6 +31,7 @@ public:
         m_decoded_image.reset();
         m_display_colour_context.reset();
         m_image_colour_context.reset();
+        m_photo_orientation.reset();
         m_is_float.reset();
     }
 
@@ -44,6 +46,7 @@ public:
     wil::com_ptr<ID2D1Bitmap> get_image() { return m_decoded_image; }
     wil::com_ptr<ID2D1ColorContext> get_image_colour_context() { return m_image_colour_context; }
     bool has_image() const { return static_cast<bool>(m_decoded_image); }
+    auto get_photo_orientation() const { return m_photo_orientation; }
     bool is_float() const { return m_is_float.value_or(false); }
 
     ArtworkDecoderTask::Ptr m_current_task;
@@ -51,6 +54,7 @@ public:
     wil::com_ptr<ID2D1Bitmap> m_decoded_image;
     wil::com_ptr<ID2D1ColorContext> m_display_colour_context;
     wil::com_ptr<ID2D1ColorContext> m_image_colour_context;
+    std::optional<wic::PhotoOrientation> m_photo_orientation;
     std::optional<bool> m_is_float{};
     std::optional<HRESULT> m_error_result{};
 };

--- a/foo_ui_columns/d2d_utils.cpp
+++ b/foo_ui_columns/d2d_utils.cpp
@@ -85,6 +85,47 @@ wil::com_ptr<ID2D1Effect> create_scale_effect(
     return scale_effect;
 }
 
+wil::com_ptr<ID2D1Effect> create_2d_affine_transform_effect(
+    const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_MATRIX_3X2_F matrix)
+{
+    wil::com_ptr<ID2D1Effect> transform_effect;
+    THROW_IF_FAILED(device_context->CreateEffect(CLSID_D2D12DAffineTransform, &transform_effect));
+    THROW_IF_FAILED(transform_effect->SetValue(
+        D2D1_2DAFFINETRANSFORM_PROP_INTERPOLATION_MODE, D2D1_2DAFFINETRANSFORM_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC));
+    THROW_IF_FAILED(transform_effect->SetValue(D2D1_2DAFFINETRANSFORM_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD));
+    THROW_IF_FAILED(transform_effect->SetValue(D2D1_2DAFFINETRANSFORM_PROP_TRANSFORM_MATRIX, matrix));
+
+    return transform_effect;
+}
+
+D2D1_MATRIX_3X2_F create_orientation_transform_matrix(
+    wic::PhotoOrientation orientation, D2D1_SIZE_F input_size, D2D1_VECTOR_2F scaling_factor)
+{
+    const auto [width, height] = input_size;
+
+    return [&] {
+        switch (orientation) {
+        case wic::PhotoOrientation::FlipX:
+            return D2D1::Matrix3x2F::Scale(-1.f, 1.f) * D2D1::Matrix3x2F::Translation(width, 0.f);
+        case wic::PhotoOrientation::FlipY:
+            return D2D1::Matrix3x2F::Scale(1.f, -1.f) * D2D1::Matrix3x2F::Translation(0.f, height);
+        case wic::PhotoOrientation::Rotate90:
+            return D2D1::Matrix3x2F::Rotation(90.f) * D2D1::Matrix3x2F::Translation(height, 0.f);
+        case wic::PhotoOrientation::Rotate180:
+            return D2D1::Matrix3x2F::Rotation(180.f) * D2D1::Matrix3x2F::Translation(width, height);
+        case wic::PhotoOrientation::Rotate270:
+            return D2D1::Matrix3x2F::Rotation(270.f) * D2D1::Matrix3x2F::Translation(0.f, width);
+        case wic::PhotoOrientation::FlipXAndRotate270:
+            return D2D1::Matrix3x2F::Scale(-1.f, 1.f) * D2D1::Matrix3x2F::Rotation(270.f);
+        case wic::PhotoOrientation::FlipXAndRotate90:
+            return D2D1::Matrix3x2F::Scale(-1.f, 1.f) * D2D1::Matrix3x2F::Rotation(90.f)
+                * D2D1::Matrix3x2F::Translation(height, width);
+        default:
+            return D2D1::Matrix3x2F::Identity();
+        }
+    }() * D2D1::Matrix3x2F::Scale(scaling_factor.x, scaling_factor.y);
+}
+
 wil::com_ptr<ID2D1Effect> create_white_level_adjustment_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
     std::optional<float> input_white_level, std::optional<float> output_white_level)
 {

--- a/foo_ui_columns/d2d_utils.h
+++ b/foo_ui_columns/d2d_utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "wic.h"
 
 namespace cui::d2d {
 
@@ -20,6 +21,12 @@ wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2
 
 wil::com_ptr<ID2D1Effect> create_scale_effect(
     const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_VECTOR_2F scale);
+
+wil::com_ptr<ID2D1Effect> create_2d_affine_transform_effect(
+    const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_MATRIX_3X2_F matrix);
+
+D2D1_MATRIX_3X2_F create_orientation_transform_matrix(
+    wic::PhotoOrientation orientation, D2D1_SIZE_F input_size, D2D1_VECTOR_2F scaling_factor);
 
 wil::com_ptr<ID2D1Effect> create_white_level_adjustment_effect(const wil::com_ptr<ID2D1DeviceContext>& device_context,
     std::optional<float> input_white_level, std::optional<float> output_white_level);

--- a/foo_ui_columns/pch.h
+++ b/foo_ui_columns/pch.h
@@ -62,6 +62,7 @@
 #include <gdiplus.h>
 #include <zmouse.h>
 #include <Uxtheme.h>
+#include <propkey.h>
 #include <wincodec.h>
 #include <strsafe.h>
 #include <strstream>

--- a/foo_ui_columns/wic.cpp
+++ b/foo_ui_columns/wic.cpp
@@ -313,4 +313,30 @@ MetadataCollection get_image_metadata(const wil::com_ptr<IWICBitmapFrameDecode>&
     return collected_metadata;
 }
 
+std::optional<PhotoOrientation> get_photo_orientation(const wil::com_ptr<IWICBitmapFrameDecode>& bitmap_frame_decode)
+{
+    try {
+        wil::com_ptr<IWICMetadataQueryReader> metadata_reader;
+        THROW_IF_FAILED(bitmap_frame_decode->GetMetadataQueryReader(&metadata_reader));
+
+        wil::unique_prop_variant variant;
+        const auto hr = metadata_reader->GetMetadataByName(L"System.Photo.Orientation", &variant);
+
+        if (hr == WINCODEC_ERR_PROPERTYNOTFOUND)
+            return {};
+
+        THROW_IF_FAILED(hr);
+
+        assert(variant.vt == VT_UI2);
+
+        if (variant.vt != VT_UI2)
+            return {};
+
+        return static_cast<PhotoOrientation>(variant.uiVal);
+    }
+    CATCH_LOG();
+
+    return {};
+}
+
 } // namespace cui::wic

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -20,6 +20,19 @@ struct BitmapData {
     std::vector<uint8_t> data;
 };
 
+enum class PhotoOrientation {
+    Normal = PHOTO_ORIENTATION_NORMAL,
+    FlipX = PHOTO_ORIENTATION_FLIPHORIZONTAL,
+    Rotate180 = PHOTO_ORIENTATION_ROTATE180,
+    FlipY = PHOTO_ORIENTATION_FLIPVERTICAL,
+    FlipXAndRotate270 = PHOTO_ORIENTATION_TRANSPOSE,
+    // 90° and 270° are swapped for some reason in the names
+    // Windows uses for the values
+    Rotate90 = PHOTO_ORIENTATION_ROTATE270,
+    FlipXAndRotate90 = PHOTO_ORIENTATION_TRANSVERSE,
+    Rotate270 = PHOTO_ORIENTATION_ROTATE90,
+};
+
 void check_hresult(HRESULT hr);
 wil::com_ptr<IWICImagingFactory> create_factory();
 wil::com_ptr<IWICBitmapSource> create_bitmap_source_from_path(const char* path);
@@ -42,5 +55,6 @@ std::optional<uint32_t> get_icc_colour_space_signature(const wil::com_ptr<IWICCo
 using MetadataValue = std::variant<std::wstring, int64_t, uint64_t>;
 using MetadataCollection = std::vector<std::tuple<std::wstring, MetadataValue>>;
 MetadataCollection get_image_metadata(const wil::com_ptr<IWICBitmapFrameDecode>& bitmap_frame_decode);
+std::optional<PhotoOrientation> get_photo_orientation(const wil::com_ptr<IWICBitmapFrameDecode>& bitmap_frame_decode);
 
 } // namespace cui::wic


### PR DESCRIPTION
#1421 

This makes the Artwork view automatically rotate and/or mirror images when embedded orientation metadata exists.

This should support all forms of orientation metadata that Windows supports.

A similar update to the playlist view will follow separately.

(Note that Direct2D has a simpler way of doing this via [ID2D1DeviceContext2::CreateTransformedImageSource](https://learn.microsoft.com/en-gb/windows/win32/api/d2d1_3/nf-d2d1_3-id2d1devicecontext2-createtransformedimagesource), however that requires Windows 10 and the use of ID2D1ImageSource.)