### PR TITLE
Don’t return all items when clearing independent Filter search toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@
 - A hidden main menu item for toggling main window transparency was added to the
   View menu. [[#1448](https://github.com/reupen/columns_ui/pull/1448)]
 
+- When there are no Filter panels in the layout, clearing the Filter search
+  toolbar now returns no items (similar to the behaviour in Columns UI 2.1.0)
+  rather than the entire media library.
+  [[#1451](https://github.com/reupen/columns_ui/pull/1451)]
+
+  Pressing the Enter key after clearing the query now returns all items in the
+  media library. The special `ALL` query can also be used to return all items.
+
 ### Bug fixes
 
 - Padding to the right of separators in the Buttons toolbar was reduced at lower


### PR DESCRIPTION
Resolves #1398

This essentially reverts #857, and makes an empty query in the Filter search toolbar return no results when there are no Filter panels in the layout.

Some feedback was received in #1398 making arguments against returning all items for an empty query. Additionally, the pop-up Library search window does not return all items with an empty query.

Pressing Enter after clearing the query will return all items now. Additonally, the special ALL query can be used to return all items.