### PR TITLE
Activate inline editing when adding new playlist view column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Development version
+
+### Features
+
+- When adding a new column in on the Playlist view preferences page, inline
+  editing for the column name in the column list is automatically activated.
+  [[#1750](https://github.com/reupen/columns_ui/pull/1750)]
+
 ## 3.5.0
 
 ### Internal changes

--- a/foo_ui_columns/config_columns_v2.cpp
+++ b/foo_ui_columns/config_columns_v2.cpp
@@ -823,6 +823,7 @@ void TabColumns::add_column(size_t index)
     m_columns_list_view.insert_items(insert_index, insert_items.size(), insert_items.data());
     m_columns_list_view.set_item_selected_single(insert_index);
     m_columns_list_view.ensure_visible(insert_index);
+    m_columns_list_view.activate_inline_editing();
 }
 
 void TabColumns::remove_column(size_t index)


### PR DESCRIPTION
This makes the Columns tab in the Playlist view preferences page automatically activate inline editing when adding a new column, so a column name can be typed straight away.