### PR TITLE
Use dark theme for Filter search toolbar tooltips in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### Bug fixes
 
-- Another Windows bug with Direct2D and DXGI window occlusion statuses,
-  occasionally causing the Artwork view and Item details not to update when the
-  display is turned on after display output was turned off by Windows, was
-  worked around. [[#1510](https://github.com/reupen/columns_ui/pull/1510)]
+- Another Windows bug with DXGI window occlusion statuses, occasionally causing
+  the Artwork view and Item details to not update when the display is turned on
+  after display output was turned off by Windows, was worked around.
+  [[#1510](https://github.com/reupen/columns_ui/pull/1510)]
+
+- Filter search button tooltips are now dark themed when dark mode is enabled.
+  [[#1511](https://github.com/reupen/columns_ui/pull/1511)]
 
 ## 3.2.0-rc.1
 

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -410,8 +410,14 @@ LRESULT FilterSearchToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp
                 } else if (lpnmtbgit->iItem == idc_clear)
                     temp = "Clear";
                 StringCchCopy(lpnmtbgit->pszText, lpnmtbgit->cchTextMax, pfc::stringcvt::string_wide_from_utf8(temp));
-            }
                 return 0;
+            }
+            case NM_TOOLTIPSCREATED: {
+                const auto lpnmttc = reinterpret_cast<LPNMTOOLTIPSCREATED>(lp);
+                SetWindowTheme(
+                    lpnmttc->hwndToolTips, colours::is_dark_mode_active() ? L"DarkMode_Explorer" : nullptr, nullptr);
+                break;
+            }
             }
             break;
         }
@@ -477,8 +483,12 @@ void FilterSearchToolbar::set_window_themes() const
     if (m_search_editbox)
         SetWindowTheme(m_search_editbox, is_dark ? L"DarkMode_CFD" : nullptr, nullptr);
 
-    if (m_wnd_toolbar)
+    if (m_wnd_toolbar) {
         SetWindowTheme(m_wnd_toolbar, is_dark ? L"DarkMode" : nullptr, nullptr);
+
+        if (const auto wnd_tooltips = reinterpret_cast<HWND>(SendMessage(m_wnd_toolbar, TB_GETTOOLTIPS, 0, 0)))
+            SetWindowTheme(wnd_tooltips, is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+    }
 }
 
 void FilterSearchToolbar::update_toolbar_icons() const


### PR DESCRIPTION
Resolves #1506 

This makes Filter search update the window theme for toolbar button tooltips when dark mode is enabled, so that the tooltips are dark themed as would be expected.

The theme is also updated if dark mode is later disabled.