### PR TITLE
Show command picker when double-clicking on items in Buttons options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   This includes being able to directly access each top-level menu using their
   access keys (e.g. Alt+F for the File menu).
 
+- Double-clicking on list items in the Buttons toolbar options dialogue now
+  opens the command picker.
+  [[#1827](https://github.com/reupen/columns_ui/pull/1827)]
+
 ### Bug fixes
 
 - Pressing main menu access keys with Shift held down (e.g. Alt+Shift+F) now

--- a/foo_ui_columns/buttons.h
+++ b/foo_ui_columns/buttons.h
@@ -76,6 +76,7 @@ public:
             void notify_on_destroy() override;
             void notify_on_selection_change(const bit_array& p_affected, const bit_array& p_status,
                 notification_source_t p_notification_source) override;
+            void execute_default_action(size_t index, size_t column, bool b_keyboard, bool b_ctrl) override;
             bool do_drag_drop(WPARAM wp) override;
             void move_selection(int delta) override;
 
@@ -94,6 +95,7 @@ public:
         void update_size_field_status();
 
         void on_selection_change(size_t index);
+        void show_command_picker();
         void populate_buttons_list();
         void refresh_buttons_list_items(size_t index, size_t count, bool b_update_display = true);
 

--- a/foo_ui_columns/buttons_config_listview.cpp
+++ b/foo_ui_columns/buttons_config_listview.cpp
@@ -29,6 +29,12 @@ void ButtonsToolbar::ConfigParam::ButtonsList::notify_on_selection_change(
     m_param.on_selection_change(index);
 }
 
+void ButtonsToolbar::ConfigParam::ButtonsList::execute_default_action(
+    size_t index, size_t column, bool b_keyboard, bool b_ctrl)
+{
+    m_param.show_command_picker();
+}
+
 bool ButtonsToolbar::ConfigParam::ButtonsList::do_drag_drop(WPARAM wp)
 {
     DWORD drop_effect{DROPEFFECT_NONE};

--- a/foo_ui_columns/buttons_config_param.cpp
+++ b/foo_ui_columns/buttons_config_param.cpp
@@ -199,6 +199,44 @@ void ButtonsToolbar::ConfigParam::on_selection_change(size_t index)
     EnableWindow(GetDlgItem(m_wnd, IDC_BROWSE_HOVER_ICON), b_enable && has_custom_hover_icon);
 }
 
+void ButtonsToolbar::ConfigParam::show_command_picker()
+{
+    if (!m_selection)
+        return;
+
+    CommandPickerDialog command_picker_dialog(
+        {m_selection->m_guid, m_selection->m_subcommand, m_selection->m_type, m_selection->m_filter});
+
+    const auto [succeeded, data] = command_picker_dialog.open_modal(m_wnd);
+
+    if (!succeeded)
+        return;
+
+    m_selection->m_type = static_cast<Type>(data.group);
+    m_selection->m_guid = data.guid;
+    m_selection->m_subcommand = data.subcommand;
+    m_selection->m_filter = static_cast<Filter>(data.filter);
+    m_selection->m_interface.release();
+
+    const auto idx = m_button_list.get_selected_item_single();
+    if (idx != pfc_infinite) {
+        refresh_buttons_list_items(idx, 1);
+    }
+
+    bool b_enable = m_selection->m_type != TYPE_SEPARATOR;
+    EnableWindow(GetDlgItem(m_wnd, IDC_SHOW), m_selection->m_type != TYPE_SEPARATOR);
+    EnableWindow(GetDlgItem(m_wnd, IDC_USE_CUSTOM_TEXT), b_enable);
+    EnableWindow(GetDlgItem(m_wnd, IDC_TEXT), b_enable && m_selection->m_use_custom_text);
+
+    EnableWindow(GetDlgItem(m_wnd, IDC_USE_CUSTOM_ICON), b_enable);
+    EnableWindow(GetDlgItem(m_wnd, IDC_ICON_PATH), b_enable && m_selection->m_use_custom);
+    EnableWindow(GetDlgItem(m_wnd, IDC_BROWSE_ICON), b_enable && m_selection->m_use_custom);
+
+    EnableWindow(GetDlgItem(m_wnd, IDC_USE_CUSTOM_HOVER_ICON), b_enable);
+    EnableWindow(GetDlgItem(m_wnd, IDC_HOVER_ICON_PATH), b_enable && m_selection->m_use_custom_hot);
+    EnableWindow(GetDlgItem(m_wnd, IDC_BROWSE_HOVER_ICON), b_enable && m_selection->m_use_custom_hot);
+}
+
 void ButtonsToolbar::ConfigParam::populate_buttons_list()
 {
     const auto count = m_buttons.size();
@@ -447,40 +485,7 @@ INT_PTR ButtonsToolbar::ConfigParam::on_dialog_message(HWND wnd, UINT msg, WPARA
             break;
         }
         case IDC_PICK: {
-            if (!m_selection)
-                break;
-
-            CommandPickerDialog command_picker_dialog(
-                {m_selection->m_guid, m_selection->m_subcommand, m_selection->m_type, m_selection->m_filter});
-
-            const auto [succeeded, data] = command_picker_dialog.open_modal(wnd);
-
-            if (!succeeded)
-                break;
-
-            m_selection->m_type = static_cast<Type>(data.group);
-            m_selection->m_guid = data.guid;
-            m_selection->m_subcommand = data.subcommand;
-            m_selection->m_filter = static_cast<Filter>(data.filter);
-            m_selection->m_interface.release();
-
-            const auto idx = m_button_list.get_selected_item_single();
-            if (idx != pfc_infinite) {
-                refresh_buttons_list_items(idx, 1);
-            }
-            bool b_enable = m_selection->m_type != TYPE_SEPARATOR;
-            EnableWindow(GetDlgItem(wnd, IDC_SHOW), m_selection->m_type != TYPE_SEPARATOR);
-            EnableWindow(GetDlgItem(wnd, IDC_USE_CUSTOM_TEXT), b_enable);
-            EnableWindow(GetDlgItem(wnd, IDC_TEXT), b_enable && m_selection->m_use_custom_text);
-
-            EnableWindow(GetDlgItem(wnd, IDC_USE_CUSTOM_ICON), b_enable);
-            EnableWindow(GetDlgItem(wnd, IDC_ICON_PATH), b_enable && m_selection->m_use_custom);
-            EnableWindow(GetDlgItem(wnd, IDC_BROWSE_ICON), b_enable && m_selection->m_use_custom);
-
-            EnableWindow(GetDlgItem(wnd, IDC_USE_CUSTOM_HOVER_ICON), b_enable);
-            EnableWindow(GetDlgItem(wnd, IDC_HOVER_ICON_PATH), b_enable && m_selection->m_use_custom_hot);
-            EnableWindow(GetDlgItem(wnd, IDC_BROWSE_HOVER_ICON), b_enable && m_selection->m_use_custom_hot);
-
+            show_command_picker();
             break;
         }
         case IDC_USE_CUSTOM_ICON:


### PR DESCRIPTION
This makes the options dialogue for the Buttons toolbar open the command picker when double-clicking on an item in the list view.