### PR TITLE
Process some keyboard shortcuts in built-in edit boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
   [#1680](https://github.com/reupen/columns_ui/pull/1680),
   [#1686](https://github.com/reupen/columns_ui/pull/1686)]
 
+- A subset of keyboard shortcuts configured in Preferences are now processed in
+  the Filter search toolbar and in inline editing edit boxes in the playlist
+  view, playlist switcher, Filter panel and Item properties.
+  [[#1687](https://github.com/reupen/columns_ui/pull/1687)]]
+
+  This allows common shortcuts such as Ctrl+P (for Preferences) to work while
+  not interfering with typing and manipulating text.
+
 ### Bug fixes
 
 - A bug where the text ‘Inactive selected item:’ was truncated at some display

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@
   scales on the Colours tab on the Colours and fonts preferences page was fixed.
   [[#1673](https://github.com/reupen/columns_ui/pull/1673)]
 
+- When a custom keyboard shortcut is assigned to a key combination, such as
+  Alt+F, that would normally open a main menu, that keyboard shortcut now only
+  activates the configured command when used in built-in panels.
+  [[#1687](https://github.com/reupen/columns_ui/pull/1687)]]
+
+  (Previously, the menu was opened and the custom command was activated.)
+
 ### Removals
 
 - Windows 7, 8 and 8.1 are no longer supported.

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -124,7 +124,8 @@ private:
     WNDPROC m_order_proc{};
     int m_max_item_width{0};
     bool m_initialised{false};
-    bool m_process_next_char{true};
+    bool m_ignore_next_wm_char_message{};
+    bool m_ignore_next_wm_syschar_message{};
     bool m_processing_selection_change{false};
     int32_t m_mousewheel_delta{0};
 };
@@ -370,26 +371,28 @@ LRESULT DropDownListToolbar<ToolbarArgs>::on_hook(HWND wnd, UINT msg, WPARAM wp,
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
     case WM_KEYDOWN: {
-        const auto processed = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-        m_process_next_char = !processed;
-        if (processed)
+        if ((m_ignore_next_wm_char_message = g_process_keydown_keyboard_shortcuts(wp)))
             return 0;
 
         if (wp == VK_TAB)
             g_on_tab(wnd);
+
         SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
         break;
     }
-    case WM_SYSKEYDOWN: {
-        const auto processed = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-        m_process_next_char = !processed;
-        if (processed)
+    case WM_SYSKEYDOWN:
+        if ((m_ignore_next_wm_syschar_message = g_process_keydown_keyboard_shortcuts(wp)))
             return 0;
         break;
-    }
     case WM_CHAR:
-        if (!m_process_next_char) {
-            m_process_next_char = true;
+        if (m_ignore_next_wm_char_message) {
+            m_ignore_next_wm_char_message = false;
+            return 0;
+        }
+        break;
+    case WM_SYSCHAR:
+        if (m_ignore_next_wm_syschar_message) {
+            m_ignore_next_wm_syschar_message = false;
             return 0;
         }
         break;

--- a/foo_ui_columns/fb2k_misc.cpp
+++ b/foo_ui_columns/fb2k_misc.cpp
@@ -18,4 +18,37 @@ wil::com_ptr_t<IDataObject> create_data_object_safe(const metadb_handle_list& tr
     return data_object;
 }
 
+namespace {
+
+uint32_t get_key_code(WPARAM wp, uint32_t modifiers)
+{
+    return static_cast<uint32_t>(wp & 0xFF) | ((modifiers & MOD_CONTROL) ? HOTKEYF_CONTROL << 8 : 0)
+        | ((modifiers & MOD_SHIFT) ? HOTKEYF_SHIFT << 8 : 0) | ((modifiers & MOD_ALT) ? HOTKEYF_ALT << 8 : 0)
+        | ((modifiers & MOD_WIN) ? HOTKEYF_EXT << 8 : 0);
+}
+
+} // namespace
+
+bool process_edit_keyboard_shortcuts(WPARAM wp)
+{
+    if (wp == VK_LEFT || wp == VK_UP || wp == VK_RIGHT || wp == VK_DOWN || wp == VK_BACK || wp == VK_DELETE
+        || wp == VK_RETURN || wp == VK_ESCAPE)
+        return false;
+
+    const auto modifiers = GetHotkeyModifierFlags();
+
+    if (modifiers == MOD_CONTROL && (wp == 'A' || wp == 'Z' || wp == 'Y' || wp == 'X' || wp == 'C' || wp == 'V'))
+        return false;
+
+    if (modifiers == (MOD_CONTROL | MOD_SHIFT) && wp == 'Z')
+        return false;
+
+    const auto key_code = get_key_code(wp, modifiers);
+
+    if (keyboard_shortcut_manager::is_typing_key_combo(key_code, modifiers))
+        return false;
+
+    return keyboard_shortcut_manager_v2::get()->process_keydown_simple(key_code);
+}
+
 } // namespace cui::fb2k_utils

--- a/foo_ui_columns/fb2k_misc.h
+++ b/foo_ui_columns/fb2k_misc.h
@@ -37,4 +37,6 @@ private:
 
 wil::com_ptr_t<IDataObject> create_data_object_safe(const metadb_handle_list& tracks);
 
+bool process_edit_keyboard_shortcuts(WPARAM wp);
+
 } // namespace cui::fb2k_utils

--- a/foo_ui_columns/filter.cpp
+++ b/foo_ui_columns/filter.cpp
@@ -536,9 +536,7 @@ bool FilterPanel::do_drag_drop(WPARAM wp)
 
 bool FilterPanel::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
 {
-    uie::window_ptr p_this = this;
-    bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-    return ret;
+    return g_process_keydown_keyboard_shortcuts(wp);
 }
 
 void FilterPanel::get_selection_handles(

--- a/foo_ui_columns/filter.h
+++ b/foo_ui_columns/filter.h
@@ -221,6 +221,7 @@ private:
         pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
     void notify_exit_inline_edit() override;
+    bool notify_inline_edit_keydown(WPARAM wp) override;
     void notify_on_set_focus(HWND wnd_lost) override;
     void notify_on_kill_focus(HWND wnd_receiving) override;
     void notify_on_create() override;

--- a/foo_ui_columns/filter_inline_edit.cpp
+++ b/foo_ui_columns/filter_inline_edit.cpp
@@ -1,4 +1,7 @@
 #include "pch.h"
+
+#include "fb2k_misc.h"
+
 #include "filter.h"
 
 namespace cui::panels::filter {
@@ -62,6 +65,11 @@ void FilterPanel::notify_exit_inline_edit()
     m_edit_fields.clear();
     m_edit_handles.remove_all();
     m_edit_previous_value.reset();
+}
+
+bool FilterPanel::notify_inline_edit_keydown(WPARAM wp)
+{
+    return fb2k_utils::process_edit_keyboard_shortcuts(wp);
 }
 
 } // namespace cui::panels::filter

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -3,6 +3,8 @@
 #include "filter_search_bar.h"
 
 #include "dark_mode_dialog.h"
+#include "fb2k_callbacks.h"
+#include "fb2k_misc.h"
 #include "filter_config_var.h"
 #include "filter_utils.h"
 #include "icons.h"
@@ -691,16 +693,23 @@ void FilterSearchToolbar::s_update_font()
 LRESULT FilterSearchToolbar::on_search_edit_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
-    case WM_KEYDOWN:
-        switch (wp) {
-        case VK_TAB: {
-            g_on_tab(wnd);
+    case WM_SYSKEYDOWN:
+        if (fb2k_utils::process_edit_keyboard_shortcuts(wp)) {
+            m_ignore_next_wm_syschar_message = true;
+            return 0;
         }
-        // return 0;
         break;
+    case WM_KEYDOWN:
+        m_ignore_next_wm_char_message = false;
+        switch (wp) {
+        case VK_TAB:
+            g_on_tab(wnd);
+            return 0;
         case VK_ESCAPE:
-            if (m_wnd_last_focused && IsWindow(m_wnd_last_focused))
+            if (m_wnd_last_focused && IsWindow(m_wnd_last_focused)) {
                 SetFocus(m_wnd_last_focused);
+                m_ignore_next_wm_char_message = true;
+            }
             return 0;
         case VK_RETURN:
             if (m_query_timer_active) {
@@ -708,13 +717,24 @@ LRESULT FilterSearchToolbar::on_search_edit_message(HWND wnd, UINT msg, WPARAM w
                 m_query_timer_active = false;
             }
             commit_search_results(uGetWindowText(m_search_editbox), true);
+            m_ignore_next_wm_char_message = true;
+            return 0;
+        }
+    default:
+        if (fb2k_utils::process_edit_keyboard_shortcuts(wp)) {
+            m_ignore_next_wm_char_message = true;
             return 0;
         }
         break;
     case WM_CHAR:
-        switch (wp) {
-        case VK_ESCAPE:
-        case VK_RETURN:
+        if (m_ignore_next_wm_char_message) {
+            m_ignore_next_wm_char_message = false;
+            return 0;
+        }
+        break;
+    case WM_SYSCHAR:
+        if (m_ignore_next_wm_syschar_message) {
+            m_ignore_next_wm_syschar_message = false;
             return 0;
         }
         break;

--- a/foo_ui_columns/filter_search_bar.h
+++ b/foo_ui_columns/filter_search_bar.h
@@ -131,6 +131,8 @@ private:
     bool m_favourite_state{};
     bool m_query_timer_active{};
     bool m_show_clear_button{cfg_showsearchclearbutton};
+    bool m_ignore_next_wm_char_message{};
+    bool m_ignore_next_wm_syschar_message{};
     pfc::string8 m_active_search_string;
     metadb_handle_list m_active_handles;
     std::optional<SortOverride> m_sort_override;

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -858,9 +858,7 @@ void ItemProperties::notify_on_column_size_change(size_t index, int new_width)
 
 bool ItemProperties::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
 {
-    uie::window_ptr p_this = this;
-    bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-    return ret;
+    return g_process_keydown_keyboard_shortcuts(wp);
 }
 
 bool ItemProperties::notify_on_keyboard_keydown_copy()

--- a/foo_ui_columns/item_properties.cpp
+++ b/foo_ui_columns/item_properties.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "item_properties.h"
 
+#include "fb2k_misc.h"
 #include "file_info_utils.h"
 
 namespace cui::panels::item_properties {
@@ -769,6 +770,11 @@ void ItemProperties::notify_save_inline_edit(const char* value)
 
     metadb_io_v2::get()->update_info_async(m_edit_handles, filter, GetAncestor(get_wnd(), GA_ROOT),
         metadb_io_v2::op_flag_no_errors | metadb_io_v2::op_flag_background | metadb_io_v2::op_flag_delay_ui, nullptr);
+}
+
+bool ItemProperties::notify_inline_edit_keydown(WPARAM wp)
+{
+    return fb2k_utils::process_edit_keyboard_shortcuts(wp);
 }
 
 void ItemProperties::execute_default_action(size_t index, size_t column, bool b_keyboard, bool b_ctrl)

--- a/foo_ui_columns/item_properties.h
+++ b/foo_ui_columns/item_properties.h
@@ -171,6 +171,7 @@ public:
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
         pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
+    bool notify_inline_edit_keydown(WPARAM wp) override;
     void execute_default_action(size_t index, size_t column, bool b_keyboard, bool b_ctrl) override;
 
     // UI SEL API

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -88,6 +88,7 @@ private:
     bool m_last_systray_r_down{};
     bool m_last_systray_x1_down{};
     bool m_last_systray_x2_down{};
+    bool m_ignore_next_wm_syschar_message{};
     ULONG_PTR m_gdiplus_instance{};
     UINT m_wm_taskbarcreated{};
     UINT m_wm_taskbarbuttoncreated{};

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -546,13 +546,15 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (process_keydown(msg, lp, wp))
             return 0;
         break;
-    case WM_SYSKEYUP:
-        if (process_keydown(msg, lp, wp))
+    case WM_SYSKEYDOWN:
+        if ((m_ignore_next_wm_syschar_message = process_keydown(msg, lp, wp)))
             return 0;
         break;
-    case WM_SYSKEYDOWN:
-        if (process_keydown(msg, lp, wp))
+    case WM_SYSCHAR:
+        if (m_ignore_next_wm_syschar_message) {
+            m_ignore_next_wm_syschar_message = false;
             return 0;
+        }
         break;
     case MSG_SYSTEM_TRAY_ICON:
         if (lp == WM_LBUTTONUP) {

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -1566,10 +1566,9 @@ size_t PlaylistView::get_highlight_item()
 
 bool PlaylistView::notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp)
 {
-    uie::window_ptr p_this = this;
-    bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-    return ret;
+    return g_process_keydown_keyboard_shortcuts(wp);
 }
+
 bool PlaylistView::notify_on_keyboard_keydown_remove()
 {
     m_playlist_api->activeplaylist_undo_backup();

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -1,14 +1,16 @@
 #pragma once
 
-#include "core_dark_list_view.h"
-#include "icons.h"
-#include "list_view_drop_target.h"
+#include "../config.h"
+#include "../core_dark_list_view.h"
+#include "../fb2k_misc.h"
+#include "../icons.h"
+#include "../list_view_drop_target.h"
+#include "../list_view_panel.h"
+#include "../playlist_search.h"
+
 #include "ng_playlist_artwork.h"
 #include "ng_playlist_groups.h"
 #include "ng_playlist_style.h"
-#include "../config.h"
-#include "../list_view_panel.h"
-#include "../playlist_search.h"
 
 namespace cui::panels::playlist_view {
 
@@ -293,6 +295,7 @@ private:
         void on_char(const wchar_t chr) override { m_playlist_search.add_char(chr); }
         void on_string_replaced(const wchar_t* text) override { m_playlist_search.set_string(text); }
         void on_close() override { m_playlist_search.reset(); }
+        bool on_keydown(WPARAM wp) override { return fb2k_utils::process_edit_keyboard_shortcuts(wp); }
 
         std::variant<wil::unique_hbitmap, wil::unique_hicon> create_icon(
             uih::lv::SearchBarIconId icon_id, int width, int height, bool is_dark) override
@@ -537,6 +540,7 @@ private:
         pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
     void notify_exit_inline_edit() override;
+    bool notify_inline_edit_keydown(WPARAM wp) override;
 
     void notify_on_set_focus(HWND wnd_lost) override;
     void notify_on_kill_focus(HWND wnd_receiving) override;

--- a/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_inline_edit.cpp
@@ -1,7 +1,9 @@
 #include "pch.h"
 
-#include "file_info_utils.h"
 #include "ng_playlist.h"
+
+#include "../fb2k_misc.h"
+#include "../file_info_utils.h"
 
 namespace cui::panels::playlist_view {
 
@@ -80,6 +82,11 @@ void PlaylistView::notify_exit_inline_edit()
 {
     m_edit_field.reset();
     m_edit_handles.remove_all();
+}
+
+bool PlaylistView::notify_inline_edit_keydown(WPARAM wp)
+{
+    return fb2k_utils::process_edit_keyboard_shortcuts(wp);
 }
 
 } // namespace cui::panels::playlist_view

--- a/foo_ui_columns/playlist_switcher_inline_edit.cpp
+++ b/foo_ui_columns/playlist_switcher_inline_edit.cpp
@@ -1,4 +1,6 @@
 #include "pch.h"
+
+#include "fb2k_misc.h"
 #include "playlist_switcher_v2.h"
 
 namespace cui::panels::playlist_switcher {
@@ -30,6 +32,11 @@ void PlaylistSwitcher::notify_save_inline_edit(const char* value)
         }
     }
     m_edit_playlist.reset();
+}
+
+bool PlaylistSwitcher::notify_inline_edit_keydown(WPARAM wp)
+{
+    return fb2k_utils::process_edit_keyboard_shortcuts(wp);
 }
 
 } // namespace cui::panels::playlist_switcher

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -142,6 +142,7 @@ public:
     bool notify_create_inline_edit(const pfc::list_base_const_t<size_t>& indices, size_t column,
         pfc::string_base& p_text, size_t& p_flags, wil::com_ptr<IUnknown>& autocomplete_entries) override;
     void notify_save_inline_edit(const char* value) override;
+    bool notify_inline_edit_keydown(WPARAM wp) override;
 
     const char* get_drag_unit_singular() const override { return "playlist"; }
     const char* get_drag_unit_plural() const override { return "playlists"; }

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -153,9 +153,7 @@ public:
 
     bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp) override
     {
-        uie::window_ptr p_this = this;
-        bool ret = get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp);
-        return ret;
+        return g_process_keydown_keyboard_shortcuts(wp);
     }
 
     bool notify_on_middleclick(bool on_item, size_t index) override

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -285,8 +285,7 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
     case WM_KEYDOWN: {
-        if (wp != VK_LEFT && wp != VK_RIGHT && get_host()->get_keyboard_shortcuts_enabled()
-            && g_process_keydown_keyboard_shortcuts(wp))
+        if (wp != VK_LEFT && wp != VK_RIGHT && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
         if (wp == VK_TAB) {
             g_on_tab(wnd);
@@ -295,8 +294,14 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     }
     case WM_SYSKEYDOWN:
-        if (get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp))
+        if ((m_ignore_next_wm_syschar_message = g_process_keydown_keyboard_shortcuts(wp)))
             return 0;
+        break;
+    case WM_SYSCHAR:
+        if (m_ignore_next_wm_syschar_message) {
+            m_ignore_next_wm_syschar_message = false;
+            return 0;
+        }
         break;
     case WM_LBUTTONDOWN: {
         {

--- a/foo_ui_columns/playlist_tabs.h
+++ b/foo_ui_columns/playlist_tabs.h
@@ -178,6 +178,7 @@ private:
     bool m_switch_timer{false};
     unsigned m_switch_playlist{0};
     bool initialised{false};
+    bool m_ignore_next_wm_syschar_message{};
 
     int32_t m_mousewheel_delta{0};
     UINT ID_CUSTOM_BASE{NULL};

--- a/foo_ui_columns/rebar.cpp
+++ b/foo_ui_columns/rebar.cpp
@@ -318,11 +318,6 @@ public:
         return api->override_status_text_create(p_out);
     }
 
-    virtual bool on_key(UINT msg, LPARAM lp, WPARAM wp, bool process_keyboard_shortcuts)
-    {
-        return process_keydown(msg, lp, wp, false, process_keyboard_shortcuts);
-    }
-
     void relinquish_ownership(HWND wnd) override
     {
         if (g_rebar_window) {

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -542,18 +542,24 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     }
     case WM_KEYDOWN: {
-        if (wp != VK_LEFT && wp != VK_RIGHT && get_host()->get_keyboard_shortcuts_enabled()
-            && g_process_keydown_keyboard_shortcuts(wp))
+        if (wp != VK_LEFT && wp != VK_RIGHT && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
         if (wp == VK_TAB) {
             g_on_tab(wnd);
             return 0;
         }
         SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
-    } break;
+        break;
+    }
     case WM_SYSKEYDOWN:
-        if (get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp))
+        if ((m_ignore_next_wm_syschar_message = g_process_keydown_keyboard_shortcuts(wp)))
             return 0;
+        break;
+    case WM_SYSCHAR:
+        if (m_ignore_next_wm_syschar_message) {
+            m_ignore_next_wm_syschar_message = false;
+            return 0;
+        }
         break;
     case WM_DESTROY:
         m_get_message_hook_token.reset();
@@ -1149,18 +1155,24 @@ LRESULT WINAPI TabStackPanel::on_hooked_message(HWND wnd, UINT msg, WPARAM wp, L
     case WM_GETDLGCODE:
         return DLGC_WANTALLKEYS;
     case WM_KEYDOWN: {
-        if (wp != VK_LEFT && wp != VK_RIGHT && get_host()->get_keyboard_shortcuts_enabled()
-            && g_process_keydown_keyboard_shortcuts(wp))
+        if (wp != VK_LEFT && wp != VK_RIGHT && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
         if (wp == VK_TAB) {
             g_on_tab(wnd);
             return 0;
         }
         SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
-    } break;
+        break;
+    }
     case WM_SYSKEYDOWN:
-        if (get_host()->get_keyboard_shortcuts_enabled() && g_process_keydown_keyboard_shortcuts(wp))
+        if ((m_ignore_next_wm_syschar_message = g_process_keydown_keyboard_shortcuts(wp)))
             return 0;
+        break;
+    case WM_SYSCHAR:
+        if (m_ignore_next_wm_syschar_message) {
+            m_ignore_next_wm_syschar_message = false;
+            return 0;
+        }
         break;
     case WM_MOUSEWHEEL: {
         if ((GetWindowLongPtr(wnd, GWL_STYLE) & TCS_MULTILINE) != 0)

--- a/foo_ui_columns/splitter_tabs.h
+++ b/foo_ui_columns/splitter_tabs.h
@@ -139,6 +139,7 @@ public:
 
 private:
     bool m_refresh_children_in_progress{};
+    bool m_ignore_next_wm_syschar_message{};
     service_ptr_t<TabStackSplitterHost> m_window_host;
     std::vector<Panel::Ptr> m_panels;
     std::vector<Panel::Ptr> m_active_panels;


### PR DESCRIPTION
Resolves #1495

This adds processing of a subset of keyboard shortcuts in the Filter search toolbar, in inline editing edit controls in the playlist view, playlist switcher, Filter panel and Item properties and in the playlist view search bar.

Some keys such as the arrow keys, Escape, Enter and Backspace remain reserved for contextual functionality in such edit boxes.

This change only affects the mentioned built-in panels, as panels handle keyboard shortcut processing themselves.

Additionally, handling of shortcuts involving an Alt modifier was improved in built-in panels to avoid opening a main menu and activating the configured command.
