### PR TITLE
Enable sorting in Filter search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Development version
+## 3.2.0-beta.2
 
 ### Features
 
@@ -20,6 +20,13 @@
   Additionally, the behaviour of the spectrum analyser when resizing the panel
   was improved.
 
+- Support for sorting results using the SORT BY operator was added to the Filter
+  search toolbar. [[#1474](https://github.com/reupen/columns_ui/pull/1474)]
+
+  Implicit sorting (for example, for time-related queries) is also now enabled
+  if ‘Sort tracks added when added to a playlist by:’ is disabled in Filter
+  preferences.
+
 ### Bug fixes
 
 - A problem where Item details and Artwork view temporarily consumed excessive
@@ -36,8 +43,8 @@
   written to FCL files.
   [[#1464](https://github.com/reupen/columns_ui/pull/1464)]
 
-- A problem where a message about an 0x88982F41 WIC error was have been logged
-  to the console when loading artwork was fixed.
+- A problem where a message about an 0x88982F41 WIC error was logged to the
+  console when loading artwork was fixed.
   [[#1472](https://github.com/reupen/columns_ui/pull/1472)]
 
   This was seen on Windows 7.

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -464,7 +464,7 @@ bool FilterPanel::do_drag_drop(WPARAM wp)
     metadb_handle_list_t<pfc::alloc_fast_aggressive> data;
     get_selection_handles(data);
     if (data.get_count() > 0) {
-        sort_tracks(data);
+        sort_tracks(data, m_stream->m_sort_override);
         const auto incoming_api = playlist_incoming_item_filter::get();
         auto pDataObject = incoming_api->create_dataobject_ex(data);
         if (pDataObject.is_valid()) {
@@ -575,7 +575,7 @@ void FilterPanel::do_items_action(const bit_array& p_nodes, Action action)
         playlist_api->playlist_clear(index);
     }
 
-    sort_tracks(handles);
+    sort_tracks(handles, m_stream->m_sort_override);
 
     if (action != action_add_to_active)
         playlist_api->playlist_add_items(index, handles, bit_array_false());
@@ -640,7 +640,7 @@ void FilterPanel::send_results_to_playlist(bool b_play)
             b_play ? "Filter Results (Playback)" : "Filter Results", pfc_infinite);
     playlist_api->playlist_clear(index);
 
-    sort_tracks(handles);
+    sort_tracks(handles, m_stream->m_sort_override);
     playlist_api->playlist_add_items(index, handles, bit_array_false());
 
     playlist_api->set_active_playlist(index);

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -4,6 +4,11 @@
 
 namespace cui::panels::filter {
 
+struct SortOverride {
+    titleformat_object::ptr object;
+    bool is_reversed{};
+};
+
 constexpr GUID items_font_id{0xd93f1ef3, 0x4aee, 0x4632, {0xb5, 0xbf, 0x2, 0x20, 0xce, 0xc7, 0x6d, 0xed}};
 constexpr GUID header_font_id{0xfca8752b, 0xc064, 0x41c4, {0x9b, 0xe3, 0xe1, 0x25, 0xc7, 0xc7, 0xfc, 0x34}};
 
@@ -79,6 +84,7 @@ public:
 
     bool m_source_overriden{false};
     metadb_handle_list m_source_handles;
+    std::optional<SortOverride> m_sort_override;
 
     bool is_visible();
 };

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -19,6 +19,7 @@ public:
                 if (!window->m_active_search_string.is_empty()) {
                     p_stream->m_source_overriden = true;
                     p_stream->m_source_handles = window->m_active_handles;
+                    p_stream->m_sort_override = window->m_sort_override;
                     break;
                 }
             }
@@ -132,6 +133,7 @@ private:
     bool m_show_clear_button{cfg_showsearchclearbutton};
     pfc::string8 m_active_search_string;
     metadb_handle_list m_active_handles;
+    std::optional<SortOverride> m_sort_override;
     HIMAGELIST m_imagelist{};
     int m_combo_cx{};
     int m_combo_cy{};

--- a/foo_ui_columns/filter_utils.h
+++ b/foo_ui_columns/filter_utils.h
@@ -4,9 +4,12 @@
 namespace cui::panels::filter {
 
 template <class Container>
-void sort_tracks(Container&& tracks)
+void sort_tracks(Container&& tracks, const std::optional<SortOverride>& sort_override = {})
 {
-    if (cfg_sort) {
+    if (sort_override) {
+        fbh::sort_metadb_handle_list_by_format(
+            std::forward<Container>(tracks), sort_override->object, nullptr, false, sort_override->is_reversed);
+    } else if (cfg_sort) {
         service_ptr_t<titleformat_object> to;
         titleformat_compiler::get()->compile_safe(to, cfg_sort_string);
         fbh::sort_metadb_handle_list_by_format(

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -582,8 +582,7 @@ EXSTYLE WS_EX_CONTROLPARENT
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     LTEXT           "Behaviour",IDC_TITLE1,7,4,313,16
-    CONTROL         "Sort tracks added when added to a playlist by:",IDC_SORT,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,30,169,10
+    CONTROL         "Sort tracks added to a playlist by:",IDC_SORT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,30,169,10
     EDITTEXT        IDC_SORT_STRING,7,42,247,14,ES_AUTOHSCROLL
     CONTROL         "Allow sorting using column titles",IDC_FILTERS_ALLOW_SORTING,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,68,124,10


### PR DESCRIPTION
Resolves #1456

This enables sorting in queries entered in the Filter search toolbar.

Explicit sorting using SORT BY is now always used and respected.

Implicit sorting (for example, for time-related queries) is used only if the sorting pattern in Filter preferences is disabled.

The dodgy wording of the sorting option in Filter preferences was also improved.