### PR TITLE
Work around another DXGI occlusion status bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## 3.2.0
+
+### Bug fixes
+
+- Another Windows bug with Direct2D and DXGI window occlusion statuses,
+  occasionally causing the Artwork view and Item details not to update when the
+  display is turned on after display output was turned off by Windows, was
+  worked around. [[#1510](https://github.com/reupen/columns_ui/pull/1510)]
+
 ## 3.2.0-rc.1
 
 ### Features

--- a/foo_ui_columns/artwork.h
+++ b/foo_ui_columns/artwork.h
@@ -177,6 +177,7 @@ private:
     wil::com_ptr<ID2D1Effect> m_transform_effect;
     std::optional<wic::PhotoOrientation> m_transform_effect_photo_orientation;
     wil::com_ptr<ID2D1Effect> m_output_effect;
+    wil::unique_hpowernotify m_power_notify_handle;
     std::optional<DWORD> m_occlusion_status_event_cookie;
     bool m_is_occlusion_status_timer_active{};
 

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -253,7 +253,7 @@ private:
     void scroll(INT sb, int position, bool b_absolute);
 
     void set_window_theme() const;
-    void invalidate_all(bool b_update = true);
+    void invalidate_all() const;
     void update_now();
     D2D1_SIZE_U get_required_d2d_render_target_size() const;
     void create_d2d_render_target();
@@ -304,6 +304,7 @@ private:
     EventToken::Ptr m_use_hardware_acceleration_change_token;
     bool m_is_occlusion_status_timer_active{};
     std::optional<DWORD> m_occlusion_status_event_cookie;
+    wil::unique_hpowernotify m_power_notify_handle;
 
     std::optional<RECT> m_text_rect{};
 


### PR DESCRIPTION
This works around another bug with DXGI windows occlusion statuses. Occasionally, when a display is turned on after Windows turned display output off due to power saving settings, DXGI would send the occlusion status change notification before presenting again is actually possible. In this scenario, the non-test `IDXGISwapChain::Present()` call returns `DXGI_STATUS_OCCLUDED`, and no further occlusion status change notifications are received.

This works around this using `RegisterPowerSettingNotification()`, and starting a timer when the problematic scenario is detected.

Some aggressive use of the `RedrawWindow()` `RDW_UPDATENOW` flag in Item details was also removed.