### PR TITLE
Fix loading of empty legacy spectrum analyser config data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.2.3
+
+### Bug fixes
+
+- A bug where importing some old FCL files failed with an ‘Unsupported format or
+  corrupted file’ error was fixed.
+  [[#1526](https://github.com/reupen/columns_ui/pull/1526)]
+
 ## 3.2.2
 
 ### Features

--- a/foo_ui_columns/vis_spectrum.cpp
+++ b/foo_ui_columns/vis_spectrum.cpp
@@ -518,7 +518,13 @@ void SpectrumAnalyserVisualisation::set_config(stream_reader* reader, size_t p_s
 
     reader->read_lendian_t(m_frame, p_abort);
 
-    [[maybe_unused]] const auto _size = reader->read_lendian_t<uint32_t>(p_abort);
+    [[maybe_unused]] const auto nested_data_size = reader->read_lendian_t<uint32_t>(p_abort);
+
+    if (nested_data_size == 0) {
+        has_migrated_spectrum_analyser_colours = true;
+        return;
+    }
+
     const auto legacy_foreground = reader->read_lendian_t<COLORREF>(p_abort);
     const auto legacy_background = reader->read_lendian_t<COLORREF>(p_abort);
 


### PR DESCRIPTION
Resolves #1525

This fixes a problem following recent changes to the spectrum analyser visualisation where the config reader did not handle a case that previously existed where the nested data blob was empty.

In particular, this caused the importation of some old FCL files to fail with an ‘Unsupported format or corrupted file’ error.