### PR TITLE
Correct build paths in build-config.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 ### Internal changes
 
 - The component is now compiled with Visual Studio 2026, toolset version 14.50.
+  [[#1683](https://github.com/reupen/columns_ui/pull/1683),
+  [#1684](https://github.com/reupen/columns_ui/pull/1684)]
 
 ## 3.4.1
 

--- a/build-config.toml
+++ b/build-config.toml
@@ -1,5 +1,5 @@
 component_name = "foo_ui_columns"
 solution_path = "vc18\\columns_ui-public.sln"
 output_path = "component-packages"
-x86_build_path = "vc18\\release-win32-v143"
-x64_build_path = "vc18\\release-x64-v143"
+x86_build_path = "vc18\\release-win32-v145"
+x64_build_path = "vc18\\release-x64-v145"


### PR DESCRIPTION
This corrects the build paths in `build-config.toml` (used by the `scripts\build-release-package.py` script) following the migration to VS 2026.