### PR TITLE
Handle playlist reordering in playlist view search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   view page in Preferences.
   [[#1671](https://github.com/reupen/columns_ui/pull/1671),
   [#1676](https://github.com/reupen/columns_ui/pull/1676),
-  [#1679](https://github.com/reupen/columns_ui/pull/1679)]
+  [#1679](https://github.com/reupen/columns_ui/pull/1679),
+  [#1680](https://github.com/reupen/columns_ui/pull/1680)]
 
 ### Bug fixes
 

--- a/foo_ui_columns/playlist_search.cpp
+++ b/foo_ui_columns/playlist_search.cpp
@@ -81,7 +81,8 @@ void PlaylistSearch::init()
     }
 
     if (!m_playlist_callback)
-        m_playlist_callback.emplace([&] { mark_results_stale(); });
+        m_playlist_callback.emplace([this] { mark_results_stale(); },
+            [this](const size_t* order, size_t count) { on_playlist_reordered(order, count); });
 
     m_are_results_current = true;
     m_last_mode = mode;
@@ -90,6 +91,7 @@ void PlaylistSearch::init()
 void PlaylistSearch::reset()
 {
     m_are_results_current = false;
+    m_match_track_index = 0;
     m_match_index = 0;
     m_match_count = 0;
     m_matches.set_size(0);
@@ -97,6 +99,30 @@ void PlaylistSearch::reset()
     m_search_terms.clear();
     m_formatted.clear();
     m_playlist_callback.reset();
+}
+
+void PlaylistSearch::on_playlist_reordered(const size_t* order, size_t count)
+{
+    if (!m_are_results_current)
+        return;
+
+    assert(m_matches.size() == count);
+    assert(m_last_mode == SearchMode::mode_query || m_formatted.size() == count);
+    assert(m_match_count == 0 || m_match_track_index < count);
+
+    m_tracks.reorder(order);
+    pfc::reorder_t(m_matches, order, count);
+
+    if (m_last_mode == SearchMode::mode_match_words_beginning_formatted_title
+        || m_last_mode == SearchMode::mode_match_words_anywhere_formatted_title)
+        pfc::reorder_t(m_formatted, order, count);
+
+    if (m_match_track_index < count && m_match_count > 0) {
+        const std::span permutation(order, count);
+        m_match_track_index = std::distance(permutation.begin(), ranges::find(permutation, m_match_track_index));
+        m_match_index = std::ranges::count(m_matches | std::views::take(m_match_track_index), true);
+        dispatch_results_statistics_change(Status::Matches, m_match_index + 1, m_match_count);
+    }
 }
 
 void PlaylistSearch::on_return() const
@@ -221,6 +247,7 @@ void PlaylistSearch::run()
     m_ensure_visible_func(target_focus);
     m_playlist_api->playlist_set_focus_item(m_playlist_index, target_focus);
 
+    m_match_track_index = target_focus;
     m_match_index = std::ranges::count(m_matches | std::views::take(target_focus), true);
     dispatch_results_statistics_change(Status::Matches, m_match_index + 1, m_match_count);
 }
@@ -282,11 +309,16 @@ void PlaylistSearch::handle_next_or_previous(NavigationType navigation_type)
 
         m_playlist_api->playlist_set_focus_item(m_playlist_index, index);
 
-        if (navigation_type == NavigationType::Next)
-            m_match_index = m_match_index + 1 == m_match_count ? 0 : m_match_index + 1;
-        else
-            m_match_index = m_match_index == 0 ? m_match_count - 1 : m_match_index - 1;
+        if (m_match_track_index == focus) {
+            if (navigation_type == NavigationType::Next)
+                m_match_index = m_match_index + 1 == m_match_count ? 0 : m_match_index + 1;
+            else
+                m_match_index = m_match_index == 0 ? m_match_count - 1 : m_match_index - 1;
+        } else {
+            m_match_index = std::ranges::count(m_matches | std::views::take(index), true);
+        }
 
+        m_match_track_index = index;
         dispatch_results_statistics_change(Status::Matches, m_match_index + 1, m_match_count);
         break;
     }

--- a/foo_ui_columns/playlist_search.h
+++ b/foo_ui_columns/playlist_search.h
@@ -15,10 +15,12 @@ enum class SearchMode : uint32_t {
 
 class PlaylistSearchPlaylistCallback : public playlist_callback_single_impl_base {
 public:
-    PlaylistSearchPlaylistCallback(std::function<void()> on_playlist_changed)
-        : playlist_callback_single_impl_base(
-              flag_on_items_added | flag_on_items_removed | flag_on_items_replaced | flag_on_playlist_switch)
+    PlaylistSearchPlaylistCallback(
+        std::function<void()> on_playlist_changed, std::function<void(const size_t*, size_t)> on_playlist_reordered)
+        : playlist_callback_single_impl_base(flag_on_items_added | flag_on_items_reordered | flag_on_items_removed
+              | flag_on_items_replaced | flag_on_playlist_switch)
         , m_on_playlist_changed(std::move(on_playlist_changed))
+        , m_on_playlist_reordered(std::move(on_playlist_reordered))
     {
         m_metadb_io_change_token
             = fb2k_utils::add_metadb_io_callback([this](metadb_handle_list_cref tracks, bool from_hook) {
@@ -43,24 +45,33 @@ public:
     }
 
 protected:
-    void on_items_added(t_size p_base, metadb_handle_list_cref p_data, const bit_array& p_selection) override
+    void on_items_added(size_t p_base, metadb_handle_list_cref p_data, const bit_array& p_selection) override
     {
         m_on_playlist_changed();
     }
-    void on_items_removed(const bit_array& p_mask, t_size p_old_count, t_size p_new_count) override
+
+    void on_items_reordered(const size_t* p_order, size_t p_count) override
+    {
+        m_on_playlist_reordered(p_order, p_count);
+    }
+
+    void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override
     {
         m_on_playlist_changed();
     }
+
     void on_items_replaced(const bit_array& p_mask,
         const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override
     {
         m_on_playlist_changed();
     }
+
     void on_playlist_switch() override { m_on_playlist_changed(); }
 
 private:
     mmh::EventToken::Ptr m_metadb_io_change_token;
     std::function<void()> m_on_playlist_changed;
+    std::function<void(const size_t*, size_t)> m_on_playlist_reordered;
 };
 
 enum class Status {
@@ -109,6 +120,7 @@ public:
         refresh();
     }
 
+    void on_playlist_reordered(const size_t* order, size_t count);
     void on_previous() { handle_next_or_previous(NavigationType::Previous); }
     void on_next() { handle_next_or_previous(NavigationType::Next); }
     void on_return() const;
@@ -135,6 +147,7 @@ private:
     metadb_handle_list_t<pfc::alloc_fast_aggressive> m_tracks;
     service_ptr_t<titleformat_object> m_titleformat_object;
     pfc::array_t<bool> m_matches;
+    size_t m_match_track_index{};
     size_t m_match_index{};
     size_t m_match_count{};
     std::wstring m_search_terms;


### PR DESCRIPTION
Resolves #1677

This adds missing handling of the active playlist being reordered to the playlist view search bar.

It also updates the logic for updating the current match index when pressing the next or previous button so that it updates correctly if another item in the playlist was manually focused.