### PR TITLE
Handle property not supported errors when querying artwork orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@
   written to FCL files.
   [[#1464](https://github.com/reupen/columns_ui/pull/1464)]
 
+- A problem where a message about an 0x88982F41 WIC error was have been logged
+  to the console when loading artwork was fixed.
+  [[#1472](https://github.com/reupen/columns_ui/pull/1472)]
+
+  This was seen on Windows 7.
+
 ### API removals
 
 - Support for the legacy `uie::visualisation` service interface was removed from

--- a/foo_ui_columns/wic.cpp
+++ b/foo_ui_columns/wic.cpp
@@ -322,7 +322,7 @@ std::optional<PhotoOrientation> get_photo_orientation(const wil::com_ptr<IWICBit
         wil::unique_prop_variant variant;
         const auto hr = metadata_reader->GetMetadataByName(L"System.Photo.Orientation", &variant);
 
-        if (hr == WINCODEC_ERR_PROPERTYNOTFOUND)
+        if (hr == WINCODEC_ERR_PROPERTYNOTFOUND || hr == WINCODEC_ERR_PROPERTYNOTSUPPORTED)
             return {};
 
         THROW_IF_FAILED(hr);


### PR DESCRIPTION
This ignores `WINCODEC_ERR_PROPERTYNOTSUPPORTED` errors when querying orientation for artwork images using WIC. This error was seen on Windows 7.