### PR TITLE
Add ‘Add before’ and ‘Add after’ submenus to live editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   reordered using drag and drop.
   [[#1535](https://github.com/reupen/columns_ui/pull/1535)]
 
+- In live layout editing context menu, the ‘Add sibling’ submenu was replaced
+  with ‘Add before’ and ‘Add after’ submenus.
+  [[#1537](https://github.com/reupen/columns_ui/pull/1537)]
+
 ## 3.2.3
 
 ### Bug fixes


### PR DESCRIPTION
Resolves #1478

This replaces the ‘Add sibling’ submenu in the live editing context menu with ‘Add before’ and ‘Add after’ submenus.

The new submenus insert a panel (in the parent) before or after the panel that was right-clicked on. (The old ‘Add sibling’ was effectively ‘Add after’.)