### PR TITLE
Tweak playlist view search bar appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
   The search bar can be configured or disabled on the Search tab on the Playlist
   view page in Preferences.
   [[#1671](https://github.com/reupen/columns_ui/pull/1671),
-  [#1676](https://github.com/reupen/columns_ui/pull/1676)]
+  [#1676](https://github.com/reupen/columns_ui/pull/1676),
+  [#1679](https://github.com/reupen/columns_ui/pull/1679)]
 
 ### Bug fixes
 


### PR DESCRIPTION
This updates ui_helpers to make a few small tweaks to the playlist view search bar.

It:
- makes the edit control use the same border style as the inline editing edit control
- makes the search bar update correctly when the playlist view items font changes
- stops using the configured vertical item padding when calculating the edit control height as the text in a single-line edit control cannot be vertically centred