### PR TITLE
Show more context menu item descriptions in status area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@
   spatial effect applied was fixed.
   [[#1812](https://github.com/reupen/columns_ui/pull/1812)]
 
-- A bug where menu item descriptions for the system tray icon context menu were
-  not shown in the status pane was fixed.
-  [[#1815](https://github.com/reupen/columns_ui/pull/1815)]
+- Menu item descriptions in various context menus are now more consistently
+  shown in the status bar and status pane.
+  [[#1815](https://github.com/reupen/columns_ui/pull/1815),
+  [#1818](https://github.com/reupen/columns_ui/pull/1818)]
 
 ### Internal changes
 

--- a/foo_ui_columns/ng_playlist/ng_playlist.cpp
+++ b/foo_ui_columns/ng_playlist/ng_playlist.cpp
@@ -1364,7 +1364,7 @@ void PlaylistView::notify_on_menu_select(WPARAM wp, LPARAM lp)
 bool PlaylistView::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
 {
     constexpr auto ID_SELECTION_BASE = 0x1000;
-    constexpr auto ID_CUSTOM_BASE = 0x10000;
+    constexpr auto ID_CUSTOM_BASE = 0x2000;
 
     const auto selection_count = m_playlist_api->activeplaylist_get_selection_count(2);
     const auto playlist_selection_exists = selection_count > 0;

--- a/foo_ui_columns/playlist_switcher_shortcut_menu.cpp
+++ b/foo_ui_columns/playlist_switcher_shortcut_menu.cpp
@@ -7,8 +7,6 @@ namespace cui::panels::playlist_switcher {
 
 bool PlaylistSwitcher::notify_on_contextmenu(const POINT& pt, bool from_keyboard)
 {
-    uie::window_ptr p_this_temp = this;
-
     uih::Menu menu;
     uih::MenuCommandCollector collector;
 
@@ -206,9 +204,17 @@ bool PlaylistSwitcher::notify_on_contextmenu(const POINT& pt, bool from_keyboard
     }
 
     menu_helpers::win32_auto_mnemonics(menu.get());
+
+    m_contextmenu_base_id = context_manager_base_id;
+    m_contextmenu_manager = contextmenu_manager;
+    get_host()->override_status_text_create(m_status_text_override);
+    ptr self{this};
+
     const auto command_id = menu.run(get_wnd(), pt);
 
-    m_status_text_override.release();
+    m_status_text_override.reset();
+    m_contextmenu_base_id.reset();
+    m_contextmenu_manager.reset();
     remove_highlight_selected_item();
 
     if (context_manager_base_id && command_id >= *context_manager_base_id)
@@ -217,6 +223,33 @@ bool PlaylistSwitcher::notify_on_contextmenu(const POINT& pt, bool from_keyboard
         collector.execute(command_id);
 
     return true;
+}
+
+void PlaylistSwitcher::notify_on_menu_select(WPARAM wp, LPARAM lp)
+{
+    if (!m_status_text_override.is_valid())
+        return;
+
+    if (HIWORD(wp) & MF_POPUP) {
+        m_status_text_override->revert_text();
+        return;
+    }
+
+    if (m_contextmenu_manager.is_valid() && m_contextmenu_base_id) {
+        const auto id = LOWORD(wp);
+
+        if (id >= *m_contextmenu_base_id) {
+            auto* node = m_contextmenu_manager->find_by_id(id - *m_contextmenu_base_id);
+
+            pfc::string8 description;
+            if (node && node->get_description(description)) {
+                m_status_text_override->override_text(description);
+                return;
+            }
+        }
+    }
+
+    m_status_text_override->revert_text();
 }
 
 } // namespace cui::panels::playlist_switcher

--- a/foo_ui_columns/playlist_switcher_v2.h
+++ b/foo_ui_columns/playlist_switcher_v2.h
@@ -151,6 +151,8 @@ public:
 
     bool notify_on_contextmenu(const POINT& pt, bool from_keyboard) override;
 
+    void notify_on_menu_select(WPARAM wp, LPARAM lp) override;
+
     bool notify_on_keyboard_keydown_filter(UINT msg, WPARAM wp, LPARAM lp) override
     {
         return g_process_keydown_keyboard_shortcuts(wp);
@@ -349,6 +351,8 @@ private:
         pfc::string8 m_playlist_name;
     };
 
+    std::optional<uint32_t> m_contextmenu_base_id;
+    contextmenu_manager::ptr m_contextmenu_manager;
     ui_status_text_override::ptr m_status_text_override;
     ui_selection_holder::ptr m_selection_holder;
 


### PR DESCRIPTION
This fixes a problem where menu item descriptions weren’t shown in the status bar or pane for most of the playlist view context menu.

This was happening as the `WM_MENUSELECT` message only supports 16-bit command IDs, and larger values were previously being used.

This also adds support for showing menu item descriptions in the status bar or pane for the Items submenu in the playlist switcher context menu.