### PR TITLE
Activate inline editing when double-clicking in Item properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@
 - A hidden main menu item for toggling main window transparency was added to the
   View menu. [[#1448](https://github.com/reupen/columns_ui/pull/1448)]
 
+- Double-clicking or pressing the Enter key in Item properties now activates
+  inline editing. [[#1452](https://github.com/reupen/columns_ui/pull/1452)]
+
 ### Bug fixes
 
 - Padding to the right of separators in the Buttons toolbar was reduced at lower

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -763,6 +763,11 @@ void ItemProperties::notify_save_inline_edit(const char* value)
         metadb_io_v2::op_flag_no_errors | metadb_io_v2::op_flag_background | metadb_io_v2::op_flag_delay_ui, nullptr);
 }
 
+void ItemProperties::execute_default_action(size_t index, size_t column, bool b_keyboard, bool b_ctrl)
+{
+    activate_inline_editing(index, 1);
+}
+
 bool ItemProperties::notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
     pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries)
 {

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -165,6 +165,7 @@ public:
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
         pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
+    void execute_default_action(size_t index, size_t column, bool b_keyboard, bool b_ctrl) override;
 
     // UI SEL API
     void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept override;


### PR DESCRIPTION
This makes Item properties activate inline editing when double-clicking on an item or when pressing the Enter key.