### PR TITLE
Add ability to reorder lists in Preferences using keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,16 @@
   the font size to one decimal place instead of rounding to the nearest whole
   number.
 
-- Items in the playlist view columns and groups lists and the Filter panel field
-  list in Preferences can now be reordered using drag and drop.
-  [[#1535](https://github.com/reupen/columns_ui/pull/1535),
-  [#1538](https://github.com/reupen/columns_ui/pull/1538)]
+- In Preferences, items in the playlist view columns list, the playlist view
+  groups list and the Filter panel field list can now be reordered using drag
+  and drop and by using Ctrl+Shift in combination with the Up, Down, PgUp, PgDn,
+  Home and End keys. [[#1535](https://github.com/reupen/columns_ui/pull/1535),
+  [#1538](https://github.com/reupen/columns_ui/pull/1538),
+  [#1543](https://github.com/reupen/columns_ui/pull/1543)]
+
+- Items in the buttons list in Buttons options can now be reordered using
+  Ctrl+Shift in combination with the Up, Down, PgUp, PgDn, Home and End keys.
+  [[#1543](https://github.com/reupen/columns_ui/pull/1543)]
 
 - In live layout editing context menu, the ‘Add sibling’ submenu was replaced
   with ‘Add before’ and ‘Add after’ submenus.

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -259,6 +259,9 @@ public:
             void notify_on_selection_change(const bit_array& p_affected, const bit_array& p_status,
                 notification_source_t p_notification_source) override;
             bool do_drag_drop(WPARAM wp) override;
+            void move_selection(int delta) override;
+
+            void move_item(size_t old_index, size_t new_index);
 
         public:
             explicit ButtonsList(ConfigParam& p_param) : CoreDarkListView(true), m_param(p_param) {}

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -788,8 +788,9 @@ void TabColumns::on_column_list_selection_change()
     m_child->set_column(index != std::numeric_limits<size_t>::max() ? m_columns[index] : PlaylistViewColumn::ptr());
 }
 
-void TabColumns::on_column_list_reorder(mmh::Permutation& permutation, size_t old_index, size_t new_index)
+void TabColumns::on_column_list_reorder(size_t old_index, size_t new_index)
 {
+    auto permutation = utils::create_shift_item_permutation(old_index, new_index, m_columns_list_view.get_item_count());
     m_columns.reorder(permutation.data());
 
     const auto first_affected = std::min(old_index, new_index);

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -244,6 +244,9 @@ void FilterPanel::s_on_fields_swapped(size_t index_1, size_t index_2)
 
 void FilterPanel::s_on_fields_reordered(mmh::Permutation& permutation, size_t old_index, size_t new_index)
 {
+    if (g_windows.empty())
+        return;
+
     if (permutation.size() != g_field_data.size()) {
         assert(false);
         return;

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -280,6 +280,7 @@
     <ClCompile Include="imaging.cpp" />
     <ClCompile Include="list_view_drop_target.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_config.cpp" />
+    <ClCompile Include="permutation_utils.cpp" />
     <ClCompile Include="playlist_selector.cpp" />
     <ClCompile Include="resource_utils.cpp" />
     <ClCompile Include="string.cpp" />
@@ -476,6 +477,7 @@
     <ClInclude Include="mw_drop_target.h" />
     <ClInclude Include="ng_playlist\ng_playlist_artwork.h" />
     <ClInclude Include="panel_utils.h" />
+    <ClInclude Include="permutation_utils.h" />
     <ClInclude Include="resource_utils.h" />
     <ClInclude Include="string.h" />
     <ClInclude Include="svg.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -659,6 +659,9 @@
     <ClCompile Include="format_code_generator.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="permutation_utils.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -993,6 +996,9 @@
       <Filter>Utilities</Filter>
     </ClInclude>
     <ClInclude Include="format_code_generator.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="permutation_utils.h">
       <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>

--- a/foo_ui_columns/list_view_drop_target.cpp
+++ b/foo_ui_columns/list_view_drop_target.cpp
@@ -192,13 +192,7 @@ HRESULT STDMETHODCALLTYPE SimpleListViewDropTarget::Drop(
         const auto item_count = m_list_view->get_item_count();
 
         if (new_index && old_index && new_index != old_index && old_index < item_count) {
-            const int step = new_index > old_index ? 1 : -1;
-            mmh::Permutation perm(item_count);
-
-            for (size_t index = *old_index; index != new_index; index += step)
-                std::swap(perm[index], perm[index + step]);
-
-            m_on_order_changed(perm, *old_index, *new_index);
+            m_on_order_changed(*old_index, *new_index);
             m_list_view->set_item_selected_single(*new_index);
             m_list_view->ensure_visible(*new_index);
         }

--- a/foo_ui_columns/list_view_drop_target.h
+++ b/foo_ui_columns/list_view_drop_target.h
@@ -6,7 +6,7 @@ wil::com_ptr<IDataObject> create_simple_list_view_data_object(HWND wnd);
 
 class SimpleListViewDropTarget : public IDropTarget {
 public:
-    using OnOrderChanged = std::function<void(mmh::Permutation& new_order, size_t new_index, size_t old_index)>;
+    using OnOrderChanged = std::function<void(size_t new_index, size_t old_index)>;
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, LPVOID FAR* ppvObject) override;
     ULONG STDMETHODCALLTYPE AddRef() override;

--- a/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
@@ -3,6 +3,7 @@
 #include "dark_mode_dialog.h"
 #include "ng_playlist.h"
 #include "ng_playlist_groups.h"
+#include "permutation_utils.h"
 
 namespace cui::panels::playlist_view {
 
@@ -240,8 +241,9 @@ void GroupsPreferencesTab::on_group_default_action(size_t index)
     }
 }
 
-void GroupsPreferencesTab::on_column_list_reorder(mmh::Permutation& permutation, size_t old_index, size_t new_index)
+void GroupsPreferencesTab::on_group_list_reorder(size_t old_index, size_t new_index)
 {
+    auto permutation = utils::create_shift_item_permutation(old_index, new_index, m_groups_list_view.get_item_count());
     g_groups.reorder(permutation.data());
 
     const auto first_affected = std::min(old_index, new_index);

--- a/foo_ui_columns/permutation_utils.cpp
+++ b/foo_ui_columns/permutation_utils.cpp
@@ -1,0 +1,19 @@
+#include "pch.h"
+
+namespace cui::utils {
+
+mmh::Permutation create_shift_item_permutation(size_t old_index, size_t new_index, size_t count)
+{
+    assert(old_index < count);
+    assert(new_index < count);
+
+    const int step = new_index > old_index ? 1 : -1;
+    mmh::Permutation permutation(count);
+
+    for (size_t index = old_index; index != new_index; index += step)
+        std::swap(permutation[index], permutation[index + step]);
+
+    return permutation;
+}
+
+} // namespace cui::utils

--- a/foo_ui_columns/permutation_utils.h
+++ b/foo_ui_columns/permutation_utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace cui::utils {
+
+mmh::Permutation create_shift_item_permutation(size_t old_index, size_t new_index, size_t count);
+
+}


### PR DESCRIPTION
This adds the ability to move the selected item upwards or downards using the keyboard in the following list views:

- the buttons list in Buttons options
- the playlist view column list in Preferences
- the playlist view group list in Preferences
- the Filter panel field list in Preferences

Items can be moved using Ctrl+Shift in combination with the Up, Down, PgUp, PgDn, Home and End keys (as in the playlist view).