### PR TITLE
Avoid suppressing smooth scrolling for fast mouse wheel scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 
 ### Bug fixes
 
+- Smooth scrolling is no longer suppressed when scrolling very quickly using a
+  mouse wheel that scrolls in fixed steps.
+  [[#1775](https://github.com/reupen/columns_ui/pull/1775)]
+
 - When using the Shift key to select multiple items in built-in list views, the
   starting position for the selection is no longer reset if the Shift key is
   temporarily released between clicks or key presses.


### PR DESCRIPTION
#1771

This updates ui_helpers where the logic that suppresses smooth scrolling for high precision scroll devices was adjusted so that it avoids suppressing smooth scrolling for very quick mouse wheel scrolling using a traditional mouse wheel that sends deltas that are a multiple of 120.

There should be no practical effect on scroll devices that send granular wheel deltas (e.g. many touch pads and some mice) where smooth scrolling will still be suppressed.