### PR TITLE
Add %playlist_name% field to grouping scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+- The `%playlist_name%` field is now available in playlist view grouping
+  scripts. [[#1757](https://github.com/reupen/columns_ui/pull/1757)]
+
 - When adding a new column in on the Playlist view preferences page, inline
   editing for the column name in the column list is automatically activated.
   [[#1750](https://github.com/reupen/columns_ui/pull/1750)]

--- a/docs/source/playlist-view/title-formatting.md
+++ b/docs/source/playlist-view/title-formatting.md
@@ -19,3 +19,9 @@ variables scripts.
 | `%is_dark%`             | Defined when dark mode is active           |
 | `%is_light%`            | Defined when light mode is active          |
 | `%playlist_name%`       | The name of the active playlist            |
+
+These fields are available in grouping scripts.
+
+| Field             | Description                     |
+| ----------------- | ------------------------------- |
+| `%playlist_name%` | The name of the active playlist |

--- a/docs/source/reference/title-formatting-index.md
+++ b/docs/source/reference/title-formatting-index.md
@@ -47,27 +47,27 @@ available in Columns UI and not available in the Default User Interface.
 
 ### Playlist view
 
-| Name                        | Reference link                                      | Supported contexts                                    |
-| --------------------------- | --------------------------------------------------- | ----------------------------------------------------- |
-| `%_back%`                   | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%_display_index%`          | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%default_font_size%`       | [Text styling](/other/text-styling)                 | Display, style, grouping and global variables scripts |
-| `%is_dark%`                 | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
-| `%_is_group%`               | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%is_light%`                | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
-| `%_is_themed%`              | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%playlist_name%`           | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
-| `%_text%`                   | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%_selected_back%`          | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%_selected_back_no_focus%` | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%_selected_text%`          | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%_selected_text_no_focus%` | [Style script](/playlist-view/style-script)         | Style scripts                                         |
-| `%_system_day%`             | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
-| `%_system_day_of_week%`     | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
-| `%_system_hour%`            | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
-| `%_system_julian_day%`      | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
-| `%_system_month%`           | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
-| `%_system_year%`            | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts  |
+| Name                        | Reference link                                      | Supported contexts                                             |
+| --------------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| `%_back%`                   | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%_display_index%`          | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%default_font_size%`       | [Text styling](/other/text-styling)                 | Display, style, grouping and global variables scripts          |
+| `%is_dark%`                 | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts           |
+| `%_is_group%`               | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%is_light%`                | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts           |
+| `%_is_themed%`              | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%playlist_name%`           | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting, grouping and global variables scripts |
+| `%_text%`                   | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%_selected_back%`          | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%_selected_back_no_focus%` | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%_selected_text%`          | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%_selected_text_no_focus%` | [Style script](/playlist-view/style-script)         | Style scripts                                                  |
+| `%_system_day%`             | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts           |
+| `%_system_day_of_week%`     | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts           |
+| `%_system_hour%`            | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts           |
+| `%_system_julian_day%`      | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts           |
+| `%_system_month%`           | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts           |
+| `%_system_year%`            | [Title formatting](/playlist-view/title-formatting) | Display, style, sorting and global variables scripts           |
 
 ### Status bar
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -1627,11 +1627,16 @@ void PlaylistView::get_insert_items(size_t start, size_t count, InsertItemsConta
     const auto group_count = m_scripts.get_count();
     const auto metadb_v2_api = metadb_v2::tryGet();
 
+    pfc::string8 playlist_name;
+    m_playlist_api->activeplaylist_get_name(playlist_name);
+
+    tf::FieldProviderTitleformatHook playlist_name_tf_hook({{"playlist_name", playlist_name}});
     tf::TextFormatTitleformatHook text_format_tf_hook(get_group_font_size_pt().value_or(0.f));
+    tf::SplitterTitleformatHook combined_tf_hooks(&playlist_name_tf_hook, &text_format_tf_hook);
 
     if (metadb_v2_api.is_valid()) {
         metadb_v2_api->queryMultiParallel_(handles,
-            [this, &handles, &items, &text_format_tf_hook, group_count](size_t index, const metadb_v2::rec_t& rec) {
+            [this, &handles, &items, &combined_tf_hooks, group_count](size_t index, const metadb_v2::rec_t& rec) {
                 metadb_handle_v2::ptr track;
                 track &= handles[index];
 
@@ -1641,7 +1646,7 @@ void PlaylistView::get_insert_items(size_t start, size_t count, InsertItemsConta
                 items[index].m_groups.resize(group_count);
 
                 for (auto&& [script, group] : ranges::views::zip(m_scripts, items[index].m_groups)) {
-                    track->formatTitle_v2(rec, &text_format_tf_hook, adapted_string, script, nullptr);
+                    track->formatTitle_v2(rec, &combined_tf_hooks, adapted_string, script, nullptr);
                     group = title.c_str();
                 }
             });
@@ -1650,12 +1655,12 @@ void PlaylistView::get_insert_items(size_t start, size_t count, InsertItemsConta
     }
 
     concurrency::parallel_for(
-        size_t{0}, count, [this, &items, &handles, &text_format_tf_hook, group_count](size_t index) {
+        size_t{0}, count, [this, &items, &handles, &combined_tf_hooks, group_count](size_t index) {
             pfc::string8_fast temp;
             temp.prealloc(32);
             items[index].m_groups.resize(group_count);
             for (size_t i = 0; i < group_count; i++) {
-                handles[index]->format_title(&text_format_tf_hook, temp, m_scripts[i], nullptr);
+                handles[index]->format_title(&combined_tf_hooks, temp, m_scripts[i], nullptr);
                 items[index].m_groups[i] = temp;
             }
         });


### PR DESCRIPTION
Resolves #1596

This makes the `%playlist_name%` field available in playlist view grouping scripts. This can be used to add conditional logic based on the playlist name. For example, the text can be varied or the group hidden (by emitting an empty string) based on the playlist name.