### PR TITLE
Add middle-click autoscroll to Item details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Development version
+## 3.6.0-beta.1
 
 ### Features
 
@@ -9,13 +9,13 @@
 Several new features were added to the built-in spectrum analyser visualisation:
 
 - A new appearance mode with solid (rather than hatched) bars was added.
-  [[#1780](https://github.com/reupen/columns_ui/pull/1781)]
+  [[#1780](https://github.com/reupen/columns_ui/pull/1780)]
 
   The new mode is named ‘Solid bars’, while the previous bars mode is now named
   ‘Hatched bars’.
 
 - The width of bars in the ‘Hatched bars’ and ‘Solid bars’ appearance modes is
-  now configurable. [[#1780](https://github.com/reupen/columns_ui/pull/1781)]
+  now configurable. [[#1780](https://github.com/reupen/columns_ui/pull/1780)]
 
 - A smooth sub-bin values option was added.
   [[#1778](https://github.com/reupen/columns_ui/pull/1778)]
@@ -49,8 +49,9 @@ Several new features were added to the built-in spectrum analyser visualisation:
 #### Other changes
 
 - Middle-click autoscroll is now available in the playlist view, the playlist
-  switcher, Filter panel and Item properties.
-  [[#1786](https://github.com/reupen/columns_ui/pull/1786)]
+  switcher, Filter panel, Item details and Item properties.
+  [[#1786](https://github.com/reupen/columns_ui/pull/1786),
+  [#1791](https://github.com/reupen/columns_ui/pull/1791)]
 
   For the playlist view and Filter panel, ‘Autoscroll’ has replaced the ‘None’
   option for the middle-click action in Preferences.
@@ -111,6 +112,10 @@ Several new features were added to the built-in spectrum analyser visualisation:
   starting position for the selection is no longer reset if the Shift key is
   temporarily released between clicks or key presses.
   [[#1758](https://github.com/reupen/columns_ui/pull/1758)]
+
+- The position of the tooltip shown when using the seekbar and volume bar was
+  corrected for some system display scales and pointer sizes.
+  [[#1790](https://github.com/reupen/columns_ui/pull/1790)]
 
 ## 3.5.0
 

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -483,6 +483,7 @@
     <ClInclude Include="panel_utils.h" />
     <ClInclude Include="permutation_utils.h" />
     <ClInclude Include="resource_utils.h" />
+    <ClInclude Include="scroll.h" />
     <ClInclude Include="string.h" />
     <ClInclude Include="svg.h" />
     <ClInclude Include="system_appearance_manager.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -1019,6 +1019,9 @@
     <ClInclude Include="buttons_config.h">
       <Filter>Buttons toolbar</Filter>
     </ClInclude>
+    <ClInclude Include="scroll.h">
+      <Filter>Utilities</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include=".clang-format" />

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -3,6 +3,7 @@
 
 #include "d2d_utils.h"
 #include "item_details_text.h"
+#include "scroll.h"
 #include "tab_setup.h"
 #include "tf_text_format.h"
 
@@ -12,6 +13,7 @@ namespace {
 
 constexpr auto MSG_OCCLUSION_STATUS_CHANGED = WM_USER + 3;
 constexpr auto MSG_SMOOTH_SCROLL = WM_USER + 4;
+constexpr auto MSG_AUTOSCROLL_TICK = WM_USER + 5;
 constexpr auto OCCLUSION_STATUS_TIMER_ID = 700;
 constexpr auto SMOOTH_SCROLL_TIMER_ID = 701;
 
@@ -799,6 +801,9 @@ void ItemDetails::set_window_theme() const
 
 LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
+    if (const auto result = m_autoscroll_helper ? m_autoscroll_helper->handle_message(wnd, msg, wp, lp) : std::nullopt)
+        return *result;
+
     switch (msg) {
     case WM_CREATE: {
         m_smooth_scroll_helper.emplace(
@@ -809,6 +814,16 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             [this](
                 uih::ScrollAxis axis, int position) { return uih::clamp_scroll_position(get_wnd(), axis, position); },
             [this](auto axis, auto new_position) { internal_scroll(axis, new_position, false); });
+
+        m_autoscroll_helper.emplace(autoscroll_cursor_info, MSG_AUTOSCROLL_TICK, colours::is_dark_mode_active(),
+            [this](int delta_x, int delta_y) {
+                if (delta_y != 0)
+                    delta_scroll(uih::ScrollAxis::Vertical, delta_y, true);
+
+                if (delta_x != 0)
+                    delta_scroll(uih::ScrollAxis::Horizontal, delta_x, true);
+            });
+
         set_window_theme();
         register_callback();
         play_callback_manager::get()->register_callback(
@@ -877,6 +892,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_d2d_factory.reset();
         m_dxgi_factory.reset();
         m_smooth_scroll_helper->shut_down();
+        m_autoscroll_helper.reset();
         break;
     }
     case WM_NCDESTROY:
@@ -898,6 +914,15 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
         break;
     }
+    case WM_MBUTTONDOWN:
+        SendMessage(wnd, WM_CANCELMODE, 0, 0);
+
+        [[fallthrough]];
+    case WM_MBUTTONDBLCLK:
+        if (m_autoscroll_helper)
+            m_autoscroll_helper->start(wnd, true);
+
+        return 0;
     case WM_MOUSEHWHEEL:
     case WM_MOUSEWHEEL: {
         LONG_PTR style = GetWindowLongPtr(get_wnd(), GWL_STYLE);
@@ -1004,6 +1029,10 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case MSG_SMOOTH_SCROLL:
         m_smooth_scroll_helper->on_message();
         return 0;
+    case WM_SETTINGCHANGE:
+        if (wp == uih::SPI_SET_POINTER_SCALE && m_autoscroll_helper)
+            m_autoscroll_helper->reset();
+        break;
     case WM_POWERBROADCAST: {
         if (wp != PBT_POWERSETTINGCHANGE)
             break;
@@ -1054,9 +1083,11 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         const auto background_colour = p_helper.get_colour(colours::colour_background);
         const auto text_colour = p_helper.get_colour(colours::colour_text);
 
-        const auto is_horizontal_scroll_bar_visible
-            = m_hscroll && !m_word_wrapping && (sih.nMax - sih.nMin - 1) > gsl::narrow_cast<int>(sih.nPage);
-        const auto is_vertical_scroll_bar_visible = (siv.nMax - siv.nMin - 1) > gsl::narrow_cast<int>(siv.nPage);
+        const auto is_horizontal_scroll_bar_visible = m_hscroll && !m_word_wrapping && sih.nMax > sih.nMin
+            && std::cmp_greater_equal(sih.nMax - sih.nMin, sih.nPage);
+        const auto is_vertical_scroll_bar_visible
+            = siv.nMax > siv.nMin && std::cmp_greater_equal(siv.nMax - siv.nMin, siv.nPage);
+
         const auto padding = gsl::narrow_cast<float>(s_get_padding());
         const auto x_offset = uih::direct_write::px_to_dip(
             gsl::narrow_cast<float>(is_horizontal_scroll_bar_visible ? -sih.nPos : 0) + padding);
@@ -1125,9 +1156,8 @@ void ItemDetails::s_on_font_change()
 
 void ItemDetails::s_on_dark_mode_status_change()
 {
-    for (auto&& window : s_windows) {
-        window->set_window_theme();
-    }
+    for (auto&& window : s_windows)
+        window->on_dark_mode_status_change();
 }
 
 void ItemDetails::s_on_colours_change()
@@ -1207,6 +1237,16 @@ void ItemDetails::on_colours_change()
 {
     m_d2d_text_brush.reset();
     invalidate_all();
+}
+
+void ItemDetails::on_dark_mode_status_change()
+{
+    const auto is_dark = colours::is_dark_mode_active();
+
+    set_window_theme();
+
+    if (m_autoscroll_helper)
+        m_autoscroll_helper->set_is_dark(is_dark);
 }
 
 ItemDetails::ItemDetails()

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -254,6 +254,7 @@ private:
     void create_text_layout();
     void on_font_change();
     void on_colours_change();
+    void on_dark_mode_status_change();
 
     inline static std::vector<ItemDetails*> s_windows;
 
@@ -299,6 +300,7 @@ private:
     int m_vertical_scroll_position{};
     int m_horizontal_scroll_position{};
     std::optional<uih::SmoothScrollHelper> m_smooth_scroll_helper{};
+    std::optional<uih::AutoscrollHelper> m_autoscroll_helper{};
 
     HWND m_wnd_config{};
 };

--- a/foo_ui_columns/list_view_panel.h
+++ b/foo_ui_columns/list_view_panel.h
@@ -2,6 +2,7 @@
 
 #include "dark_mode.h"
 #include "font_utils.h"
+#include "scroll.h"
 
 namespace cui::utils {
 
@@ -33,9 +34,7 @@ public:
             set_dark_edit_colours(
                 dark::get_dark_system_colour(COLOR_WINDOWTEXT), dark::get_dark_system_colour(COLOR_WINDOW));
             set_use_smooth_scroll(config::use_smooth_scrolling);
-            configure_autoscroll({IDC_AUTOSCROLL_VERT_HORZ, IDC_AUTOSCROLL_VERT, IDC_AUTOSCROLL_HORZ, IDC_SCROLL_UP,
-                IDC_SCROLL_DOWN, IDC_SCROLL_LEFT, IDC_SCROLL_RIGHT, IDC_SCROLL_UP_RIGHT, IDC_SCROLL_UP_LEFT,
-                IDC_SCROLL_DOWN_RIGHT, IDC_SCROLL_DOWN_LEFT});
+            configure_autoscroll(autoscroll_cursor_info);
             m_use_smooth_scroll_change_token = config::use_smooth_scrolling.on_change(
                 [this](bool new_value, auto) { set_use_smooth_scroll(new_value); });
 

--- a/foo_ui_columns/scroll.h
+++ b/foo_ui_columns/scroll.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace cui {
+
+constexpr uih::AutoscrollCursorInfo autoscroll_cursor_info{IDC_AUTOSCROLL_VERT_HORZ, IDC_AUTOSCROLL_VERT,
+    IDC_AUTOSCROLL_HORZ, IDC_SCROLL_UP, IDC_SCROLL_DOWN, IDC_SCROLL_LEFT, IDC_SCROLL_RIGHT, IDC_SCROLL_UP_RIGHT,
+    IDC_SCROLL_UP_LEFT, IDC_SCROLL_DOWN_RIGHT, IDC_SCROLL_DOWN_LEFT};
+
+} // namespace cui


### PR DESCRIPTION
This extends middle-click autoscroll support to the Item details panel.

A minor bug where rendering did not handle the case where only 1 or 2 pixels were scrollable correctly was also fixed.