### PR TITLE
Update options available in Quick setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@
   switcher, inline editing for the playlist name is automatically activated.
   [[#1753](https://github.com/reupen/columns_ui/pull/1753)]
 
+- Quick setup was updated to include options for smooth scrolling, sticky
+  playlist view group headings and sticky playlist view artwork.
+  [[#1764](https://github.com/reupen/columns_ui/pull/1764)]
+
+  The option to enable or disable the themed colour scheme was removed from the
+  dialogue. (All options remain available in their existing locations in
+  Preferences.)
+
 - In the ‘Export configuration’ dialogue box, the Target option was renamed
   Export type and the names of the choices were updated for clarity.
   [[#1761](https://github.com/reupen/columns_ui/pull/1761)]

--- a/foo_ui_columns/config_vars.h
+++ b/foo_ui_columns/config_vars.h
@@ -4,6 +4,11 @@
 
 namespace cui::config {
 
+enum class SourceID : uint32_t {
+    Preferences,
+    QuickSetup,
+};
+
 constexpr GUID advconfig_branch_columns_ui_id{
     0xd2dd7ffc, 0xf780, 0x4fa3, {0x89, 0x52, 0x38, 0xd8, 0x2c, 0x8c, 0x1e, 0x4b}};
 constexpr GUID advconfig_branch_system_tray_id{

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -301,21 +301,24 @@ BEGIN
     LTEXT           "",IDC_MENU_DESC,7,254,313,10
 END
 
-IDD_QUICK_SETUP DIALOGEX 0, 0, 268, 234
+IDD_QUICK_SETUP DIALOGEX 0, 0, 268, 268
 STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Quick setup – Columns UI"
 FONT 8, "Segoe UI", 400, 0, 0x0
 BEGIN
     LTEXT           "Layout",IDC_STATIC,14,7,60,8
-    LTEXT           "Light or dark mode",IDC_STATIC,14,96,75,8
-    COMBOBOX        IDC_DARK_MODE,14,106,240,49,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Theming",IDC_STATIC,14,126,30,8
-    COMBOBOX        IDC_THEMING,14,136,240,49,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "Playlist grouping and artwork",IDC_STATIC,14,156,152,8
-    COMBOBOX        IDC_GROUPING,14,166,240,49,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
-    LTEXT           "You can later re-run this setup from preferences.",IDC_STATIC,14,189,240,10
-    DEFPUSHBUTTON   "OK",IDOK,149,213,50,14,WS_GROUP
-    PUSHBUTTON      "Cancel",IDCANCEL,204,213,50,14
+    LTEXT           "Light or dark mode",IDC_STATIC,14,97,75,8
+    COMBOBOX        IDC_DARK_MODE,14,107,240,49,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "Playlist grouping and artwork",IDC_STATIC,14,128,152,8
+    COMBOBOX        IDC_GROUPING,14,138,240,49,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    CONTROL         "Keep playlist group headings in view when scrolling",IDC_STICKY_GROUP_HEADERS,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,161,177,10
+    CONTROL         "Keep playlist artwork in view when scrolling",IDC_STICKY_ARTWORK,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,181,155,10
+    CONTROL         "Use smooth scrolling",IDC_USE_SMOOTH_SCROLLING,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,201,86,10
+    LTEXT           "Quick setup can be opened from Preferences at any time.",IDC_STATIC,14,221,240,8
+    DEFPUSHBUTTON   "OK",IDOK,149,247,50,14,WS_GROUP
+    PUSHBUTTON      "Cancel",IDCANCEL,204,247,50,14
 END
 
 IDD_FCL_IMPORT DIALOGEX 0, 0, 242, 172
@@ -926,7 +929,7 @@ BEGIN
         LEFTMARGIN, 14
         RIGHTMARGIN, 254
         TOPMARGIN, 7
-        BOTTOMMARGIN, 227
+        BOTTOMMARGIN, 261
     END
 
     IDD_FCL_IMPORT, DIALOG

--- a/foo_ui_columns/ng_playlist/ng_playlist.h
+++ b/foo_ui_columns/ng_playlist/ng_playlist.h
@@ -699,6 +699,7 @@ private:
     bool m_initialised{};
     GroupsListView m_groups_list_view{this};
     prefs::PreferencesTabHelper m_helper{{IDC_TITLE1}, {IDC_H2_TITLE}};
+    std::vector<mmh::EventToken::Ptr> m_event_tokens;
 };
 } // namespace cui::panels::playlist_view
 

--- a/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist_prefs_groups.cpp
@@ -4,6 +4,7 @@
 #include "ng_playlist.h"
 #include "ng_playlist_groups.h"
 #include "permutation_utils.h"
+#include "prefs_utils.h"
 
 namespace cui::panels::playlist_view {
 
@@ -94,8 +95,7 @@ BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         ShowWindow(m_groups_list_view.get_wnd(), SW_SHOWNORMAL);
 
         Button_SetCheck(GetDlgItem(wnd, IDC_GROUPING), cfg_grouping ? BST_CHECKED : BST_UNCHECKED);
-        Button_SetCheck(
-            GetDlgItem(wnd, IDC_STICKY_GROUP_HEADERS), cfg_sticky_group_headers ? BST_CHECKED : BST_UNCHECKED);
+        m_event_tokens.emplace_back(prefs::bind_checkbox(wnd, IDC_STICKY_GROUP_HEADERS, cfg_sticky_group_headers));
         Button_SetCheck(GetDlgItem(wnd, IDC_INDENT_GROUPS), cfg_indent_groups ? BST_CHECKED : BST_UNCHECKED);
         Button_SetCheck(GetDlgItem(wnd, IDC_USE_CUSTOM_INDENTATION),
             cfg_use_custom_group_indentation_amount ? BST_CHECKED : BST_UNCHECKED);
@@ -125,7 +125,8 @@ BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             break;
         }
         case IDC_STICKY_GROUP_HEADERS: {
-            cfg_sticky_group_headers = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
+            cfg_sticky_group_headers.set(Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED,
+                WI_EnumValue(config::SourceID::Preferences));
             refresh_enabled_options();
             PlaylistView::s_on_sticky_group_headers_change();
             break;
@@ -216,6 +217,7 @@ BOOL GroupsPreferencesTab::ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     case WM_DESTROY:
         m_groups_list_view.destroy();
+        m_event_tokens.clear();
         m_wnd = nullptr;
         break;
     }

--- a/foo_ui_columns/prefs_utils.h
+++ b/foo_ui_columns/prefs_utils.h
@@ -11,4 +11,28 @@ HFONT create_default_ui_font(unsigned point_size);
 HFONT create_default_title_font();
 void show_generic_title_formatting_tools_menu(HWND dialog_wnd, HWND button_wnd, GUID font_id);
 
+[[nodiscard]] auto bind_checkbox(
+    HWND control_wnd, auto& config_item, config::SourceID ignored_source_id = config::SourceID::Preferences)
+{
+    if (config_item)
+        Button_SetCheck(control_wnd, BST_CHECKED);
+
+    auto on_change = [control_wnd, ignored_source_id, &config_item](auto source_id) {
+        if (source_id != WI_EnumValue(ignored_source_id))
+            Button_SetCheck(control_wnd, config_item ? BST_CHECKED : BST_UNCHECKED);
+    };
+
+    if constexpr (requires { config_item.on_change([](auto, auto) {}); })
+        return config_item.on_change([on_change](auto new_value, auto source_id) { on_change(source_id); });
+    else
+        return config_item.on_change(
+            [on_change](auto new_value, auto old_value, auto source_id) { on_change(source_id); });
+}
+
+[[nodiscard]] auto bind_checkbox(HWND dialog_wnd, UINT control_id, auto& config_item,
+    config::SourceID ignored_source_id = config::SourceID::Preferences)
+{
+    return bind_checkbox(GetDlgItem(dialog_wnd, control_id), config_item, ignored_source_id);
+}
+
 } // namespace cui::prefs

--- a/foo_ui_columns/resource.h
+++ b/foo_ui_columns/resource.h
@@ -257,7 +257,6 @@
 #define IDC_DUPLICATE_PRESET            1130
 #define IDC_COLOURS_SCHEME              1131
 #define IDC_COLOURS_ELEMENT             1132
-#define IDC_THEMING                     1134
 #define IDC_DEST                        1135
 #define IDC_DARK_MODE                   1135
 #define IDC_SORT_STRING                 1143
@@ -347,7 +346,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        210
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1221
+#define _APS_NEXT_CONTROL_VALUE         1222
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/foo_ui_columns/setup_dialog.cpp
+++ b/foo_ui_columns/setup_dialog.cpp
@@ -5,6 +5,7 @@
 #include "dark_mode.h"
 #include "ng_playlist/ng_playlist.h"
 #include "main_window.h"
+#include "prefs_utils.h"
 
 INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
@@ -19,7 +20,6 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
         m_presets_list_view.set_font_from_log_font(font);
 
         HWND wnd_mode = GetDlgItem(wnd, IDC_DARK_MODE);
-        HWND wnd_theming = GetDlgItem(wnd, IDC_THEMING);
         HWND wnd_grouping = GetDlgItem(wnd, IDC_GROUPING);
 
         const auto monitor = MonitorFromWindow(wnd, MONITOR_DEFAULTTONEAREST);
@@ -39,9 +39,6 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
 
             SetWindowPos(wnd, nullptr, left, top, 0, 0, SWP_NOZORDER | SWP_NOSIZE);
         }
-
-        LVCOLUMN lvc{};
-        lvc.mask = LVCF_TEXT | LVCF_WIDTH;
 
         cfg_layout.get_preset(cfg_layout.get_active(), m_previous_layout);
 
@@ -63,30 +60,29 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
         m_previous_mode = static_cast<cui::colours::DarkModeStatus>(cui::colours::dark_mode_status.get());
         ComboBox_SetCurSel(wnd_mode, cui::colours::dark_mode_status.get());
 
-        ComboBox_InsertString(wnd_theming, 0, L"No");
-        ComboBox_InsertString(wnd_theming, 1, L"Yes");
-
         m_previous_light_colour_scheme = g_get_global_colour_scheme(false);
         m_previous_dark_colour_scheme = g_get_global_colour_scheme(true);
-        const auto active_colour_scheme = g_get_global_colour_scheme();
-
-        size_t select = -1;
-        if (active_colour_scheme == cui::colours::ColourSchemeThemed)
-            select = 1;
-        else if (active_colour_scheme == cui::colours::ColourSchemeSystem)
-            select = 0;
-
-        ComboBox_SetCurSel(wnd_theming, select);
 
         m_previous_show_grouping = cui::panels::playlist_view::cfg_grouping;
         m_previous_show_artwork = cui::panels::playlist_view::cfg_show_artwork;
+        m_previous_enable_sticky_group_headers = cui::panels::playlist_view::cfg_sticky_group_headers;
+        m_previous_enable_sticky_artwork = cui::panels::playlist_view::cfg_sticky_artwork;
+        m_previous_use_smooth_scrolling = cui::config::use_smooth_scrolling;
 
         ComboBox_InsertString(wnd_grouping, 0, L"Disabled");
         ComboBox_InsertString(wnd_grouping, 1, L"Groups (without artwork)");
         ComboBox_InsertString(wnd_grouping, 2, L"Groups (with artwork)");
 
-        select = cui::panels::playlist_view::cfg_grouping ? (cui::panels::playlist_view::cfg_show_artwork ? 2 : 1) : 0;
-        ComboBox_SetCurSel(wnd_grouping, select);
+        const auto active_grouping_index
+            = cui::panels::playlist_view::cfg_grouping ? (cui::panels::playlist_view::cfg_show_artwork ? 2 : 1) : 0;
+        ComboBox_SetCurSel(wnd_grouping, active_grouping_index);
+
+        m_event_tokens.emplace_back(cui::prefs::bind_checkbox(wnd, IDC_STICKY_GROUP_HEADERS,
+            cui::panels::playlist_view::cfg_sticky_group_headers, cui::config::SourceID::QuickSetup));
+        m_event_tokens.emplace_back(cui::prefs::bind_checkbox(wnd, IDC_STICKY_ARTWORK,
+            cui::panels::playlist_view::cfg_sticky_artwork, cui::config::SourceID::QuickSetup));
+        m_event_tokens.emplace_back(cui::prefs::bind_checkbox(
+            wnd, IDC_USE_SMOOTH_SCROLLING, cui::config::use_smooth_scrolling, cui::config::SourceID::QuickSetup));
 
         ShowWindow(m_presets_list_view.get_wnd(), SW_SHOWNORMAL);
         return TRUE;
@@ -99,10 +95,28 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
             cui::colours::dark_mode_status.set(WI_EnumValue(m_previous_mode));
             g_set_global_colour_scheme(m_previous_light_colour_scheme, false);
             g_set_global_colour_scheme(m_previous_dark_colour_scheme, true);
-            cui::panels::playlist_view::cfg_show_artwork = m_previous_show_artwork;
-            cui::panels::playlist_view::cfg_grouping = m_previous_show_grouping;
-            cui::panels::playlist_view::PlaylistView::g_on_show_artwork_change();
-            cui::panels::playlist_view::PlaylistView::g_on_groups_change();
+
+            if (cui::panels::playlist_view::cfg_show_artwork != m_previous_show_artwork) {
+                cui::panels::playlist_view::cfg_show_artwork = m_previous_show_artwork;
+                cui::panels::playlist_view::PlaylistView::g_on_show_artwork_change();
+            }
+
+            if (cui::panels::playlist_view::cfg_grouping != m_previous_show_grouping) {
+                cui::panels::playlist_view::cfg_grouping = m_previous_show_grouping;
+                cui::panels::playlist_view::PlaylistView::g_on_groups_change();
+            }
+
+            if (cui::panels::playlist_view::cfg_sticky_group_headers != m_previous_enable_sticky_group_headers) {
+                cui::panels::playlist_view::cfg_sticky_group_headers = m_previous_enable_sticky_group_headers;
+                cui::panels::playlist_view::PlaylistView::s_on_sticky_group_headers_change();
+            }
+
+            if (cui::panels::playlist_view::cfg_sticky_artwork != m_previous_enable_sticky_artwork) {
+                cui::panels::playlist_view::cfg_sticky_artwork = m_previous_enable_sticky_artwork;
+                cui::panels::playlist_view::PlaylistView::s_on_sticky_artwork_change();
+            }
+
+            cui::config::use_smooth_scrolling = m_previous_use_smooth_scrolling;
 
             DestroyWindow(wnd);
             return 0;
@@ -110,14 +124,22 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
         case IDOK:
             DestroyWindow(wnd);
             return 0;
-        case CBN_SELCHANGE << 16 | IDC_THEMING: {
-            const size_t selection = ComboBox_GetCurSel(reinterpret_cast<HWND>(lp));
-            if (selection == 1)
-                g_set_global_colour_scheme(cui::colours::ColourSchemeThemed);
-            else if (selection == 0)
-                g_set_global_colour_scheme(cui::colours::ColourSchemeSystem);
+        case IDC_STICKY_GROUP_HEADERS:
+            cui::panels::playlist_view::cfg_sticky_group_headers.set(
+                Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED,
+                WI_EnumValue(cui::config::SourceID::QuickSetup));
+            cui::panels::playlist_view::PlaylistView::s_on_sticky_group_headers_change();
             break;
-        }
+        case IDC_STICKY_ARTWORK:
+            cui::panels::playlist_view::cfg_sticky_artwork.set(
+                Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED,
+                WI_EnumValue(cui::config::SourceID::QuickSetup));
+            cui::panels::playlist_view::PlaylistView::s_on_sticky_artwork_change();
+            break;
+        case IDC_USE_SMOOTH_SCROLLING:
+            cui::config::use_smooth_scrolling.set_value(Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED,
+                WI_EnumValue(cui::config::SourceID::QuickSetup));
+            break;
         case CBN_SELCHANGE << 16 | IDC_DARK_MODE: {
             const auto index = ComboBox_GetCurSel(reinterpret_cast<HWND>(lp));
             cui::colours::dark_mode_status.set(index);
@@ -145,6 +167,7 @@ INT_PTR QuickSetupDialog::handle_dialog_message(HWND wnd, UINT msg, WPARAM wp, L
         return 0;
     case WM_DESTROY:
         m_presets_list_view.destroy();
+        m_event_tokens.clear();
         std::erase(s_instances, this);
         break;
     case WM_NCDESTROY:
@@ -169,8 +192,9 @@ void QuickSetupDialog::on_preset_list_selection_change()
 
 void QuickSetupDialog::s_run()
 {
-    const cui::dark::DialogDarkModeConfig dark_mode_config{
-        .button_ids = {IDOK, IDCANCEL}, .combo_box_ids = {IDC_DARK_MODE, IDC_THEMING, IDC_GROUPING}};
+    const cui::dark::DialogDarkModeConfig dark_mode_config{.button_ids = {IDOK, IDCANCEL},
+        .checkbox_ids = {IDC_USE_SMOOTH_SCROLLING, IDC_STICKY_GROUP_HEADERS, IDC_STICKY_ARTWORK},
+        .combo_box_ids = {IDC_DARK_MODE, IDC_GROUPING}};
 
     modeless_dialog_box(IDD_QUICK_SETUP, dark_mode_config, cui::main_window.get_wnd(),
         [dialog = std::make_shared<QuickSetupDialog>()](

--- a/foo_ui_columns/setup_dialog.h
+++ b/foo_ui_columns/setup_dialog.h
@@ -50,4 +50,8 @@ private:
     cui::colours::ColourScheme m_previous_dark_colour_scheme{columns_ui::colours::ColourSchemeThemed};
     bool m_previous_show_artwork{};
     bool m_previous_show_grouping{};
+    bool m_previous_enable_sticky_group_headers{};
+    bool m_previous_enable_sticky_artwork{};
+    bool m_previous_use_smooth_scrolling{};
+    std::vector<mmh::EventToken::Ptr> m_event_tokens;
 };

--- a/foo_ui_columns/tab_pview_artwork.cpp
+++ b/foo_ui_columns/tab_pview_artwork.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "ng_playlist/ng_playlist.h"
 #include "config.h"
+#include "prefs_utils.h"
 
 namespace cui::prefs {
 
@@ -16,10 +17,12 @@ public:
     const char* get_name() override { return "Artwork"; }
 
 private:
-    void initialise_controls() const
+    void initialise_controls()
     {
+        m_event_tokens.emplace_back(
+            bind_checkbox(m_wnd, IDC_STICKY_ARTWORK, panels::playlist_view::cfg_sticky_artwork));
+
         SendDlgItemMessage(m_wnd, IDC_SHOWARTWORK, BM_SETCHECK, panels::playlist_view::cfg_show_artwork, 0);
-        SendDlgItemMessage(m_wnd, IDC_STICKY_ARTWORK, BM_SETCHECK, panels::playlist_view::cfg_sticky_artwork, 0);
         SendDlgItemMessage(m_wnd, IDC_ARTWORKREFLECTION, BM_SETCHECK, panels::playlist_view::cfg_artwork_reflection, 0);
         SendDlgItemMessage(m_wnd, IDC_ARTWORK_HEADER_SPACING, BM_SETCHECK,
             panels::playlist_view::cfg_artwork_group_header_spacing_enabled, 0);
@@ -50,6 +53,7 @@ private:
             break;
         case WM_DESTROY:
             m_wnd = nullptr;
+            m_event_tokens.clear();
             m_initialised = false;
             break;
         case WM_COMMAND:
@@ -60,8 +64,9 @@ private:
                 panels::playlist_view::PlaylistView::g_on_show_artwork_change();
                 break;
             case IDC_STICKY_ARTWORK:
-                panels::playlist_view::cfg_sticky_artwork
-                    = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
+                panels::playlist_view::cfg_sticky_artwork.set(
+                    Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED,
+                    WI_EnumValue(config::SourceID::Preferences));
                 panels::playlist_view::PlaylistView::s_on_sticky_artwork_change();
                 break;
             case IDC_ARTWORKREFLECTION:
@@ -89,6 +94,7 @@ private:
     HWND m_wnd{};
     bool m_initialised{};
     PreferencesTabHelper m_helper{{IDC_TITLE1}};
+    std::vector<mmh::EventToken::Ptr> m_event_tokens;
 };
 
 TabPlaylistViewArtwork g_tab_pview_artwork;

--- a/foo_ui_columns/tab_setup.cpp
+++ b/foo_ui_columns/tab_setup.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "dark_mode.h"
 #include "main_window.h"
+#include "prefs_utils.h"
 
 namespace cui::prefs {
 
@@ -32,8 +33,7 @@ public:
             if (config::use_hardware_acceleration)
                 Button_SetCheck(GetDlgItem(wnd, IDC_HARDWARE_ACCELERATION), BST_CHECKED);
 
-            if (config::use_smooth_scrolling)
-                Button_SetCheck(GetDlgItem(wnd, IDC_USE_SMOOTH_SCROLLING), BST_CHECKED);
+            m_event_tokens.emplace_back(bind_checkbox(wnd, IDC_USE_SMOOTH_SCROLLING, config::use_smooth_scrolling));
 
             if (!main_window.get_wnd())
                 EnableWindow(GetDlgItem(wnd, IDC_QUICKSETUP), FALSE);
@@ -53,6 +53,9 @@ public:
 
             break;
         }
+        case WM_DESTROY:
+            m_event_tokens.clear();
+            break;
         case WM_COMMAND:
             switch (wp) {
             case IDC_QUICKSETUP:
@@ -72,7 +75,8 @@ public:
 
                 break;
             case IDC_USE_SMOOTH_SCROLLING:
-                config::use_smooth_scrolling = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
+                config::use_smooth_scrolling.set_value(Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED,
+                    WI_EnumValue(config::SourceID::Preferences));
                 break;
             }
             break;
@@ -106,6 +110,8 @@ public:
     const char* get_name() override { return "Setup"; }
 
     PreferencesTabHelper m_helper{{IDC_TITLE1, IDC_TITLE2, IDC_TITLE3}};
+
+    std::vector<mmh::EventToken::Ptr> m_event_tokens;
 };
 
 SetupTab setup_tab;


### PR DESCRIPTION
This makes a few tweaks to the options in the Quick setup dialogue. It:

- adds ‘Keep playlist group headings in view when scrolling’
- adds ‘Keep playlist artwork in view when scrolling’
- adds ‘Use smooth scrolling’
- removes the ‘Themed’ yes/no drop-down

The Themed option was removed as it’s less obvious what it does these days, and it remains available on the Colours tab on the Colours and fonts preferences page.