### PR TITLE
Load full metadata in Item details on foobar2000 2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 3.2.2
 
+### Features
+
+- Support was added to Item details for loading full track metadata for
+  non-playing tracks when using `LargeFieldsConfig-v2.txt` on foobar2000 2.26
+  preview 2025-12-28 and newer.
+  [[#1521](https://github.com/reupen/columns_ui/pull/1521)]
+
+### Bug fixes
+
 - Some crashes when tracks using the foobar2000 relative path protocol creep
   into a non-portable foobar2000 installation were fixed.
   [[#1520](https://github.com/reupen/columns_ui/pull/1520)]

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -303,9 +303,6 @@ void ItemDetails::set_handles(const metadb_handle_list& handles)
 
 void ItemDetails::request_full_file_info()
 {
-    if (static_api_test_t<metadb_v2>())
-        return;
-
     if (m_full_file_info_requested)
         return;
 
@@ -315,8 +312,13 @@ void ItemDetails::request_full_file_info()
         return;
 
     const auto handle = m_handles[0];
+
+    if (const auto info_ref = handle->get_info_ref(); !info_ref->isInfoPartial())
+        return;
+
     if (filesystem::g_is_remote_or_unrecognized(handle->get_path()))
         return;
+
     m_full_file_info_request = std::make_unique<helpers::FullFileInfoRequest>(
         std::move(handle), [self = service_ptr_t<ItemDetails>{this}](auto&& request) {
             self->on_full_file_info_request_completion(std::forward<decltype(request)>(request));


### PR DESCRIPTION
This updates Item details to re-enable the loading of full metadata for non-playing tracks on foobar2000 2.x. This is to support `LargeFieldsConfig-v2.txt` on foobar2000 2.26 preview 2025-12-28 and newer.

Additionally, loading full metadata is now skipped if `metadb_info_container::isInfoPartial()` returns false.