### PR TITLE
Fix behaviour of playlist view search bar when results are stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
   The search bar can be configured or disabled on the Search tab on the Playlist
   view page in Preferences.
-  [[#1671](https://github.com/reupen/columns_ui/pull/1671)]
+  [[#1671](https://github.com/reupen/columns_ui/pull/1671),
+  [#1676](https://github.com/reupen/columns_ui/pull/1676)]
 
 ### Bug fixes
 

--- a/foo_ui_columns/fcl_playlist_view.cpp
+++ b/foo_ui_columns/fcl_playlist_view.cpp
@@ -236,6 +236,7 @@ class PlaylistViewAppearanceDataSet : public fcl::dataset {
         panels::playlist_view::PlaylistView::s_on_sticky_artwork_change();
         panels::playlist_view::PlaylistView::s_on_artwork_group_header_spacing_change();
         panels::playlist_view::PlaylistView::s_on_sticky_group_headers_change();
+        playlist_search::PlaylistSearch::s_mark_results_stale();
     }
 };
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -982,20 +982,20 @@ void PlaylistView::notify_on_initialisation()
     m_playlist_search->on_results_statistics_change(
         [this](playlist_search::Status status, auto&& match_index, auto&& match_count, auto&& query_error) {
             switch (status) {
-            case playlist_search::NoMatches:
+            case playlist_search::Status::NoMatches:
                 set_search_bar_results_text(L"No matches found");
                 break;
-            case playlist_search::Matches:
+            case playlist_search::Status::Matches:
                 set_search_bar_results_text(std::format(
                     L"{:L} of {:L} match{}", *match_index, *match_count, *match_count != 1 ? L"es"sv : L""sv));
                 break;
-            case playlist_search::Stale:
+            case playlist_search::Status::Stale:
                 set_search_bar_results_text(L"Results are out of date");
                 break;
-            case playlist_search::NoQuery:
+            case playlist_search::Status::NoQuery:
                 set_search_bar_results_text(L"");
                 break;
-            case playlist_search::QueryError:
+            case playlist_search::Status::QueryError:
                 set_search_bar_results_text(mmh::to_utf16(query_error));
                 break;
             }

--- a/foo_ui_columns/playlist_search.cpp
+++ b/foo_ui_columns/playlist_search.cpp
@@ -38,7 +38,7 @@ bool match_string(
 
 void PlaylistSearch::init()
 {
-    if (m_running)
+    if (m_are_results_current)
         return;
 
     titleformat_compiler::get()->compile(m_titleformat_object, cfg_search_bar_script);
@@ -83,27 +83,25 @@ void PlaylistSearch::init()
     if (!m_playlist_callback)
         m_playlist_callback.emplace([&] { mark_results_stale(); });
 
-    m_running = true;
-    m_are_results_stale = false;
+    m_are_results_current = true;
     m_last_mode = mode;
 }
 
 void PlaylistSearch::reset()
 {
-    m_running = false;
-    m_are_results_stale = false;
+    m_are_results_current = false;
     m_match_index = 0;
     m_match_count = 0;
     m_matches.set_size(0);
     m_tracks.remove_all();
-    m_string.clear();
+    m_search_terms.clear();
     m_formatted.clear();
     m_playlist_callback.reset();
 }
 
 void PlaylistSearch::on_return() const
 {
-    if (!m_running)
+    if (!m_are_results_current)
         return;
 
     const auto focus_index = fbh::as_optional(m_playlist_api->playlist_get_focus_item(m_playlist_index));
@@ -131,9 +129,9 @@ void PlaylistSearch::run()
     m_match_count = 0;
     std::optional<std::string> query_error;
 
-    if (mode == SearchMode::mode_query && !m_string.empty()) {
+    if (mode == SearchMode::mode_query && !m_search_terms.empty()) {
         const auto filter_api = search_filter_manager_v2::get();
-        const auto string_utf8 = mmh::to_utf8(m_string);
+        const auto string_utf8 = mmh::to_utf8(m_search_terms);
         search_filter_v2::ptr filter;
 
         try {
@@ -148,20 +146,20 @@ void PlaylistSearch::run()
             filter->test_multi(m_tracks, m_matches.get_ptr());
     }
 
-    if (clear_selection || m_string.empty()) {
+    if (clear_selection || m_search_terms.empty()) {
         m_playlist_api->playlist_clear_selection(m_playlist_index);
 
         if (query_error)
-            dispatch_results_statistics_change(QueryError, {}, {}, *query_error);
+            dispatch_results_statistics_change(Status::QueryError, {}, {}, *query_error);
         else
-            dispatch_results_statistics_change(NoQuery);
+            dispatch_results_statistics_change(Status::NoQuery);
         return;
     }
 
     const auto is_words_match = mode == SearchMode::mode_match_words_beginning_formatted_title
         || mode == SearchMode::mode_match_words_anywhere_formatted_title;
 
-    const auto terms = is_words_match ? split_into_words(m_string) | ranges::to<std::vector<std::wstring_view>>()
+    const auto terms = is_words_match ? split_into_words(m_search_terms) | ranges::to<std::vector<std::wstring_view>>()
                                       : std::vector<std::wstring_view>{};
 
     if (mode == SearchMode::mode_match_words_beginning_formatted_title) {
@@ -201,7 +199,7 @@ void PlaylistSearch::run()
         m_playlist_index, bit_array_true(), pfc::bit_array_lambda([&](auto index) { return m_matches[index]; }));
 
     if (m_match_count == 0) {
-        dispatch_results_statistics_change(NoMatches, 0, m_match_count);
+        dispatch_results_statistics_change(Status::NoMatches, 0, m_match_count);
         return;
     }
 
@@ -224,7 +222,7 @@ void PlaylistSearch::run()
     m_playlist_api->playlist_set_focus_item(m_playlist_index, target_focus);
 
     m_match_index = std::ranges::count(m_matches | std::views::take(target_focus), true);
-    dispatch_results_statistics_change(Matches, m_match_index + 1, m_match_count);
+    dispatch_results_statistics_change(Status::Matches, m_match_index + 1, m_match_count);
 }
 
 void PlaylistSearch::dispatch_results_statistics_change(Status status, std::optional<size_t> match_index,
@@ -239,31 +237,26 @@ void PlaylistSearch::refresh()
     run();
 }
 
-bool PlaylistSearch::refresh_if_stale()
-{
-    if (!m_are_results_stale && WI_EnumValue(m_last_mode) == cfg_search_bar_mode.get())
-        return false;
-
-    m_running = false;
-    refresh();
-    return true;
-}
 void PlaylistSearch::mark_results_stale()
 {
-    if (!m_running)
+    if (!m_are_results_current)
         return;
 
-    m_are_results_stale = true;
-    dispatch_results_statistics_change(Stale);
+    m_are_results_current = false;
+
+    if (!m_search_terms.empty())
+        dispatch_results_statistics_change(Status::Stale);
 }
 
 void PlaylistSearch::handle_next_or_previous(NavigationType navigation_type)
 {
-    if (!m_running)
+    if (m_search_terms.empty())
         return;
 
-    if (refresh_if_stale())
+    if (!m_are_results_current) {
+        refresh();
         return;
+    }
 
     const auto total_items = m_matches.size();
 
@@ -294,7 +287,7 @@ void PlaylistSearch::handle_next_or_previous(NavigationType navigation_type)
         else
             m_match_index = m_match_index == 0 ? m_match_count - 1 : m_match_index - 1;
 
-        dispatch_results_statistics_change(Matches, m_match_index + 1, m_match_count);
+        dispatch_results_statistics_change(Status::Matches, m_match_index + 1, m_match_count);
         break;
     }
 }

--- a/foo_ui_columns/playlist_search.h
+++ b/foo_ui_columns/playlist_search.h
@@ -63,7 +63,7 @@ private:
     std::function<void()> m_on_playlist_changed;
 };
 
-enum Status {
+enum class Status {
     NoMatches,
     Matches,
     Stale,
@@ -96,16 +96,16 @@ public:
 
     void add_char(unsigned c)
     {
-        m_string.push_back(c);
+        m_search_terms.push_back(c);
         refresh();
     }
 
     void set_string(std::wstring text)
     {
-        if (m_running)
+        if (m_are_results_current)
             m_matches.fill(true);
 
-        m_string = std::move(text);
+        m_search_terms = std::move(text);
         refresh();
     }
 
@@ -117,7 +117,6 @@ private:
     void init();
     void run();
     void refresh();
-    bool refresh_if_stale();
     void mark_results_stale();
 
     void dispatch_results_statistics_change(Status status, std::optional<size_t> match_index = {},
@@ -132,19 +131,18 @@ private:
 
     inline static std::vector<PlaylistSearch*> s_instances;
 
-    bool m_running{};
+    bool m_are_results_current{};
     metadb_handle_list_t<pfc::alloc_fast_aggressive> m_tracks;
     service_ptr_t<titleformat_object> m_titleformat_object;
     pfc::array_t<bool> m_matches;
     size_t m_match_index{};
     size_t m_match_count{};
-    std::wstring m_string;
+    std::wstring m_search_terms;
     static_api_ptr_t<playlist_manager> m_playlist_api;
     size_t m_playlist_index{};
     SearchMode m_last_mode{};
     std::vector<std::wstring> m_formatted;
     std::optional<PlaylistSearchPlaylistCallback> m_playlist_callback;
-    bool m_are_results_stale{};
     EnsureVisibleFunc m_ensure_visible_func;
     ResultsStatisticsChange m_results_statistics_change_func;
 };


### PR DESCRIPTION
#1675

This fixes a bug where the playlist view search bar did not behave correctly when editing the search terms while the results are stale.

Additionally, it makes a minor tweak to the FCL import logic to ensure that any current playlist view search bar search results are marked as stale after importing an FCL file.