### PR TITLE
Add context menu to playlist view search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
   [#1680](https://github.com/reupen/columns_ui/pull/1680),
   [#1686](https://github.com/reupen/columns_ui/pull/1686),
   [#1689](https://github.com/reupen/columns_ui/pull/1689),
-  [#1693](https://github.com/reupen/columns_ui/pull/1693)]
+  [#1693](https://github.com/reupen/columns_ui/pull/1693),
+  [#1704](https://github.com/reupen/columns_ui/pull/1704)]
 
 - The horizontal lines next to group headings in the playlist view can now be
   customised using the global style script.

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -682,6 +682,16 @@ const char* PlaylistView::PlaylistViewSearchContext::get_item_text(size_t index)
     return m_items[index]->c_str();
 }
 
+bool PlaylistView::PlaylistViewSearchBarHost::on_context_menu(HWND wnd, POINT pt)
+{
+    uih::Menu menu;
+    uih::MenuCommandCollector collector;
+    menu.append_command(collector.add([] { cui::prefs::page_playlist_view.get_static_instance().show_tab("Search"); }),
+        L"Search bar options");
+    collector.execute(menu.run(wnd, pt));
+    return true;
+}
+
 void PlaylistView::s_create_message_window()
 {
     uie::container_window_v3_config config(L"{columns_ui_playlist_view_message_window_goJRO8xwg7s}", false);

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -299,6 +299,7 @@ private:
         }
         void on_close() override { m_playlist_search.reset(); }
         bool on_keydown(WPARAM wp) override { return fb2k_utils::process_edit_keyboard_shortcuts(wp); }
+        bool on_context_menu(HWND wnd, POINT pt) override;
 
         std::variant<wil::unique_hbitmap, wil::unique_hicon> create_icon(
             uih::lv::SearchBarIconId icon_id, int width, int height, bool is_dark) override


### PR DESCRIPTION
This adds a simple context menu to the playlist view search bar.

The context menu contains a single item that opens the Search tab on the Playlist view preferences page.