### PR TITLE
Avoid unwanted playlist updates when removing Filter search toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@
   between light and dark mode due to slight differences in separator spacing.
   [[#1435](https://github.com/reupen/columns_ui/pull/1435)]
 
+- When a query has been entered in the Filter search toolbar and there are no
+  Filter panels in the layout, removing the toolbar from the layout or switching
+  layout preset no longer sends the entire media library to the Filter results
+  playlist. [[#1449](https://github.com/reupen/columns_ui/pull/1449)]
+
 ## 3.1.5
 
 ### Bug fixes

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -95,7 +95,7 @@ private:
 
     void on_show_clear_button_change();
     void on_search_editbox_change();
-    void commit_search_results(const char* str, bool b_force_autosend = false, bool b_stream_update = false);
+    void commit_search_results(const char* str, bool force_autosend = false, bool is_destroying = false);
 
     void refresh_favourites(bool is_initial);
     void update_favourite_icon(const char* p_new = nullptr);


### PR DESCRIPTION
#1398

If a query was entered in the Filter search toolbar and autosend was enabled in Preferences, removing the toolbar from the layout would always update the Filter results playlist (with the entire media library contents).

This stops the toolbar doing that when there are no Filter panels in the layout. It also avoids doing it if there are Filter panels but they are also being removed (for example, during a layout preset switch). (Avoiding it in the latter scenario is a best effort, as it’s not a straightforward scenario to detect.)

If the toolbar is removed from the layout but Filter panels remain, they will be updated as normal, and autosend will be triggered if enabled in Preferences.