### PR TITLE
Truncate long system tray icon tooltips with an ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,31 @@
 
 ## 3.4.0
 
+### Features
+
+- System tray icon tooltips are now truncated with an ellipsis when they exceed
+  the maximum number of characters that Windows supports.
+  [[#1643](https://github.com/reupen/columns_ui/pull/1643)]
+
+  Additionally, the character limit is now mentioned on the ‘System tray’ tab in
+  Preferences.
+
+- The default system tray icon tooltip title formatting script was updated to
+  use `$char(10)` instead of `$crlf()` to use less of the character limit.
+  [[#1643](https://github.com/reupen/columns_ui/pull/1643)]
+
+- The word ‘Unpaused’ was changed to ‘Resumed’ in system tray balloon tips.
+  [[#1643](https://github.com/reupen/columns_ui/pull/1643)]
+
 ### Bug fixes
 
 - A bug where some operations in the Layout tree in Preferences may have behaved
   incorrectly after changing the container type of the root panel was fixed.
   [[#1642](https://github.com/reupen/columns_ui/pull/1642)]
+
+- If there is an active system tray balloon tip when stopping playback, it’s now
+  automatically dismissed.
+  [[#1643](https://github.com/reupen/columns_ui/pull/1643)]
 
 ## 3.4.0-beta.1
 

--- a/foo_ui_columns/config_items.cpp
+++ b/foo_ui_columns/config_items.cpp
@@ -16,7 +16,7 @@ const char* default_status_bar_script
 const char* default_system_tray_icon_script
     = "//This is the default script for the content of the system tray icon tooltip "
       "during playback.\r\n\r\n"
-      "[%title%]$crlf()[%artist%][$crlf()%album%]";
+      "[%title%][$char(10)%artist%][$char(10)%album%]";
 
 const char* default_main_window_title_script
     = "//This is the default script for the title of the main window during playback.\r\n\r\n"

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -115,7 +115,8 @@ BEGIN
     CONTROL         "Show now playing sub-menu in icon context menu",IDC_NOWPL,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,120,183,10
     LTEXT           "Tooltip title formatting script",IDC_STATIC,7,140,97,8
-    EDITTEXT        IDC_STRING,7,151,313,113,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL
+    EDITTEXT        IDC_STRING,7,151,313,103,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL
+    LTEXT           "System tray tooltips are limited to approximately 127 characters.",IDC_STATIC,7,256,216,8
 END
 
 IDD_PREFS_PLAYLISTS_DRAGDROP DIALOGEX 0, 0, 327, 271

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -49,10 +49,8 @@ HIMAGELIST g_imagelist = nullptr;
 
 HWND g_status = nullptr;
 
-bool g_icon_created = false;
-bool ui_initialising = false, g_minimised = false;
-
-HICON g_icon = nullptr;
+bool ui_initialising{};
+bool g_minimised{};
 
 bool remember_window_pos()
 {
@@ -193,10 +191,6 @@ void cui::MainWindow::shutdown()
     DestroyWindow(m_wnd);
     UnregisterClass(main_window_class_name, core_api::get_my_instance());
     m_wnd = nullptr;
-    if (g_icon)
-        DestroyIcon(g_icon);
-    g_icon = nullptr;
-
     OleUninitialize();
 }
 

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -11,7 +11,6 @@
 #include "system_tray.h"
 
 extern HWND g_status;
-extern bool g_icon_created;
 
 namespace statusbar_contextmenus {
 enum {
@@ -66,8 +65,8 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     }
 
     if (m_wm_taskbarcreated && msg == m_wm_taskbarcreated) {
-        if (g_icon_created) {
-            g_icon_created = false;
+        if (systray::is_system_tray_icon_created) {
+            systray::is_system_tray_icon_created = false;
             systray::create_icon();
             systray::update_icon_tooltip();
         }
@@ -178,7 +177,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         status_bar::destroy_window();
         m_taskbar_list.reset();
         RevokeDragDrop(m_wnd);
-        systray::remove_icon();
+        systray::deinitialise();
         on_destroy();
         m_is_destroying = false;
         break;
@@ -511,9 +510,9 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             ULONG_PTR styles = GetWindowLongPtr(wnd, GWL_STYLE);
             if (styles & WS_MINIMIZE) {
                 cfg_main_window_is_hidden = cfg_main_window_is_hidden || cfg_minimise_to_tray;
-                if (!g_icon_created && cfg_main_window_is_hidden)
+                if (!systray::is_system_tray_icon_created && cfg_main_window_is_hidden)
                     systray::create_icon();
-                if (g_icon_created && cfg_main_window_is_hidden)
+                if (systray::is_system_tray_icon_created && cfg_main_window_is_hidden)
                     ShowWindow(wnd, SW_HIDE);
             } else {
                 resize_child_windows();

--- a/foo_ui_columns/system_tray.cpp
+++ b/foo_ui_columns/system_tray.cpp
@@ -4,17 +4,20 @@
 #include "main_window.h"
 #include "win32.h"
 
-extern HICON g_icon;
-extern bool g_icon_created;
-
 namespace cui::systray {
+
+bool is_system_tray_icon_created = false;
 
 namespace {
 
-const std::unordered_map<systray::BalloonTipTitle, const char*> balloon_tip_title_map = {
-    {systray::BalloonTipTitle::NowPlaying, "Now playing:"},
-    {systray::BalloonTipTitle::Paused, "Paused:"},
-    {systray::BalloonTipTitle::Unpaused, "Unpaused:"},
+constexpr auto system_tray_icon_id = 1u;
+
+wil::unique_hicon system_tray_icon;
+
+const std::unordered_map<BalloonTipTitle, wil::zwstring_view> balloon_tip_title_map = {
+    {BalloonTipTitle::NowPlaying, L"Now playing:"_zv},
+    {BalloonTipTitle::Paused, L"Paused:"_zv},
+    {BalloonTipTitle::Resumed, L"Resumed:"_zv},
 };
 
 std::string get_tooltip_text()
@@ -53,31 +56,137 @@ std::string escape_tooltip_text(std::string text)
     return escaped_text;
 }
 
+std::optional<std::wstring> truncate_string(std::wstring_view text, size_t max_code_units)
+{
+    if (text.size() <= max_code_units)
+        return {};
+
+    std::optional<std::wstring> truncated_text{text};
+
+    size_t code_unit_counter{};
+    const wchar_t* pos{truncated_text->c_str()};
+
+    while (true) {
+        uint32_t code_point{};
+        const auto code_point_length = pfc::utf16_decode_char(pos, &code_point);
+
+        if (code_point_length == 0 || code_unit_counter + code_point_length > max_code_units - 1)
+            break;
+
+        pos += code_point_length;
+        code_unit_counter += code_point_length;
+    }
+
+    truncated_text->resize(code_unit_counter + 1);
+    (*truncated_text)[code_unit_counter] = L'…';
+
+    return truncated_text;
+}
+
+template <size_t Size>
+void copy_and_truncate_string(wil::zwstring_view source, wchar_t (&destination)[Size])
+{
+    static_assert(Size >= 2);
+
+    const auto truncated_string = truncate_string(source, Size - 1);
+
+    wcsncpy_s(destination, truncated_string ? truncated_string->c_str() : source.c_str(), _TRUNCATE);
+}
+
+void create_systray_icon(HICON icon, uint32_t callback_msg, wil::zwstring_view text)
+{
+    NOTIFYICONDATA nid{};
+    nid.cbSize = sizeof(nid);
+    nid.hWnd = main_window.get_wnd();
+    nid.uID = system_tray_icon_id;
+    nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+    nid.hIcon = icon;
+    nid.uCallbackMessage = callback_msg;
+
+    copy_and_truncate_string(text, nid.szTip);
+
+    Shell_NotifyIcon(NIM_ADD, &nid);
+}
+
+void update_systray_icon_icon(HICON icon)
+{
+    NOTIFYICONDATA nid{};
+    nid.cbSize = sizeof(nid);
+    nid.hWnd = main_window.get_wnd();
+    nid.uID = system_tray_icon_id;
+    nid.uFlags = NIF_ICON;
+    nid.hIcon = icon;
+
+    Shell_NotifyIcon(NIM_MODIFY, &nid);
+}
+
+void update_systray_icon_tooltip(wil::zwstring_view text)
+{
+    NOTIFYICONDATA nid{};
+    nid.cbSize = sizeof(nid);
+    nid.hWnd = main_window.get_wnd();
+    nid.uID = system_tray_icon_id;
+    // Set NIF_INFO to remove any previous balloon tip
+    nid.uFlags = NIF_TIP | NIF_INFO;
+
+    copy_and_truncate_string(text, nid.szTip);
+
+    Shell_NotifyIcon(NIM_MODIFY, &nid);
+}
+
+void update_systray_icon_balloon_tip(wil::zwstring_view title, wil::zwstring_view body)
+{
+    NOTIFYICONDATA nid{};
+    nid.cbSize = sizeof(nid);
+    nid.hWnd = main_window.get_wnd();
+    nid.uID = system_tray_icon_id;
+    nid.uFlags = NIF_INFO;
+    nid.dwInfoFlags = NIIF_INFO | NIIF_NOSOUND;
+
+    copy_and_truncate_string(title, nid.szInfoTitle);
+    copy_and_truncate_string(body, nid.szInfo);
+
+    Shell_NotifyIcon(NIM_MODIFY, &nid);
+}
+
+void remove_systray_icon()
+{
+    NOTIFYICONDATA nid{};
+    nid.cbSize = sizeof(nid);
+    nid.hWnd = main_window.get_wnd();
+    nid.uID = system_tray_icon_id;
+    Shell_NotifyIcon(NIM_DELETE, &nid);
+}
+
 } // namespace
 
 void update_icon_tooltip(std::optional<BalloonTipTitle> balloon_tip_title, bool force_balloon)
 {
-    if (!g_icon_created)
+    if (!is_system_tray_icon_created)
         return;
 
     const auto title = get_tooltip_text();
     const auto escaped_title = escape_tooltip_text(title);
 
+    update_systray_icon_tooltip(mmh::to_utf16(escaped_title));
+
     if (balloon_tip_title && (cfg_balloon || force_balloon)) {
-        uShellNotifyIconEx(
-            NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title.c_str(), "", "");
-        uShellNotifyIconEx(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title.c_str(),
-            balloon_tip_title_map.at(*balloon_tip_title), title.c_str());
-    } else
-        uShellNotifyIcon(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon, escaped_title.c_str());
+        update_systray_icon_balloon_tip(balloon_tip_title_map.at(*balloon_tip_title), mmh::to_utf16(title));
+    }
 }
 
 void remove_icon()
 {
-    if (g_icon_created) {
-        uShellNotifyIcon(NIM_DELETE, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, nullptr, nullptr);
-        g_icon_created = false;
+    if (is_system_tray_icon_created) {
+        remove_systray_icon();
+        is_system_tray_icon_created = false;
     }
+}
+
+void deinitialise()
+{
+    remove_icon();
+    system_tray_icon.reset();
 }
 
 void on_show_icon_change()
@@ -88,9 +197,10 @@ void on_show_icon_change()
     const auto is_iconic = IsIconic(main_window.get_wnd()) != 0;
     const auto close_to_icon = config::advbool_close_to_system_tray_icon.get();
 
-    if (cfg_show_systray && !g_icon_created) {
+    if (cfg_show_systray && !is_system_tray_icon_created) {
         create_icon();
-    } else if (!cfg_show_systray && g_icon_created && (!is_iconic || !(cfg_minimise_to_tray || close_to_icon))) {
+    } else if (!cfg_show_systray && is_system_tray_icon_created
+        && (!is_iconic || !(cfg_minimise_to_tray || close_to_icon))) {
         remove_icon();
         if (is_iconic)
             standard_commands::main_activate();
@@ -99,13 +209,16 @@ void on_show_icon_change()
 
 void create_icon()
 {
-    const auto tooltip_text = escape_tooltip_text(get_tooltip_text());
-    uShellNotifyIcon(g_icon_created ? NIM_MODIFY : NIM_ADD, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon,
-        tooltip_text.c_str());
+    const auto escaped_title = escape_tooltip_text(get_tooltip_text());
 
-    // NIM_SETVERSION is not used as caused some undesirable behaviour with some mouse clicks.
+    if (is_system_tray_icon_created) {
+        update_systray_icon_tooltip(mmh::to_utf16(escaped_title));
+    } else {
+        create_systray_icon(system_tray_icon.get(), MSG_SYSTEM_TRAY_ICON, mmh::to_utf16(escaped_title));
+        // NIM_SETVERSION is not used as caused some undesirable behaviour with some mouse clicks.
+    }
 
-    g_icon_created = true;
+    is_system_tray_icon_created = true;
 }
 
 void create_icon_handle()
@@ -113,17 +226,17 @@ void create_icon_handle()
     const unsigned cx = GetSystemMetrics(SM_CXSMICON);
     const unsigned cy = GetSystemMetrics(SM_CYSMICON);
 
-    if (g_icon) {
-        DestroyIcon(g_icon);
-        g_icon = nullptr;
-    }
+    wil::unique_hicon old_icon = std::move(system_tray_icon);
 
     if (cfg_custom_icon)
-        g_icon
-            = (HICON)uLoadImage(core_api::get_my_instance(), cfg_tray_icon_path, IMAGE_ICON, cx, cy, LR_LOADFROMFILE);
+        system_tray_icon.reset(
+            static_cast<HICON>(uLoadImage(nullptr, cfg_tray_icon_path, IMAGE_ICON, cx, cy, LR_LOADFROMFILE)));
 
-    if (!g_icon)
-        g_icon = ui_control::get()->load_main_icon(cx, cy);
+    if (!system_tray_icon)
+        system_tray_icon.reset(ui_control::get()->load_main_icon(cx, cy));
+
+    if (is_system_tray_icon_created)
+        update_systray_icon_icon(system_tray_icon.get());
 }
 
 } // namespace cui::systray

--- a/foo_ui_columns/system_tray.h
+++ b/foo_ui_columns/system_tray.h
@@ -2,16 +2,19 @@
 
 namespace cui::systray {
 
+extern bool is_system_tray_icon_created;
+
 enum class BalloonTipTitle {
     NowPlaying,
     Paused,
-    Unpaused,
+    Resumed,
 };
 
 void create_icon_handle();
 void create_icon();
 void update_icon_tooltip(std::optional<BalloonTipTitle> balloon_tip_title = {}, bool force_balloon = false);
 void remove_icon();
+void deinitialise();
 void on_show_icon_change();
 
 } // namespace cui::systray

--- a/foo_ui_columns/system_tray_callbacks.cpp
+++ b/foo_ui_columns/system_tray_callbacks.cpp
@@ -1,9 +1,5 @@
 #include "pch.h"
-#include "main_window.h"
 #include "system_tray.h"
-
-extern HICON g_icon;
-extern bool g_icon_created;
 
 namespace cui::systray {
 
@@ -20,15 +16,14 @@ public:
 
     void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override
     {
-        if (g_icon_created && p_reason != play_control::stop_reason_shutting_down) {
-            uShellNotifyIcon(NIM_MODIFY, main_window.get_wnd(), 1, MSG_SYSTEM_TRAY_ICON, g_icon,
-                core_version_info_v2::get()->get_name());
-        }
+        if (is_system_tray_icon_created && p_reason != play_control::stop_reason_shutting_down)
+            update_icon_tooltip();
     }
+
     void on_playback_seek(double p_time) override {}
     void on_playback_pause(bool b_state) noexcept override
     {
-        update_icon_tooltip(b_state ? BalloonTipTitle::Paused : BalloonTipTitle::Unpaused);
+        update_icon_tooltip(b_state ? BalloonTipTitle::Paused : BalloonTipTitle::Resumed);
     }
 
     void on_playback_edited(metadb_handle_ptr p_track) override {}

--- a/foo_ui_columns/tab_system_tray.cpp
+++ b/foo_ui_columns/tab_system_tray.cpp
@@ -49,18 +49,15 @@ public:
             case IDC_USE_CUSTOM_ICON: {
                 cfg_custom_icon = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
                 EnableWindow(GetDlgItem(wnd, IDC_BROWSE_ICON), cfg_custom_icon);
-                cui::systray::create_icon_handle();
-                cui::systray::create_icon();
+                systray::create_icon_handle();
             } break;
             case IDC_BROWSE_ICON: {
                 pfc::string8 path = cfg_tray_icon_path;
                 if (uGetOpenFileName(wnd, "Icon Files (*.ico)|*.ico|All Files (*.*)|*.*", 0, "ico", "Choose Icon",
                         nullptr, path, FALSE)) {
                     cfg_tray_icon_path = path;
-                    if (cfg_custom_icon) {
-                        cui::systray::create_icon_handle();
-                        cui::systray::create_icon();
-                    }
+                    if (cfg_custom_icon)
+                        systray::create_icon_handle();
                 }
             } break;
 

--- a/foo_ui_columns/user_interface_impl.cpp
+++ b/foo_ui_columns/user_interface_impl.cpp
@@ -5,8 +5,6 @@
 #include "system_tray.h"
 #include "main_window.h"
 
-extern bool g_icon_created;
-
 namespace cui {
 
 namespace {
@@ -184,7 +182,7 @@ public:
 
         cfg_main_window_is_hidden = false;
 
-        if (g_icon_created && !cfg_show_systray)
+        if (systray::is_system_tray_icon_created && !cfg_show_systray)
             systray::remove_icon();
 
         if (GetForegroundWindow() != wnd)


### PR DESCRIPTION
If the system tray icon tooltip exceed the buffer size in the `NOTIFYICONDATA` structure (128 UTF-16 code units, including a null terminator), it’s now truncated with an ellipsis character.

The default system tray tooltip title formatting script also now uses `$char(10)` instead of `$crlf()`, to use slightly less of the character limit.

Additionally, the character limit is now mentioned in Preferences on the ‘System tray’ tab.

Some minor tweaks to balloon tip behaviour were also made. They now automatically dismiss when stopping playback, and the word ‘Unpaused’ was changed to the more conventional ‘Resumed’.