### PR TITLE
Suppress unwanted console error when reading metadata from BMP images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Development version
+
+### Bug fixes
+
+- A problem where a message mentioning that ‘The operation is unsupported’ was
+  logged to the console when loading artwork images in the BMP format was fixed.
+  [[#1560](https://github.com/reupen/columns_ui/pull/1560)]
+
 ## 3.3.0-beta.2
 
 ### Bug fixes


### PR DESCRIPTION
It seems `IWICBitmapFrameDecode::GetMetadataQueryReader()` fails with `WINCODEC_ERR_UNSUPPORTEDOPERATION` for BMP images. This suppresses the logging of that error as it’s clearly expected.