### PR TITLE
Set shared.dll call path for some worker threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - The word ‘Unpaused’ was changed to ‘Resumed’ in system tray balloon tips.
   [[#1643](https://github.com/reupen/columns_ui/pull/1643)]
 
+- Call paths in crash logs are now set for some additional Columns UI background
+  threads. [[#1644](https://github.com/reupen/columns_ui/pull/1644)]
+
 ### Bug fixes
 
 - A bug where some operations in the Layout tree in Preferences may have behaved

--- a/foo_ui_columns/artwork.cpp
+++ b/foo_ui_columns/artwork.cpp
@@ -1140,6 +1140,7 @@ void ArtworkPanel::show_in_file_explorer()
         return;
 
     m_show_in_explorer_thread = std::jthread([this, self{ptr{this}}, path{std::string{path}}] {
+        TRACK_CALL_TEXT("ArtworkPanel::show_in_file_explorer::thread");
         (void)mmh::set_thread_description(GetCurrentThread(), L"[Columns UI] Show in Explorer");
 
         auto scope_exit

--- a/foo_ui_columns/vis_spectrum_renderer.cpp
+++ b/foo_ui_columns/vis_spectrum_renderer.cpp
@@ -148,6 +148,7 @@ void SpectrumAnalyserRenderer::start()
     reset_dib();
 
     m_render_thread = std::jthread([this](std::stop_token stop_token) {
+        TRACK_CALL_TEXT("SpectrumAnalyserRenderer::thread");
         mmh::set_thread_description(GetCurrentThread(), L"[Columns UI] Spectrum analyser renderer");
 
         GdiSetBatchLimit(1);


### PR DESCRIPTION
This adds a call path entry for foobar2000 crash logs in some threads created by Columns UI where an entry previously wasn’t added.

(Of note is that `foo_input_sacd` appears to be causing visualisation crashes again, so this makes those crashes a bit easier to identify.)