### PR TITLE
Retrieve and set Direct3D device context pointer correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   logged to the console when loading artwork images in the BMP format was fixed.
   [[#1560](https://github.com/reupen/columns_ui/pull/1560)]
 
+- A possible error when the Artwork view reinitialises Direct3D and Direct2D
+  resources was fixed. [[#1561](https://github.com/reupen/columns_ui/pull/1561)]
+
 ## 3.3.0-beta.2
 
 ### Bug fixes

--- a/foo_ui_columns/d3d_utils.cpp
+++ b/foo_ui_columns/d3d_utils.cpp
@@ -6,12 +6,12 @@ wil::com_ptr<ID3D11Device> create_d3d_device(
     const std::span<const D3D_FEATURE_LEVEL> feature_levels, ID3D11DeviceContext** device_context)
 {
     if (!config::use_hardware_acceleration)
-        return uih::d3d::create_d3d_device(D3D_DRIVER_TYPE_WARP, feature_levels);
+        return uih::d3d::create_d3d_device(D3D_DRIVER_TYPE_WARP, feature_levels, device_context);
 
     try {
-        return uih::d3d::create_d3d_device(D3D_DRIVER_TYPE_HARDWARE, feature_levels);
+        return uih::d3d::create_d3d_device(D3D_DRIVER_TYPE_HARDWARE, feature_levels, device_context);
     } catch (const wil::ResultException&) {
-        const auto device = uih::d3d::create_d3d_device(D3D_DRIVER_TYPE_WARP, feature_levels);
+        const auto device = uih::d3d::create_d3d_device(D3D_DRIVER_TYPE_WARP, feature_levels, device_context);
         console::print("Columns UI – failed to create a hardware Direct3D renderer, using a software renderer instead");
         return device;
     }


### PR DESCRIPTION
This fixes a bug where `cui::d3d::create_d3d_device()` did not pass the `ID3D11DeviceContext**` pointer for the immediate device context on to `uih::d3d::create_d3d_device()` and in turn `D3D11CreateDevice()`.

This would have stopped the Artwork view from calling the `ClearState()` and `Flush()` methods on the device context when releasing or recreating Direct3D and Direct2D resources.

This seems to have regressed in:

https://github.com/reupen/columns_ui/commit/24edec9448d22f3eb486d38a781d2d5acd8ac7e7#diff-5873d652ab9918ca053ca8a9aad53c29ac13e62300d8ad67aef2999156de247d

(I haven’t noticed any problems with the `ClearState()` and `Flush()` calls omitted, but I’m sure they were put in for a reason…)