### PR TITLE
Disable Dependabot cooldown for submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 0
     groups:
       submodules:
         patterns:


### PR DESCRIPTION
This disables the Dependabot cooldown (that was recently enabled by default) for submodules, as the submodules are all first-party repos.