### PR TITLE
Improve live editing compatiblity with non-main-thread windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Development version
+## 3.5.0-alpha.1
 
 ### Features
 
@@ -69,6 +69,16 @@
   [[#1692](https://github.com/reupen/columns_ui/pull/1692)]
 
 ### Bug fixes
+
+- During live layout editing, right-clicking on panels that embed Microsoft Edge
+  WebView2 controls now behaves as expected.
+  [[#1705](https://github.com/reupen/columns_ui/pull/1705)]
+
+  The same fix applies to any panel that embeds windows in a different thread or
+  process.
+
+  Showing the live editing context menu using the application key remains
+  unsupported in such panels.
 
 - A bug in the playlist view where, when auto-sizing columns and grouping are
   enabled, columns weren’t resized correctly when changing the items font was

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -279,6 +279,7 @@
     <ClCompile Include="icons.cpp" />
     <ClCompile Include="imaging.cpp" />
     <ClCompile Include="list_view_drop_target.cpp" />
+    <ClCompile Include="live_editing_utils.cpp" />
     <ClCompile Include="ng_playlist\ng_playlist_config.cpp" />
     <ClCompile Include="permutation_utils.cpp" />
     <ClCompile Include="playlist_selector.cpp" />
@@ -476,6 +477,7 @@
     <ClInclude Include="item_details_text.h" />
     <ClInclude Include="item_properties.h" />
     <ClInclude Include="list_view_drop_target.h" />
+    <ClInclude Include="live_editing_utils.h" />
     <ClInclude Include="menu_helpers.h" />
     <ClInclude Include="metadb_helpers.h" />
     <ClInclude Include="mw_drop_target.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -668,6 +668,9 @@
     <ClCompile Include="tab_pview_search.cpp">
       <Filter>Config UI</Filter>
     </ClCompile>
+    <ClCompile Include="live_editing_utils.cpp">
+      <Filter>Layout host</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -1015,6 +1018,9 @@
     </ClInclude>
     <ClInclude Include="buttons_config.h">
       <Filter>Buttons toolbar</Filter>
+    </ClInclude>
+    <ClInclude Include="live_editing_utils.h">
+      <Filter>Layout host</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/layout.cpp
+++ b/foo_ui_columns/layout.cpp
@@ -2,6 +2,7 @@
 #include "layout.h"
 
 #include "dark_mode_dialog.h"
+#include "live_editing_utils.h"
 #include "splitter_utils.h"
 #include "main_window.h"
 #include "panel_utils.h"
@@ -365,16 +366,59 @@ void LayoutWindow::enter_layout_editing_mode()
 {
     if (get_wnd()) {
         register_message_hook(uih::MessageHookType::type_get_message, this);
-        register_message_hook(uih::MessageHookType::type_mouse, this);
+
+        m_low_level_token = cui::layout::add_low_level_mouse_handler(
+            [this, layout_wnd = get_wnd(), main_thread_id = GetCurrentThreadId(), rbutton_down_handled{false}](
+                WPARAM msg, const MSLLHOOKSTRUCT& mllhs) mutable -> bool {
+                if (msg != WM_RBUTTONDOWN && (msg != WM_RBUTTONUP || !rbutton_down_handled))
+                    return false;
+
+                rbutton_down_handled = false;
+                const auto wnd = WindowFromPoint(mllhs.pt);
+
+                if (!IsChild(layout_wnd, wnd))
+                    return false;
+
+                if (core_api::is_shutting_down())
+                    return false;
+
+                if (GUITHREADINFO gti{sizeof(gti)};
+                    GetGUIThreadInfo(main_thread_id, &gti) && gti.hwndMenuOwner != nullptr) {
+                    PostMessage(gti.hwndMenuOwner, WM_CANCELMODE, 0, 0);
+                }
+
+                if (msg == WM_RBUTTONDOWN) {
+                    rbutton_down_handled = true;
+                    return true;
+                }
+
+                fb2k::inMainThread([this, wnd, pt{mllhs.pt}] {
+                    if (!m_layout_editing_active)
+                        return;
+
+                    uie::splitter_window_v2_ptr splitter_v2;
+                    splitter_v2 &= m_child;
+
+                    pfc::list_t<uie::window::ptr> hierarchy;
+                    if (splitter_v2.is_valid() && !splitter_v2->is_point_ours(wnd, pt, hierarchy))
+                        return;
+
+                    if (!splitter_v2.is_valid() && m_child.is_valid())
+                        hierarchy.add_item(m_child);
+
+                    if (!m_trans_fill.get_wnd())
+                        run_live_edit_base_delayed(wnd, pt, hierarchy);
+                });
+
+                return true;
+            });
     }
-    //__enter_layout_editing_mode_recur(m_child);
 }
 
 void LayoutWindow::exit_layout_editing_mode()
 {
+    m_low_level_token.reset();
     deregister_message_hook(uih::MessageHookType::type_get_message, this);
-    deregister_message_hook(uih::MessageHookType::type_mouse, this);
-    //__exit_layout_editing_mode_recur(m_child);
 }
 
 bool LayoutWindow::is_menu_focused()
@@ -1073,37 +1117,7 @@ bool LayoutWindow::on_hooked_message(uih::MessageHookType p_type, int code, WPAR
         }
         return false;
     }
-    if (p_type == uih::MessageHookType::type_mouse) {
-        const auto* lpmhs = reinterpret_cast<LPMOUSEHOOKSTRUCT>(lp);
-        if (lpmhs->hwnd != get_wnd() && !IsChild(get_wnd(), lpmhs->hwnd))
-            return false;
 
-        uie::splitter_window_v2_ptr splitter_v2;
-
-        if (m_child.is_valid())
-            m_child->service_query_t(splitter_v2);
-
-        const auto is_rbutton_down = wp == WM_RBUTTONDOWN || wp == WM_NCRBUTTONDOWN;
-        const auto is_rbutton_up = wp == WM_RBUTTONUP || wp == WM_NCRBUTTONUP;
-
-        if (!is_rbutton_down && !is_rbutton_up)
-            return false;
-
-        pfc::list_t<uie::window::ptr> hierarchy;
-        if (splitter_v2.is_valid() && !splitter_v2->is_point_ours(lpmhs->hwnd, lpmhs->pt, hierarchy))
-            return false;
-
-        if (is_rbutton_down) {
-            SendMessage(lpmhs->hwnd, WM_CANCELMODE, NULL, NULL);
-        } else {
-            if (!splitter_v2.is_valid() && m_child.is_valid())
-                hierarchy.add_item(m_child);
-
-            if (!m_trans_fill.get_wnd())
-                run_live_edit_base_delayed(lpmhs->hwnd, lpmhs->pt, hierarchy);
-        }
-        return true;
-    }
     return false;
 }
 
@@ -1166,7 +1180,7 @@ LRESULT LayoutWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         const auto cmd = static_cast<unsigned>(TrackPopupMenu(menu.get(),
             TPM_RIGHTBUTTON | TPM_NONOTIFY | TPM_RETURNCMD | (is_keyboard ? TPM_CENTERALIGN | TPM_VCENTERALIGN : 0),
-            screen_pt.x, screen_pt.y, 0, wnd, nullptr));
+            screen_pt.x, screen_pt.y, 0, get_wnd(), nullptr));
 
         if (cmd >= base_id)
             extension_menu_nodes->execute_by_id(cmd);
