### PR TITLE
Fix incorrect processing of keyboard shortcuts in Filter search toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.5.0-alpha.2
+
+### Bug fixes
+
+- A bug where keyboard shortcuts were incorrectly triggered when the Filter
+  search toolbar was in the layout or toolbar area was fixed.
+  [[#1716](https://github.com/reupen/columns_ui/pull/1716)]
+
 ## 3.5.0-alpha.1
 
 ### Features

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -719,11 +719,12 @@ LRESULT FilterSearchToolbar::on_search_edit_message(HWND wnd, UINT msg, WPARAM w
             commit_search_results(uGetWindowText(m_search_editbox), true);
             m_ignore_next_wm_char_message = true;
             return 0;
-        }
-    default:
-        if (fb2k_utils::process_edit_keyboard_shortcuts(wp)) {
-            m_ignore_next_wm_char_message = true;
-            return 0;
+        default:
+            if (fb2k_utils::process_edit_keyboard_shortcuts(wp)) {
+                m_ignore_next_wm_char_message = true;
+                return 0;
+            }
+            break;
         }
         break;
     case WM_CHAR:


### PR DESCRIPTION
This fixes a bug where the Filter search toolbar triggered keyboard shortcuts incorrectly due to a misplaced brace.