### PR TITLE
Reduce Direct2D panels memory consumption if resized while hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 ### Bug fixes
 
+- A problem where Item details and Artwork view temporarily consumed excessive
+  memory if resized when in a hidden tab was fixed.
+  [[#1467](https://github.com/reupen/columns_ui/pull/1467)]
+
+  This occurred if Direct2D hardware acceleration was disabled.
+
 - A bug in the playlist view where the drag-and-drop insertion marker did not
   render in the correct place when scrolled right was fixed.
   [[#1464](https://github.com/reupen/columns_ui/pull/1464)]

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -147,6 +147,7 @@ private:
     void handle_wm_contextmenu(HWND wnd, POINT pt);
 
     void update_dxgi_output_desc();
+    void update_swap_chain_buffers_size() const;
     void create_d2d_device_resources();
     void reset_d2d_device_resources(bool keep_devices = false);
     void register_occlusion_event();

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -255,6 +255,7 @@ private:
     void set_window_theme() const;
     void invalidate_all(bool b_update = true);
     void update_now();
+    D2D1_SIZE_U get_required_d2d_render_target_size() const;
     void create_d2d_render_target();
     void reset_d2d_device_resources();
     void register_occlusion_event();


### PR DESCRIPTION
This resolves a problem where Item details and Artwork view temporarily consumed a lot of memory if they were resized while hidden (for example, when in an inactive tab).

Presumably resources were building up which were then not flushed until the panel became visible again.

This just stops resizing the render target in WM_SIZE, and instead adds a check at the beginning of WM_PAINT to see if the render target needs resizing. This solves the problem and seems to work well enough.