### PR TITLE
Add Focus Filter search toolbar menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   [[#1425](https://github.com/reupen/columns_ui/pull/1425),
   [#1426](https://github.com/reupen/columns_ui/pull/1426)]
 
+- A hidden menu item, ‘View/Focus Filter search’, for focusing the Filter search
+  toolbar was added. [[#1427](https://github.com/reupen/columns_ui/pull/1427)]
+
+  This can be assigned to a keyboard shortcut.
+
 ## 3.1.5
 
 ### Bug fixes

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -456,7 +456,7 @@ size_t FilterPanel::get_highlight_item()
 
 bool FilterPanel::notify_on_keyboard_keydown_search()
 {
-    return FilterSearchToolbar::g_activate();
+    return FilterSearchToolbar::s_activate();
 }
 
 bool FilterPanel::do_drag_drop(WPARAM wp)

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -7,7 +7,7 @@ namespace cui::panels::filter {
 
 class FilterSearchToolbar : public uie::container_uie_window_v3 {
 public:
-    static bool g_activate();
+    static bool s_activate(bool show_message_if_no_toolbar_found = false);
     static bool g_filter_search_bar_has_stream(
         FilterSearchToolbar const* p_seach_bar, const FilterStream::ptr& p_stream);
     static void s_on_favourites_change();

--- a/foo_ui_columns/menu_items.cpp
+++ b/foo_ui_columns/menu_items.cpp
@@ -4,6 +4,7 @@
 #include "ng_playlist/ng_playlist.h"
 #include "main_window.h"
 #include "button_items.h"
+#include "filter_search_bar.h"
 
 namespace cui::main_menu {
 
@@ -107,6 +108,13 @@ static const MainMenuCommand live_editing{toggle_live_editing_id, "Live editing"
     },
     [] { return g_layout_window.get_layout_editing_active(); }};
 
+static const MainMenuCommand focus_filter_search{
+    .guid{0x9ff94c30, 0x7b34, 0x4b5f, {0x99, 0x52, 0xed, 0x14, 0x8a, 0x9a, 0x3f, 0x5c}},
+    .name = "Focus Filter search",
+    .description = "Focuses the Filter search toolbar.",
+    .execute_callback = [] { panels::filter::FilterSearchToolbar::s_activate(true); },
+    .hide_without_shift_key = true};
+
 class MainMenuCommands : public mainmenu_commands {
 public:
     template <class... Commands>
@@ -167,6 +175,9 @@ static service_factory_single_t<MainMenuCommands> mainmenu_commands_playlist_set
 
 static service_factory_single_t<MainMenuCommands> mainmenu_commands_playlist_font(
     groups::playlist_font_part, mainmenu_commands::sort_priority_dontcare, increase_font, decrease_font);
+
+static service_factory_single_t<MainMenuCommands> mainmenu_commands_view_misc(
+    mainmenu_groups::view, mainmenu_commands::sort_priority_dontcare, focus_filter_search);
 
 class MainMenuLayoutPresets : public mainmenu_commands {
     uint32_t get_command_count() override { return gsl::narrow<uint32_t>(cfg_layout.get_presets().get_count()); }


### PR DESCRIPTION
Resolves #385

This adds a hidden menu item for focusing the Filter search toolbar.

This is designed for use as a keyboard shortcut. Note that using the F3 key when a Filter panel is focused was already supported.

When opening the View menu, the new command will only appear if the Shift key was held down.