### PR TITLE
Add the ability to customise group lines using style script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@
   Layout preferences page. The legacy behaviour is enabled by default for
   upgrades to avoid unwanted layout changes.
 
+- The horizontal lines next to group headings in the playlist view can now be
+  customised using the global style script.
+  [[#1699](https://github.com/reupen/columns_ui/pull/1699)]
+
+  This covers hiding the lines and changing the colour of them. See
+  [Style script](https://columns-ui.readthedocs.io/page/playlist-view/style-script.html#setting-the-group-line-style)
+  for more details.
+
 - A subset of keyboard shortcuts configured in Preferences are now processed in
   the Filter search toolbar and in inline editing edit boxes in the playlist
   view, playlist switcher, Filter panel and Item properties.

--- a/docs/source/playlist-view/style-script.md
+++ b/docs/source/playlist-view/style-script.md
@@ -6,13 +6,13 @@ Per-column style scripts can be used to set colours for a particular column.
 
 ## Functions
 
-### \$set_style
+### \$set_style()
 
 A single function, `$set_style()`, is used to set colours. Colours are specified
 using the `$rgb()` function.
 
 ```{note}
-Selection colours can not be overridden if the chosen colour scheme
+Selection colours cannot be overridden if the chosen colour scheme
 for the playlist view is Themed on the Colours and fonts preferences page. You
 must use the Custom or System scheme to override selection colours.
 ```
@@ -35,6 +35,31 @@ You can set the background colour as follows:
 $set_style(back,<background colour>,<selected item background colour>[,<selected item background colour when window is not focused>])
 ```
 
+##### Setting the group line style
+
+Horizontal lines to the right of group headings can be configured using the
+global style script.
+
+To hide these lines, use:
+
+```
+$set_style(group-line,false)
+```
+
+To change the colour of these lines, use:
+
+```
+$set_style(group-line,true,<colour>)
+```
+
+where `<colour>` is a colour code.
+
+For example, this makes these lines red:
+
+```
+$set_style(group-line,true,$rgb(255,0,0))
+```
+
 ##### Setting the frame style
 
 You can set the frame style as follows:
@@ -46,8 +71,12 @@ $set_style(<frame part>,<enabled state>[,<colour>])
 where
 
 - `<frame part>` is either `frame-top`,`frame-left`,`frame-bottom`,`frame-right`
-- `<enabled state>` is either `1` (true) or `0` (false).
+- `<enabled state>` is any of `true`, `1`, `false` or `0`
 - `<colour>` is the colour of the frame, required if `<enabled state>` is `1`.
+
+```{note}
+Support for using `true` and `false` for the second paramter, instead of `0` and `1`, was added in Columns UI 3.5.0
+```
 
 #### Example
 

--- a/foo_ui_columns/config_vars.cpp
+++ b/foo_ui_columns/config_vars.cpp
@@ -117,7 +117,10 @@ cfg_string cfg_pgenstring(GUID{0x07bee8c2, 0xc6f1, 0x9db3, {0x52, 0x55, 0x43, 0x
     "%album%\\$directory(%_path%,2)");
 
 const char* default_global_style_script
-    = "// Uncomment the next line to enable the shading of alternate rows\r\n"
+    = "// Uncomment the next line to hide horizontal lines to the right of group headings\r\n"
+      "// $set_style(group-line,false)\r\n"
+      "\r\n"
+      "// Uncomment the next line to enable the shading of alternate rows\r\n"
       "// $puts(shade-alternate-rows,1)\r\n"
       "\r\n"
       "$if($get(shade-alternate-rows),$if($and(%isplaying%,$not(%_is_group%)),\r\n"

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -397,8 +397,11 @@ void PlaylistView::update_all_items()
         p_compiler->compile_safe(m_script_global, cfg_globalstring);
     p_compiler->compile_safe(m_script_global_style, cfg_colour);
 
-    refresh_all_items_text();
+    invalidate_styles(0, get_item_count());
+    ListView::update_items(0, get_item_count(), false);
+    invalidate_all();
 }
+
 void PlaylistView::refresh_all_items_text()
 {
     update_items(0, get_item_count());

--- a/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_callbacks.cpp
@@ -2,6 +2,7 @@
 #include "ng_playlist.h"
 
 namespace cui::panels::playlist_view {
+
 void PlaylistView::on_items_added(size_t playlist, size_t start,
     const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) noexcept
 {

--- a/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_renderer.cpp
@@ -204,7 +204,10 @@ void PlaylistViewRenderer::render_group(const uih::lv::RendererContext& context,
     bool b_theme_enabled = p_helper.get_themed();
 
     const auto* group = m_playlist_view->get_item(item_index)->get_group(group_index);
-    if (!group->m_style_data.is_valid())
+
+    const auto& style_data = group->m_style_data;
+
+    if (!style_data.is_valid())
         m_playlist_view->notify_update_item_data(item_index);
 
     COLORREF cr = NULL;
@@ -212,9 +215,9 @@ void PlaylistViewRenderer::render_group(const uih::lv::RendererContext& context,
             && IsThemePartDefined(context.list_view_theme, LVP_GROUPHEADER, NULL)
             && SUCCEEDED(
                 GetThemeColor(context.list_view_theme, LVP_GROUPHEADER, LVGH_OPEN, TMT_HEADING1TEXTCOLOR, &cr))))
-        cr = group->m_style_data->text_colour;
+        cr = style_data->text_colour;
 
-    if (const auto background_colour = group->m_style_data->background_colour;
+    if (const auto background_colour = style_data->background_colour;
         background_colour != p_helper.get_colour(colours::colour_identifier_t::colour_background)) {
         SetDCBrushColor(context.dc, background_colour);
         PatBlt(context.dc, rc.left, rc.top, wil::rect_width(rc), wil::rect_height(rc), PATCOPY);
@@ -227,7 +230,10 @@ void PlaylistViewRenderer::render_group(const uih::lv::RendererContext& context,
         x_offset, border, rc, cr,
         {.bitmap_render_target = context.bitmap_render_target,
             .enable_ellipses = cfg_ellipsis != 0,
-            .initial_format = group->m_style_data->format_properties});
+            .initial_format = style_data->format_properties});
+
+    if (!style_data->show_group_line)
+        return;
 
     const auto line_height = 1_spx;
     const auto line_top = rc.top + wil::rect_height(rc) / 2 - line_height / 2;
@@ -238,25 +244,34 @@ void PlaylistViewRenderer::render_group(const uih::lv::RendererContext& context,
         line_top + line_height,
     };
 
-    if (rc_line.right > rc_line.left) {
-        if (b_theme_enabled && context.list_view_theme
-            && IsThemePartDefined(context.list_view_theme, LVP_GROUPHEADERLINE, NULL)
-            && SUCCEEDED(DrawThemeBackground(
-                context.list_view_theme, context.dc, LVP_GROUPHEADERLINE, LVGH_OPEN, &rc_line, nullptr))) {
-        } else {
-            COLORREF cr = NULL;
-            if (!(b_theme_enabled && context.list_view_theme
-                    && IsThemePartDefined(context.list_view_theme, LVP_GROUPHEADER, NULL)
-                    && SUCCEEDED(GetThemeColor(
-                        context.list_view_theme, LVP_GROUPHEADER, LVGH_OPEN, TMT_HEADING1TEXTCOLOR, &cr))))
-                cr = group->m_style_data->text_colour;
-            wil::unique_hpen pen(CreatePen(PS_SOLID, uih::scale_dpi_value(1), cr));
-            HPEN pen_old = SelectPen(context.dc, pen.get());
-            MoveToEx(context.dc, rc_line.left, rc_line.top, nullptr);
-            LineTo(context.dc, rc_line.right, rc_line.top);
-            SelectPen(context.dc, pen_old);
-        }
+    if (rc_line.right <= rc_line.left)
+        return;
+
+    if (b_theme_enabled && context.list_view_theme && !style_data->group_line_colour
+        && IsThemePartDefined(context.list_view_theme, LVP_GROUPHEADERLINE, NULL)
+        && SUCCEEDED(DrawThemeBackground(
+            context.list_view_theme, context.dc, LVP_GROUPHEADERLINE, LVGH_OPEN, &rc_line, nullptr))) {
+        return;
     }
+
+    const auto line_colour = [&]() -> COLORREF {
+        if (style_data->group_line_colour)
+            return *style_data->group_line_colour;
+
+        if (COLORREF theme_line_colour{}; b_theme_enabled && context.list_view_theme
+            && IsThemePartDefined(context.list_view_theme, LVP_GROUPHEADER, NULL)
+            && SUCCEEDED(GetThemeColor(
+                context.list_view_theme, LVP_GROUPHEADER, LVGH_OPEN, TMT_HEADING1TEXTCOLOR, &theme_line_colour)))
+            return theme_line_colour;
+
+        return style_data->text_colour;
+    }();
+
+    wil::unique_hpen pen(CreatePen(PS_SOLID, 1_spx, line_colour));
+
+    auto _select_pen = wil::SelectObject(context.dc, pen.get());
+    MoveToEx(context.dc, rc_line.left, rc_line.top, nullptr);
+    LineTo(context.dc, rc_line.right, rc_line.top);
 }
 
 } // namespace cui::panels::playlist_view

--- a/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
@@ -3,7 +3,38 @@
 #include "ng_playlist.h"
 #include "ng_playlist_style.h"
 
+#include "tf_utils.h"
+
 namespace cui::panels::playlist_view {
+
+namespace {
+
+Colour get_colour_param(titleformat_hook_function_params& params, size_t index)
+{
+    const auto text = tf::get_param(params, index);
+    const auto colour_text = text.size() > 0 && text[0] == 3 ? text.substr(1) : text;
+    return Colour(mmh::strtoul_n(colour_text.data(), colour_text.size(), 0x10));
+}
+
+std::tuple<Colour, Colour> get_colour_pair_param(titleformat_hook_function_params& params, size_t index)
+{
+    const auto text = tf::get_param(params, index);
+    const auto colour_text = text.size() > 0 && text[0] == 3 ? text.substr(1) : text;
+    const auto colour_1 = mmh::strtoul_n(colour_text.data(), colour_text.size(), 0x10);
+
+    const auto colour_2 = [&] {
+        if (const auto bar_pos = colour_text.find_first_of('|'); bar_pos != std::string_view::npos) {
+            const auto colour_2_text = colour_text.substr(bar_pos + 1);
+            return mmh::strtoul_n(colour_2_text.data(), colour_2_text.size(), 0x10);
+        }
+        return 0xffffff - colour_1;
+    }();
+
+    return std::make_tuple(Colour(colour_1), Colour(colour_2));
+}
+
+} // namespace
+
 namespace style_cache_manager {
 
 pfc::list_t<SharedCellStyleData*> m_objects;
@@ -48,8 +79,8 @@ bool StyleTitleformatHook::process_field(
 {
     p_found_flag = false;
     {
-        if (p_name_length > 1 && !stricmp_utf8_ex(p_name, 1, "_", pfc_infinite)) {
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "text", pfc_infinite)) {
+        if (p_name_length > 1 && !stricmp_utf8_ex(p_name, 1, "_", SIZE_MAX)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "text", SIZE_MAX)) {
                 if (!text.get_ptr()) {
                     text.set_size(33);
                     text.fill(0);
@@ -59,7 +90,7 @@ bool StyleTitleformatHook::process_field(
                 p_found_flag = true;
                 return true;
             }
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "selected_text", pfc_infinite)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "selected_text", SIZE_MAX)) {
                 if (!selected_text.get_ptr()) {
                     selected_text.set_size(33);
                     selected_text.fill(0);
@@ -70,7 +101,7 @@ bool StyleTitleformatHook::process_field(
                 p_found_flag = true;
                 return true;
             }
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "back", pfc_infinite)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "back", SIZE_MAX)) {
                 if (!back.get_ptr()) {
                     back.set_size(33);
                     back.fill(0);
@@ -80,7 +111,7 @@ bool StyleTitleformatHook::process_field(
                 p_found_flag = true;
                 return true;
             }
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "selected_back", pfc_infinite)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "selected_back", SIZE_MAX)) {
                 if (!selected_back.get_ptr()) {
                     selected_back.set_size(33);
                     selected_back.fill(0);
@@ -91,7 +122,7 @@ bool StyleTitleformatHook::process_field(
                 p_found_flag = true;
                 return true;
             }
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "selected_back_no_focus", pfc_infinite)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "selected_back_no_focus", SIZE_MAX)) {
                 if (!selected_back_no_focus.get_ptr()) {
                     selected_back_no_focus.set_size(33);
                     selected_back_no_focus.fill(0);
@@ -103,7 +134,7 @@ bool StyleTitleformatHook::process_field(
                 p_found_flag = true;
                 return true;
             }
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "selected_text_no_focus", pfc_infinite)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "selected_text_no_focus", SIZE_MAX)) {
                 if (!selected_text_no_focus.get_ptr()) {
                     selected_text_no_focus.set_size(33);
                     selected_text_no_focus.fill(0);
@@ -115,7 +146,7 @@ bool StyleTitleformatHook::process_field(
                 p_found_flag = true;
                 return true;
             }
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "themed", pfc_infinite)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "themed", SIZE_MAX)) {
                 colours::helper p_helper(ColoursClient::id);
                 if (p_helper.get_themed()) {
                     p_out->write(titleformat_inputtypes::unknown, "1", 1);
@@ -123,7 +154,7 @@ bool StyleTitleformatHook::process_field(
                 }
                 return true;
             }
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "display_index", pfc_infinite)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "display_index", SIZE_MAX)) {
                 if (!m_index_text) {
                     m_index_text = fmt::format("{}", m_index + 1);
                 }
@@ -131,7 +162,7 @@ bool StyleTitleformatHook::process_field(
                 p_found_flag = true;
                 return true;
             }
-            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "is_group", pfc_infinite)) {
+            if (!stricmp_utf8_ex(p_name + 1, p_name_length - 1, "is_group", SIZE_MAX)) {
                 if (m_is_group) {
                     p_out->write(titleformat_inputtypes::unknown, "1", 1);
                     p_found_flag = true;
@@ -148,170 +179,68 @@ bool StyleTitleformatHook::process_function(titleformat_text_out* p_out, const c
     titleformat_hook_function_params* p_params, bool& p_found_flag)
 {
     p_found_flag = false;
-    if (!stricmp_utf8_ex(p_name, p_name_length, "set_style", pfc_infinite)) {
+    if (!stricmp_utf8_ex(p_name, p_name_length, "set_style", SIZE_MAX)) {
         if (p_params->get_param_count() >= 2) {
-            const char* name;
-            size_t name_length;
-            p_params->get_param(0, name, name_length);
-            if (!stricmp_utf8_ex(name, name_length, "text", pfc_infinite)) {
-                {
-                    const char* value;
-                    size_t value_length;
-                    p_params->get_param(1, value, value_length);
-                    if (value_length && *value == 3) {
-                        value++;
-                        value_length--;
-                    }
-                    p_colours.text_colour.set(mmh::strtoul_n(value, value_length, 0x10));
-                    if (value_length == 6 * 2 + 2 && value[6] == '|') {
-                        value += 7;
-                        value_length -= 7;
-                        p_colours.selected_text_colour.set(mmh::strtoul_n(value, value_length, 0x10));
-                    } else
-                        p_colours.selected_text_colour.set(0xffffff - p_colours.text_colour);
+            const auto name = tf::get_param(*p_params, 0);
+            if (!stricmp_utf8_ex(name.data(), name.size(), "text", SIZE_MAX)) {
+                if (p_params->get_param_count() == 2) {
+                    std::tie(p_colours.text_colour, p_colours.selected_text_colour)
+                        = get_colour_pair_param(*p_params, 1);
+                } else {
+                    p_colours.text_colour = get_colour_param(*p_params, 1);
+                    p_colours.selected_text_colour = get_colour_param(*p_params, 2);
                 }
-                if (p_params->get_param_count() >= 3) {
-                    {
-                        const char* value;
-                        size_t value_length;
-                        p_params->get_param(2, value, value_length);
-                        if (value_length && *value == 3) {
-                            value++;
-                            value_length--;
-                        }
-                        p_colours.selected_text_colour.set(mmh::strtoul_n(value, value_length, 0x10));
-                    }
-                }
-                if (p_params->get_param_count() >= 4) {
-                    const char* value;
-                    size_t value_length;
-                    p_params->get_param(3, value, value_length);
-                    if (value_length && *value == 3) {
-                        value++;
-                        value_length--;
-                    }
-                    p_colours.selected_text_colour_non_focus.set(mmh::strtoul_n(value, value_length, 0x10));
-                } else
-                    p_colours.selected_text_colour_non_focus.set(p_colours.selected_text_colour);
-            } else if (!stricmp_utf8_ex(name, name_length, "back", pfc_infinite)) {
-                {
-                    const char* value;
-                    size_t value_length;
-                    p_params->get_param(1, value, value_length);
-                    if (value_length && *value == 3) {
-                        value++;
-                        value_length--;
-                    }
-                    p_colours.background_colour.set(mmh::strtoul_n(value, value_length, 0x10));
 
-                    if (value_length == 6 * 2 + 2 && value[6] == '|') {
-                        value += 7;
-                        value_length -= 7;
-                        p_colours.selected_background_colour.set(mmh::strtoul_n(value, value_length, 0x10));
-                    } else
-                        p_colours.selected_background_colour.set(0xffffff - p_colours.background_colour);
+                if (p_params->get_param_count() >= 4)
+                    p_colours.selected_text_colour_non_focus = get_colour_param(*p_params, 3);
+                else
+                    p_colours.selected_text_colour_non_focus = p_colours.selected_text_colour;
+            } else if (!stricmp_utf8_ex(name.data(), name.size(), "back", SIZE_MAX)) {
+                if (p_params->get_param_count() == 2) {
+                    std::tie(p_colours.background_colour, p_colours.selected_background_colour)
+                        = get_colour_pair_param(*p_params, 1);
+                } else {
+                    p_colours.background_colour = get_colour_param(*p_params, 1);
+                    p_colours.selected_background_colour = get_colour_param(*p_params, 2);
                 }
-                if (p_params->get_param_count() >= 3) {
-                    {
-                        const char* value;
-                        size_t value_length;
-                        p_params->get_param(2, value, value_length);
-                        if (value_length && *value == 3) {
-                            value++;
-                            value_length--;
-                        }
-                        p_colours.selected_background_colour.set(mmh::strtoul_n(value, value_length, 0x10));
-                    }
-                    if (p_params->get_param_count() >= 4) {
-                        const char* value;
-                        size_t value_length;
-                        p_params->get_param(3, value, value_length);
-                        if (value_length && *value == 3) {
-                            value++;
-                            value_length--;
-                        }
-                        p_colours.selected_background_colour_non_focus.set(mmh::strtoul_n(value, value_length, 0x10));
-                    } else
-                        p_colours.selected_background_colour_non_focus.set(p_colours.selected_background_colour);
-                } else
-                    p_colours.selected_background_colour_non_focus.set(p_colours.selected_background_colour);
-            } else if (name_length >= 6 && !stricmp_utf8_ex(name, 6, "frame-", pfc_infinite)) {
-                const char* p_side = name;
-                p_side += 6;
-                if (!stricmp_utf8_ex(p_side, name_length - 6, "left", pfc_infinite)) {
-                    const char* value;
-                    size_t value_length;
-                    p_params->get_param(1, value, value_length);
-                    p_colours.use_frame_left = (value_length == 1 && *value == '1');
-                    if (p_params->get_param_count() >= 3) {
-                        {
-                            const char* value;
-                            size_t value_length;
-                            p_params->get_param(2, value, value_length);
-                            if (value_length && *value == 3) {
-                                value++;
-                                value_length--;
-                            }
-                            p_colours.frame_left.set(mmh::strtoul_n(value, value_length, 0x10));
-                        }
-                    }
-                } else if (!stricmp_utf8_ex(p_side, name_length - 6, "top", pfc_infinite)) {
-                    const char* value;
-                    size_t value_length;
-                    p_params->get_param(1, value, value_length);
-                    p_colours.use_frame_top = (value_length == 1 && *value == '1');
-                    if (p_params->get_param_count() >= 3) {
-                        {
-                            const char* value;
-                            size_t value_length;
-                            p_params->get_param(2, value, value_length);
-                            if (value_length && *value == 3) {
-                                value++;
-                                value_length--;
-                            }
-                            p_colours.frame_top.set(mmh::strtoul_n(value, value_length, 0x10));
-                        }
-                    }
-                } else if (!stricmp_utf8_ex(p_side, name_length - 6, "right", pfc_infinite)) {
-                    const char* value;
-                    size_t value_length;
-                    p_params->get_param(1, value, value_length);
-                    p_colours.use_frame_right = (value_length == 1 && *value == '1');
-                    if (p_params->get_param_count() >= 3) {
-                        {
-                            const char* value;
-                            size_t value_length;
-                            p_params->get_param(2, value, value_length);
-                            if (value_length && *value == 3) {
-                                value++;
-                                value_length--;
-                            }
-                            p_colours.frame_right.set(mmh::strtoul_n(value, value_length, 0x10));
-                        }
-                    }
-                } else if (!stricmp_utf8_ex(p_side, name_length - 6, "bottom", pfc_infinite)) {
-                    const char* value;
-                    size_t value_length;
-                    p_params->get_param(1, value, value_length);
-                    p_colours.use_frame_bottom = (value_length == 1 && *value == '1');
-                    if (p_params->get_param_count() >= 3) {
-                        {
-                            const char* value;
-                            size_t value_length;
-                            p_params->get_param(2, value, value_length);
-                            if (value_length && *value == 3) {
-                                value++;
-                                value_length--;
-                            }
-                            p_colours.frame_bottom.set(mmh::strtoul_n(value, value_length, 0x10));
-                        }
-                    }
+
+                if (p_params->get_param_count() >= 4)
+                    p_colours.selected_background_colour_non_focus = get_colour_param(*p_params, 3);
+                else
+                    p_colours.selected_background_colour_non_focus = p_colours.selected_background_colour;
+            } else if (name.size() >= 6 && !stricmp_utf8_ex(name.data(), 6, "frame-", SIZE_MAX)) {
+                const auto side_name = name.substr(6);
+                const auto use_frame = tf::get_param(*p_params, 1) == "1"sv;
+                const auto colour = p_params->get_param_count() >= 3
+                    ? std::make_optional(get_colour_param(*p_params, 2))
+                    : std::nullopt;
+
+                if (!stricmp_utf8_ex(side_name.data(), side_name.size(), "left", SIZE_MAX)) {
+                    p_colours.use_frame_left = use_frame;
+
+                    if (colour)
+                        p_colours.frame_left = *colour;
+                } else if (!stricmp_utf8_ex(side_name.data(), side_name.size(), "top", SIZE_MAX)) {
+                    p_colours.use_frame_top = use_frame;
+
+                    if (colour)
+                        p_colours.frame_top = *colour;
+                } else if (!stricmp_utf8_ex(side_name.data(), side_name.size(), "right", SIZE_MAX)) {
+                    p_colours.use_frame_right = use_frame;
+
+                    if (colour)
+                        p_colours.frame_right = *colour;
+                } else if (!stricmp_utf8_ex(side_name.data(), side_name.size(), "bottom", SIZE_MAX)) {
+                    p_colours.use_frame_bottom = use_frame;
+
+                    if (colour)
+                        p_colours.frame_bottom = *colour;
                 }
             }
             p_found_flag = true;
             return true;
         }
-    } else if (!stricmp_utf8_ex(p_name, p_name_length, "calculate_blend_target", pfc_infinite)) {
+    } else if (!stricmp_utf8_ex(p_name, p_name_length, "calculate_blend_target", SIZE_MAX)) {
         if (p_params->get_param_count() == 1) {
             const char* p_val;
             size_t p_val_length;
@@ -328,7 +257,7 @@ bool StyleTitleformatHook::process_function(titleformat_text_out* p_out, const c
             p_found_flag = true;
             return true;
         }
-    } else if (!stricmp_utf8_ex(p_name, p_name_length, "offset_colour", pfc_infinite)) {
+    } else if (!stricmp_utf8_ex(p_name, p_name_length, "offset_colour", SIZE_MAX)) {
         if (p_params->get_param_count() == 3) {
             const char* p_val;
             const char* p_val2;

--- a/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_style.cpp
@@ -208,9 +208,16 @@ bool StyleTitleformatHook::process_function(titleformat_text_out* p_out, const c
                     p_colours.selected_background_colour_non_focus = get_colour_param(*p_params, 3);
                 else
                     p_colours.selected_background_colour_non_focus = p_colours.selected_background_colour;
+            } else if (!stricmp_utf8_ex(name.data(), name.size(), "group-line", SIZE_MAX)) {
+                const auto param_1 = tf::get_param(*p_params, 1);
+                p_colours.show_group_line = param_1 == "1"sv || param_1 == "true"sv;
+
+                if (p_params->get_param_count() == 3)
+                    p_colours.group_line_colour = get_colour_param(*p_params, 2);
             } else if (name.size() >= 6 && !stricmp_utf8_ex(name.data(), 6, "frame-", SIZE_MAX)) {
                 const auto side_name = name.substr(6);
-                const auto use_frame = tf::get_param(*p_params, 1) == "1"sv;
+                const auto param_1 = tf::get_param(*p_params, 1);
+                const auto use_frame = param_1 == "1"sv || param_1 == "true"sv;
                 const auto colour = p_params->get_param_count() >= 3
                     ? std::make_optional(get_colour_param(*p_params, 2))
                     : std::nullopt;

--- a/foo_ui_columns/ng_playlist/ng_playlist_style.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist_style.h
@@ -19,6 +19,8 @@ struct CellStyleData {
     bool use_frame_top : 1 {};
     bool use_frame_right : 1 {};
     bool use_frame_bottom : 1 {};
+    bool show_group_line : 1 {true};
+    std::optional<Colour> group_line_colour;
     uih::text_style::FormatProperties format_properties;
 
     static CellStyleData create_default();


### PR DESCRIPTION
Resolves #1583

This adds the ability to hide or change the colour of the horizontal lines next to group headings in the playlist view using the `$set_style()` function in the global style script.

For example, `$set_style(group-line,false)` hides the lines while `$set_style(group-line,true,$rgb(255,0,0))` makes them red.