### PR TITLE
Add support for image orientation metadata to playlist view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Features
 
-- The Artwork view now automatically rotates and/or mirrors images when embedded
-  orientation metadata exists.
-  [[#1425](https://github.com/reupen/columns_ui/pull/1425)]
+- The Artwork and playlist views now automatically rotate and/or mirror artwork
+  according to orientation information in embedded image metadata.
+  [[#1425](https://github.com/reupen/columns_ui/pull/1425),
+  [#1426](https://github.com/reupen/columns_ui/pull/1426)]
 
 ## 3.1.5
 

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -871,7 +871,7 @@ void ArtworkPanel::create_effects()
 
     const auto& bitmap = m_artwork_decoder.get_image();
     const auto& image_colour_context = m_artwork_decoder.get_image_colour_context();
-    const auto orientation = m_artwork_decoder.get_photo_orientation().value_or(wic::PhotoOrientation::Normal);
+    const auto orientation = m_artwork_decoder.get_photo_orientation().value_or(wic::PhotoOrientation::Original);
 
     if (!m_d2d_device_context || !bitmap)
         return;
@@ -1400,10 +1400,7 @@ D2D1_VECTOR_2F ArtworkPanel::calculate_scaling_factor(
 {
     auto [bitmap_width, bitmap_height] = bitmap->GetPixelSize();
 
-    const auto are_axes_swapped = orientation == wic::PhotoOrientation::Rotate90
-        || orientation == wic::PhotoOrientation::Rotate270 || orientation == wic::PhotoOrientation::FlipXAndRotate270
-        || orientation == wic::PhotoOrientation::FlipXAndRotate90;
-
+    const auto are_axes_swapped = wic::does_orientation_swap_axes(orientation);
     const auto oriented_bitmap_width = are_axes_swapped ? bitmap_height : bitmap_width;
     const auto oriented_bitmap_height = are_axes_swapped ? bitmap_width : bitmap_height;
 

--- a/foo_ui_columns/d2d_utils.cpp
+++ b/foo_ui_columns/d2d_utils.cpp
@@ -72,19 +72,6 @@ wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2
     return colour_management_effect;
 }
 
-wil::com_ptr<ID2D1Effect> create_scale_effect(
-    const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_VECTOR_2F scale)
-{
-    wil::com_ptr<ID2D1Effect> scale_effect;
-    THROW_IF_FAILED(device_context->CreateEffect(CLSID_D2D1Scale, &scale_effect));
-    THROW_IF_FAILED(
-        scale_effect->SetValue(D2D1_SCALE_PROP_INTERPOLATION_MODE, D2D1_SCALE_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC));
-    THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD));
-    THROW_IF_FAILED(scale_effect->SetValue(D2D1_SCALE_PROP_SCALE, scale));
-
-    return scale_effect;
-}
-
 wil::com_ptr<ID2D1Effect> create_2d_affine_transform_effect(
     const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_MATRIX_3X2_F matrix)
 {

--- a/foo_ui_columns/d2d_utils.h
+++ b/foo_ui_columns/d2d_utils.h
@@ -19,9 +19,6 @@ wil::com_ptr<ID2D1Effect> create_colour_management_effect(const wil::com_ptr<ID2
     std::optional<D2D1_COLORMANAGEMENT_RENDERING_INTENT> source_rendering_intent = {},
     std::optional<D2D1_COLORMANAGEMENT_RENDERING_INTENT> dest_rendering_intent = {});
 
-wil::com_ptr<ID2D1Effect> create_scale_effect(
-    const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_VECTOR_2F scale);
-
 wil::com_ptr<ID2D1Effect> create_2d_affine_transform_effect(
     const wil::com_ptr<ID2D1DeviceContext>& device_context, D2D1_MATRIX_3X2_F matrix);
 

--- a/foo_ui_columns/wic.h
+++ b/foo_ui_columns/wic.h
@@ -21,7 +21,7 @@ struct BitmapData {
 };
 
 enum class PhotoOrientation {
-    Normal = PHOTO_ORIENTATION_NORMAL,
+    Original = PHOTO_ORIENTATION_NORMAL,
     FlipX = PHOTO_ORIENTATION_FLIPHORIZONTAL,
     Rotate180 = PHOTO_ORIENTATION_ROTATE180,
     FlipY = PHOTO_ORIENTATION_FLIPVERTICAL,
@@ -32,6 +32,12 @@ enum class PhotoOrientation {
     FlipXAndRotate90 = PHOTO_ORIENTATION_TRANSVERSE,
     Rotate270 = PHOTO_ORIENTATION_ROTATE90,
 };
+
+constexpr bool does_orientation_swap_axes(PhotoOrientation orientation)
+{
+    return orientation == PhotoOrientation::Rotate90 || orientation == PhotoOrientation::Rotate270
+        || orientation == PhotoOrientation::FlipXAndRotate270 || orientation == PhotoOrientation::FlipXAndRotate90;
+}
 
 void check_hresult(HRESULT hr);
 wil::com_ptr<IWICImagingFactory> create_factory();


### PR DESCRIPTION
Resolves #1421

This makes the playlist view automatically rotate and/or mirror images when embedded orientation metadata exists, similar to what was done for the Artwork view in #1425.