### PR TITLE
Improve focus indicator hiding behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   Columns UI on Windows 8.1 was improved.
   [[#1722](https://github.com/reupen/columns_ui/pull/1722)]
 
+- Pressing multimedia keys no longer shows hidden focused item indicators.
+  [[#1723](https://github.com/reupen/columns_ui/pull/1723)]
+
+  Additionally, the Tab key unhides hidden focused item indicators in more
+  scenarios.
+
 ## 3.5.0-alpha.3
 
 ### Bug fixes

--- a/foo_ui_columns/drop_down_list_toolbar.h
+++ b/foo_ui_columns/drop_down_list_toolbar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "win32.h"
+
 template <class ToolbarArgs>
 class DropDownListToolbar : public ui_extension::container_uie_window_v3 {
 public:
@@ -374,10 +376,12 @@ LRESULT DropDownListToolbar<ToolbarArgs>::on_hook(HWND wnd, UINT msg, WPARAM wp,
         if ((m_ignore_next_wm_char_message = g_process_keydown_keyboard_shortcuts(wp)))
             return 0;
 
-        if (wp == VK_TAB)
-            g_on_tab(wnd);
+        if (wp == VK_TAB) {
+            cui::win32::handle_tab_key(wnd);
+            return 0;
+        }
 
-        SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
+        uih::show_focus_indicator_on_keydown(get_wnd(), wp);
         break;
     }
     case WM_SYSKEYDOWN:

--- a/foo_ui_columns/filter_search_bar.cpp
+++ b/foo_ui_columns/filter_search_bar.cpp
@@ -8,6 +8,7 @@
 #include "filter_config_var.h"
 #include "filter_utils.h"
 #include "icons.h"
+#include "win32.h"
 
 namespace cui::panels::filter {
 
@@ -703,7 +704,7 @@ LRESULT FilterSearchToolbar::on_search_edit_message(HWND wnd, UINT msg, WPARAM w
         m_ignore_next_wm_char_message = false;
         switch (wp) {
         case VK_TAB:
-            g_on_tab(wnd);
+            cui::win32::handle_tab_key(wnd);
             return 0;
         case VK_ESCAPE:
             if (m_wnd_last_focused && IsWindow(m_wnd_last_focused)) {

--- a/foo_ui_columns/get_msg_hook.cpp
+++ b/foo_ui_columns/get_msg_hook.cpp
@@ -3,6 +3,7 @@
 #include "layout.h"
 #include "rebar.h"
 #include "main_window.h"
+#include "win32.h"
 
 extern cui::rebar::RebarWindow* g_rebar_window;
 
@@ -39,11 +40,10 @@ bool GetMsgHook::on_hooked_message(uih::MessageHookType p_type, int code, WPARAM
 
             const auto flags = SendMessage(lpmsg->hwnd, WM_GETDLGCODE, 0, reinterpret_cast<LPARAM>(lpmsg));
             if (!((flags & DLGC_WANTTAB) || (flags & DLGC_WANTMESSAGE))) {
-                ui_extension::window::g_on_tab(lpmsg->hwnd);
+                cui::win32::handle_tab_key(lpmsg->hwnd);
                 lpmsg->message = WM_NULL;
                 lpmsg->lParam = 0;
                 lpmsg->wParam = 0;
-                SendMessage(lpmsg->hwnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
             }
         }
     } else if (lpmsg->message == WM_MOUSEWHEEL && IsChild(cui::main_window.get_wnd(), lpmsg->hwnd)) {

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -436,25 +436,6 @@ void cui::MainWindow::resize_child_windows()
     }
 }
 
-bool process_keydown(UINT msg, LPARAM lp, WPARAM wp, bool playlist, bool keyb)
-{
-    const auto keyboard_api = keyboard_shortcut_manager_v2::get();
-
-    if (msg == WM_SYSKEYDOWN) {
-        if (keyb && uie::window::g_process_keydown_keyboard_shortcuts(wp)) {
-            return true;
-        }
-    } else if (msg == WM_KEYDOWN) {
-        if (keyb && uie::window::g_process_keydown_keyboard_shortcuts(wp)) {
-            return true;
-        }
-        if (wp == VK_TAB) {
-            uie::window::g_on_tab(GetFocus());
-        }
-    }
-    return false;
-}
-
 class MainWindowPlaylistCallback : public playlist_callback_single_static {
 public:
     void on_items_added(

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -17,8 +17,6 @@ enum {
 
 bool remember_window_pos();
 
-bool process_keydown(UINT msg, LPARAM lp, WPARAM wp, bool playlist = false, bool keyb = true);
-
 void on_show_status_change();
 void on_show_status_pane_change();
 void on_show_toolbars_change();

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -9,6 +9,7 @@
 #include "rebar.h"
 #include "status_bar.h"
 #include "system_tray.h"
+#include "win32.h"
 
 extern HWND g_status;
 
@@ -543,11 +544,16 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
         break;
     case WM_KEYDOWN:
-        if (process_keydown(msg, lp, wp))
+        if (uie::window::g_process_keydown_keyboard_shortcuts(wp))
             return 0;
+
+        if (wp == VK_TAB) {
+            win32::handle_tab_key(wnd);
+            return 0;
+        }
         break;
     case WM_SYSKEYDOWN:
-        if ((m_ignore_next_wm_syschar_message = process_keydown(msg, lp, wp)))
+        if ((m_ignore_next_wm_syschar_message = uie::window::g_process_keydown_keyboard_shortcuts(wp)))
             return 0;
         break;
     case WM_SYSCHAR:

--- a/foo_ui_columns/playlist_tabs.cpp
+++ b/foo_ui_columns/playlist_tabs.cpp
@@ -4,6 +4,7 @@
 #include "dark_mode_spin.h"
 #include "dark_mode_tabs.h"
 #include "playlist_manager_utils.h"
+#include "win32.h"
 
 namespace cui::panels::playlist_tabs {
 
@@ -287,10 +288,13 @@ LRESULT WINAPI PlaylistTabs::hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_KEYDOWN: {
         if (wp != VK_LEFT && wp != VK_RIGHT && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
+
         if (wp == VK_TAB) {
-            g_on_tab(wnd);
+            win32::handle_tab_key(wnd);
+            return 0;
         }
-        SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
+
+        uih::show_focus_indicator_on_keydown(get_wnd(), wp);
         break;
     }
     case WM_SYSKEYDOWN:

--- a/foo_ui_columns/splitter_tabs.cpp
+++ b/foo_ui_columns/splitter_tabs.cpp
@@ -3,6 +3,7 @@
 
 #include "dark_mode.h"
 #include "dark_mode_tabs.h"
+#include "win32.h"
 
 namespace cui::panels::tab_stack {
 
@@ -544,11 +545,13 @@ LRESULT TabStackPanel::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_KEYDOWN: {
         if (wp != VK_LEFT && wp != VK_RIGHT && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
+
         if (wp == VK_TAB) {
-            g_on_tab(wnd);
+            win32::handle_tab_key(wnd);
             return 0;
         }
-        SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
+
+        uih::show_focus_indicator_on_keydown(get_wnd(), wp);
         break;
     }
     case WM_SYSKEYDOWN:
@@ -1157,11 +1160,13 @@ LRESULT WINAPI TabStackPanel::on_hooked_message(HWND wnd, UINT msg, WPARAM wp, L
     case WM_KEYDOWN: {
         if (wp != VK_LEFT && wp != VK_RIGHT && g_process_keydown_keyboard_shortcuts(wp))
             return 0;
+
         if (wp == VK_TAB) {
-            g_on_tab(wnd);
+            win32::handle_tab_key(wnd);
             return 0;
         }
-        SendMessage(wnd, WM_CHANGEUISTATE, MAKEWPARAM(UIS_CLEAR, UISF_HIDEFOCUS), NULL);
+
+        uih::show_focus_indicator_on_keydown(get_wnd(), wp);
         break;
     }
     case WM_SYSKEYDOWN:

--- a/foo_ui_columns/win32.cpp
+++ b/foo_ui_columns/win32.cpp
@@ -49,4 +49,10 @@ void remove_window_styles(HWND wnd, DWORD styles_to_remove)
     SetWindowLongPtr(wnd, GWL_STYLE, current_styles & ~static_cast<DWORD_PTR>(styles_to_remove));
 }
 
+void handle_tab_key(HWND wnd)
+{
+    if (const auto focused_wnd = uie::window::g_on_tab(wnd))
+        uih::show_focus_indicator(focused_wnd);
+}
+
 } // namespace cui::win32

--- a/foo_ui_columns/win32.h
+++ b/foo_ui_columns/win32.h
@@ -9,4 +9,6 @@ std::wstring get_display_device_key(HMONITOR monitor);
 void add_window_styles(HWND wnd, DWORD styles_to_add);
 void remove_window_styles(HWND wnd, DWORD styles_to_remove);
 
+void handle_tab_key(HWND wnd);
+
 } // namespace cui::win32


### PR DESCRIPTION
This stops built-in panels from showing hidden focus indicators when pressing multimedia keys, the Windows key and certain other keys.

It also makes the tab key unhide any hidden focus indicators in the newly focused window.