### PR TITLE
Don’t execute last search when opening playlist view search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
   [#1676](https://github.com/reupen/columns_ui/pull/1676),
   [#1679](https://github.com/reupen/columns_ui/pull/1679),
   [#1680](https://github.com/reupen/columns_ui/pull/1680),
-  [#1686](https://github.com/reupen/columns_ui/pull/1686)]
+  [#1686](https://github.com/reupen/columns_ui/pull/1686),
+  [#1689](https://github.com/reupen/columns_ui/pull/1689)]
 
 - A subset of keyboard shortcuts configured in Preferences are now processed in
   the Filter search toolbar and in inline editing edit boxes in the playlist

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -992,6 +992,9 @@ void PlaylistView::notify_on_initialisation()
             case playlist_search::Status::Stale:
                 set_search_bar_results_text(L"Results are out of date");
                 break;
+            case playlist_search::Status::StaleInitial:
+                set_search_bar_results_text(L"Press F3 to repeat previous search");
+                break;
             case playlist_search::Status::NoQuery:
                 set_search_bar_results_text(L"");
                 break;

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -293,7 +293,10 @@ private:
         void on_next() override { m_playlist_search.on_next(); }
         void on_return() override { m_playlist_search.on_return(); }
         void on_char(const wchar_t chr) override { m_playlist_search.add_char(chr); }
-        void on_string_replaced(const wchar_t* text) override { m_playlist_search.set_string(text); }
+        void on_string_replaced(const wchar_t* text, bool is_initial) override
+        {
+            m_playlist_search.set_string(text, is_initial);
+        }
         void on_close() override { m_playlist_search.reset(); }
         bool on_keydown(WPARAM wp) override { return fb2k_utils::process_edit_keyboard_shortcuts(wp); }
 

--- a/foo_ui_columns/playlist_search.h
+++ b/foo_ui_columns/playlist_search.h
@@ -78,6 +78,7 @@ enum class Status {
     NoMatches,
     Matches,
     Stale,
+    StaleInitial,
     NoQuery,
     QueryError,
 };
@@ -111,12 +112,18 @@ public:
         refresh();
     }
 
-    void set_string(std::wstring text)
+    void set_string(std::wstring text, bool is_initial)
     {
+        m_search_terms = std::move(text);
+
         if (m_are_results_current)
             m_matches.fill(true);
 
-        m_search_terms = std::move(text);
+        if (is_initial) {
+            dispatch_results_statistics_change(Status::StaleInitial);
+            return;
+        }
+
         refresh();
     }
 


### PR DESCRIPTION
Resolves #1674

This stops the playlist view search bar automatically executing the last search (if there was one in the current session) when the search bar is reopened.

The previous search terms are still repopulated but now an action (such as pressing F3) needs to be taken to perform the search again.