### PR TITLE
Don’t reload playlist view artwork on non-metadata changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
 - The default playlist view artwork width was increased.
   [[#1443](https://github.com/reupen/columns_ui/pull/1443)]
 
+- The playlist view no longer reloads artwork when custom title-formatting
+  fields provided by other components change.
+  [[#1444](https://github.com/reupen/columns_ui/pull/1444)]
+
 ### Bug fixes
 
 - Padding to the right of separators in the Buttons toolbar was reduced at lower

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -260,7 +260,7 @@ private:
     static void s_create_message_window();
     static void s_destroy_message_window();
 
-    void invalidate_artwork_images(size_t index, size_t count);
+    void register_metadb_io_callback();
 
     void flush_artwork_images()
     {
@@ -497,6 +497,7 @@ private:
     service_ptr_t<titleformat_object> m_script_global, m_script_global_style;
     service_ptr_t<playlist_manager_v4> m_playlist_api;
     bool m_ignore_callback{false};
+    EventToken::Ptr m_metadb_io_change_token;
 
     mainmenu_manager::ptr m_mainmenu_manager;
     contextmenu_manager::ptr m_contextmenu_manager;

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -88,9 +88,7 @@ void PlaylistView::on_items_modified(size_t playlist, const bit_array& p_mask) n
         if (i > start) {
             InsertItemsContainer items;
             get_insert_items(start, i - start, items);
-            // If grouping is enabled, the entire client area is invalidated
             replace_items(start, items);
-            invalidate_artwork_images(start, i - start);
         }
     }
 }


### PR DESCRIPTION
This makes the playlist view use `metadb_io_callback::on_changed_sorted()` (instead of `playlist_callback::on_items_modified()`) for triggering artwork flushing on metadata changes.

Changes where the `p_fromhook` argument is true are ignored, as these are due to things like custom title-formatting fields provided by other components changing and are usually irrelevant.

(The old behaviour was, for example, causing playlist view artwork to reload for the playing or focused track when the volume was changed with the Output Info component.)