@@ -1175,8 +1189,8 @@ LRESULT LayoutWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     }
     case WM_DESTROY:
         destroy_child();
+        m_low_level_token.reset();
         deregister_message_hook(uih::MessageHookType::type_get_message, this);
-        deregister_message_hook(uih::MessageHookType::type_mouse, this);
         break;
     }
     return DefWindowProc(wnd, msg, wp, lp);

--- a/foo_ui_columns/layout.h
+++ b/foo_ui_columns/layout.h
@@ -125,6 +125,7 @@ private:
     HWND m_child_wnd{nullptr};
     bool m_layout_editing_active{false};
     LiveEditData m_live_edit_data;
+    mmh::EventToken::Ptr m_low_level_token;
 };
 
 extern LayoutWindow g_layout_window;

--- a/foo_ui_columns/live_editing_utils.cpp
+++ b/foo_ui_columns/live_editing_utils.cpp
@@ -1,0 +1,103 @@
+#include "pch.h"
+
+#include "live_editing_utils.h"
+
+namespace cui::layout {
+
+namespace {
+
+constexpr auto MSG_QUIT_THREAD = WM_APP;
+
+std::vector<std::shared_ptr<LowLevelMouseHandler>> ll_mouse_handlers;
+std::optional<std::jthread> ll_mouse_thread;
+std::mutex ll_mouse_handlers_mutex;
+
+class LowLevelMouseHookToken : public mmh::EventToken {
+public:
+    explicit LowLevelMouseHookToken(std::shared_ptr<LowLevelMouseHandler> this_handler)
+        : m_this_handler(std::move(this_handler))
+    {
+    }
+
+    ~LowLevelMouseHookToken() override
+    {
+        {
+            std::scoped_lock _(ll_mouse_handlers_mutex);
+            std::erase(ll_mouse_handlers, m_this_handler);
+
+            if (!ll_mouse_handlers.empty())
+                return;
+        }
+
+        if (!ll_mouse_thread)
+            return;
+
+        const auto thread_id = GetThreadId(ll_mouse_thread->native_handle());
+        PostThreadMessage(thread_id, MSG_QUIT_THREAD, 0, 0);
+        ll_mouse_thread.reset();
+    }
+
+private:
+    std::shared_ptr<LowLevelMouseHandler> m_this_handler;
+};
+
+LRESULT CALLBACK handle_hooked_message(int code, WPARAM wp, LPARAM lp) noexcept
+{
+    if (code >= 0) {
+        decltype(ll_mouse_handlers) handlers_copy;
+
+        {
+            std::scoped_lock _(ll_mouse_handlers_mutex);
+            handlers_copy = ll_mouse_handlers;
+        }
+
+        for (const auto& handler : handlers_copy) {
+            if ((*handler)(wp, *reinterpret_cast<LPMSLLHOOKSTRUCT>(lp)))
+                return TRUE;
+        }
+    }
+
+    return CallNextHookEx(nullptr, code, wp, lp);
+}
+
+} // namespace
+
+mmh::EventToken::Ptr add_low_level_mouse_handler(LowLevelMouseHandler handler)
+{
+    auto event_handler_ptr = std::make_shared<LowLevelMouseHandler>(handler);
+
+    {
+        std::scoped_lock _(ll_mouse_handlers_mutex);
+        ll_mouse_handlers.emplace_back(event_handler_ptr);
+    }
+
+    if (!ll_mouse_thread) {
+        ll_mouse_thread.emplace([&]() {
+            TRACK_CALL_TEXT("cui::layout::LLMouseHookThread");
+            (void)mmh::set_thread_description(GetCurrentThread(), L"[Columns UI] Live editing mouse hook");
+
+            const auto hook
+                = SetWindowsHookEx(WH_MOUSE_LL, &handle_hooked_message, wil::GetModuleInstanceHandle(), NULL);
+            MSG msg{};
+            BOOL res{};
+
+            while ((res = GetMessage(&msg, nullptr, 0, 0)) != 0) {
+                if (res == -1)
+                    uBugCheck();
+
+                if (msg.hwnd == nullptr && msg.message == MSG_QUIT_THREAD) {
+                    PostQuitMessage(0);
+                } else {
+                    TranslateMessage(&msg);
+                    DispatchMessage(&msg);
+                }
+            }
+
+            UnhookWindowsHookEx(hook);
+        });
+    }
+
+    return std::make_unique<LowLevelMouseHookToken>(std::move(event_handler_ptr));
+}
+
+} // namespace cui::layout

--- a/foo_ui_columns/live_editing_utils.h
+++ b/foo_ui_columns/live_editing_utils.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace cui::layout {
+
+using LowLevelMouseHandler = std::function<bool(WPARAM msg, const MSLLHOOKSTRUCT& mllhs)>;
+mmh::EventToken::Ptr add_low_level_mouse_handler(LowLevelMouseHandler handler);
+
+} // namespace cui::layout


### PR DESCRIPTION
#1577

This makes live editing correctly intercept right-clicks on panels that have child windows in a different thread or process. This includes panels that have embedded Microsoft Edge WebView2 windows.

This was achieved using a low-level mouse hook, similar to how auto-hide is implemented in rows and panels.

Note that live editing still does not intercept presses of the application (menu) key in such panels. (I’m reluctant to add a low-level keyboard hook, though it looks like even Chromium uses one for something…)