### PR TITLE
Enable Dependabot cooldown feature

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
     groups:
       actions:
         patterns:
@@ -23,6 +25,8 @@ updates:
     directory: /docs
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3
     groups:
       docs:
         patterns:


### PR DESCRIPTION
This sets the Dependabot cooldown option in the Dependabot configuration for GitHub Actions and uv package updates, to help to protect against malicious or otherwise problematic updates.