### PR TITLE
Remember Shift-select starting point in built-in list views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@
   switcher, inline editing for the playlist name is automatically activated.
   [[#1753](https://github.com/reupen/columns_ui/pull/1753)]
 
+### Bug fixes
+
+- When using the Shift key to select multiple items in built-in list views, the
+  starting position for the selection is no longer reset if the Shift key is
+  temporarily released between clicks or key presses.
+  [[#1758](https://github.com/reupen/columns_ui/pull/1758)]
+
 ## 3.5.0
 
 ### Internal changes


### PR DESCRIPTION
#1678

This updates ui_helpers to pick up some Shift-select behaviour changes in the list view.

Built-in list views now remember the starting position when Shift-selecting (using the mouse or the keyboard) if the Shift key is released between clicks or arrow key presses. This behaviour is more in line with File Explorer and Default UI.

The starting position is now reset on certain other events, such as clicking on an item or inserting or removing items.