### PR TITLE
Fix font picker crash when restored state has invalid font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## 3.5.0-alpha.3
+
+### Bug fixes
+
+- A regression in alpha 1 that caused the Fonts tab on the Colours and fonts
+  preferences to crash when a previously selected font could not be found was
+  fixed. [[#1717](https://github.com/reupen/columns_ui/pull/1717)]
+
 ## 3.5.0-alpha.2
 
 ### Bug fixes

--- a/foo_ui_columns/font_picker.cpp
+++ b/foo_ui_columns/font_picker.cpp
@@ -673,15 +673,16 @@ void DirectWriteFontPicker::handle_family_change(bool skip_face_change)
     m_font_faces.clear();
     m_font_faces_text_formats.clear();
 
-    std::vector<uih::direct_write::AxisRange> axes;
-
-    if (m_configure_axes_button) {
-        const auto axes = m_font_family->get().axes();
-        EnableWindow(m_configure_axes_button, m_font_family && !axes.empty());
+    if (!m_font_family) {
+        if (m_configure_axes_button)
+            EnableWindow(m_configure_axes_button, FALSE);
+        return;
     }
 
-    if (!m_font_family)
-        return;
+    const auto axes = m_font_family->get().axes();
+
+    if (m_configure_axes_button)
+        EnableWindow(m_configure_axes_button, !axes.empty());
 
     try {
         m_font_faces = m_font_family->get().fonts();


### PR DESCRIPTION
This fixes a regression in fdfdc312a26a4d74adca0d9421ba7765f5b89442 that caused the DirectWrite-based font picker to crash when restoring a previous font selection if the font that was previously selected no longer exists.