### PR TITLE
Fix compilation with VS toolset version 14.51

### DIFF
--- a/vcpkg-ports/ms-gsl/portfile.cmake
+++ b/vcpkg-ports/ms-gsl/portfile.cmake
@@ -1,0 +1,25 @@
+#header-only library with an install target
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Microsoft/GSL
+    REF ${VERSION}
+    SHA512 231f80217c9296bc5fc3eca023347a1785d1c2ba3371378d20e987209a71ae6b4c3b23808d6d38312162b96c66d0ceb8366f009a3c2aeee914a19933991cc0df
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DGSL_TEST=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME Microsoft.GSL
+    CONFIG_PATH share/cmake/Microsoft.GSL
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/ms-gsl/vcpkg.json
+++ b/vcpkg-ports/ms-gsl/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "ms-gsl",
+  "version-string": "0249144ad1487bea10a2b553918e581c0c16a1c5",
+  "description": "Microsoft implementation of the Guidelines Support Library",
+  "homepage": "https://github.com/Microsoft/GSL",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,10 +20,6 @@
       "version": "2025.5.0"
     },
     {
-      "name": "ms-gsl",
-      "version": "4.2.0"
-    },
-    {
       "name": "range-v3",
       "version": "0.12.0#4"
     },

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "columns-ui",
   "version-string": "git",
-  "builtin-baseline": "84bab45d415d22042bd0b9081aea57f362da3f35",
+  "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713",
   "dependencies": [
     "cppwinrt",
     "fmt",
@@ -25,7 +25,7 @@
     },
     {
       "name": "wil",
-      "version": "1.0.250325.1"
+      "version": "1.0.260126.7"
     }
   ]
 }


### PR DESCRIPTION
This updates the Microsoft GSL library to the latest commit currently on GitHub to get rid of a compiler warning that was causing the build to fail when using the 14.51 toolset included with VS 2026 18.6.0. (See https://github.com/microsoft/GSL/issues/1231 and https://github.com/microsoft/GSL/issues/1242.)

Additionally, it updates WIL to the latest version.