### PR TITLE
Don’t use front cover stub image in Artwork view for other image types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 3.2.0
 
+### Features
+
+- If a front cover stub image is configured on the Display preferences page, the
+  Artwork view no longer uses it as a fallback for other stub image types.
+  [[#1512](https://github.com/reupen/columns_ui/pull/1512)]
+
+  If you were previously relying on that behaviour, you should explicitly
+  configure the stub image for all artwork types as needed.
+
 ### Bug fixes
 
 - Another Windows bug with DXGI window occlusion statuses, occasionally causing


### PR DESCRIPTION
This stops the Artwork view using the front cover stub image configured on the Display preferences page as a fallback for other stub image types (which was the behaviour added in #345).

Stub images can be explicitly configured for each image type, so using the front cover stub image as a fallback for other stub image types doesn’t make much sense. The path of the front cover stub image can be copied to the other stub image path fields if needed.

The built-in placeholder image is still used when no stub image is defined in Preferences for the artwork type.