### PR TITLE
Avoid spectrum analyser slow down after using debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@
   Additionally, the Tab key unhides hidden focused item indicators in more
   scenarios.
 
+- If a keyboard shortcut has been assigned to Ctrl+F, pressing Ctrl+F when the
+  playlist view search bar is focused will now trigger the assigned shortcut.
+  [[#1733](https://github.com/reupen/columns_ui/pull/1733)]
+
+### Bug fixes
+
+- The built-in spectrum analyser visualisation frame rate is no longer
+  temporarily reduced if execution was paused (for example, using a debugger)
+  while the visualisation was rendering a frame.
+  [[#1734](https://github.com/reupen/columns_ui/pull/1734)]
+
 ### Internal changes
 
 - The component is now compiled with Visual Studio 2026 toolset version 14.51.

--- a/foo_ui_columns/vis_spectrum_renderer.cpp
+++ b/foo_ui_columns/vis_spectrum_renderer.cpp
@@ -269,8 +269,11 @@ void SpectrumAnalyserRenderer::start()
             if (stop_token.stop_requested())
                 return;
 
-            const auto frame_time = (std::chrono::steady_clock::now() - frame_start) / 1.ms;
-            frame_time_averager.add_frame(frame_time);
+            const auto frame_time = std::chrono::steady_clock::now() - frame_start;
+
+            // Ignore excessively large frame times (likely to be a result of e.g. debugger use)
+            if (frame_time < 1.s)
+                frame_time_averager.add_frame(frame_time / 1.ms);
 
             // Will typically sleep for longer in practice (as the usual Windows timer resolution is 15.6ms)
             if (need_to_sleep)


### PR DESCRIPTION
This avoids the spectrum analyser frame rate being reduced after pausing and resuming execution (for example, after using a debugger) while the visualisation was rendering a frame.

This was due to the frame rate limiting logic designed to limit CPU usage (for example, at high desktop refresh rates or large visualisation resolutions) kicking in. The logic now just ignores any frame times greater than one second which are unlikely to be genuine.