### PR TITLE
Optimise updating of scroll position in Item details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   [#1604](https://github.com/reupen/columns_ui/pull/1604),
   [#1605](https://github.com/reupen/columns_ui/pull/1605),
   [#1607](https://github.com/reupen/columns_ui/pull/1607),
-  [#1609](https://github.com/reupen/columns_ui/pull/1609)]
+  [#1609](https://github.com/reupen/columns_ui/pull/1609),
+  [#1612](https://github.com/reupen/columns_ui/pull/1612)]
 
   This affects the playlist view, playlist switcher, Filter panel, Item details
   and Item properties. The option is located on the Setup tab on the root

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -780,16 +780,11 @@ void ItemDetails::internal_scroll(uih::ScrollAxis axis, int position, bool is_de
     current_si.fMask = SIF_POS | SIF_RANGE;
     GetScrollInfo(get_wnd(), scroll_bar_type, &current_si);
 
-    const auto new_pos = std::clamp(position + (is_delta ? current_si.nPos : 0), current_si.nMin, current_si.nMax);
+    const auto clamped_pos = std::clamp(position + (is_delta ? current_si.nPos : 0), current_si.nMin, current_si.nMax);
+    const auto new_position = uih::set_scroll_position(get_wnd(), axis, current_si.nPos, clamped_pos);
 
-    if (new_pos == current_si.nPos)
+    if (new_position == current_si.nPos)
         return;
-
-    SCROLLINFO new_si{};
-    new_si.cbSize = sizeof(new_si);
-    new_si.fMask = SIF_POS;
-    new_si.nPos = new_pos;
-    const auto new_position = SetScrollInfo(get_wnd(), scroll_bar_type, &new_si, TRUE);
 
     if (axis == uih::ScrollAxis::Vertical)
         m_vertical_scroll_position = new_position;


### PR DESCRIPTION
This updates Item details to use the optimised `uih::set_scroll_position()` function to update scroll positions.