### PR TITLE
Allow changing the menu toolbar font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@
   This allows common shortcuts such as Ctrl+P (for Preferences) to work while
   not interfering with typing and manipulating text.
 
+- The menu toolbar font can now be customised.
+  [[#1690](https://github.com/reupen/columns_ui/pull/1690)]
+
+  The configured font applies only to the toolbar itself and not to any opened
+  menus.
+
 ### Bug fixes
 
 - A bug where the text ‘Inactive selected item:’ was truncated at some display

--- a/foo_ui_columns/callbacks_config.cpp
+++ b/foo_ui_columns/callbacks_config.cpp
@@ -9,7 +9,7 @@ class AlwaysOnTopNotifyReceiver : public config_object_notify {
         if (cui::main_window.get_wnd()) {
             bool aot = false;
             p_object->get_data_bool(aot);
-            uPostMessage(cui::main_window.get_wnd(), MSG_SET_AOT, aot, 0);
+            PostMessage(cui::main_window.get_wnd(), MSG_SET_AOT, aot, 0);
         }
     }
 };

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -2,16 +2,13 @@
 
 #include "menu_mnemonics.h"
 
-cfg_int cfg_fullsizemenu(GUID{0xe880f267, 0x73de, 0x7952, {0x5b, 0x79, 0xb5, 0xda, 0x77, 0x28, 0x6d, 0xb6}}, 0);
+namespace cui::toolbars::menu {
 
-#define ID_MENU 2001
-
-enum {
-    MSG_HIDE_MENUACC = WM_USER + 1,
-    MSG_SHOW_MENUACC = WM_USER + 2,
-    MSG_CREATE_MENU = WM_USER + 3,
-    MSG_SIZE_LIMIT_CHANGE
-};
+constexpr auto ID_MENU = 2001u;
+constexpr auto MSG_HIDE_MENUACC = WM_USER + 3u;
+constexpr auto MSG_SHOW_MENUACC = WM_USER + 4u;
+constexpr auto MSG_CREATE_MENU = WM_USER + 5u;
+constexpr auto MSG_SIZE_LIMIT_CHANGE = WM_USER + 6u;
 
 class MainMenuRootGroup {
 public:
@@ -26,6 +23,7 @@ public:
     {
         return pfc::compare_t(p_item1.m_sort_priority, p_item2.m_sort_priority);
     }
+
     static void g_get_root_items(pfc::list_base_t<MainMenuRootGroup>& p_out)
     {
         p_out.remove_all();
@@ -61,42 +59,26 @@ class MenuToolbar
     : public uie::container_uie_window_v3_t<uie::menu_window_v2>
     , uih::MessageHook {
 public:
-    static bool hooked;
+    static constexpr GUID extension_guid{0x76e6db50, 0xde3, 0x4f30, {0xa7, 0xe4, 0x93, 0xfd, 0x62, 0x8b, 0x14, 0x1}};
 
-    bool redrop{true};
-    bool is_submenu{false};
-    int active_item{0};
-    int actual_active{0};
-    int sub_menu_ref_count{-1};
-    service_ptr_t<mainmenu_manager> p_manager;
-    service_ptr_t<ui_status_text_override> m_status_override;
+    MenuToolbar();
 
     uie::container_window_v3_config get_window_config() override
     {
-        uie::container_window_v3_config config(class_name);
+        uie::container_window_v3_config config(L"columns_ui_menu_toolbar_DnWbOvEVLmo");
         config.invalidate_children_on_move_or_resize = true;
         return config;
     }
 
-    HWND wnd_menu{nullptr};
-    HWND wnd_prev_focus{nullptr};
-    pfc::list_t<MainMenuRootGroup> m_buttons;
-
-    LRESULT WINAPI hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    static LRESULT WINAPI main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
+    LRESULT WINAPI handle_toolbar_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static LRESULT WINAPI s_handle_toolbar_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
 
     bool on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp) override;
-
     void make_menu(int idx);
-
     void destroy_menu() const { SendMessage(get_wnd(), WM_CANCELMODE, 0, 0); }
-
-    void update_menu_acc() const { uPostMessage(get_wnd(), MSG_HIDE_MENUACC, 0, 0); }
-
-    void show_menu_acc() const { uPostMessage(get_wnd(), MSG_SHOW_MENUACC, 0, 0); }
-
-    static const GUID extension_guid;
+    void update_menu_acc() const { PostMessage(get_wnd(), MSG_HIDE_MENUACC, 0, 0); }
+    void show_menu_acc() const { PostMessage(get_wnd(), MSG_SHOW_MENUACC, 0, 0); }
 
     const GUID& get_extension_guid() const override { return extension_guid; }
 
@@ -114,91 +96,99 @@ public:
     bool is_menu_focused() const override;
     HWND get_previous_focus_window() const override;
 
-    MenuToolbar();
-
 private:
     void set_window_theme();
 
-    static const TCHAR* class_name;
+    inline static bool s_hooked{};
 
-    WNDPROC menuproc{nullptr};
-    bool initialised{false};
+    bool m_redrop_menu{true};
+    bool m_is_submenu{false};
+    int m_wanted_active_item{0};
+    int m_actual_active_item{0};
+    int m_num_menus_open{-1};
+    service_ptr_t<mainmenu_manager> m_manager;
+    service_ptr_t<ui_status_text_override> m_status_override;
+
+    HWND m_toolbar_wnd{nullptr};
+    HWND m_previous_focus_wnd{nullptr};
+    pfc::list_t<MainMenuRootGroup> m_buttons;
+
+    WNDPROC m_menu_proc{nullptr};
+    bool m_is_initialised{false};
     bool m_menu_key_pressed{false};
-    std::unique_ptr<cui::colours::dark_mode_notifier> m_dark_mode_notifier;
+    std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
 };
 
-bool MenuToolbar::hooked = false;
-
-MenuToolbar::MenuToolbar() : p_manager(nullptr) {}
-
-const TCHAR* MenuToolbar::class_name = _T("{76E6DB50-0DE3-4f30-A7E4-93FD628B1401}");
+MenuToolbar::MenuToolbar() : m_manager(nullptr) {}
 
 bool MenuToolbar::is_menu_focused() const
 {
-    return GetFocus() == wnd_menu;
+    return GetFocus() == m_toolbar_wnd;
 }
 
 HWND MenuToolbar::get_previous_focus_window() const
 {
-    return wnd_prev_focus;
+    return m_previous_focus_wnd;
 }
 
 void MenuToolbar::set_window_theme()
 {
-    SetWindowTheme(wnd_menu, cui::colours::is_dark_mode_active() ? L"DarkMode" : nullptr, nullptr);
+    SetWindowTheme(m_toolbar_wnd, cui::colours::is_dark_mode_active() ? L"DarkMode" : nullptr, nullptr);
 }
 
-LRESULT WINAPI MenuToolbar::main_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
+LRESULT WINAPI MenuToolbar::s_handle_toolbar_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
 {
-    auto p_this = reinterpret_cast<MenuToolbar*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
-    return p_this ? p_this->hook(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
+    auto self = reinterpret_cast<MenuToolbar*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
+    return self ? self->handle_toolbar_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
 }
 
 LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE: {
-        initialised = true;
+        m_is_initialised = true;
 
         MainMenuRootGroup::g_get_root_items(m_buttons);
         size_t button_count = m_buttons.get_count();
 
         std::vector<TBBUTTON> tb_buttons(button_count);
 
-        wnd_menu = CreateWindowEx(WS_EX_TOOLWINDOW, TOOLBARCLASSNAME, nullptr,
+        m_toolbar_wnd = CreateWindowEx(WS_EX_TOOLWINDOW, TOOLBARCLASSNAME, nullptr,
             WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | TBSTYLE_FLAT | TBSTYLE_TRANSPARENT
                 | TBSTYLE_LIST | CCS_NORESIZE | CCS_NOPARENTALIGN | CCS_NODIVIDER,
-            0, 0, 0, 25, wnd, (HMENU)ID_MENU, core_api::get_my_instance(), nullptr);
+            0, 0, 0, 25, wnd, reinterpret_cast<HMENU>(static_cast<size_t>(ID_MENU)), core_api::get_my_instance(),
+            nullptr);
 
-        if (wnd_menu) {
-            SetWindowLongPtr(wnd_menu, GWLP_USERDATA, (LPARAM)(this));
+        if (!m_toolbar_wnd)
+            break;
 
-            set_window_theme();
-            m_dark_mode_notifier
-                = std::make_unique<cui::colours::dark_mode_notifier>([this, self = ptr{this}] { set_window_theme(); });
+        SetWindowLongPtr(m_toolbar_wnd, GWLP_USERDATA, reinterpret_cast<LPARAM>(this));
 
-            SendMessage(wnd_menu, TB_SETBITMAPSIZE, (WPARAM)0, MAKELONG(0, 0));
-            SendMessage(wnd_menu, TB_SETBUTTONSIZE, (WPARAM)0, MAKELONG(0, 0));
+        set_window_theme();
+        m_dark_mode_notifier
+            = std::make_unique<cui::colours::dark_mode_notifier>([this, self = ptr{this}] { set_window_theme(); });
 
-            SendMessage(wnd_menu, TB_BUTTONSTRUCTSIZE, (WPARAM)sizeof(TBBUTTON), 0);
+        SendMessage(m_toolbar_wnd, TB_SETBITMAPSIZE, 0, MAKELONG(0, 0));
+        SendMessage(m_toolbar_wnd, TB_SETBUTTONSIZE, 0, MAKELONG(0, 0));
 
-            for (auto&& [n, tb_button] : ranges::views::enumerate(tb_buttons)) {
-                tb_button.iBitmap = I_IMAGECALLBACK;
-                tb_button.idCommand = gsl::narrow<int>(n + 1);
-                tb_button.fsState = TBSTATE_ENABLED;
-                tb_button.fsStyle = BTNS_DROPDOWN | BTNS_AUTOSIZE;
-                tb_button.dwData = 0;
-                tb_button.iString = reinterpret_cast<INT_PTR>(m_buttons[n].m_name_with_accelerators.get_ptr());
-            }
+        SendMessage(m_toolbar_wnd, TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
 
-            SendMessage(wnd_menu, TB_ADDBUTTONS, (WPARAM)tb_buttons.size(), (LPARAM)(LPTBBUTTON)tb_buttons.data());
-
-            BOOL a = true;
-            SystemParametersInfo(SPI_GETKEYBOARDCUES, 0, &a, 0);
-            SendMessage(wnd_menu, WM_UPDATEUISTATE, MAKEWPARAM(a ? UIS_CLEAR : UIS_SET, UISF_HIDEACCEL), 0);
-
-            menuproc = (WNDPROC)SetWindowLongPtr(wnd_menu, GWLP_WNDPROC, (LPARAM)main_hook);
+        for (auto&& [n, tb_button] : ranges::views::enumerate(tb_buttons)) {
+            tb_button.iBitmap = I_IMAGECALLBACK;
+            tb_button.idCommand = gsl::narrow<int>(n + 1);
+            tb_button.fsState = TBSTATE_ENABLED;
+            tb_button.fsStyle = BTNS_DROPDOWN | BTNS_AUTOSIZE;
+            tb_button.dwData = 0;
+            tb_button.iString = reinterpret_cast<INT_PTR>(m_buttons[n].m_name_with_accelerators.get_ptr());
         }
+
+        SendMessage(m_toolbar_wnd, TB_ADDBUTTONS, tb_buttons.size(), reinterpret_cast<LPARAM>(tb_buttons.data()));
+
+        BOOL a = true;
+        SystemParametersInfo(SPI_GETKEYBOARDCUES, 0, &a, 0);
+        SendMessage(m_toolbar_wnd, WM_UPDATEUISTATE, MAKEWPARAM(a ? UIS_CLEAR : UIS_SET, UISF_HIDEACCEL), 0);
+
+        m_menu_proc = (WNDPROC)SetWindowLongPtr(m_toolbar_wnd, GWLP_WNDPROC, (LPARAM)s_handle_toolbar_message);
 
         break;
     }
@@ -210,12 +200,12 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             int cx = lpwp->cx;
             int cy = lpwp->cy;
             int extra = 0;
-            if (count && (BOOL)SendMessage(wnd_menu, TB_GETITEMRECT, count - 1, (LPARAM)(&rc))) {
+            if (count && (BOOL)SendMessage(m_toolbar_wnd, TB_GETITEMRECT, count - 1, (LPARAM)(&rc))) {
                 cx = std::min(cx, gsl::narrow_cast<int>(rc.right));
                 cy = std::min(cy, gsl::narrow_cast<int>(rc.bottom));
                 extra = (lpwp->cy - rc.bottom) / 2;
             }
-            SetWindowPos(wnd_menu, nullptr, 0, extra, cx, cy, SWP_NOZORDER);
+            SetWindowPos(m_toolbar_wnd, nullptr, 0, extra, cx, cy, SWP_NOZORDER);
             RedrawWindow(wnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
         }
         break;
@@ -227,14 +217,14 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             case TBN_HOTITEMCHANGE: {
                 if (!(((LPNMTBHOTITEM)lp)->dwFlags & HICF_LEAVING)
                     && (((LPNMTBHOTITEM)lp)->dwFlags & HICF_MOUSE || ((LPNMTBHOTITEM)lp)->dwFlags & HICF_LMOUSE))
-                    redrop = true;
+                    m_redrop_menu = true;
                 break;
             }
             case TBN_DROPDOWN: {
-                if (redrop)
+                if (m_redrop_menu)
                     PostMessage(wnd, MSG_CREATE_MENU, ((LPNMTOOLBAR)lp)->iItem, 0);
                 else
-                    redrop = true;
+                    m_redrop_menu = true;
 
                 return TBDDRET_DEFAULT;
             }
@@ -245,36 +235,36 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case MSG_HIDE_MENUACC: {
         BOOL a = true;
         SystemParametersInfo(SPI_GETKEYBOARDCUES, 0, &a, 0);
-        if ((SendMessage(wnd_menu, WM_QUERYUISTATE, 0, 0) & UISF_HIDEACCEL) != !a)
-            SendMessage(wnd_menu, WM_UPDATEUISTATE, MAKEWPARAM(a ? UIS_CLEAR : UIS_SET, UISF_HIDEACCEL), 0);
+        if ((SendMessage(m_toolbar_wnd, WM_QUERYUISTATE, 0, 0) & UISF_HIDEACCEL) != !a)
+            SendMessage(m_toolbar_wnd, WM_UPDATEUISTATE, MAKEWPARAM(a ? UIS_CLEAR : UIS_SET, UISF_HIDEACCEL), 0);
         break;
     }
     case MSG_SHOW_MENUACC: {
-        SendMessage(wnd_menu, WM_UPDATEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEACCEL), 0);
+        SendMessage(m_toolbar_wnd, WM_UPDATEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEACCEL), 0);
         break;
     }
     case MSG_CREATE_MENU: {
         if (lp)
-            SetFocus(wnd_menu);
-        active_item = gsl::narrow_cast<int>(wp);
+            SetFocus(m_toolbar_wnd);
+        m_wanted_active_item = gsl::narrow_cast<int>(wp);
 
-        make_menu(active_item);
+        make_menu(m_wanted_active_item);
         break;
     }
     case WM_MENUSELECT: {
         if (HIWORD(wp) & MF_POPUP) {
-            is_submenu = true;
+            m_is_submenu = true;
             m_status_override.release();
         } else {
-            is_submenu = false;
-            if (p_manager.is_valid()) {
+            m_is_submenu = false;
+            if (m_manager.is_valid()) {
                 unsigned id = LOWORD(wp);
 
                 bool set = false;
 
                 pfc::string8 blah;
 
-                set = p_manager->get_description(id - 1, blah);
+                set = m_manager->get_description(id - 1, blah);
 
                 service_ptr_t<ui_status_text_override> p_status_override;
 
@@ -291,18 +281,18 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     }
     case WM_INITMENUPOPUP: {
-        sub_menu_ref_count++;
+        m_num_menus_open++;
         break;
     }
     case WM_UNINITMENUPOPUP: {
-        sub_menu_ref_count--;
+        m_num_menus_open--;
         break;
     }
     case WM_GETMINMAXINFO: {
-        auto mmi = LPMINMAXINFO(lp);
+        const auto mmi = reinterpret_cast<LPMINMAXINFO>(lp);
 
         RECT rc = {0, 0, 0, 0};
-        SendMessage(wnd_menu, TB_GETITEMRECT, m_buttons.get_count() - 1, (LPARAM)(&rc));
+        SendMessage(m_toolbar_wnd, TB_GETITEMRECT, m_buttons.get_count() - 1, (LPARAM)(&rc));
 
         mmi->ptMinTrackSize.x = rc.right;
         mmi->ptMinTrackSize.y = rc.bottom;
@@ -318,8 +308,8 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case SPI_GETKEYBOARDCUES: {
         BOOL a = TRUE;
         SystemParametersInfo(SPI_GETKEYBOARDCUES, 0, &a, 0);
-        SendMessage(wnd_menu, WM_UPDATEUISTATE,
-            MAKEWPARAM((a || GetFocus() == wnd_menu) ? UIS_CLEAR : UIS_SET, UISF_HIDEACCEL), 0);
+        SendMessage(m_toolbar_wnd, WM_UPDATEUISTATE,
+            MAKEWPARAM((a || GetFocus() == m_toolbar_wnd) ? UIS_CLEAR : UIS_SET, UISF_HIDEACCEL), 0);
         break;
     }
     case MSG_SIZE_LIMIT_CHANGE: {
@@ -329,28 +319,28 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     }
     case WM_DESTROY: {
         m_dark_mode_notifier.reset();
-        DestroyWindow(wnd_menu);
-        wnd_menu = nullptr;
+        DestroyWindow(m_toolbar_wnd);
+        m_toolbar_wnd = nullptr;
         m_buttons.remove_all();
-        initialised = false;
+        m_is_initialised = false;
         break;
     }
     }
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-LRESULT WINAPI MenuToolbar::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI MenuToolbar::handle_toolbar_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_KILLFOCUS: {
         m_menu_key_pressed = false;
         update_menu_acc();
-        wnd_prev_focus = nullptr;
+        m_previous_focus_wnd = nullptr;
     } break;
     case WM_SETFOCUS: {
         m_menu_key_pressed = false;
         show_menu_acc();
-        wnd_prev_focus = (HWND)wp;
+        m_previous_focus_wnd = (HWND)wp;
     } break;
     case WM_CHAR:
         if (wp == ' ')
@@ -363,8 +353,8 @@ LRESULT WINAPI MenuToolbar::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             && !lpkeyb.previous_key_state) {
             update_menu_acc();
             if (wp == VK_ESCAPE) {
-                if (wnd_prev_focus && IsWindow(wnd_prev_focus))
-                    SetFocus(wnd_prev_focus);
+                if (m_previous_focus_wnd && IsWindow(m_previous_focus_wnd))
+                    SetFocus(m_previous_focus_wnd);
             } else {
                 m_menu_key_pressed = true;
                 PostMessage(wnd, TB_SETHOTITEM, -1, 0);
@@ -377,41 +367,44 @@ LRESULT WINAPI MenuToolbar::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 PostMessage(wndparent, WM_SYSKEYDOWN, wp, lp | (1 << 29));
             return 0;
         }
-    } break;
+        break;
+    }
     case WM_SYSKEYUP: {
         if (m_menu_key_pressed && (wp == VK_MENU || wp == VK_F10)) {
-            if (wnd_prev_focus && IsWindow(wnd_prev_focus))
-                SetFocus(wnd_prev_focus);
+            if (m_previous_focus_wnd && IsWindow(m_previous_focus_wnd))
+                SetFocus(m_previous_focus_wnd);
             m_menu_key_pressed = false;
             return 0;
         }
-    } break;
+        break;
     }
-    return CallWindowProc(menuproc, wnd, msg, wp, lp);
+    }
+    return CallWindowProc(m_menu_proc, wnd, msg, wp, lp);
 }
 
 void MenuToolbar::make_menu(int idx)
 {
-    if (idx == actual_active || hooked || idx < 1 || idx > gsl::narrow<int>(m_buttons.get_count()))
+    if (idx == m_actual_active_item || s_hooked || idx < 1 || idx > gsl::narrow<int>(m_buttons.get_count()))
         return;
 
-    service_ptr_t<MenuToolbar> dummy = this; // menu command may delete us
+    // The menu command may cause the menu toolbar to be destroyed
+    ptr self{this};
 
-    actual_active = idx;
+    m_actual_active_item = idx;
 
     RECT rc;
     POINT pt;
 
-    SendMessage(wnd_menu, TB_GETRECT, idx, (LPARAM)&rc);
+    SendMessage(m_toolbar_wnd, TB_GETRECT, idx, (LPARAM)&rc);
 
-    MapWindowPoints(wnd_menu, HWND_DESKTOP, (LPPOINT)&rc, 2);
+    MapWindowPoints(m_toolbar_wnd, HWND_DESKTOP, (LPPOINT)&rc, 2);
 
     pt.x = rc.left;
     pt.y = rc.bottom;
 
     HMENU menu = CreatePopupMenu();
 
-    hooked = true;
+    s_hooked = true;
     register_message_hook(uih::MessageHookType::type_message_filter, this);
     service_ptr_t<mainmenu_manager> p_menu = standard_api_create_t<mainmenu_manager>();
 
@@ -423,25 +416,25 @@ void MenuToolbar::make_menu(int idx)
         menu_helpers::win32_auto_mnemonics(menu);
     }
 
-    SendMessage(wnd_menu, TB_PRESSBUTTON, idx, TRUE);
-    SendMessage(wnd_menu, TB_SETHOTITEM, idx - 1, 0);
-    is_submenu = false;
+    SendMessage(m_toolbar_wnd, TB_PRESSBUTTON, idx, TRUE);
+    SendMessage(m_toolbar_wnd, TB_SETHOTITEM, idx - 1, 0);
+    m_is_submenu = false;
 
-    sub_menu_ref_count = -1; // we get a notificationwhen the inital menu is created
+    m_num_menus_open = -1;
 
-    p_manager = p_menu;
+    m_manager = p_menu;
 
     TPMPARAMS tpmp{};
     tpmp.cbSize = sizeof(tpmp);
 
-    GetWindowRect(wnd_menu, &tpmp.rcExclude);
+    GetWindowRect(m_toolbar_wnd, &tpmp.rcExclude);
 
-    HMONITOR mon = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+    HMONITOR monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
 
-    if (mon) {
+    if (monitor) {
         MONITORINFO mi{};
         mi.cbSize = sizeof(MONITORINFO);
-        if (uGetMonitorInfo(mon, &mi)) {
+        if (uGetMonitorInfo(monitor, &mi)) {
             if (pt.x < mi.rcMonitor.left)
                 pt.x = mi.rcMonitor.left;
             tpmp.rcExclude.left = mi.rcMonitor.left;
@@ -449,32 +442,31 @@ void MenuToolbar::make_menu(int idx)
         }
     }
 
-    if (GetFocus() != wnd_menu)
-        wnd_prev_focus = GetFocus();
+    if (GetFocus() != m_toolbar_wnd)
+        m_previous_focus_wnd = GetFocus();
 
     int cmd = TrackPopupMenuEx(menu, TPM_LEFTBUTTON | TPM_RETURNCMD, pt.x, pt.y, get_wnd(), &tpmp);
     m_status_override.release();
 
-    PostMessage(wnd_menu, TB_PRESSBUTTON, idx, FALSE);
+    PostMessage(m_toolbar_wnd, TB_PRESSBUTTON, idx, FALSE);
 
-    if (GetFocus() != wnd_menu) {
-        PostMessage(wnd_menu, TB_SETHOTITEM, -1, 0);
-    }
+    if (GetFocus() != m_toolbar_wnd)
+        PostMessage(m_toolbar_wnd, TB_SETHOTITEM, -1, 0);
 
     DestroyMenu(menu);
 
     if (cmd > 0 && p_menu.is_valid()) {
-        if (IsWindow(wnd_prev_focus))
-            SetFocus(wnd_prev_focus);
+        if (IsWindow(m_previous_focus_wnd))
+            SetFocus(m_previous_focus_wnd);
         p_menu->execute_command(cmd - 1);
     }
 
-    p_manager.release();
+    m_manager.release();
     p_menu.release();
 
     deregister_message_hook(uih::MessageHookType::type_message_filter, this);
-    hooked = false;
-    actual_active = 0;
+    s_hooked = false;
+    m_actual_active_item = 0;
 }
 
 bool MenuToolbar::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp)
@@ -485,7 +477,7 @@ bool MenuToolbar::on_hooked_message(uih::MessageHookType p_type, int code, WPARA
         switch (((MSG*)lp)->message) {
         case WM_LBUTTONDOWN:
         case WM_RBUTTONDOWN: {
-            SendMessage(wnd_menu, TB_SETHOTITEM, -1, 0);
+            SendMessage(m_toolbar_wnd, TB_SETHOTITEM, -1, 0);
             if (((MSG*)lp)->message == WM_LBUTTONDOWN) {
                 POINT pt;
                 RECT toolbar;
@@ -493,46 +485,48 @@ bool MenuToolbar::on_hooked_message(uih::MessageHookType p_type, int code, WPARA
                 pt.y = GET_Y_LPARAM(((MSG*)lp)->lParam);
                 pt.x = GET_X_LPARAM(((MSG*)lp)->lParam);
 
-                if (ScreenToClient(wnd_menu, &pt) && PtInRect(&toolbar, pt)) {
-                    size_t idx = SendMessage(wnd_menu, TB_HITTEST, 0, reinterpret_cast<LPARAM>(&pt));
+                if (ScreenToClient(m_toolbar_wnd, &pt) && PtInRect(&toolbar, pt)) {
+                    size_t idx = SendMessage(m_toolbar_wnd, TB_HITTEST, 0, reinterpret_cast<LPARAM>(&pt));
 
                     if (idx >= 0 && idx < m_buttons.get_count())
-                        redrop = false;
+                        m_redrop_menu = false;
                 }
             }
-        } break;
+            break;
+        }
         case WM_KEYDOWN: {
             switch (((MSG*)lp)->wParam) {
             case VK_LEFT:
-                if (!sub_menu_ref_count) {
+                if (!m_num_menus_open) {
                     destroy_menu();
-                    if (active_item == 1)
-                        active_item = gsl::narrow<int>(m_buttons.get_count());
+                    if (m_wanted_active_item == 1)
+                        m_wanted_active_item = gsl::narrow<int>(m_buttons.get_count());
                     else
-                        active_item--;
-                    uPostMessage(get_wnd(), MSG_CREATE_MENU, active_item, 0);
+                        --m_wanted_active_item;
+                    PostMessage(get_wnd(), MSG_CREATE_MENU, m_wanted_active_item, 0);
                 }
 
                 break;
             case VK_RIGHT:
-                if (!is_submenu) {
+                if (!m_is_submenu) {
                     destroy_menu();
-                    if (active_item == gsl::narrow<int>(m_buttons.get_count()))
-                        active_item = 1;
+                    if (m_wanted_active_item == gsl::narrow<int>(m_buttons.get_count()))
+                        m_wanted_active_item = 1;
                     else
-                        active_item++;
-                    uPostMessage(get_wnd(), MSG_CREATE_MENU, active_item, 0);
+                        ++m_wanted_active_item;
+                    PostMessage(get_wnd(), MSG_CREATE_MENU, m_wanted_active_item, 0);
                 }
                 break;
             case VK_ESCAPE:
-                if (!sub_menu_ref_count) {
-                    SetFocus(wnd_menu);
-                    SendMessage(wnd_menu, TB_SETHOTITEM, active_item - 1, 0);
+                if (!m_num_menus_open) {
+                    SetFocus(m_toolbar_wnd);
+                    SendMessage(m_toolbar_wnd, TB_SETHOTITEM, m_wanted_active_item - 1, 0);
                     destroy_menu();
                 }
                 break;
             }
-        } break;
+            break;
+        }
 
         case WM_MOUSEMOVE: {
             POINT px;
@@ -540,23 +534,25 @@ bool MenuToolbar::on_hooked_message(uih::MessageHookType p_type, int code, WPARA
             px.x = GET_X_LPARAM(((MSG*)lp)->lParam);
             if (px.x != last_pt.x || px.y != last_pt.y) {
                 HWND wnd_hit = WindowFromPoint(px);
-                if (wnd_hit == wnd_menu) {
+                if (wnd_hit == m_toolbar_wnd) {
                     POINT pt = px;
 
-                    if (ScreenToClient(wnd_menu, &pt)) {
-                        const int idx
-                            = static_cast<int>(SendMessage(wnd_menu, TB_HITTEST, 0, reinterpret_cast<LPARAM>(&pt)));
+                    if (ScreenToClient(m_toolbar_wnd, &pt)) {
+                        const int idx = static_cast<int>(
+                            SendMessage(m_toolbar_wnd, TB_HITTEST, 0, reinterpret_cast<LPARAM>(&pt)));
 
-                        if (idx >= 0 && idx < gsl::narrow<int>(m_buttons.get_count()) && (active_item - 1) != idx) {
+                        if (idx >= 0 && idx < gsl::narrow<int>(m_buttons.get_count())
+                            && (m_wanted_active_item - 1) != idx) {
                             destroy_menu();
-                            active_item = idx + 1;
-                            uPostMessage(get_wnd(), MSG_CREATE_MENU, active_item, 0);
+                            m_wanted_active_item = idx + 1;
+                            PostMessage(get_wnd(), MSG_CREATE_MENU, m_wanted_active_item, 0);
                         }
                     }
                 }
             }
             last_pt = px;
-        } break;
+            break;
+        }
         }
     }
     return false;
@@ -566,6 +562,7 @@ void MenuToolbar::get_name(pfc::string_base& out) const
 {
     out.set_string("Menu");
 }
+
 void MenuToolbar::get_category(pfc::string_base& out) const
 {
     out.set_string("Toolbars");
@@ -573,37 +570,36 @@ void MenuToolbar::get_category(pfc::string_base& out) const
 
 void MenuToolbar::set_focus()
 {
-    {
-        SetFocus(wnd_menu);
-    }
+    SetFocus(m_toolbar_wnd);
 }
+
 void MenuToolbar::show_accelerators()
 {
-    {
-        show_menu_acc();
-    }
+    show_menu_acc();
 }
+
 void MenuToolbar::hide_accelerators()
 {
-    {
-        if (GetFocus() != wnd_menu)
-            update_menu_acc();
-    }
+    if (GetFocus() != m_toolbar_wnd)
+        update_menu_acc();
 }
 
 bool MenuToolbar::on_menuchar(unsigned short chr)
 {
-    {
-        UINT id;
-        if (SendMessage(wnd_menu, TB_MAPACCELERATOR, chr, (LPARAM)&id)) {
-            uPostMessage(get_wnd(), MSG_CREATE_MENU, id, TRUE);
-            return true;
-        }
+    UINT id{};
+
+    if (SendMessage(m_toolbar_wnd, TB_MAPACCELERATOR, chr, (LPARAM)&id)) {
+        PostMessage(get_wnd(), MSG_CREATE_MENU, id, TRUE);
+        return true;
     }
+
     return false;
 }
 
-// {76E6DB50-0DE3-4f30-A7E4-93FD628B1401}
-const GUID MenuToolbar::extension_guid = {0x76e6db50, 0xde3, 0x4f30, {0xa7, 0xe4, 0x93, 0xfd, 0x62, 0x8b, 0x14, 0x1}};
+namespace {
 
-ui_extension::window_factory<MenuToolbar> blah;
+ui_extension::window_factory<MenuToolbar> _menu_toolbar_factory;
+
+}
+
+} // namespace cui::toolbars::menu

--- a/foo_ui_columns/menubar.cpp
+++ b/foo_ui_columns/menubar.cpp
@@ -10,6 +10,8 @@ constexpr auto MSG_SHOW_MENUACC = WM_USER + 4u;
 constexpr auto MSG_CREATE_MENU = WM_USER + 5u;
 constexpr auto MSG_SIZE_LIMIT_CHANGE = WM_USER + 6u;
 
+constexpr GUID font_id{0x6f3b4d11, 0xebe6, 0x4d30, {0x8b, 0x1f, 0xea, 0x2e, 0x2f, 0x16, 0x2b, 0x04}};
+
 class MainMenuRootGroup {
 public:
     pfc::string8 m_name;
@@ -61,6 +63,8 @@ class MenuToolbar
 public:
     static constexpr GUID extension_guid{0x76e6db50, 0xde3, 0x4f30, {0xa7, 0xe4, 0x93, 0xfd, 0x62, 0x8b, 0x14, 0x1}};
 
+    static void s_on_font_change();
+
     MenuToolbar();
 
     uie::container_window_v3_config get_window_config() override
@@ -73,6 +77,9 @@ public:
     LRESULT WINAPI handle_toolbar_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     static LRESULT WINAPI s_handle_toolbar_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept;
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
+
+    void on_font_change();
+    void on_size(int client_width, int client_height) const;
 
     bool on_hooked_message(uih::MessageHookType p_type, int code, WPARAM wp, LPARAM lp) override;
     void make_menu(int idx);
@@ -97,9 +104,11 @@ public:
     HWND get_previous_focus_window() const override;
 
 private:
-    void set_window_theme();
+    void set_window_theme() const;
 
     inline static bool s_hooked{};
+    inline static std::vector<MenuToolbar*> s_instances;
+    inline static wil::unique_hfont s_font;
 
     bool m_redrop_menu{true};
     bool m_is_submenu{false};
@@ -119,6 +128,15 @@ private:
     std::unique_ptr<colours::dark_mode_notifier> m_dark_mode_notifier;
 };
 
+void MenuToolbar::s_on_font_change()
+{
+    auto old_font = std::move(s_font);
+    s_font.reset(fonts::create_hfont_with_fallback(font_id));
+
+    for (auto&& instance : s_instances)
+        instance->on_font_change();
+}
+
 MenuToolbar::MenuToolbar() : m_manager(nullptr) {}
 
 bool MenuToolbar::is_menu_focused() const
@@ -131,9 +149,10 @@ HWND MenuToolbar::get_previous_focus_window() const
     return m_previous_focus_wnd;
 }
 
-void MenuToolbar::set_window_theme()
+void MenuToolbar::set_window_theme() const
 {
     SetWindowTheme(m_toolbar_wnd, cui::colours::is_dark_mode_active() ? L"DarkMode" : nullptr, nullptr);
+    SetWindowFont(m_toolbar_wnd, s_font.get(), FALSE);
 }
 
 LRESULT WINAPI MenuToolbar::s_handle_toolbar_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) noexcept
@@ -147,6 +166,11 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     switch (msg) {
     case WM_CREATE: {
         m_is_initialised = true;
+
+        s_instances.push_back(this);
+
+        if (s_instances.size() == 1)
+            s_font.reset(fonts::create_hfont_with_fallback(font_id));
 
         MainMenuRootGroup::g_get_root_items(m_buttons);
         size_t button_count = m_buttons.get_count();
@@ -165,6 +189,7 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         SetWindowLongPtr(m_toolbar_wnd, GWLP_USERDATA, reinterpret_cast<LPARAM>(this));
 
         set_window_theme();
+
         m_dark_mode_notifier
             = std::make_unique<cui::colours::dark_mode_notifier>([this, self = ptr{this}] { set_window_theme(); });
 
@@ -193,24 +218,15 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     }
     case WM_WINDOWPOSCHANGED: {
-        auto lpwp = (LPWINDOWPOS)lp;
+        const auto lpwp = reinterpret_cast<LPWINDOWPOS>(lp);
+
         if (!(lpwp->flags & SWP_NOSIZE)) {
-            RECT rc = {0, 0, 0, 0};
-            size_t count = m_buttons.get_count();
-            int cx = lpwp->cx;
-            int cy = lpwp->cy;
-            int extra = 0;
-            if (count && (BOOL)SendMessage(m_toolbar_wnd, TB_GETITEMRECT, count - 1, (LPARAM)(&rc))) {
-                cx = std::min(cx, gsl::narrow_cast<int>(rc.right));
-                cy = std::min(cy, gsl::narrow_cast<int>(rc.bottom));
-                extra = (lpwp->cy - rc.bottom) / 2;
-            }
-            SetWindowPos(m_toolbar_wnd, nullptr, 0, extra, cx, cy, SWP_NOZORDER);
-            RedrawWindow(wnd, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
+            on_size(lpwp->cx, lpwp->cy);
+            RedrawWindow(get_wnd(), nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
         }
+
         break;
     }
-
     case WM_NOTIFY: {
         if (((LPNMHDR)lp)->idFrom == ID_MENU) {
             switch (((LPNMHDR)lp)->code) {
@@ -323,10 +339,62 @@ LRESULT MenuToolbar::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_toolbar_wnd = nullptr;
         m_buttons.remove_all();
         m_is_initialised = false;
+
+        std::erase(s_instances, this);
+
+        if (s_instances.empty())
+            s_font.reset();
+
         break;
     }
     }
     return DefWindowProc(wnd, msg, wp, lp);
+}
+
+void MenuToolbar::on_font_change()
+{
+    SetWindowRedraw(m_toolbar_wnd, FALSE);
+    SetWindowFont(m_toolbar_wnd, s_font.get(), FALSE);
+
+    TBBUTTONINFO tbbi{};
+    tbbi.cbSize = sizeof(tbbi);
+    tbbi.dwMask = TBIF_TEXT | TBIF_BYINDEX;
+
+    for (auto&& [index, button] : ranges::views::enumerate(m_buttons)) {
+        tbbi.pszText = button.m_name_with_accelerators.get_ptr();
+        SendMessage(m_toolbar_wnd, TB_SETBUTTONINFO, index, reinterpret_cast<LPARAM>(&tbbi));
+    }
+
+    SetWindowRedraw(m_toolbar_wnd, TRUE);
+    get_host()->on_size_limit_change(get_wnd(), uie::size_limit_all);
+
+    RECT client_rect{};
+    GetClientRect(get_wnd(), &client_rect);
+    on_size(wil::rect_width(client_rect), wil::rect_height(client_rect));
+}
+
+void MenuToolbar::on_size(int client_width, int client_height) const
+{
+    size_t button_count = m_buttons.get_count();
+
+    if (!m_toolbar_wnd) {
+        RedrawWindow(get_wnd(), nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
+        return;
+    }
+
+    RECT last_button_rect{};
+    int extra{};
+    int toolbar_width{};
+    int toolbar_height{};
+
+    if (button_count > 0
+        && SendMessage(m_toolbar_wnd, TB_GETITEMRECT, button_count - 1, reinterpret_cast<LPARAM>(&last_button_rect))) {
+        toolbar_width = std::min(client_width, static_cast<int>(last_button_rect.right));
+        toolbar_height = std::min(client_height, static_cast<int>(last_button_rect.bottom));
+        extra = std::max(0, (client_height - static_cast<int>(last_button_rect.bottom)) / 2);
+    }
+
+    SetWindowPos(m_toolbar_wnd, nullptr, 0, extra, toolbar_width, toolbar_height, SWP_NOZORDER);
 }
 
 LRESULT WINAPI MenuToolbar::handle_toolbar_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
@@ -598,8 +666,20 @@ bool MenuToolbar::on_menuchar(unsigned short chr)
 
 namespace {
 
+class MenuToolbarFontClient : public fonts::client {
+public:
+    const GUID& get_client_guid() const override { return font_id; }
+    void get_name(pfc::string_base& p_out) const override { p_out = "Menu toolbar"; }
+
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_labels; }
+
+    void on_font_changed() const override { MenuToolbar::s_on_font_change(); }
+};
+
 ui_extension::window_factory<MenuToolbar> _menu_toolbar_factory;
 
-}
+fonts::client::factory<MenuToolbarFontClient> _menu_font_client_factory;
+
+} // namespace
 
 } // namespace cui::toolbars::menu


### PR DESCRIPTION
Resolves #1665

This adds the ability to configure the font used by the menu toolbar.

The configured font applies only to the toolbar itself and not to any opened menus.

Some menu toolbar code was also cleaned up.