### PR TITLE
Add %is_dark% and %is_light% title formatting fields to playlist view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Features
 
+- Two new fields, `%is_dark%` and `%is_light%`, are now available in the
+  playlist view display, style, sorting and global variables scripts.
+  [[#1732](https://github.com/reupen/columns_ui/pull/1732)]
+
+  `%is_dark%` is defined when dark mode is active and `%is_light%` is defined
+  when light mode is active. The fields can be used with `$if()` for styling
+  conditional on the current mode.
+
 - The playlist view search bar font can now be configured independently of the
   items font. [[#1731](https://github.com/reupen/columns_ui/pull/1731)]
 

--- a/docs/source/playlist-view/title-formatting.md
+++ b/docs/source/playlist-view/title-formatting.md
@@ -5,7 +5,7 @@ details on functions and fields specific to those scripts.
 
 ## Fields
 
-These fields are available in display scripts, style scripts and global
+These fields are available in display scripts, style scripts, sorting and global
 variables scripts.
 
 | Field                   | Description                                |
@@ -16,4 +16,6 @@ variables scripts.
 | `%_system_day_of_week%` | The current day of the week, as a number   |
 | `%_system_hour%`        | The current hour                           |
 | `%_system_julian_day%`  | The current Julian day                     |
+| `%is_dark%`             | Defined when dark mode is active           |
+| `%is_light%`            | Defined when light mode is active          |
 | `%playlist_name%`       | The name of the active playlist            |

--- a/docs/source/reference/title-formatting-index.md
+++ b/docs/source/reference/title-formatting-index.md
@@ -52,20 +52,22 @@ available in Columns UI and not available in the Default User Interface.
 | `%_back%`                   | [Style script](/playlist-view/style-script)         | Style scripts                                         |
 | `%_display_index%`          | [Style script](/playlist-view/style-script)         | Style scripts                                         |
 | `%default_font_size%`       | [Text styling](/other/text-styling)                 | Display, style, grouping and global variables scripts |
+| `%is_dark%`                 | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
 | `%_is_group%`               | [Style script](/playlist-view/style-script)         | Style scripts                                         |
+| `%is_light%`                | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
 | `%_is_themed%`              | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%playlist_name%`           | [Title formatting](/playlist-view/title-formatting) | Display, style and global variables scripts           |
+| `%playlist_name%`           | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
 | `%_text%`                   | [Style script](/playlist-view/style-script)         | Style scripts                                         |
 | `%_selected_back%`          | [Style script](/playlist-view/style-script)         | Style scripts                                         |
 | `%_selected_back_no_focus%` | [Style script](/playlist-view/style-script)         | Style scripts                                         |
 | `%_selected_text%`          | [Style script](/playlist-view/style-script)         | Style scripts                                         |
 | `%_selected_text_no_focus%` | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%_system_day%`             | [Title formatting](/playlist-view/title-formatting) | Display, style and global variables scripts           |
-| `%_system_day_of_week%`     | [Title formatting](/playlist-view/title-formatting) | Display, style and global variables scripts           |
-| `%_system_hour%`            | [Title formatting](/playlist-view/title-formatting) | Display, style and global variables scripts           |
-| `%_system_julian_day%`      | [Title formatting](/playlist-view/title-formatting) | Display, style and global variables scripts           |
-| `%_system_month%`           | [Title formatting](/playlist-view/title-formatting) | Display, style and global variables scripts           |
-| `%_system_year%`            | [Title formatting](/playlist-view/title-formatting) | Display, style and global variables scripts           |
+| `%_system_day%`             | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
+| `%_system_day_of_week%`     | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
+| `%_system_hour%`            | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
+| `%_system_julian_day%`      | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
+| `%_system_month%`           | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
+| `%_system_year%`            | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
 
 ### Status bar
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -656,34 +656,35 @@ const char* PlaylistView::PlaylistViewSearchContext::get_item_text(size_t index)
     const auto batch_tracks = pfc::list_partial_ref_t(m_tracks, index, batch_size);
 
     const bool has_global_variables = m_global_script.is_valid();
+    auto extra_fields_provider_tf_hook = create_extra_fields_provider_tf_hook();
 
-    m_metadb->queryMulti_(batch_tracks, [this, index, has_global_variables](size_t offset, const metadb_v2_rec_t& rec) {
-        metadb_handle_v2::ptr track;
-        track &= m_tracks[index + offset];
+    m_metadb->queryMulti_(batch_tracks,
+        [this, index, has_global_variables, &extra_fields_provider_tf_hook](size_t offset, const metadb_v2_rec_t& rec) {
+            metadb_handle_v2::ptr track;
+            track &= m_tracks[index + offset];
 
-        GlobalVariableList global_variables;
-        DateTitleformatHook tf_hook_date(&m_systemtime);
-        PlaylistNameTitleformatHook tf_hook_playlist_name;
+            GlobalVariableList global_variables;
+            DateTitleformatHook tf_hook_date(&m_systemtime);
 
-        if (has_global_variables) {
-            SetGlobalTitleformatHook<true, false> tf_hook_set_global(global_variables);
-            tf::SplitterTitleformatHook tf_hook(&tf_hook_set_global, &tf_hook_date, &tf_hook_playlist_name);
-            pfc::string8 _;
-            track->formatTitle_v2(rec, &tf_hook, _, m_global_script, nullptr);
-        }
+            if (has_global_variables) {
+                SetGlobalTitleformatHook<true, false> tf_hook_set_global(global_variables);
+                tf::SplitterTitleformatHook tf_hook(&tf_hook_set_global, &tf_hook_date, &extra_fields_provider_tf_hook);
+                pfc::string8 _;
+                track->formatTitle_v2(rec, &tf_hook, _, m_global_script, nullptr);
+            }
 
-        std::string title;
-        mmh::StringAdaptor adapted_title(title);
+            std::string title;
+            mmh::StringAdaptor adapted_title(title);
 
-        SetGlobalTitleformatHook<false, true> tf_hook_get_global(global_variables);
-        tf::NullTextFormatTitleformatHook null_text_format_tf_hook;
+            SetGlobalTitleformatHook<false, true> tf_hook_get_global(global_variables);
+            tf::NullTextFormatTitleformatHook null_text_format_tf_hook;
 
-        tf::SplitterTitleformatHook tf_hook(has_global_variables ? &tf_hook_get_global : nullptr, &tf_hook_date,
-            &tf_hook_playlist_name, &null_text_format_tf_hook);
+            tf::SplitterTitleformatHook tf_hook(has_global_variables ? &tf_hook_get_global : nullptr, &tf_hook_date,
+                &extra_fields_provider_tf_hook, &null_text_format_tf_hook);
 
-        track->formatTitle_v2(rec, &tf_hook, adapted_title, m_column_script, nullptr);
-        m_items[index + offset] = std::move(title);
-    });
+            track->formatTitle_v2(rec, &tf_hook, adapted_title, m_column_script, nullptr);
+            m_items[index + offset] = std::move(title);
+        });
 
     return m_items[index]->c_str();
 }
@@ -803,6 +804,7 @@ void PlaylistView::sort_by_column_fb2k_v1(size_t column_index, bool b_descending
         m_playlist_api->activeplaylist_get_selection_mask(mask);
 
     tf::NullTextFormatTitleformatHook null_text_format_tf_hook;
+    auto extra_fields_provider_tf_hook = create_extra_fields_provider_tf_hook();
 
     SYSTEMTIME st;
     GetLocalTime(&st);
@@ -815,12 +817,11 @@ void PlaylistView::sort_by_column_fb2k_v1(size_t column_index, bool b_descending
 
             {
                 DateTitleformatHook tf_hook_date(&st);
-                PlaylistNameTitleformatHook tf_hook_playlist_name;
 
                 if (extra) {
                     SetGlobalTitleformatHook<true, false> tf_hook_set_global(extra_items);
                     tf::SplitterTitleformatHook tf_hook(
-                        &tf_hook_set_global, &tf_hook_date, &tf_hook_playlist_name, &null_text_format_tf_hook);
+                        &tf_hook_set_global, &tf_hook_date, &extra_fields_provider_tf_hook, &null_text_format_tf_hook);
                     pfc::string8 output;
                     m_playlist_api->activeplaylist_item_format_title(
                         n, &tf_hook, output, m_script_global, nullptr, play_control::display_level_none);
@@ -828,7 +829,7 @@ void PlaylistView::sort_by_column_fb2k_v1(size_t column_index, bool b_descending
 
                 SetGlobalTitleformatHook<false, true> tf_hook_get_global(extra_items);
                 tf::SplitterTitleformatHook tf_hook(extra ? &tf_hook_get_global : nullptr, &tf_hook_date,
-                    &tf_hook_playlist_name, &null_text_format_tf_hook);
+                    &extra_fields_provider_tf_hook, &null_text_format_tf_hook);
                 m_playlist_api->activeplaylist_item_format_title(n, &tf_hook, temp,
                     m_column_data[column_index].m_sort_script, nullptr, play_control::display_level_none);
             }
@@ -890,20 +891,23 @@ void PlaylistView::sort_by_column_fb2k_v2(size_t column_index, bool b_descending
     tf::NullTextFormatTitleformatHook null_text_format_tf_hook;
     std::vector<std::wstring> data{tracks.size()};
 
-    metadb_v2::get()->queryMultiParallel_(tracks,
+    struct Context {
+        tf::FieldProviderTitleformatHook extra_fields_provider_tf_hook{create_extra_fields_provider_tf_hook()};
+    };
+
+    metadb_v2::get()->queryMultiParallelEx_<Context>(tracks,
         [this, &tracks, &data, &null_text_format_tf_hook, &st, extra, column_index](
-            size_t index, const metadb_v2::rec_t& rec) {
+            size_t index, const metadb_v2::rec_t& rec, auto& context) {
             metadb_handle_v2::ptr track;
             track &= tracks[index];
 
             GlobalVariableList extra_items;
             DateTitleformatHook tf_hook_date(&st);
-            PlaylistNameTitleformatHook tf_hook_playlist_name;
 
             if (extra) {
                 SetGlobalTitleformatHook<true, false> tf_hook_set_global(extra_items);
-                tf::SplitterTitleformatHook tf_hook(
-                    &tf_hook_set_global, &tf_hook_date, &tf_hook_playlist_name, &null_text_format_tf_hook);
+                tf::SplitterTitleformatHook tf_hook(&tf_hook_set_global, &tf_hook_date,
+                    &context.extra_fields_provider_tf_hook, &null_text_format_tf_hook);
                 pfc::string8 output;
                 track->formatTitle_v2(rec, &tf_hook, output, m_script_global, nullptr);
             }
@@ -913,7 +917,7 @@ void PlaylistView::sort_by_column_fb2k_v2(size_t column_index, bool b_descending
 
             SetGlobalTitleformatHook<false, true> tf_hook_get_global(extra_items);
             tf::SplitterTitleformatHook tf_hook(extra ? &tf_hook_get_global : nullptr, &tf_hook_date,
-                &tf_hook_playlist_name, &null_text_format_tf_hook);
+                &context.extra_fields_provider_tf_hook, &null_text_format_tf_hook);
             track->formatTitle_v2(rec, &tf_hook, adapted_title, m_column_data[column_index].m_sort_script, nullptr);
 
             const char* ptr = title.c_str();
@@ -985,6 +989,8 @@ void PlaylistView::sort_by_column_fb2k_v2_26(size_t column_index, bool is_descen
     std::vector<std::wstring> data{sort_item_count};
     concurrency::combinable<std::string> format_buffer;
     concurrency::combinable<std::string> cleaned_format_buffer;
+    concurrency::combinable<tf::FieldProviderTitleformatHook> extra_fields_provider_tf_hook(
+        create_extra_fields_provider_tf_hook);
 
     concurrency::parallel_for(size_t{}, sort_item_count, [&](size_t sort_item_index) {
         const auto item_index = is_selection_only ? source_indices[sort_item_index] : sort_item_index;
@@ -994,12 +1000,12 @@ void PlaylistView::sort_by_column_fb2k_v2_26(size_t column_index, bool is_descen
         {
             GlobalVariableList extra_items;
             DateTitleformatHook tf_hook_date(&st);
-            PlaylistNameTitleformatHook tf_hook_playlist_name;
+            auto& local_extra_fields_provider_tf_hook = extra_fields_provider_tf_hook.local();
 
             if (use_global_variables) {
                 SetGlobalTitleformatHook<true, false> tf_hook_set_global(extra_items);
-                tf::SplitterTitleformatHook tf_hook(
-                    &tf_hook_set_global, &tf_hook_date, &tf_hook_playlist_name, &null_text_format_tf_hook);
+                tf::SplitterTitleformatHook tf_hook(&tf_hook_set_global, &tf_hook_date,
+                    &local_extra_fields_provider_tf_hook, &null_text_format_tf_hook);
                 pfc::string8 output;
                 m_playlist_api->activeplaylist_item_format_title(
                     item_index, &tf_hook, output, m_script_global, nullptr, play_control::display_level_basic);
@@ -1007,7 +1013,7 @@ void PlaylistView::sort_by_column_fb2k_v2_26(size_t column_index, bool is_descen
 
             SetGlobalTitleformatHook<false, true> tf_hook_get_global(extra_items);
             tf::SplitterTitleformatHook tf_hook(use_global_variables ? &tf_hook_get_global : nullptr, &tf_hook_date,
-                &tf_hook_playlist_name, &null_text_format_tf_hook);
+                &local_extra_fields_provider_tf_hook, &null_text_format_tf_hook);
 
             mmh::StringAdaptor adapted_format_buffer(format_buffer_ref);
             m_playlist_api->activeplaylist_item_format_title(item_index, &tf_hook, adapted_format_buffer,
@@ -1486,7 +1492,7 @@ void PlaylistView::notify_update_item_data(size_t index)
     GetLocalTime(&st);
 
     DateTitleformatHook tf_hook_date(&st);
-    PlaylistNameTitleformatHook tf_hook_playlist_name;
+    auto extra_fields_provider_tf_hook = create_extra_fields_provider_tf_hook();
 
     const auto items_font_size = get_items_font_size_pt().value_or(0.f);
     const auto group_font_size = get_group_font_size_pt().value_or(0.f);
@@ -1495,7 +1501,7 @@ void PlaylistView::notify_update_item_data(size_t index)
     if (b_global) {
         SetGlobalTitleformatHook<true, false> tf_hook_set_global(globals);
         tf::SplitterTitleformatHook tf_hook(
-            &tf_hook_set_global, &tf_hook_date, &tf_hook_playlist_name, &text_format_tf_hook);
+            &tf_hook_set_global, &tf_hook_date, &extra_fields_provider_tf_hook, &text_format_tf_hook);
         m_playlist_api->activeplaylist_item_format_title(
             index, &tf_hook, str_dummy, m_script_global, nullptr, play_control::display_level_all);
     }
@@ -1529,7 +1535,7 @@ void PlaylistView::notify_update_item_data(size_t index)
         if (ptr.is_valid() && m_script_global_style.is_valid()) {
             StyleTitleformatHook tf_hook_style(style_data_group, group_display_index, true);
             tf::SplitterTitleformatHook tf_hook(&tf_hook_style, b_global ? &tf_hook_get_global : nullptr, &tf_hook_date,
-                &tf_hook_playlist_name, &group_style_text_format_tf_hook);
+                &extra_fields_provider_tf_hook, &group_style_text_format_tf_hook);
             ptr->format_title(&tf_hook, temp, m_script_global_style, nullptr);
         }
 
@@ -1540,8 +1546,8 @@ void PlaylistView::notify_update_item_data(size_t index)
     uih::text_style::FormatProperties global_format_properties;
 
     for (size_t i = 0; i < count; i++) {
-        tf::SplitterTitleformatHook tf_hook(
-            b_global ? &tf_hook_get_global : nullptr, &tf_hook_date, &tf_hook_playlist_name, &text_format_tf_hook);
+        tf::SplitterTitleformatHook tf_hook(b_global ? &tf_hook_get_global : nullptr, &tf_hook_date,
+            &extra_fields_provider_tf_hook, &text_format_tf_hook);
 
         m_playlist_api->activeplaylist_item_format_title(
             index, &tf_hook, temp, m_column_data[i].m_display_script, nullptr, playback_control::display_level_all);
@@ -1557,7 +1563,7 @@ void PlaylistView::notify_update_item_data(size_t index)
                 StyleTitleformatHook tf_hook_style(style_data_item, item_display_index);
                 tf::MergingTextFormatTitleformatHook global_style_text_format_tf_hook(items_font_size, {});
                 tf::SplitterTitleformatHook global_style_tf_hook(&tf_hook_style,
-                    b_global ? &tf_hook_get_global : nullptr, &tf_hook_date, &tf_hook_playlist_name,
+                    b_global ? &tf_hook_get_global : nullptr, &tf_hook_date, &extra_fields_provider_tf_hook,
                     &global_style_text_format_tf_hook);
 
                 m_playlist_api->activeplaylist_item_format_title(index, &global_style_tf_hook, temp,
@@ -1576,7 +1582,7 @@ void PlaylistView::notify_update_item_data(size_t index)
             tf::MergingTextFormatTitleformatHook item_style_text_format_tf_hook(
                 items_font_size, global_format_properties);
             tf::SplitterTitleformatHook column_style_tf_hook(&tf_hook_style, b_global ? &tf_hook_get_global : nullptr,
-                &tf_hook_date, &tf_hook_playlist_name, &item_style_text_format_tf_hook);
+                &tf_hook_date, &extra_fields_provider_tf_hook, &item_style_text_format_tf_hook);
 
             m_playlist_api->activeplaylist_item_format_title(index, &column_style_tf_hook, temp,
                 m_column_data[i].m_style_script, nullptr, play_control::display_level_all);

--- a/foo_ui_columns/playlist_switcher_title_formatting.cpp
+++ b/foo_ui_columns/playlist_switcher_title_formatting.cpp
@@ -78,8 +78,10 @@ pfc::string8 format_playlist_title(
     auto length_getter = [&lazy_fields]() { return std::string(pfc::format_time_ex(lazy_fields.total_duration(), 0)); };
 
     tf::FieldProviderTitleformatHook::FieldMap field_map{{"title", name}, {"size", std::string(pfc::format_uint(size))},
-        {"is_locked", is_locked}, {"is_active", is_active}, {"is_playing", is_playing}, {"filesize", file_size_getter},
-        {"filesize_raw", file_size_raw_getter}, {"length", length_getter}};
+        {"is_locked", is_locked}, {"is_active", is_active}, {"is_playing", is_playing},
+        {"filesize", std::function<std::string()>{file_size_getter}},
+        {"filesize_raw", std::function<std::string()>{file_size_raw_getter}},
+        {"length", std::function<std::string()>{length_getter}}};
 
     if (is_locked) {
         pfc::string8 lock_name;

--- a/foo_ui_columns/playlist_view_tfhook.cpp
+++ b/foo_ui_columns/playlist_view_tfhook.cpp
@@ -1,29 +1,7 @@
 #include "pch.h"
+
 #include "playlist_view_tfhooks.h"
-
-bool PlaylistNameTitleformatHook::process_field(
-    titleformat_text_out* p_out, const char* p_name, size_t p_name_length, bool& p_found_flag)
-{
-    if (p_name_length && *p_name == '_') {
-        p_name++;
-        p_name_length--;
-    }
-    if (!stricmp_utf8_ex(p_name, p_name_length, "playlist_name", pfc_infinite)) {
-        initialise();
-        p_out->write(titleformat_inputtypes::unknown, m_name);
-        p_found_flag = true;
-        return true;
-    }
-    return false;
-}
-
-void PlaylistNameTitleformatHook::initialise()
-{
-    if (!m_initialised) {
-        playlist_manager_v3::get()->activeplaylist_get_name(m_name);
-        m_initialised = true;
-    }
-}
+#include "tf_field_provider.h"
 
 int date_to_julian(const SYSTEMTIME* st)
 {
@@ -152,3 +130,42 @@ bool DateTitleformatHook::process_function(titleformat_text_out* p_out, const ch
     p_found_flag = false;
     return false;
 }
+
+namespace cui::panels::playlist_view {
+
+tf::FieldProviderTitleformatHook create_extra_fields_provider_tf_hook()
+{
+    auto playlist_name = std::make_shared<std::optional<std::string>>();
+
+    auto get_playlist_name = [playlist_name] {
+        if (!*playlist_name) {
+            playlist_name->emplace();
+            mmh::StringAdaptor adapted_string(**playlist_name);
+            playlist_manager_v3::get()->activeplaylist_get_name(adapted_string);
+        }
+
+        return std::string_view{**playlist_name};
+    };
+
+    auto is_dark = std::make_shared<std::optional<bool>>();
+
+    auto get_is_dark = [is_dark] {
+        if (!*is_dark)
+            *is_dark = colours::is_dark_mode_active();
+
+        return **is_dark;
+    };
+
+    auto get_is_light = [is_dark] {
+        if (!*is_dark)
+            *is_dark = colours::is_dark_mode_active();
+
+        return !**is_dark;
+    };
+
+    return tf::FieldProviderTitleformatHook(
+        {{"playlist_name", get_playlist_name}, {"_playlist_name", get_playlist_name},
+            {"is_dark", std::move(get_is_dark)}, {"is_light", std::move(get_is_light)}});
+}
+
+} // namespace cui::panels::playlist_view

--- a/foo_ui_columns/playlist_view_tfhooks.h
+++ b/foo_ui_columns/playlist_view_tfhooks.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "tf_field_provider.h"
 
 class GlobalVariable {
 public:
@@ -103,19 +104,8 @@ public:
     explicit DateTitleformatHook(const SYSTEMTIME* st = nullptr) : p_st(st) {}
 };
 
-class PlaylistNameTitleformatHook : public titleformat_hook {
-    bool m_initialised{false};
-    pfc::string8 m_name;
+namespace cui::panels::playlist_view {
 
-public:
-    void initialise();
-    bool process_field(
-        titleformat_text_out* p_out, const char* p_name, size_t p_name_length, bool& p_found_flag) override;
+tf::FieldProviderTitleformatHook create_extra_fields_provider_tf_hook();
 
-    bool process_function(titleformat_text_out* p_out, const char* p_name, size_t p_name_length,
-        titleformat_hook_function_params* p_params, bool& p_found_flag) override
-    {
-        return false;
-    }
-    PlaylistNameTitleformatHook() = default;
-};
+}

--- a/foo_ui_columns/prefs_utils.cpp
+++ b/foo_ui_columns/prefs_utils.cpp
@@ -26,16 +26,18 @@ void preview_to_console(const char* spec, bool extra)
         SYSTEMTIME st{};
         GetLocalTime(&st);
 
+        auto extra_fields_provider_tf_hook = cui::panels::playlist_view::create_extra_fields_provider_tf_hook();
+
         GlobalVariableList extra_items;
         if (extra) {
             pfc::string8_fast_aggressive str_dummy;
             service_ptr_t<titleformat_object> to_global;
             titleformat_compiler::get()->compile_safe(to_global, cfg_globalstring);
 
-            PlaylistNameTitleformatHook tf_hook_playlist_name;
             DateTitleformatHook tf_hook_date(&st);
             SetGlobalTitleformatHook<true, false> tf_hook_set_global(extra_items);
-            cui::tf::SplitterTitleformatHook tf_hook(&tf_hook_set_global, &tf_hook_date, &tf_hook_playlist_name);
+            cui::tf::SplitterTitleformatHook tf_hook(
+                &tf_hook_set_global, &tf_hook_date, &extra_fields_provider_tf_hook);
             playlist_api->activeplaylist_item_format_title(
                 idx, &tf_hook, str_dummy, to_global, nullptr, play_control::display_level_all);
         }
@@ -46,7 +48,7 @@ void preview_to_console(const char* spec, bool extra)
         SetGlobalTitleformatHook<false, true> tf_hook_set_global(extra_items);
         DateTitleformatHook tf_hook_date(&st);
 
-        titleformat_hook_impl_splitter tf_hook(&tf_hook_set_global, &tf_hook_date);
+        cui::tf::SplitterTitleformatHook tf_hook(&tf_hook_set_global, &tf_hook_date, &extra_fields_provider_tf_hook);
 
         playlist_api->activeplaylist_item_format_title(
             idx, &tf_hook, temp, to_temp, nullptr, play_control::display_level_all);

--- a/foo_ui_columns/tf_field_provider.cpp
+++ b/foo_ui_columns/tf_field_provider.cpp
@@ -34,6 +34,8 @@ public:
     }
 
     bool operator()(const std::function<std::string()>& value) const { return (*this)(value()); }
+    bool operator()(const std::function<std::string_view()>& value) const { return (*this)(value()); }
+    bool operator()(const std::function<bool()>& value) const { return (*this)(value()); }
 
 private:
     titleformat_text_out* m_out{};
@@ -47,9 +49,9 @@ bool FieldProviderTitleformatHook::process_field(
     if (iter == m_field_map.end())
         return false;
 
-    p_found_flag = true;
+    p_found_flag = std::visit(ValueVisitor(p_out), iter->second);
 
-    return std::visit(ValueVisitor(p_out), iter->second);
+    return p_found_flag;
 }
 
 } // namespace cui::tf

--- a/foo_ui_columns/tf_field_provider.h
+++ b/foo_ui_columns/tf_field_provider.h
@@ -17,7 +17,8 @@ struct CaseInsensitiveUtf8Comparator {
 
 class FieldProviderTitleformatHook : public titleformat_hook {
 public:
-    using FieldValue = std::variant<std::string, std::string_view, pfc::string8, bool, std::function<std::string()>>;
+    using FieldValue = std::variant<std::string, std::string_view, pfc::string8, bool, std::function<std::string()>,
+        std::function<std::string_view()>, std::function<bool()>>;
     using FieldMap = std::map<std::string_view, FieldValue, internal::CaseInsensitiveUtf8Comparator>;
 
     explicit FieldProviderTitleformatHook(FieldMap field_map) : m_field_map(std::move(field_map)) {}


### PR DESCRIPTION
Resolves #1702

This adds `%is_dark%` and `%is_light%` title formatting fields to playlist view display, style, sorting and global variables scripts.

`%is_dark%` is defined when dark mode is active and `%is_light%` is defined when light mode is active. The fields can be used with `$if()` for styling conditional on the current mode.