### PR TITLE
Add separate font entry for playlist view search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+- The playlist view search bar font can now be configured independently of the
+  items font. [[#1731](https://github.com/reupen/columns_ui/pull/1731)]
+
 - The unsupported operating system error message that appears when trying to use
   Columns UI on Windows 8.1 was improved.
   [[#1722](https://github.com/reupen/columns_ui/pull/1722)]
@@ -13,6 +16,13 @@
 
   Additionally, the Tab key unhides hidden focused item indicators in more
   scenarios.
+
+### Internal changes
+
+- The component is now compiled with Visual Studio 2026 toolset version 14.51.
+
+- Some dependencies were updated.
+  [[#1730](https://github.com/reupen/columns_ui/pull/1730)]
 
 ## 3.5.0-alpha.3
 

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -6,7 +6,7 @@
 namespace cui::utils {
 
 template <GUID ColoursClientId, GUID ItemsFontId, GUID HeaderFontId = GUID{}, GUID GroupFontId = GUID{},
-    typename t_window = uie::window>
+    GUID SearchBarFontId = GUID{}, typename t_window = uie::window>
 class ListViewPanelBase
     : public uih::ListView
     , public t_window {
@@ -102,6 +102,17 @@ protected:
         const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
         const auto group_font = font_api->get_font(GroupFontId);
         set_group_font(fonts::get_text_format(group_font, layout_cache_size));
+    }
+
+    void recreate_search_bar_text_format(size_t layout_cache_size = 32)
+    {
+        if (SearchBarFontId == GUID{})
+            return;
+
+        const auto font_api = fb2k::std_api_get<fonts::manager_v3>();
+        const auto search_bar_font = font_api->get_font(SearchBarFontId);
+        const auto search_bar_log_font = search_bar_font->log_font();
+        set_search_bar_font(fonts::get_text_format(search_bar_font, layout_cache_size), search_bar_log_font);
     }
 
 private:

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -508,6 +508,12 @@ void PlaylistView::s_on_group_font_change()
         window->on_group_font_change();
 }
 
+void PlaylistView::s_on_search_bar_font_change()
+{
+    for (auto& window : s_windows)
+        window->recreate_search_bar_text_format();
+}
+
 void PlaylistView::s_update_all_items()
 {
     for (auto& window : s_windows)
@@ -1067,6 +1073,7 @@ void PlaylistView::notify_on_initialisation()
     recreate_items_text_format(item_text_layout_cache_size);
     recreate_header_text_format();
     recreate_group_text_format(group_text_layout_cache_size);
+    recreate_search_bar_text_format();
 
     set_sorting_enabled(cfg_header_hottrack != 0);
     set_show_sort_indicators(cfg_show_sort_arrows != 0);
@@ -1814,6 +1821,8 @@ uie::window_factory<PlaylistView> g_pvt;
 
 ColoursClient::factory<ColoursClient> g_appearance_client_ngpv_impl;
 
+namespace {
+
 class PlaylistViewItemFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return items_font_id; }
@@ -1823,6 +1832,8 @@ public:
 
     void on_font_changed() const override { PlaylistView::s_on_font_change(); }
 };
+
+PlaylistViewItemFontClient::factory<PlaylistViewItemFontClient> _font_client_ngpv;
 
 class PlaylistViewHeaderFontClient : public fonts::client {
 public:
@@ -1834,6 +1845,8 @@ public:
     void on_font_changed() const override { PlaylistView::s_on_header_font_change(); }
 };
 
+PlaylistViewHeaderFontClient::factory<PlaylistViewHeaderFontClient> _font_header_client_ngpv;
+
 class PlaylistViewGroupFontClient : public fonts::client {
 public:
     const GUID& get_client_guid() const override { return group_font_id; }
@@ -1844,9 +1857,21 @@ public:
     void on_font_changed() const override { PlaylistView::s_on_group_font_change(); }
 };
 
-PlaylistViewItemFontClient::factory<PlaylistViewItemFontClient> g_font_client_ngpv;
-PlaylistViewHeaderFontClient::factory<PlaylistViewHeaderFontClient> g_font_header_client_ngpv;
-PlaylistViewGroupFontClient::factory<PlaylistViewGroupFontClient> g_font_group_header_client_ngpv;
+PlaylistViewGroupFontClient::factory<PlaylistViewGroupFontClient> _font_group_header_client_ngpv;
+
+class PlaylistViewSearchBarFontClient : public fonts::client {
+public:
+    const GUID& get_client_guid() const override { return search_bar_font_id; }
+    void get_name(pfc::string_base& p_out) const override { p_out = "Playlist view: Search bar"; }
+
+    fonts::font_type_t get_default_font_type() const override { return fonts::font_type_items; }
+
+    void on_font_changed() const override { PlaylistView::s_on_search_bar_font_change(); }
+};
+
+PlaylistViewSearchBarFontClient::factory<PlaylistViewSearchBarFontClient> _font_search_bar_client_ngpv;
+
+} // namespace
 
 void ColoursClient::on_colour_changed(uint32_t mask) const
 {

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -14,9 +14,10 @@
 
 namespace cui::panels::playlist_view {
 
-constexpr GUID items_font_id = {0x19f8e0b3, 0xe822, 0x4f07, {0xb2, 0x0, 0xd4, 0xa6, 0x7e, 0x48, 0x72, 0xf9}};
-constexpr GUID header_font_id = {0x30fbd64c, 0x2031, 0x4f0b, {0xa9, 0x37, 0xf2, 0x16, 0x71, 0xa2, 0xe1, 0x95}};
-constexpr GUID group_font_id = {0xfb127ffa, 0x1b35, 0x4572, {0x9c, 0x1a, 0x4b, 0x96, 0xa5, 0xc5, 0xd5, 0x37}};
+constexpr GUID items_font_id{0x19f8e0b3, 0xe822, 0x4f07, {0xb2, 0x0, 0xd4, 0xa6, 0x7e, 0x48, 0x72, 0xf9}};
+constexpr GUID header_font_id{0x30fbd64c, 0x2031, 0x4f0b, {0xa9, 0x37, 0xf2, 0x16, 0x71, 0xa2, 0xe1, 0x95}};
+constexpr GUID group_font_id{0xfb127ffa, 0x1b35, 0x4572, {0x9c, 0x1a, 0x4b, 0x96, 0xa5, 0xc5, 0xd5, 0x37}};
+constexpr GUID search_bar_font_id{0xf9de2ffa, 0x1101, 0x43ab, {0xa2, 0x92, 0x17, 0x64, 0xbe, 0x2e, 0xe5, 0x67}};
 
 extern cfg_bool cfg_artwork_reflection;
 extern fbh::ConfigUint32DpiAware cfg_artwork_width;
@@ -169,7 +170,7 @@ public:
 
 class PlaylistView
     : public utils::ListViewPanelBase<ColoursClient::id, items_font_id, header_font_id, group_font_id,
-          uie::playlist_window>
+          search_bar_font_id, uie::playlist_window>
     , playlist_callback {
     friend class NgTfThread;
     friend class PlaylistViewRenderer;
@@ -204,6 +205,7 @@ public:
     static void s_on_font_change();
     static void s_on_header_font_change();
     static void s_on_group_font_change();
+    static void s_on_search_bar_font_change();
     static void g_on_sorting_enabled_change();
     static void g_on_show_sort_indicators_change();
     static void g_on_edge_style_change();


### PR DESCRIPTION
This adds a dedicated entry for the playlist view search bar on the Fonts tab on the Colours and Fonts preferences page, so that the font used in the search bar can be configured independently of the font used for items in the playlist view.