### PR TITLE
Update stale playlist view search bar results when pressing Enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,21 @@
   [[#1671](https://github.com/reupen/columns_ui/pull/1671),
   [#1676](https://github.com/reupen/columns_ui/pull/1676),
   [#1679](https://github.com/reupen/columns_ui/pull/1679),
-  [#1680](https://github.com/reupen/columns_ui/pull/1680)]
+  [#1680](https://github.com/reupen/columns_ui/pull/1680),
+  [#1686](https://github.com/reupen/columns_ui/pull/1686)]
 
 ### Bug fixes
 
 - A bug where the text ‘Inactive selected item:’ was truncated at some display
   scales on the Colours tab on the Colours and fonts preferences page was fixed.
   [[#1673](https://github.com/reupen/columns_ui/pull/1673)]
+
+### Removals
+
+- Windows 7, 8 and 8.1 are no longer supported.
+  [[#1683](https://github.com/reupen/columns_ui/pull/1683)]
+
+  Windows 10 is now the minimum required version.
 
 ### Internal changes
 

--- a/foo_ui_columns/playlist_search.cpp
+++ b/foo_ui_columns/playlist_search.cpp
@@ -125,10 +125,15 @@ void PlaylistSearch::on_playlist_reordered(const size_t* order, size_t count)
     }
 }
 
-void PlaylistSearch::on_return() const
+void PlaylistSearch::on_return()
 {
-    if (!m_are_results_current)
+    if (m_search_terms.empty())
         return;
+
+    if (!m_are_results_current) {
+        refresh();
+        return;
+    }
 
     const auto focus_index = fbh::as_optional(m_playlist_api->playlist_get_focus_item(m_playlist_index));
 

--- a/foo_ui_columns/playlist_search.h
+++ b/foo_ui_columns/playlist_search.h
@@ -123,7 +123,7 @@ public:
     void on_playlist_reordered(const size_t* order, size_t count);
     void on_previous() { handle_next_or_previous(NavigationType::Previous); }
     void on_next() { handle_next_or_previous(NavigationType::Next); }
-    void on_return() const;
+    void on_return();
 
 private:
     void init();


### PR DESCRIPTION

Resolves #1675

This makes the playlist view search bar refresh the search results if the Enter key is pressed in the search box while the ‘Results are out of date’ message is shown.

The behaviour of the Enter key is unchanged when there are valid search results.