### PR TITLE
Add fallback main menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## Development version
 
+### Features
+
+- Pressing Alt now shows the main menu as a pop-up menu in the top-left corner
+  of the main window when there is no menu bar in the toolbar area or in the
+  layout. [[#1816](https://github.com/reupen/columns_ui/pull/1816)]
+
+  This includes being able to directly access each top-level menu using their
+  access keys (e.g. Alt+F for the File menu).
+
 ### Bug fixes
+
+- Pressing main menu access keys with Shift held down (e.g. Alt+Shift+F) now
+  opens the relevant menu (with hidden items shown) as expected.
+  [[#1816](https://github.com/reupen/columns_ui/pull/1816)]
 
 - A bug where message box alert sounds may have played with an unexpected
   spatial effect applied was fixed.

--- a/foo_ui_columns/fallback_menu.cpp
+++ b/foo_ui_columns/fallback_menu.cpp
@@ -1,0 +1,163 @@
+#include "pch.h"
+
+#include "fallback_menu.h"
+#include "menu_mnemonics.h"
+#include "win32.h"
+
+namespace cui {
+
+void FallbackMenu::show(HWND wnd)
+{
+    show_internal(wnd, {});
+}
+
+void FallbackMenu::show_for_accelerator(HWND wnd, wchar_t accelerator)
+{
+    initialise();
+
+    if (ranges::find_if(m_root_items, [&](const auto& item) { return item.accelerator == accelerator; })
+        == ranges::end(m_root_items))
+        return;
+
+    fb2k::inMainThread([this, self{weak_from_this()}, wnd, accelerator] {
+        if (self.expired())
+            return;
+
+        show_internal(wnd, accelerator);
+    });
+}
+
+bool FallbackMenu::on_menu_select(uint32_t id, uint32_t flags) const
+{
+    if (!m_status_text_override.is_valid() || m_root_items.empty() || m_base_id_increment == 0)
+        return false;
+
+    if (flags & MF_POPUP) {
+        m_status_text_override->revert_text();
+        return true;
+    }
+
+    const auto root_group_index = (id - 1) / m_base_id_increment;
+
+    if (root_group_index >= m_root_items.size())
+        return false;
+
+    pfc::string8 description;
+
+    m_root_items[root_group_index].manager->get_description(
+        id - 1 - m_base_id_increment * gsl::narrow<uint32_t>(root_group_index), description);
+
+    if (description.empty())
+        m_status_text_override->revert_text();
+    else
+        m_status_text_override->override_text(description);
+
+    return true;
+}
+
+void FallbackMenu::initialise()
+{
+    if (m_initialised)
+        return;
+
+    m_initialised = true;
+
+    MnemonicManager mnemonic_manager;
+
+    for (const auto group : mainmenu_group::enumerate()) {
+        if (group->get_parent() != GUID{})
+            continue;
+
+        mainmenu_group_popup::ptr popup_group;
+        popup_group &= group;
+
+        if (!popup_group.is_valid())
+            continue;
+
+        FallbackMenuRootItem root_item;
+
+        std::string name;
+        mmh::StringAdaptor adapted_name(name);
+        popup_group->get_display_string(adapted_name);
+
+        mmh::StringAdaptor adapted_name_with_accelerator(root_item.name_with_accelerator);
+        root_item.accelerator = mnemonic_manager.process_string(name.c_str(), adapted_name_with_accelerator);
+
+        root_item.sort_priority = popup_group->get_sort_priority();
+        root_item.manager = mainmenu_manager::get();
+        root_item.manager->instantiate(popup_group->get_guid());
+
+        m_root_items.emplace_back(std::move(root_item));
+    }
+
+    std::ranges::sort(
+        m_root_items, [](const auto& left, const auto& right) { return left.sort_priority < right.sort_priority; });
+
+    m_base_id_increment = UINT16_MAX / gsl::narrow<uint16_t>(m_root_items.size());
+}
+
+void FallbackMenu::show_internal(HWND wnd, std::optional<wchar_t> accelerator)
+{
+    initialise();
+
+    if (m_root_items.empty() || m_base_id_increment == 0)
+        return;
+
+    const auto menu_flags
+        = standard_config_objects::query_show_keyboard_shortcuts_in_menus() ? mainmenu_manager::flag_show_shortcuts : 0;
+
+    uih::Menu menu;
+    HMENU accelerator_menu{};
+
+    for (auto&& [index, root_item] : ranges::views::enumerate(m_root_items)) {
+        uih::Menu submenu;
+
+        if (accelerator && root_item.accelerator == accelerator)
+            accelerator_menu = submenu.get();
+
+        root_item.manager->generate_menu_win32(
+            submenu.get(), 1 + m_base_id_increment * gsl::narrow<uint32_t>(index), m_base_id_increment, menu_flags);
+        menu.append_submenu(std::move(submenu), mmh::to_utf16(root_item.name_with_accelerator.c_str()));
+    }
+
+    menu_helpers::win32_auto_mnemonics(menu.get());
+
+    fb2k::inMainThread([accelerator, accelerator_menu, menu{menu.get()}] {
+        const auto menu_wnd = win32::find_window_for_menu(menu);
+
+        if (!menu_wnd)
+            return;
+
+        if (accelerator && accelerator_menu) {
+            SendMessage(menu_wnd, WM_CHAR, *accelerator, 0);
+
+            if (const auto submenu_wnd = win32::find_window_for_menu(accelerator_menu))
+                PostMessage(submenu_wnd, WM_KEYDOWN, VK_DOWN, 0);
+        } else {
+            PostMessage(menu_wnd, WM_KEYDOWN, VK_DOWN, 0);
+        }
+    });
+
+    const auto self = shared_from_this();
+
+    ui_control::get()->override_status_text_create(m_status_text_override);
+
+    POINT pt{};
+    ClientToScreen(wnd, &pt);
+    const auto id = menu.run(wnd, pt, {.is_right_button = false});
+
+    m_status_text_override.reset();
+
+    if (id == 0)
+        return;
+
+    const auto root_group_index = (id - 1) / m_base_id_increment;
+
+    if (root_group_index >= m_root_items.size())
+        return;
+
+    m_root_items[root_group_index].manager->execute_command(
+        id - 1 - m_base_id_increment * gsl::narrow<uint32_t>(root_group_index));
+}
+
+} // namespace cui

--- a/foo_ui_columns/fallback_menu.h
+++ b/foo_ui_columns/fallback_menu.h
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace cui {
+
+struct FallbackMenuRootItem {
+    std::string name_with_accelerator;
+    std::optional<wchar_t> accelerator;
+    uint32_t sort_priority{};
+    mainmenu_manager::ptr manager;
+};
+
+class FallbackMenu : public std::enable_shared_from_this<FallbackMenu> {
+public:
+    using Ptr = std::shared_ptr<FallbackMenu>;
+
+    void show(HWND wnd);
+    void show_for_accelerator(HWND wnd, wchar_t accelerator);
+    bool on_menu_select(uint32_t id, uint32_t flags) const;
+
+private:
+    void initialise();
+    void show_internal(HWND wnd, std::optional<wchar_t> accelerator = {});
+
+    bool m_initialised{};
+    std::vector<FallbackMenuRootItem> m_root_items;
+    ui_status_text_override::ptr m_status_text_override;
+    uint32_t m_base_id_increment{};
+};
+
+} // namespace cui

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -268,6 +268,7 @@
     <ClCompile Include="dark_mode_active_ui.cpp" />
     <ClCompile Include="dark_mode_dialog.cpp" />
     <ClCompile Include="dark_mode_spin.cpp" />
+    <ClCompile Include="fallback_menu.cpp" />
     <ClCompile Include="fb2k_callbacks.cpp" />
     <ClCompile Include="fb2k_misc.cpp" />
     <ClCompile Include="file_info_utils.cpp" />
@@ -462,6 +463,7 @@
     <ClInclude Include="dark_mode_dialog.h" />
     <ClInclude Include="dark_mode_active_ui.h" />
     <ClInclude Include="dark_mode_spin.h" />
+    <ClInclude Include="fallback_menu.h" />
     <ClInclude Include="fb2k_callbacks.h" />
     <ClInclude Include="fb2k_misc.h" />
     <ClInclude Include="file_info_utils.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -671,6 +671,9 @@
     <ClCompile Include="tab_pview_search.cpp">
       <Filter>Config UI</Filter>
     </ClCompile>
+    <ClCompile Include="fallback_menu.cpp">
+      <Filter>Main window</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -1021,6 +1024,9 @@
     </ClInclude>
     <ClInclude Include="scroll.h">
       <Filter>Utilities</Filter>
+    </ClInclude>
+    <ClInclude Include="fallback_menu.h">
+      <Filter>Main window</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include "fallback_menu.h"
 #include "icons.h"
 
 /** Main window UI control IDs */
@@ -12,7 +14,7 @@ enum {
     MSG_RUN_INITIAL_SETUP,
     MSG_SYSTEM_TRAY_ICON,
     MSG_CREATE_TASKBAR_BUTTONS,
-    MSG_UPDATE_TASKBAR_BUTTONS
+    MSG_UPDATE_TASKBAR_BUTTONS,
 };
 
 bool remember_window_pos();
@@ -88,6 +90,7 @@ private:
     bool m_last_systray_x1_down{};
     bool m_last_systray_x2_down{};
     bool m_ignore_next_wm_syschar_message{};
+    FallbackMenu::Ptr m_fallback_menu;
     ULONG_PTR m_gdiplus_instance{};
     UINT m_wm_taskbarcreated{};
     UINT m_wm_taskbarbuttoncreated{};

--- a/foo_ui_columns/menu_mnemonics.h
+++ b/foo_ui_columns/menu_mnemonics.h
@@ -28,11 +28,11 @@
  */
 class MnemonicManager {
     pfc::string8_fast_aggressive used;
-    bool is_used(unsigned c)
+    bool is_used(unsigned c) const
     {
         char temp[8];
         temp[pfc::utf8_encode_char(uCharLower(c), temp)] = 0;
-        return !!strstr(used, temp);
+        return strstr(used, temp) != nullptr;
     }
 
     static bool is_alphanumeric(char c)
@@ -40,54 +40,37 @@ class MnemonicManager {
         return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
     }
 
-    void insert(const char* src, unsigned idx, pfc::string_base& out)
+    char insert(const char* src, unsigned idx, pfc::string_base& out)
     {
         out.reset();
         out.add_string(src, idx);
         out.add_string("&");
         out.add_string(src + idx);
-        used.add_char(uCharLower(src[idx]));
+        const auto lower_char = uCharLower(src[idx]);
+        used.add_char(lower_char);
+        return static_cast<char>(lower_char);
     }
 
 public:
-    bool check_string(const char* src)
-    { // check for existing mnemonics
-        const char* ptr = src;
-        while ((ptr = strchr(ptr, '&'))) {
-            if (ptr[1] == '&')
-                ptr += 2;
-            else {
-                unsigned c = 0;
-                if (pfc::utf8_decode_char(ptr + 1, c) > 0) {
-                    if (!is_used(c))
-                        used.add_char(uCharLower(c));
-                }
-                return true;
-            }
-        }
-        return false;
-    }
-    bool process_string(const char* src, pfc::string_base& out) // returns if changed
+    std::optional<char> process_string(const char* src, pfc::string_base& out) // returns if changed
     {
-        if (check_string(src)) {
-            out = src;
-            return false;
-        }
         unsigned idx = 0;
+
         while (src[idx] == ' ')
-            idx++;
+            ++idx;
+
         while (src[idx]) {
-            if (is_alphanumeric(src[idx]) && !is_used(src[idx])) {
-                insert(src, idx, out);
-                return true;
-            }
+            if (is_alphanumeric(src[idx]) && !is_used(src[idx]))
+                return insert(src, idx, out);
 
             while (src[idx] && src[idx] != ' ' && src[idx] != '\t')
-                idx++;
+                ++idx;
+
             if (src[idx] == '\t')
                 break;
+
             while (src[idx] == ' ')
-                idx++;
+                ++idx;
         }
 
         // no success picking first letter of one of words
@@ -95,15 +78,15 @@ public:
         while (src[idx]) {
             if (src[idx] == '\t')
                 break;
-            if (is_alphanumeric(src[idx]) && !is_used(src[idx])) {
-                insert(src, idx, out);
-                return true;
-            }
-            idx++;
+
+            if (is_alphanumeric(src[idx]) && !is_used(src[idx]))
+                return insert(src, idx, out);
+
+            ++idx;
         }
 
         // giving up
         out = src;
-        return false;
+        return {};
     }
 };

--- a/foo_ui_columns/mw_wnd_proc.cpp
+++ b/foo_ui_columns/mw_wnd_proc.cpp
@@ -185,6 +185,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     case WM_NCDESTROY:
         m_taskbar_button_images.reset();
         m_buffered_paint_initialiser.reset();
+        m_fallback_menu.reset();
         break;
     case WM_CLOSE:
         if (config::advbool_close_to_system_tray_icon.get()) {
@@ -213,6 +214,12 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
     } break;
     case WM_MENUSELECT: {
+        const auto id = LOWORD(wp);
+        const auto flags = HIWORD(wp);
+
+        if (m_fallback_menu && m_fallback_menu->on_menu_select(id, flags))
+            break;
+
         if (!m_status_text_override.is_valid())
             break;
 
@@ -222,12 +229,10 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                 || statusbar_contextmenus::g_main_nowplaying.is_valid()))
             break;
 
-        if (HIWORD(wp) & MF_POPUP) {
+        if (flags & MF_POPUP) {
             m_status_text_override->revert_text();
             break;
         }
-
-        unsigned id = LOWORD(wp);
 
         pfc::string8 item_description;
         if (statusbar_contextmenus::g_main_nowplaying.is_valid()) {
@@ -295,7 +300,7 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     case WM_SYSCOMMAND:
         switch (wp) {
-        case SC_KEYMENU:
+        case SC_KEYMENU: {
             if (lp)
                 break;
 
@@ -303,12 +308,22 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             if (HIBYTE(GetKeyState(VK_CONTROL)))
                 break;
 
-            if (rebar::g_rebar_window && rebar::g_rebar_window->set_menu_focus())
+            if (rebar::g_rebar_window && rebar::g_rebar_window->set_menu_focus()) {
                 g_layout_window.hide_menu_access_keys();
-            else
-                g_layout_window.set_menu_focus();
+                return 0;
+            }
+
+            if (g_layout_window.set_menu_focus())
+                return 0;
+
+            if (!m_fallback_menu)
+                m_fallback_menu = std::make_shared<FallbackMenu>();
+
+            m_fallback_menu->show(wnd);
 
             return 0;
+        }
+
         case SC_MINIMIZE:
             if (GetForegroundWindow() == wnd)
                 save_focus_state();
@@ -316,15 +331,22 @@ LRESULT cui::MainWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
         break;
     case WM_MENUCHAR: {
-        unsigned short chr = LOWORD(wp);
-        bool processed = false;
-        if (rebar::g_rebar_window) {
-            processed = rebar::g_rebar_window->on_menu_char(chr);
-        }
-        if (!processed)
-            g_layout_window.on_menu_char(chr);
-    }
+        const wchar_t chr = static_cast<wchar_t>(uCharLower(LOWORD(wp)));
+
+        [&] {
+            if (rebar::g_rebar_window && rebar::g_rebar_window->on_menu_char(chr))
+                return;
+
+            if (g_layout_window.on_menu_char(chr))
+                return;
+
+            if (!m_fallback_menu)
+                m_fallback_menu = std::make_shared<FallbackMenu>();
+
+            m_fallback_menu->show_for_accelerator(wnd, chr);
+        }();
         return (MNC_CLOSE << 16);
+    }
     case WM_CONTEXTMENU:
         if (g_status && (HWND)wp == g_status) {
             POINT pt = {(short)(LOWORD(lp)), (short)(HIWORD(lp))};

--- a/foo_ui_columns/win32.cpp
+++ b/foo_ui_columns/win32.cpp
@@ -55,4 +55,40 @@ void handle_tab_key(HWND wnd)
         uih::show_focus_indicator(focused_wnd);
 }
 
+namespace {
+
+struct EnumThreadWindowsContext {
+    HMENU m_menu{};
+    HWND m_found_menu_wnd{};
+};
+
+} // namespace
+
+HWND find_window_for_menu(HMENU menu)
+{
+    EnumThreadWindowsContext context{.m_menu = menu};
+
+    EnumThreadWindows(
+        0,
+        [](HWND wnd, LPARAM lp) {
+            const auto context = reinterpret_cast<EnumThreadWindowsContext*>(lp);
+
+            std::array<wchar_t, 256> class_name{};
+            if (GetClassName(wnd, class_name.data(), gsl::narrow<int>(class_name.size())) == 0)
+                return TRUE;
+
+            if (wcsncmp(L"#32768", class_name.data(), class_name.size()) != 0)
+                return TRUE;
+
+            if (reinterpret_cast<HMENU>(SendMessage(wnd, MN_GETHMENU, 0, 0)) != context->m_menu)
+                return TRUE;
+
+            context->m_found_menu_wnd = wnd;
+            return FALSE;
+        },
+        reinterpret_cast<LPARAM>(&context));
+
+    return context.m_found_menu_wnd;
+}
+
 } // namespace cui::win32

--- a/foo_ui_columns/win32.h
+++ b/foo_ui_columns/win32.h
@@ -11,4 +11,6 @@ void remove_window_styles(HWND wnd, DWORD styles_to_remove);
 
 void handle_tab_key(HWND wnd);
 
+HWND find_window_for_menu(HMENU menu);
+
 } // namespace cui::win32


### PR DESCRIPTION
Resolves #33

This adds a fallback main menu when there is no menu bar in the toolbar area or in the layout.

This is shown by pressing the Alt key. It appears as a pop-up menu in the top-left corner of the main window.

The behaviour is intended to be similar to Windows Media Player Legacy. This includes being able to directly access each top-level menu using their access keys (e.g. Alt+F for the File menu).