### PR TITLE
Remove ‘Close panel’ from panel caption context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Development version
+## 3.3.0-beta.1
 
 ### Features
 
@@ -19,10 +19,11 @@
   These functions and fields behave as they do in Item details and allow text
   styling to be changed for specific parts of text. Note that `$set_format()`
   does not affect item heights, which is fixed based on the size of the font
-  configured on the Colours and fonts preferences page font and vertical item
-  padding settings where available. See
+  configured on the Colours and fonts preferences page and the vertical item
+  padding setting where available. See
   [Text styling](https://columns-ui.readthedocs.io/page/other/text-styling.html)
-  for full documentation for the functions.
+  for full documentation for the functions and some examples of how they can be
+  used.
 
   Additionally, `%default_font_size%` has been modified universally to return
   the font size to one decimal place instead of rounding to the nearest whole
@@ -64,6 +65,10 @@
 - In live layout editing context menu, the ‘Add sibling’ submenu was replaced
   with ‘Add before’ and ‘Add after’ submenus.
   [[#1537](https://github.com/reupen/columns_ui/pull/1537)]
+
+- In the context menu for panel captions, the ‘Close panel’ item was removed to
+  prevent accidental panel removals.
+  [[#1553](https://github.com/reupen/columns_ui/pull/1553)]
 
 ### Bug fixes
 

--- a/foo_ui_columns/splitter_panel_container.cpp
+++ b/foo_ui_columns/splitter_panel_container.cpp
@@ -258,8 +258,7 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
         break;
     case WM_CONTEXTMENU: {
         enum {
-            IDM_CLOSE = 1,
-            IDM_MOVE_UP,
+            IDM_MOVE_UP = 1,
             IDM_MOVE_DOWN,
             IDM_LOCK,
             IDM_CAPTION,
@@ -293,7 +292,6 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
         AppendMenu(menu, (MF_SEPARATOR), 0, _T(""));
         AppendMenu(menu, (MF_STRING), IDM_MOVE_UP, _T("Move &up"));
         AppendMenu(menu, (MF_STRING), IDM_MOVE_DOWN, _T("Move &down"));
-        AppendMenu(menu, (MF_STRING), IDM_CLOSE, _T("&Close panel"));
 
         pfc::refcounted_object_ptr_t<ui_extension::menu_hook_impl> extension_menu_nodes
             = new ui_extension::menu_hook_impl;
@@ -321,13 +319,7 @@ LRESULT FlatSplitterPanel::Panel::PanelContainer::on_message(HWND wnd, UINT msg,
 
         DestroyMenu(menu);
 
-        if (cmd == IDM_CLOSE && p_panel->m_child.is_valid()) {
-            service_ptr_t<FlatSplitterPanel> p_this = m_this;
-            p_panel->destroy();
-            std::erase(p_this->m_panels, p_panel);
-            p_this->get_host()->on_size_limit_change(p_this->get_wnd(), uie::size_limit_all);
-            p_this->on_size_changed();
-        } else if (cmd == IDM_MOVE_UP) {
+        if (cmd == IDM_MOVE_UP) {
             if (auto new_iter = std::ranges::find(m_this->m_panels, p_panel);
                 new_iter != m_this->m_panels.begin() && new_iter != m_this->m_panels.end()) {
                 std::iter_swap(new_iter, std::prev(new_iter));


### PR DESCRIPTION
This removes the ‘Close panel’ item from the context menu for panel captions in Row and Column containers.

The context menu itself is very old and predates live editing. ‘Close panel’ removes the panel from the layout, which is a destructive action and doesn’t need to be so prominently availble. Removing the item from the context menu has been requested a few times.