### PR TITLE
Avoid crashes related to relative paths in non-portable installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## 3.2.2
+
+- Some crashes when tracks using the foobar2000 relative path protocol creep
+  into a non-portable foobar2000 installation were fixed.
+  [[#1520](https://github.com/reupen/columns_ui/pull/1520)]
+
+  Note that such paths do not work in non-portable installations; this change is
+  simply to avoid Columns UI-related crashes when such paths are encountered.
+
 ## 3.2.1
 
 ### Bug fixes

--- a/foo_ui_columns/fb2k_misc.cpp
+++ b/foo_ui_columns/fb2k_misc.cpp
@@ -1,0 +1,21 @@
+#include "pch.h"
+
+#include "fb2k_misc.h"
+
+namespace cui::fb2k_utils {
+
+wil::com_ptr_t<IDataObject> create_data_object_safe(const metadb_handle_list& tracks)
+{
+    wil::com_ptr_t<IDataObject> data_object;
+    const auto ole_api = ole_interaction::get();
+
+    try {
+        data_object.attach(ole_api->create_dataobject(tracks).detach());
+    } catch (const std::exception& ex) {
+        console::print("Columns UI – failed to create data object: ", ex.what());
+    }
+
+    return data_object;
+}
+
+} // namespace cui::fb2k_utils

--- a/foo_ui_columns/fb2k_misc.h
+++ b/foo_ui_columns/fb2k_misc.h
@@ -35,4 +35,6 @@ private:
     service_ptr_t<Service> m_ptr;
 };
 
+wil::com_ptr_t<IDataObject> create_data_object_safe(const metadb_handle_list& tracks);
+
 } // namespace cui::fb2k_utils

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "filter.h"
 
+#include "fb2k_misc.h"
 #include "filter_config_var.h"
 #include "filter_search_bar.h"
 #include "filter_utils.h"
@@ -465,13 +466,12 @@ bool FilterPanel::do_drag_drop(WPARAM wp)
     get_selection_handles(data);
     if (data.get_count() > 0) {
         sort_tracks(data, m_stream->m_sort_override);
-        const auto incoming_api = playlist_incoming_item_filter::get();
-        auto pDataObject = incoming_api->create_dataobject_ex(data);
-        if (pDataObject.is_valid()) {
+        const auto data_object = fb2k_utils::create_data_object_safe(data);
+        if (data_object) {
             m_drag_item_count = data.get_count();
             DWORD blah = DROPEFFECT_NONE;
             uih::ole::do_drag_drop(
-                get_wnd(), wp, pDataObject.get_ptr(), DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
+                get_wnd(), wp, data_object.get(), DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
             m_drag_item_count = 0;
         }
     }

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -270,6 +270,7 @@
     <ClCompile Include="dark_mode_dialog.cpp" />
     <ClCompile Include="dark_mode_spin.cpp" />
     <ClCompile Include="fb2k_callbacks.cpp" />
+    <ClCompile Include="fb2k_misc.cpp" />
     <ClCompile Include="file_info_utils.cpp" />
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="font_manager_v3.cpp" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -647,6 +647,9 @@
     <ClCompile Include="fb2k_callbacks.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="fb2k_misc.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">

--- a/foo_ui_columns/ng_playlist/ng_playlist_dropsource.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_dropsource.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "ng_playlist.h"
+#include "fb2k_misc.h"
 
 namespace cui::panels::playlist_view {
 bool PlaylistView::do_drag_drop(WPARAM wp)
@@ -7,18 +8,17 @@ bool PlaylistView::do_drag_drop(WPARAM wp)
     metadb_handle_list_t<pfc::alloc_fast_aggressive> data;
     m_playlist_api->activeplaylist_get_selected_items(data);
     if (data.get_count() > 0) {
-        const auto incoming_api = playlist_incoming_item_filter::get();
-        auto pDataObject = incoming_api->create_dataobject_ex(data);
-        if (pDataObject.is_valid()) {
+        const auto data_object = cui::fb2k_utils::create_data_object_safe(data);
+        if (data_object) {
             // pfc::com_ptr_t<IAsyncOperation> pAsyncOperation;
             // HRESULT hr = pDataObject->QueryInterface(IID_IAsyncOperation, (void**)pAsyncOperation.receive_ptr());
             DWORD blah = DROPEFFECT_NONE;
             {
                 m_dragging = true;
-                m_DataObject = pDataObject.get_ptr();
+                m_DataObject = data_object.get();
                 m_dragging_initial_playlist = m_playlist_api->get_active_playlist();
                 uih::ole::do_drag_drop(
-                    get_wnd(), wp, pDataObject.get_ptr(), DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
+                    get_wnd(), wp, data_object.get(), DROPEFFECT_COPY | DROPEFFECT_MOVE, DROPEFFECT_COPY, &blah);
 
                 m_dragging = false;
                 m_DataObject.reset();


### PR DESCRIPTION
This avoids some crashes when `file-relative://` paths are encountered in non-portable installations.

The crashes occurred because some exceptions were thrown by certain API methods when tracks with such paths are encountered, and those exceptions weren’t being handled.

Such paths can currently creep into a non-portable installation simply by copying tracks using such paths from a portable installation and pasting them in a non-portable installation.

Note that other non-Columns UI operations may still crash with such tracks (copying the tracks again from the non-portable installation crashes on foobar2000’s side in some versions).