### PR TITLE
Add reload commands for playlist view artwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change log
 
+## Development version
+
+### Features
+
+- Right-clicking on artwork on the playlist view now shows a context menu with
+  commands to reload that specific image or all artwork in the playlist.
+  [[#1796](https://github.com/reupen/columns_ui/pull/1796)]
+
+- Some minor optimisations to autoscroll were made.
+  [[#1795](https://github.com/reupen/columns_ui/pull/1795)]
+
 ## 3.6.0-beta.1
 
 ### Features

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -1363,20 +1363,16 @@ void PlaylistView::notify_on_menu_select(WPARAM wp, LPARAM lp)
 
 bool PlaylistView::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
 {
-    enum {
-        ID_PLAY = 1,
-        ID_CUT,
-        ID_COPY,
-        ID_PASTE,
-        ID_SELECTION,
-        ID_CUSTOM_BASE = 0x8000,
-    };
+    constexpr auto ID_SELECTION_BASE = 0x1000;
+    constexpr auto ID_CUSTOM_BASE = 0x10000;
 
     playlist_position_reference_tracker selected_item;
     const auto selection_count = m_playlist_api->activeplaylist_get_selection_count(2);
     const auto playlist_selection_exists = selection_count > 0;
     const auto show_shortcuts = standard_config_objects::query_show_keyboard_shortcuts_in_menus();
-    HMENU menu = CreatePopupMenu();
+
+    const uih::Menu menu;
+    uih::MenuCommandCollector collector;
 
     auto mainmenu_api = mainmenu_manager::get();
     const auto mainmenu_flags = show_shortcuts ? mainmenu_manager::flag_show_shortcuts : 0;
@@ -1396,41 +1392,44 @@ bool PlaylistView::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
             }
         }
 
-        constexpr auto play_text = L"Play"sv;
-
-        MENUITEMINFO mii{};
-        mii.cbSize = sizeof(MENUITEMINFO);
-        mii.fMask = MIIM_STRING | MIIM_ID | MIIM_STATE;
-        mii.dwTypeData = const_cast<wchar_t*>(play_text.data());
-        mii.cch = gsl::narrow<UINT>(play_text.size());
-        mii.wID = ID_PLAY;
-        mii.fState = MFS_DEFAULT;
-
-        InsertMenuItem(menu, 0, TRUE, &mii);
-        AppendMenu(menu, MF_SEPARATOR, 0, nullptr);
+        menu.append_command(collector.add([&] {
+            if (selected_item.m_playlist != std::numeric_limits<size_t>::max()
+                && selected_item.m_item != std::numeric_limits<size_t>::max()) {
+                m_playlist_api->playlist_execute_default_action(selected_item.m_playlist, selected_item.m_item);
+            }
+        }),
+            L"Play"_zv, {.is_default = true});
+        menu.append_separator();
     }
 
     mainmenu_api->instantiate(mainmenu_part);
-    mainmenu_api->generate_menu_win32(menu, ID_SELECTION, ID_CUSTOM_BASE - ID_SELECTION, mainmenu_flags);
+    mainmenu_api->generate_menu_win32(
+        menu.get(), ID_SELECTION_BASE, ID_CUSTOM_BASE - ID_SELECTION_BASE, mainmenu_flags);
 
-    if (GetMenuItemCount(menu) > 0)
-        uAppendMenu(menu, MF_SEPARATOR, 0, "");
+    if (menu.size() > 0)
+        menu.append_separator();
 
     if (playlist_selection_exists) {
-        AppendMenu(menu, MF_STRING, ID_CUT, L"Cut");
-        AppendMenu(menu, MF_STRING, ID_COPY, L"Copy");
+        menu.append_command(collector.add([&] { playlist_utils::cut(); }), L"Cut");
+        menu.append_command(collector.add([&] { playlist_utils::copy(); }), L"Copy");
     }
 
     const auto can_paste = playlist_utils::check_clipboard();
-    if (can_paste)
-        AppendMenu(menu, MF_STRING, ID_PASTE, L"Paste");
-    else if (!playlist_selection_exists)
-        AppendMenu(menu, MF_STRING | MF_GRAYED, 0, L"Paste");
+
+    if (can_paste || !playlist_selection_exists)
+        menu.append_command(collector.add([&] {
+            if (playlist_selection_exists || from_keyboard) {
+                playlist_utils::paste_at_focused_item(get_wnd());
+            } else {
+                playlist_utils::paste(get_wnd(), (std::numeric_limits<size_t>::max)());
+            }
+        }),
+            L"Paste", {.is_disabled = !can_paste});
 
     contextmenu_manager::ptr contextmenu_api;
 
     if (playlist_selection_exists) {
-        AppendMenu(menu, MF_SEPARATOR, 0, nullptr);
+        menu.append_separator();
 
         contextmenu_api = contextmenu_manager::get();
         const auto contextmenu_flags = show_shortcuts ? contextmenu_manager::flag_show_shortcuts : 0;
@@ -1439,44 +1438,30 @@ bool PlaylistView::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
             = {keyboard_shortcut_manager::TYPE_CONTEXT_PLAYLIST, keyboard_shortcut_manager::TYPE_CONTEXT};
         contextmenu_api->set_shortcut_preference(shortcuts, gsl::narrow<unsigned>(std::size(shortcuts)));
         contextmenu_api->init_context_playlist(contextmenu_flags);
-        contextmenu_api->win32_build_menu(menu, ID_CUSTOM_BASE, -1);
+        contextmenu_api->win32_build_menu(menu.get(), ID_CUSTOM_BASE, -1);
     }
 
-    menu_helpers::win32_auto_mnemonics(menu);
+    menu_helpers::win32_auto_mnemonics(menu.get());
     m_contextmenu_manager_base = ID_CUSTOM_BASE;
-    m_mainmenu_manager_base = ID_SELECTION;
+    m_mainmenu_manager_base = ID_SELECTION_BASE;
     m_mainmenu_manager = mainmenu_api;
     m_contextmenu_manager = contextmenu_api;
 
     uie::window_ptr self_ptr = this;
-    const auto tpm_flags = TPM_RIGHTBUTTON | TPM_NONOTIFY | TPM_RETURNCMD;
-    const int cmd = TrackPopupMenu(menu, tpm_flags, pt.x, pt.y, 0, get_wnd(), nullptr);
 
-    DestroyMenu(menu);
+    const auto cmd = menu.run(get_wnd(), pt);
+
     m_status_text_override.release();
     m_mainmenu_manager.release();
     m_contextmenu_manager.release();
 
-    if (cmd == ID_PLAY) {
-        if (selected_item.m_playlist != std::numeric_limits<size_t>::max()
-            && selected_item.m_item != std::numeric_limits<size_t>::max()) {
-            m_playlist_api->playlist_execute_default_action(selected_item.m_playlist, selected_item.m_item);
-        }
-    } else if (cmd == ID_CUT) {
-        playlist_utils::cut();
-    } else if (cmd == ID_COPY) {
-        playlist_utils::copy();
-    } else if (cmd == ID_PASTE) {
-        if (playlist_selection_exists || from_keyboard) {
-            playlist_utils::paste_at_focused_item(get_wnd());
-        } else {
-            playlist_utils::paste(get_wnd(), (std::numeric_limits<size_t>::max)());
-        }
-    } else if (cmd >= ID_SELECTION && cmd < ID_CUSTOM_BASE && mainmenu_api.is_valid()) {
-        mainmenu_api->execute_command(cmd - ID_SELECTION);
-    } else if (cmd >= ID_CUSTOM_BASE && contextmenu_api.is_valid()) {
+    if (cmd >= ID_CUSTOM_BASE && contextmenu_api.is_valid())
         contextmenu_api->execute_by_id(cmd - ID_CUSTOM_BASE);
-    }
+    else if (cmd >= ID_SELECTION_BASE && cmd < ID_CUSTOM_BASE && mainmenu_api.is_valid())
+        mainmenu_api->execute_command(cmd - ID_SELECTION_BASE);
+    else if (cmd > 0 && cmd < ID_SELECTION_BASE)
+        collector.execute(cmd);
+
     return true;
 }
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -1366,7 +1366,6 @@ bool PlaylistView::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
     constexpr auto ID_SELECTION_BASE = 0x1000;
     constexpr auto ID_CUSTOM_BASE = 0x10000;
 
-    playlist_position_reference_tracker selected_item;
     const auto selection_count = m_playlist_api->activeplaylist_get_selection_count(2);
     const auto playlist_selection_exists = selection_count > 0;
     const auto show_shortcuts = standard_config_objects::query_show_keyboard_shortcuts_in_menus();
@@ -1374,71 +1373,104 @@ bool PlaylistView::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
     const uih::Menu menu;
     uih::MenuCommandCollector collector;
 
-    auto mainmenu_api = mainmenu_manager::get();
-    const auto mainmenu_flags = show_shortcuts ? mainmenu_manager::flag_show_shortcuts : 0;
-    const auto mainmenu_part
-        = playlist_selection_exists ? mainmenu_groups::edit_part2_selection : mainmenu_groups::edit_part1;
-
-    if (selection_count == 1) {
-        selected_item.m_playlist = m_playlist_api->get_active_playlist();
-
-        pfc::bit_array_bittable selection(m_playlist_api->activeplaylist_get_item_count());
-        m_playlist_api->activeplaylist_get_selection_mask(selection);
-
-        for (const auto index : std::ranges::views::iota(size_t{}, selection.size())) {
-            if (selection[index]) {
-                selected_item.m_item = index;
-                break;
-            }
-        }
-
-        menu.append_command(collector.add([&] {
-            if (selected_item.m_playlist != std::numeric_limits<size_t>::max()
-                && selected_item.m_item != std::numeric_limits<size_t>::max()) {
-                m_playlist_api->playlist_execute_default_action(selected_item.m_playlist, selected_item.m_item);
-            }
-        }),
-            L"Play"_zv, {.is_default = true});
-        menu.append_separator();
-    }
-
-    mainmenu_api->instantiate(mainmenu_part);
-    mainmenu_api->generate_menu_win32(
-        menu.get(), ID_SELECTION_BASE, ID_CUSTOM_BASE - ID_SELECTION_BASE, mainmenu_flags);
-
-    if (menu.size() > 0)
-        menu.append_separator();
-
-    if (playlist_selection_exists) {
-        menu.append_command(collector.add([&] { playlist_utils::cut(); }), L"Cut");
-        menu.append_command(collector.add([&] { playlist_utils::copy(); }), L"Copy");
-    }
-
-    const auto can_paste = playlist_utils::check_clipboard();
-
-    if (can_paste || !playlist_selection_exists)
-        menu.append_command(collector.add([&] {
-            if (playlist_selection_exists || from_keyboard) {
-                playlist_utils::paste_at_focused_item(get_wnd());
-            } else {
-                playlist_utils::paste(get_wnd(), (std::numeric_limits<size_t>::max)());
-            }
-        }),
-            L"Paste", {.is_disabled = !can_paste});
-
+    mainmenu_manager::ptr mainmenu_api;
     contextmenu_manager::ptr contextmenu_api;
 
-    if (playlist_selection_exists) {
-        menu.append_separator();
+    playlist_position_reference_tracker tracked_item;
+    tracked_item.m_playlist = m_playlist_api->get_active_playlist();
 
-        contextmenu_api = contextmenu_manager::get();
-        const auto contextmenu_flags = show_shortcuts ? contextmenu_manager::flag_show_shortcuts : 0;
+    auto client_pt = pt;
+    ScreenToClient(get_wnd(), &client_pt);
+    const auto hit_test = hit_test_ex(client_pt);
 
-        const keyboard_shortcut_manager::shortcut_type shortcuts[]
-            = {keyboard_shortcut_manager::TYPE_CONTEXT_PLAYLIST, keyboard_shortcut_manager::TYPE_CONTEXT};
-        contextmenu_api->set_shortcut_preference(shortcuts, gsl::narrow<unsigned>(std::size(shortcuts)));
-        contextmenu_api->init_context_playlist(contextmenu_flags);
-        contextmenu_api->win32_build_menu(menu.get(), ID_CUSTOM_BASE, -1);
+    if (hit_test.category == HitTestCategory::OnGroupInfoArea) {
+        tracked_item.m_item = hit_test.index;
+
+        menu.append_command(collector.add([&] {
+            if (tracked_item.m_playlist == SIZE_MAX || tracked_item.m_item == SIZE_MAX
+                || tracked_item.m_playlist != m_playlist_api->get_active_playlist())
+                return;
+
+            const auto item = get_item(tracked_item.m_item);
+            const auto group = item->get_leaf_group();
+
+            if (!group)
+                return;
+
+            group->reset_artwork();
+            m_artwork_manager->cancel_for_group(group);
+            invalidate_item_group_info_area(tracked_item.m_item);
+        }),
+            L"Reload");
+
+        menu.append_command(collector.add([&] {
+            flush_artwork_images();
+            invalidate_all();
+        }),
+            L"Reload all");
+    } else {
+        const auto mainmenu_flags = show_shortcuts ? mainmenu_manager::flag_show_shortcuts : 0;
+        const auto mainmenu_part
+            = playlist_selection_exists ? mainmenu_groups::edit_part2_selection : mainmenu_groups::edit_part1;
+
+        if (selection_count == 1) {
+            pfc::bit_array_bittable selection(m_playlist_api->activeplaylist_get_item_count());
+            m_playlist_api->activeplaylist_get_selection_mask(selection);
+
+            for (const auto index : std::ranges::views::iota(size_t{}, selection.size())) {
+                if (selection[index]) {
+                    tracked_item.m_item = index;
+                    break;
+                }
+            }
+
+            menu.append_command(collector.add([&] {
+                if (tracked_item.m_playlist != std::numeric_limits<size_t>::max()
+                    && tracked_item.m_item != std::numeric_limits<size_t>::max()) {
+                    m_playlist_api->playlist_execute_default_action(tracked_item.m_playlist, tracked_item.m_item);
+                }
+            }),
+                L"Play"_zv, {.is_default = true});
+            menu.append_separator();
+        }
+
+        mainmenu_api = mainmenu_manager::get();
+        mainmenu_api->instantiate(mainmenu_part);
+        mainmenu_api->generate_menu_win32(
+            menu.get(), ID_SELECTION_BASE, ID_CUSTOM_BASE - ID_SELECTION_BASE, mainmenu_flags);
+
+        if (menu.size() > 0)
+            menu.append_separator();
+
+        if (playlist_selection_exists) {
+            menu.append_command(collector.add([&] { playlist_utils::cut(); }), L"Cut");
+            menu.append_command(collector.add([&] { playlist_utils::copy(); }), L"Copy");
+        }
+
+        const auto can_paste = playlist_utils::check_clipboard();
+
+        if (can_paste || !playlist_selection_exists)
+            menu.append_command(collector.add([&] {
+                if (playlist_selection_exists || from_keyboard) {
+                    playlist_utils::paste_at_focused_item(get_wnd());
+                } else {
+                    playlist_utils::paste(get_wnd(), (std::numeric_limits<size_t>::max)());
+                }
+            }),
+                L"Paste", {.is_disabled = !can_paste});
+
+        if (playlist_selection_exists) {
+            menu.append_separator();
+
+            contextmenu_api = contextmenu_manager::get();
+            const auto contextmenu_flags = show_shortcuts ? contextmenu_manager::flag_show_shortcuts : 0;
+
+            const keyboard_shortcut_manager::shortcut_type shortcuts[]
+                = {keyboard_shortcut_manager::TYPE_CONTEXT_PLAYLIST, keyboard_shortcut_manager::TYPE_CONTEXT};
+            contextmenu_api->set_shortcut_preference(shortcuts, gsl::narrow<unsigned>(std::size(shortcuts)));
+            contextmenu_api->init_context_playlist(contextmenu_flags);
+            contextmenu_api->win32_build_menu(menu.get(), ID_CUSTOM_BASE, -1);
+        }
     }
 
     menu_helpers::win32_auto_mnemonics(menu.get());


### PR DESCRIPTION
This adds a context menu to artwork in the playlist view. This contains two commands – one to reload artwork for that group, and one to reload all artwork in the playlist.

The rest of the playlist view context menu code was also refactored and updated to use `uih::Menu`.