### PR TITLE
Set Buttons toolbar separator size explicitly in light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@
   A zero-width space (`$char(8203)`) can be used in a group title formatting
   script to force it to be shown when it evaluates to an empty string.
 
+### Bug fixes
+
+- Padding to the right of separators in the Buttons toolbar was reduced at lower
+  system display scale (DPI) settings in light mode.
+  [[#1435](https://github.com/reupen/columns_ui/pull/1435)]
+
+- The minimum width of Buttons toolbars is now recalculated when switching
+  between light and dark mode due to slight differences in separator spacing.
+  [[#1435](https://github.com/reupen/columns_ui/pull/1435)]
+
 ## 3.1.5
 
 ### Bug fixes

--- a/foo_ui_columns/buttons.cpp
+++ b/foo_ui_columns/buttons.cpp
@@ -260,7 +260,7 @@ void ButtonsToolbar::create_toolbar()
             if (button.m_type == TYPE_SEPARATOR) {
                 tbbutton.idCommand = gsl::narrow<int>(index);
                 tbbutton.fsStyle = is_dark ? BTNS_BUTTON | BTNS_SHOWTEXT : BTNS_SEP;
-                tbbutton.iBitmap = I_IMAGENONE;
+                tbbutton.iBitmap = is_dark ? I_IMAGENONE : 1 + 4_spx;
             } else {
                 if (button.m_show == SHOW_IMAGE || button.m_show == SHOW_IMAGE_TEXT) {
                     tbbutton.iBitmap = image.add_to_imagelist(m_standard_images.get());
@@ -419,6 +419,9 @@ LRESULT ButtonsToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_dark_mode_notifier = std::make_unique<colours::dark_mode_notifier>([this, self = ptr{this}] {
             destroy_toolbar();
             create_toolbar();
+
+            if (get_host().is_valid())
+                get_host()->on_size_limit_change(get_wnd(), uie::size_limit_all);
         });
         break;
     }


### PR DESCRIPTION
Resolves #1433

This sets the width of separators explicitly in the Buttons toolbar in light mode. This resolves a problem where separators had a fair bit of padding to the right of them at low DPIs.

(It turns out, for separators, the `iBitmap` member of `TBBUTTON` is the width in pixels of the separator. But the toolbar control does not centre the separator line in the space occupied, nor does it DPI-scale the separator line, so this is all still a bit messy.)

For dark mode, native toolbar separators are not being used as they did not render correctly when last tested.

When switching between light and dark mode, the panel host is now told that the minimum width has changed, as there can still be slight differences in separator padding between light and dark mode.