### PR TITLE
Extend support for $set_format() to the status pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 
 - Support for the `$set_format()`, `$reset_format()` and `%default_font_size%`
   title formatting functions and fields was added to playlist view display,
-  group and global scripts and to the playlist switcher.
-  [[#1529](https://github.com/reupen/columns_ui/pull/1529),
+  group and global scripts, to the playlist switcher, to the Filter panel and to
+  the status pane. [[#1529](https://github.com/reupen/columns_ui/pull/1529),
   [#1530](https://github.com/reupen/columns_ui/pull/1530),
-  [#1531](https://github.com/reupen/columns_ui/pull/1531)]
+  [#1531](https://github.com/reupen/columns_ui/pull/1531),
+  [#1532](https://github.com/reupen/columns_ui/pull/1532)]
 
   These functions and fields behave as they do in Item details and allow text
   styling to be changed for specific parts of text. Note that `$set_format()`

--- a/foo_ui_columns/status_pane.h
+++ b/foo_ui_columns/status_pane.h
@@ -17,30 +17,6 @@ class StatusPane
     };
     VolumeBar<false, false, StatusPaneVolumeBarAttributes> m_volume_control;
 
-    class StatusPaneTitleformatHook : public titleformat_hook {
-    public:
-        bool process_field(
-            titleformat_text_out* p_out, const char* p_name, size_t p_name_length, bool& p_found_flag) override
-        {
-            p_found_flag = false;
-            if (!stricmp_utf8_ex(p_name, p_name_length, "is_status_pane", pfc_infinite)) {
-                p_out->write(titleformat_inputtypes::unknown, "true");
-                p_found_flag = true;
-                return true;
-            }
-            return false;
-        }
-
-        bool process_function(titleformat_text_out* p_out, const char* p_name, size_t p_name_length,
-            titleformat_hook_function_params* p_params, bool& p_found_flag) override
-        {
-            p_found_flag = false;
-            return false;
-        }
-
-        StatusPaneTitleformatHook() = default;
-    };
-
     /** PLAYLIST CALLBACKS */
     void on_items_added(size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data,
         const bit_array& p_selection) noexcept override


### PR DESCRIPTION
#1502

This adds support for the `$set_format()`, `$reset_format()` and `%default_font_size%` title formatting functions and fields to the status pane.