### PR TITLE
Don't trigger keyboard shortcuts for Shift+character in edit boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   opens the relevant menu (with hidden items shown) as expected.
   [[#1816](https://github.com/reupen/columns_ui/pull/1816)]
 
+- Keyboard shortcuts are no longer triggered when typing capital letters or
+  symbols with the shift key in Filter search toolbar and in inline editing edit
+  boxes in the playlist view, playlist switcher, Filter panel and Item
+  properties. [[#1824](https://github.com/reupen/columns_ui/pull/1824)]
+
 - A bug where message box alert sounds may have played with an unexpected
   spatial effect applied was fixed.
   [[#1812](https://github.com/reupen/columns_ui/pull/1812)]

--- a/foo_ui_columns/fb2k_misc.cpp
+++ b/foo_ui_columns/fb2k_misc.cpp
@@ -43,11 +43,10 @@ bool process_edit_keyboard_shortcuts(WPARAM wp)
     if (modifiers == (MOD_CONTROL | MOD_SHIFT) && wp == 'Z')
         return false;
 
-    const auto key_code = get_key_code(wp, modifiers);
-
-    if (keyboard_shortcut_manager::is_typing_key_combo(key_code, modifiers))
+    if (keyboard_shortcut_manager::is_typing_key_combo(static_cast<uint32_t>(wp), modifiers))
         return false;
 
+    const auto key_code = get_key_code(wp, modifiers);
     return keyboard_shortcut_manager_v2::get()->process_keydown_simple(key_code);
 }
 


### PR DESCRIPTION
Resolves #1823

This fixes a bug in the processing of keyboard shortcuts in built-in edit boxes that inadvertently caused keyboard shortcuts to be triggered when using Shift in combination with a character (e.g. to type capital letters).

This was simply due to the wrong argument being passed to another function.