### PR TITLE
Fix ‘Configure panel…’ button for root panel in Preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@
 
   This is intended to restore the behaviour of versions before 3.0.0.
 
+- A bug where, when the root panel in a layout has a configuration dialogue, its
+  ‘Configure panel…’ button on the Layout preferences tab did not work was
+  fixed. [[#1617](https://github.com/reupen/columns_ui/pull/1617)]
+
 ### Internal changes
 
 - Some code was cleaned up.

--- a/foo_ui_columns/tab_layout.cpp
+++ b/foo_ui_columns/tab_layout.cpp
@@ -472,22 +472,15 @@ void LayoutTab::set_item_property_stream(HWND wnd, const GUID& guid, stream_read
 
 void LayoutTab::run_configure(HWND wnd)
 {
-    HTREEITEM ti = TreeView_GetSelection(m_wnd_tree);
-    if (!ti)
+    const auto selected_ti = TreeView_GetSelection(m_wnd_tree);
+
+    if (!selected_ti)
         return;
 
-    HTREEITEM ti_parent = TreeView_GetParent(m_wnd_tree, ti);
-    if (!ti_parent)
-        return;
+    const auto node = m_node_map.at(selected_ti);
 
-    auto p_node = m_node_map.at(ti);
-    auto p_node_parent = m_node_map.at(ti_parent);
-    unsigned index = tree_view_get_child_index(m_wnd_tree, ti);
-    if (index < p_node_parent->m_splitter->get_panel_count()) {
-        if (p_node->m_window.is_valid() && p_node->m_window->show_config_popup(wnd)) {
-            save_item(wnd, ti);
-        }
-    }
+    if (node->m_window.is_valid() && node->m_window->show_config_popup(wnd))
+        save_item(wnd, selected_ti);
 }
 
 void LayoutTab::initialise_tree(HWND wnd)


### PR DESCRIPTION
If the root panel in a layout is configurable, the ‘Configure panel…’ button for that panel on the Layout preferences tab was enabled but did nothing.

This fixes that (by removing some incorrect checks) so that the button works.