### PR TITLE
Improve usability of field list in Item properties options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@
   Ctrl+Shift in combination with the Up, Down, PgUp, PgDn, Home and End keys.
   [[#1543](https://github.com/reupen/columns_ui/pull/1543)]
 
+- Items in the field list in Item properties options can now be reordered using
+  drag and drop and by using Ctrl+Shift in combination with the Up, Down, PgUp,
+  PgDn, Home and End keys.
+  [[#1551](https://github.com/reupen/columns_ui/pull/1551)]
+
+- Double-clicking in the field list in Item properties options now activates
+  inline editing. [[#1551](https://github.com/reupen/columns_ui/pull/1551)]
+
 - In live layout editing context menu, the ‘Add sibling’ submenu was replaced
   with ‘Add before’ and ‘Add after’ submenus.
   [[#1537](https://github.com/reupen/columns_ui/pull/1537)]

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -36,6 +36,11 @@ public:
 
     void get_insert_items(size_t base, size_t count, pfc::list_t<InsertItem>& items);
     void notify_on_create() override;
+    bool do_drag_drop(WPARAM wp) override;
+    void move_selection(int delta) override;
+
+    void execute_default_action(size_t index, size_t column, bool b_keyboard, bool b_ctrl) override;
+
     bool notify_before_create_inline_edit(
         const pfc::list_base_const_t<size_t>& indices, size_t column, bool b_source_mouse) override;
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
@@ -43,6 +48,7 @@ public:
     void notify_save_inline_edit(const char* value) override;
 
 private:
+    void reorder_item(size_t old_index, size_t new_index);
 };
 
 size_t g_get_info_section_id_by_name(const char* p_name);

--- a/foo_ui_columns/item_properties_config_list_view.cpp
+++ b/foo_ui_columns/item_properties_config_list_view.cpp
@@ -1,5 +1,7 @@
 #include "pch.h"
 #include "item_properties.h"
+#include "list_view_drop_target.h"
+#include "permutation_utils.h"
 
 namespace cui::panels::item_properties {
 
@@ -50,6 +52,39 @@ void FieldsList::notify_on_create()
     pfc::list_t<InsertItem> items;
     get_insert_items(0, count, items);
     insert_items(0, count, items.get_ptr());
+
+    wil::com_ptr drop_target(new utils::SimpleListViewDropTarget(
+        this, [this](size_t old_index, size_t new_index) { reorder_item(old_index, new_index); }));
+
+    RegisterDragDrop(get_wnd(), drop_target.get());
+}
+
+bool FieldsList::do_drag_drop(WPARAM wp)
+{
+    DWORD drop_effect{DROPEFFECT_NONE};
+    const auto data_object = utils::create_simple_list_view_data_object(get_wnd());
+    LOG_IF_FAILED(uih::ole::do_drag_drop(get_wnd(), wp, data_object.get(), DROPEFFECT_MOVE, NULL, &drop_effect));
+    return true;
+}
+
+void FieldsList::move_selection(int delta)
+{
+    const auto selection_index = fbh::as_optional(get_selected_item_single());
+
+    if (!selection_index)
+        return;
+
+    const auto new_index = std::clamp(
+        gsl::narrow<ptrdiff_t>(*selection_index) + delta, ptrdiff_t{}, gsl::narrow<ptrdiff_t>(get_item_count() - 1));
+
+    reorder_item(*selection_index, gsl::narrow<size_t>(new_index));
+    set_item_selected_single(new_index, false);
+    ensure_visible(new_index);
+}
+
+void FieldsList::execute_default_action(size_t index, size_t column, bool b_keyboard, bool b_ctrl)
+{
+    activate_inline_editing(index, column);
 }
 
 void FieldsList::get_insert_items(size_t base, size_t count, pfc::list_t<InsertItem>& items)
@@ -68,6 +103,21 @@ FieldsList::FieldsList(pfc::list_t<Field>& p_fields)
     , m_edit_column(pfc_infinite)
     , m_fields(p_fields)
 {
+}
+
+void FieldsList::reorder_item(size_t old_index, size_t new_index)
+{
+    auto permutation = utils::create_shift_item_permutation(old_index, new_index, get_item_count());
+    m_fields.reorder(permutation.data());
+
+    const auto first_affected = std::min(old_index, new_index);
+    const auto last_affected = std::max(old_index, new_index);
+    const auto affected_count = last_affected - first_affected + 1;
+
+    pfc::list_t<InsertItem> insert_items;
+    get_insert_items(first_affected, affected_count, insert_items);
+
+    replace_items(first_affected, insert_items.size(), insert_items.get_ptr());
 }
 
 } // namespace cui::panels::item_properties


### PR DESCRIPTION
This ports recent list view usability improvements elsewhere to the field list in Item properties.

It:

- makes it possible to reorder fields using drag and drop
- makes it possible to reorder fields using using Ctrl+Shift in combination with the Up, Down, PgUp, PgDn, Home and End keys
- makes it possible to activate inline editing by double-clicking on cells