### PR TITLE
Work around inconsistent window occlusion status when display is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## 3.2.0-beta.5
+
+### Bug fixes
+
+- A problem where Windows reports inconsistent Direct2D and DXGI window
+  occlusion status when the display is turned off, leading to excessive CPU
+  usage in Item details, was worked around.
+  [[#1491](https://github.com/reupen/columns_ui/pull/1491)]
+
 ## 3.2.0-beta.4
 
 ### Bug fixes

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -671,13 +671,13 @@ void ItemDetails::deregister_occlusion_event()
     }
 }
 
-bool ItemDetails::check_occlusion_status()
+bool ItemDetails::check_occlusion_status(bool allow_deregister_event)
 {
     const auto is_occluded = (m_d2d_render_target->CheckWindowState() & D2D1_WINDOW_STATE_OCCLUDED) != 0;
 
     if (is_occluded)
         register_occlusion_event();
-    else
+    else if (allow_deregister_event)
         deregister_occlusion_event();
 
     return is_occluded;
@@ -1008,7 +1008,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
             THROW_IF_FAILED(result);
 
-            check_occlusion_status();
+            check_occlusion_status(true);
         }
         CATCH_LOG()
 

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -260,7 +260,7 @@ private:
     void reset_d2d_device_resources();
     void register_occlusion_event();
     void deregister_occlusion_event();
-    bool check_occlusion_status();
+    bool check_occlusion_status(bool allow_deregister_event = false);
 
     enum class ScrollbarType {
         vertical = SB_VERT,


### PR DESCRIPTION
This works around a problem where Direct2D and DXGI cannot decide if a window is occluded when the display is turned off.

For `ID2D1HwndRenderTarget`, the `CheckWindowState` method reports the window is occluded after `EndDraw` is called, but then when called again it reports that the window isn’t occluded.

For `IDXGISwapChain`, it seems like test presentations report that the window isn’t occluded, while real ones report that it is occluded.

For Item details, the inconsistency was causing it to think that occlusion status was continuously changing, leading to excessive drawing activity.

This change amends the logic in Item details so that it doesn’t trust `ID2D1HwndRenderTarget::CheckWindowState()` reporting that a window isn’t occluded so much when it isn’t called immediately after `ID2D1HwndRenderTarget::EndDraw()`.