### PR TITLE
Fix rendering of playlist view when scrolled right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.2.0-beta.3
+
+### Bug fixes
+
+- A bug introduced in 3.2.0-beta.2 where the playlist view did not render
+  correctly when scrolled right was fixed.
+  [[#1483](https://github.com/reupen/columns_ui/pull/1483)]
+
 ## 3.2.0-beta.2
 
 ### Features

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -115,6 +115,8 @@ void PlaylistViewRenderer::render_item(const uih::lv::RendererContext& context, 
 
         rc_subitem.right = rc_subitem.left + sub_item.width;
 
+        auto _ = wil::scope_exit([&] { rc_subitem.left = rc_subitem.right; });
+
         if (!RectVisible(context.dc, &rc_subitem))
             continue;
 
@@ -178,7 +180,6 @@ void PlaylistViewRenderer::render_item(const uih::lv::RendererContext& context, 
             SelectObject(context.dc, pen_old);
             DeleteObject(pen);
         }
-        rc_subitem.left = rc_subitem.right;
     }
     if (b_focused) {
         render_focus_rect(context, should_hide_focus, rc);


### PR DESCRIPTION
This fixes a regression introduced by #1468 that caused columns to be rendered in the wrong place in the playlist view when it was scrolled right by more than one column.