### PR TITLE
Fix evaluation of playlist view style scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.3.0-beta.2
+
+### Bug fixes
+
+- A bug in beta 1 causing playlist view style scripts to be evaluated
+  incorrectly was fixed.
+  [[#1557](https://github.com/reupen/columns_ui/pull/1557)]
+
 ## 3.3.0-beta.1
 
 ### Features

--- a/foo_ui_columns/tf_text_format.cpp
+++ b/foo_ui_columns/tf_text_format.cpp
@@ -80,14 +80,13 @@ bool MergingTextFormatTitleformatHook::process_field(
     if (stricmp_utf8_ex(
             p_name, p_name_length, TextFormatTitleformatHook::default_font_size_field_name.c_str(), pfc_infinite)
         != 0) {
-        p_out->write(titleformat_inputtypes::unknown, fmt::format("{:.1f}", m_default_font_size_pt).c_str());
-        p_found_flag = true;
-        return true;
+        p_found_flag = false;
+        return false;
     }
 
-    p_found_flag = false;
-
-    return false;
+    p_out->write(titleformat_inputtypes::unknown, fmt::format("{:.1f}", m_default_font_size_pt).c_str());
+    p_found_flag = true;
+    return true;
 }
 
 bool MergingTextFormatTitleformatHook::process_function(titleformat_text_out* p_out, const char* p_name,


### PR DESCRIPTION
This fixes a bug that caused style scripts to not be evaluated correctly, due to an error in one of the title formatting hooks.