### PR TITLE
Select all on Ctrl+F in playlist view search box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
   [#1679](https://github.com/reupen/columns_ui/pull/1679),
   [#1680](https://github.com/reupen/columns_ui/pull/1680),
   [#1686](https://github.com/reupen/columns_ui/pull/1686),
-  [#1689](https://github.com/reupen/columns_ui/pull/1689)]
+  [#1689](https://github.com/reupen/columns_ui/pull/1689),
+  [#1693](https://github.com/reupen/columns_ui/pull/1693)]
 
 - A subset of keyboard shortcuts configured in Preferences are now processed in
   the Filter search toolbar and in inline editing edit boxes in the playlist


### PR DESCRIPTION
Resolves #1691

This updates ui_helpers to pick up some tweaks to keyboard shortcut handling.

If Ctrl+F is pressed while the playlist view search bar edit control is focused, it now selects all text in the control.

List view keyboard shortcuts involving the Ctrl key (such as Ctrl+A) now check that the Shift and Windows keys are not held down. This helps avoid any conflicts or confusion if shortcuts using Ctrl in combination with other modifiers are assigned.