### PR TITLE
Refactor and improve Item details track tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,14 @@
   boxes in the playlist view, playlist switcher, Filter panel and Item
   properties. [[#1824](https://github.com/reupen/columns_ui/pull/1824)]
 
+- A bug where Item details did not correctly track items being added or removed
+  from the playlist in playlist selection tracking modes was fixed.
+  [[#1846](https://github.com/reupen/columns_ui/pull/1846)]
+
+- A bug where some text labels in Quick setup were truncated at some display
+  scales was fixed. [[#1845](https://github.com/reupen/columns_ui/pull/1845)
+  (contributed by [@marc2k3](https://github.com/marc2k3))]
+
 - A bug where message box alert sounds may have played with an unexpected
   spatial effect applied was fixed.
   [[#1812](https://github.com/reupen/columns_ui/pull/1812)]

--- a/foo_ui_columns/context_tracker.cpp
+++ b/foo_ui_columns/context_tracker.cpp
@@ -67,7 +67,8 @@ wil::zstring_view get_tracking_mode_name(TrackingMode mode)
 
 ContextTracker::ContextTracker(TrackingMode tracking_mode, bool track_single_item, ContextTrackerCallback callback)
     : play_callback_impl_base(flag_on_playback_new_track | flag_on_playback_stop)
-    , playlist_callback_single_impl_base(flag_on_items_selection_change | flag_on_playlist_switch)
+    , playlist_callback_single_impl_base(flag_on_items_added | flag_on_items_removing | flag_on_items_removed
+          | flag_on_items_selection_change | flag_on_playlist_switch)
     , m_tracking_mode(tracking_mode)
     , m_track_single_item(track_single_item)
     , m_callback(std::move(callback))
@@ -104,6 +105,51 @@ void ContextTracker::on_selection_changed(const pfc::list_base_const_t<metadb_ha
         && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
         set_selection_tracks(m_ui_selection_tracks);
     }
+}
+
+void ContextTracker::on_items_added(
+    size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
+{
+    if (!tracking_includes_playlist_selection()
+        || (tracking_prioritises_playing_item() && !m_playback_control->is_playing()))
+        return;
+
+    for (const auto index : ranges::views::iota(p_base, p_base + p_data.size())) {
+        if (p_selection[index]) {
+            set_selection_tracks(get_playlist_selection());
+            return;
+        }
+    }
+}
+
+void ContextTracker::on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
+{
+    m_process_playlist_items_removed = false;
+
+    if (!tracking_includes_playlist_selection()
+        || (tracking_prioritises_playing_item() && !m_playback_control->is_playing()))
+        return;
+
+    m_playlist_manager->activeplaylist_enum_items(
+        [&](size_t index, const metadb_handle_ptr& track, bool is_selected) {
+            m_process_playlist_items_removed = true;
+            return !is_selected;
+        },
+        p_mask);
+}
+
+void ContextTracker::on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
+{
+    if (!m_process_playlist_items_removed)
+        return;
+
+    m_process_playlist_items_removed = false;
+
+    if (!tracking_includes_playlist_selection()
+        || (tracking_prioritises_playing_item() && !m_playback_control->is_playing()))
+        return;
+
+    set_selection_tracks(get_playlist_selection());
 }
 
 void ContextTracker::on_playlist_switch() noexcept

--- a/foo_ui_columns/context_tracker.cpp
+++ b/foo_ui_columns/context_tracker.cpp
@@ -1,0 +1,232 @@
+#include "pch.h"
+
+#include "context_tracker.h"
+
+namespace cui::utils {
+
+namespace {
+
+const std::unordered_map<TrackingMode, wil::zstring_view> tracking_mode_labels{
+    {TrackingMode::playing_item_or_active_selection, "Playing item or current selection"},
+    {TrackingMode::active_selection_or_playing_item, "Current selection or playing item"},
+    {TrackingMode::playing_item_or_playlist_selection, "Playing item or playlist selection"},
+    {TrackingMode::playlist_selection_or_playing_item, "Playlist selection or playing item"},
+    {TrackingMode::active_selection, "Current selection"},
+    {TrackingMode::playlist_selection, "Playlist selection"},
+    {TrackingMode::playing_item, "Playing item"},
+};
+
+bool check_process_on_selection_changed()
+{
+    HWND wnd_focus = GetFocus();
+    if (wnd_focus == nullptr)
+        return false;
+
+    DWORD processid = NULL;
+    GetWindowThreadProcessId(wnd_focus, &processid);
+    return processid == GetCurrentProcessId();
+}
+
+} // namespace
+
+void ContextTracker::on_playback_new_track(metadb_handle_ptr p_track) noexcept
+{
+    if (tracking_includes_playing_item())
+        m_playing_item = p_track;
+
+    if (m_is_tracking_playing || tracking_prioritises_playing_item()
+        || (tracking_falls_back_to_playing_item() && m_tracks.size() == 0)) {
+        m_is_tracking_playing = true;
+        set_tracks(pfc::list_single_ref_t(p_track));
+    }
+}
+
+void ContextTracker::on_playback_stop(play_control::t_stop_reason p_reason) noexcept
+{
+    if (p_reason != play_control::stop_reason_starting_another)
+        m_playing_item.reset();
+
+    if (m_is_tracking_playing && p_reason != play_control::stop_reason_starting_another
+        && p_reason != play_control::stop_reason_shutting_down) {
+        m_is_tracking_playing = false;
+
+        metadb_handle_list tracks;
+        if (m_tracking_mode == TrackingMode::playing_item_or_playlist_selection) {
+            tracks = get_playlist_selection();
+        } else if (m_tracking_mode == TrackingMode::playing_item_or_active_selection) {
+            tracks = m_ui_selection_tracks;
+        }
+        set_tracks(tracks);
+    }
+}
+
+wil::zstring_view get_tracking_mode_name(TrackingMode mode)
+{
+    return tracking_mode_labels.at(mode);
+}
+
+ContextTracker::ContextTracker(TrackingMode tracking_mode, bool track_single_item, ContextTrackerCallback callback)
+    : play_callback_impl_base(flag_on_playback_new_track | flag_on_playback_stop)
+    , playlist_callback_single_impl_base(flag_on_items_selection_change | flag_on_playlist_switch)
+    , m_tracking_mode(tracking_mode)
+    , m_track_single_item(track_single_item)
+    , m_callback(std::move(callback))
+    , m_playback_control(playback_control_v3::get())
+    , m_playlist_manager(playlist_manager_v4::get())
+{
+    refresh_tracks();
+}
+
+void ContextTracker::set_tracking_mode(TrackingMode tracking_mode)
+{
+    if (tracking_mode == m_tracking_mode)
+        return;
+
+    m_tracking_mode = tracking_mode;
+
+    refresh_tracks();
+    m_callback();
+}
+
+void ContextTracker::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept
+{
+    if (!check_process_on_selection_changed())
+        return;
+
+    if (!m_track_single_item)
+        m_ui_selection_tracks = p_selection;
+    else if (p_selection.size() > 0)
+        m_ui_selection_tracks = pfc::list_single_ref_t(p_selection[0]);
+    else
+        m_ui_selection_tracks.remove_all();
+
+    if (tracking_includes_active_selection()
+        && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
+        set_selection_tracks(m_ui_selection_tracks);
+    }
+}
+
+void ContextTracker::on_playlist_switch() noexcept
+{
+    if (tracking_includes_playlist_selection()
+        && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
+        set_selection_tracks(get_playlist_selection());
+    }
+}
+
+void ContextTracker::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept
+{
+    if (tracking_includes_playlist_selection()
+        && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
+        set_selection_tracks(get_playlist_selection());
+    }
+}
+
+void ContextTracker::refresh_tracks()
+{
+    metadb_handle_list tracks;
+
+    m_is_tracking_playing = false;
+
+    if (tracking_includes_playlist_selection()) {
+        tracks = get_playlist_selection();
+    } else if (tracking_includes_active_selection()) {
+        tracks = m_ui_selection_tracks;
+    }
+
+    if (tracking_includes_playing_item())
+        m_playback_control->get_now_playing(m_playing_item);
+
+    if ((tracking_prioritises_playing_item() || (tracking_falls_back_to_playing_item() && tracks.size() == 0))
+        && m_playback_control->is_playing()) {
+        tracks.add_item(m_playing_item);
+        m_is_tracking_playing = true;
+    }
+
+    m_tracks = std::move(tracks);
+}
+
+bool ContextTracker::tracking_prioritises_playing_item() const
+{
+    return m_tracking_mode == TrackingMode::playing_item_or_playlist_selection
+        || m_tracking_mode == TrackingMode::playing_item_or_active_selection
+        || m_tracking_mode == TrackingMode::playing_item;
+}
+
+bool ContextTracker::tracking_falls_back_to_playing_item() const
+{
+    return m_tracking_mode == TrackingMode::playlist_selection_or_playing_item
+        || m_tracking_mode == TrackingMode::active_selection_or_playing_item;
+}
+
+bool ContextTracker::tracking_includes_playing_item() const
+{
+    return m_tracking_mode == TrackingMode::playlist_selection_or_playing_item
+        || m_tracking_mode == TrackingMode::active_selection_or_playing_item
+        || m_tracking_mode == TrackingMode::playing_item_or_playlist_selection
+        || m_tracking_mode == TrackingMode::playing_item_or_active_selection
+        || m_tracking_mode == TrackingMode::playing_item;
+}
+
+bool ContextTracker::tracking_includes_playlist_selection() const
+{
+    return m_tracking_mode == TrackingMode::playing_item_or_playlist_selection
+        || m_tracking_mode == TrackingMode::playlist_selection
+        || m_tracking_mode == TrackingMode::playlist_selection_or_playing_item;
+}
+
+bool ContextTracker::tracking_includes_active_selection() const
+{
+    return m_tracking_mode == TrackingMode::playing_item_or_active_selection
+        || m_tracking_mode == TrackingMode::active_selection
+        || m_tracking_mode == TrackingMode::active_selection_or_playing_item;
+}
+
+metadb_handle_list ContextTracker::get_playlist_selection() const
+{
+    metadb_handle_list tracks;
+
+    if (m_track_single_item) {
+        m_playlist_manager->activeplaylist_enum_items(
+            [&](size_t index, const metadb_handle_ptr& item, bool is_selected) {
+                if (is_selected)
+                    tracks.add_item(item);
+
+                return !is_selected;
+            },
+            bit_array_true());
+    } else {
+        m_playlist_manager->activeplaylist_get_selected_items(tracks);
+    }
+
+    return tracks;
+}
+
+void ContextTracker::set_selection_tracks(metadb_handle_list tracks)
+{
+    if (tracking_falls_back_to_playing_item() && tracks.size() == 0) {
+        const auto is_playing = m_playback_control->is_playing();
+
+        if (is_playing && !m_is_tracking_playing) {
+            m_is_tracking_playing = true;
+            set_tracks(pfc::list_single_ref_t(m_playing_item));
+        }
+
+        if (m_is_tracking_playing)
+            return;
+    }
+
+    m_is_tracking_playing = false;
+    set_tracks(std::move(tracks));
+}
+
+void ContextTracker::set_tracks(metadb_handle_list tracks)
+{
+    if (!m_is_tracking_playing && m_track_single_item && tracks == m_tracks)
+        return;
+
+    m_tracks = std::move(tracks);
+    m_callback();
+}
+
+} // namespace cui::utils

--- a/foo_ui_columns/context_tracker.h
+++ b/foo_ui_columns/context_tracker.h
@@ -37,6 +37,10 @@ public:
 protected:
     void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept override;
 
+    void on_items_added(
+        size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override;
+    void on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
+    void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
     void on_playlist_switch() noexcept override;
     void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept override;
 
@@ -63,6 +67,7 @@ private:
     metadb_handle_list m_tracks;
     metadb_handle_list m_ui_selection_tracks;
     bool m_is_tracking_playing{};
+    bool m_process_playlist_items_removed{};
 };
 
 } // namespace cui::utils

--- a/foo_ui_columns/context_tracker.h
+++ b/foo_ui_columns/context_tracker.h
@@ -1,0 +1,68 @@
+#pragma once
+
+namespace cui::utils {
+
+enum class TrackingMode : uint32_t {
+    playing_item_or_playlist_selection,
+    playlist_selection,
+    playing_item,
+    playing_item_or_active_selection,
+    active_selection,
+    playlist_selection_or_playing_item,
+    active_selection_or_playing_item,
+};
+
+wil::zstring_view get_tracking_mode_name(TrackingMode mode);
+
+using ContextTrackerCallback = std::function<void()>;
+
+class ContextTracker
+    : public ui_selection_callback_impl_base_ex<ui_selection_manager_v2::flag_no_now_playing>
+    , public play_callback_impl_base
+    , public playlist_callback_single_impl_base {
+public:
+    ContextTracker(TrackingMode tracking_mode, bool track_single_item, ContextTrackerCallback callback);
+
+    bool is_playing_item() const { return m_is_tracking_playing; }
+    const metadb_handle_list& get_tracks() const { return m_tracks; }
+
+    void activate_ui_selection_tracking() { ui_selection_callback_activate(true); }
+    void deactivate_ui_selection_tracking() { ui_selection_callback_activate(false); }
+
+    void set_tracking_mode(TrackingMode tracking_mode);
+
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override;
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override;
+
+protected:
+    void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept override;
+
+    void on_playlist_switch() noexcept override;
+    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept override;
+
+    void refresh_tracks();
+
+private:
+    bool tracking_prioritises_playing_item() const;
+    bool tracking_falls_back_to_playing_item() const;
+    bool tracking_includes_playing_item() const;
+    bool tracking_includes_playlist_selection() const;
+    bool tracking_includes_active_selection() const;
+
+    metadb_handle_list get_playlist_selection() const;
+
+    void set_selection_tracks(metadb_handle_list tracks);
+    void set_tracks(metadb_handle_list tracks);
+
+    TrackingMode m_tracking_mode;
+    bool m_track_single_item{};
+    ContextTrackerCallback m_callback;
+    playback_control_v3::ptr m_playback_control;
+    playlist_manager_v4::ptr m_playlist_manager;
+    metadb_handle_ptr m_playing_item;
+    metadb_handle_list m_tracks;
+    metadb_handle_list m_ui_selection_tracks;
+    bool m_is_tracking_playing{};
+};
+
+} // namespace cui::utils

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -262,6 +262,7 @@
     <ClCompile Include="colour_utils.cpp" />
     <ClCompile Include="columns_v2.cpp" />
     <ClCompile Include="colour_manager.cpp" />
+    <ClCompile Include="context_tracker.cpp" />
     <ClCompile Include="core_dark_list_view.cpp" />
     <ClCompile Include="d2d_utils.cpp" />
     <ClCompile Include="d3d_utils.cpp" />
@@ -459,6 +460,7 @@
     <ClInclude Include="config_appearance.h" />
     <ClInclude Include="config_defaults.h" />
     <ClInclude Include="config_items.h" />
+    <ClInclude Include="context_tracker.h" />
     <ClInclude Include="core_dark_list_view.h" />
     <ClInclude Include="core_drop_down_list_toolbar.h" />
     <ClInclude Include="d2d_utils.h" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -680,6 +680,9 @@
     <ClCompile Include="dialog_placement.cpp">
       <Filter>Config storage</Filter>
     </ClCompile>
+    <ClCompile Include="context_tracker.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">
@@ -1042,6 +1045,9 @@
     </ClInclude>
     <ClInclude Include="dialog_placement.h">
       <Filter>Config storage</Filter>
+    </ClInclude>
+    <ClInclude Include="context_tracker.h">
+      <Filter>Utilities</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -17,16 +17,6 @@ constexpr auto MSG_AUTOSCROLL_TICK = WM_USER + 5;
 constexpr auto OCCLUSION_STATUS_TIMER_ID = 700;
 constexpr auto SMOOTH_SCROLL_TIMER_ID = 701;
 
-const std::unordered_map<uint32_t, wil::zstring_view> tracking_mode_labels{
-    {ItemDetails::track_auto_playing_item_or_active_selection, "Playing item or current selection"},
-    {ItemDetails::track_auto_active_selection_or_playing_item, "Current selection or playing item"},
-    {ItemDetails::track_auto_playing_item_or_playlist_selection, "Playing item or playlist selection"},
-    {ItemDetails::track_auto_playlist_selection_or_playing_item, "Playlist selection or playing item"},
-    {ItemDetails::track_active_selection, "Current selection"},
-    {ItemDetails::track_playlist_selection, "Playlist selection"},
-    {ItemDetails::track_playing_item, "Playing item"},
-};
-
 } // namespace
 
 // {59B4F428-26A5-4a51-89E5-3945D327B4CB}
@@ -140,30 +130,36 @@ bool ItemDetails::show_config_popup(HWND wnd_parent)
 
 void ItemDetails::set_config(stream_reader* p_reader, size_t p_size, abort_callback& p_abort)
 {
-    if (p_size) {
-        const auto version = p_reader->read_lendian_t<uint32_t>(p_abort);
-        if (version <= stream_version_current) {
-            p_reader->read_string(m_script, p_abort);
-            p_reader->read_lendian_t(m_tracking_mode, p_abort);
-            p_reader->read_lendian_t(m_hscroll, p_abort);
-            p_reader->read_lendian_t(m_horizontal_alignment, p_abort);
-            if (version >= 1) {
-                p_reader->read_lendian_t(m_word_wrapping, p_abort);
-                if (version >= 2) {
-                    p_reader->read_lendian_t(m_edge_style, p_abort);
+    if (p_size == 0)
+        return;
 
-                    m_vertical_alignment = static_cast<VerticalAlignment>(p_reader->read_lendian_t<int32_t>(p_abort));
-                }
-            }
-        }
-    }
+    const auto version = p_reader->read_lendian_t<uint32_t>(p_abort);
+
+    if (version > stream_version_current)
+        return;
+
+    p_reader->read_string(m_script, p_abort);
+    m_tracking_mode = static_cast<utils::TrackingMode>(p_reader->read_lendian_t<uint32_t>(p_abort));
+    p_reader->read_lendian_t(m_hscroll, p_abort);
+    p_reader->read_lendian_t(m_horizontal_alignment, p_abort);
+
+    if (version < 1)
+        return;
+
+    p_reader->read_lendian_t(m_word_wrapping, p_abort);
+
+    if (version < 2)
+        return;
+
+    p_reader->read_lendian_t(m_edge_style, p_abort);
+    m_vertical_alignment = static_cast<VerticalAlignment>(p_reader->read_lendian_t<int32_t>(p_abort));
 }
 
 void ItemDetails::get_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
     p_writer->write_lendian_t(static_cast<uint32_t>(stream_version_current), p_abort);
     p_writer->write_string(m_script, p_abort);
-    p_writer->write_lendian_t(m_tracking_mode, p_abort);
+    p_writer->write_lendian_t(WI_EnumValue(m_tracking_mode), p_abort);
     p_writer->write_lendian_t(m_hscroll, p_abort);
     p_writer->write_lendian_t(m_horizontal_alignment, p_abort);
     p_writer->write_lendian_t(m_word_wrapping, p_abort);
@@ -192,28 +188,10 @@ void ItemDetails::on_app_activate(bool b_activated)
 {
     if (b_activated) {
         if (GetFocus() != get_wnd())
-            register_callback();
+            m_context_tracker->activate_ui_selection_tracking();
     } else {
-        deregister_callback();
+        m_context_tracker->deactivate_ui_selection_tracking();
     }
-}
-
-void ItemDetails::set_selection_handles(const metadb_handle_list& handles)
-{
-    if (tracking_falls_back_to_playing_item() && handles.size() == 0) {
-        const auto is_playing = m_playback_control->is_playing();
-
-        if (is_playing && !m_nowplaying_active) {
-            m_nowplaying_active = true;
-            set_handles(pfc::list_single_ref_t(m_playing_item));
-        }
-
-        if (m_nowplaying_active)
-            return;
-    }
-
-    m_nowplaying_active = false;
-    set_handles(handles);
 }
 
 const GUID& ItemDetails::get_extension_guid() const
@@ -231,19 +209,6 @@ void ItemDetails::get_category(pfc::string_base& p_out) const
 unsigned ItemDetails::get_type() const
 {
     return uie::type_panel;
-}
-
-void ItemDetails::register_callback()
-{
-    if (!m_callback_registered)
-        g_ui_selection_manager_register_callback_no_now_playing_fallback(this);
-    m_callback_registered = true;
-}
-void ItemDetails::deregister_callback()
-{
-    if (m_callback_registered)
-        ui_selection_manager::get()->unregister_callback(this);
-    m_callback_registered = false;
 }
 
 void ItemDetails::update_scrollbar(uih::ScrollAxis axis, bool reset_position)
@@ -327,21 +292,6 @@ void ItemDetails::update_scrollbars(bool reset_vertical_position, bool reset_hor
         update_scrollbar(uih::ScrollAxis::Vertical, reset_vertical_position);
 }
 
-void ItemDetails::set_handles(const metadb_handle_list& handles)
-{
-    const auto old_handles = std::move(m_handles);
-    m_handles = handles;
-    if (handles.get_count() == 0 || old_handles.get_count() == 0 || handles[0].get_ptr() != old_handles[0].get_ptr()) {
-        if (m_full_file_info_request) {
-            m_full_file_info_request->abort();
-            m_aborting_full_file_info_requests.emplace_back(std::move(m_full_file_info_request));
-        }
-        m_full_file_info_requested = false;
-        m_full_file_info.reset();
-    }
-    refresh_contents(true, true);
-}
-
 void ItemDetails::request_full_file_info()
 {
     if (m_full_file_info_requested)
@@ -349,10 +299,12 @@ void ItemDetails::request_full_file_info()
 
     m_full_file_info_requested = true;
 
-    if (m_handles.get_count() == 0)
+    const auto& tracks = m_context_tracker->get_tracks();
+
+    if (tracks.get_count() == 0)
         return;
 
-    const auto handle = m_handles[0];
+    const auto handle = tracks[0];
 
     if (const auto info_ref = handle->get_info_ref(); !info_ref->isInfoPartial())
         return;
@@ -403,7 +355,9 @@ void ItemDetails::release_all_full_file_info_requests()
 void ItemDetails::refresh_contents(
     bool reset_vertical_scroll_position, bool reset_horizontal_scroll_position, bool force_update)
 {
-    if (m_handles.get_count()) {
+    const auto& tracks = m_context_tracker->get_tracks();
+
+    if (tracks.size() > 0) {
         const auto font = fonts::get_font(g_guid_item_details_font_client);
         const auto font_size = uih::direct_write::dip_to_pt(font->size());
 
@@ -414,16 +368,16 @@ void ItemDetails::refresh_contents(
         pfc::string8_fast_aggressive temp;
         temp.prealloc(2048);
 
-        if (m_nowplaying_active) {
+        if (m_context_tracker->is_playing_item()) {
             m_playback_control->playback_format_title(
                 &tf_hook, temp, m_to, nullptr, playback_control::display_level_all);
         } else {
-            const auto handle = m_handles[0];
+            const auto handle = tracks[0];
             if (m_full_file_info) {
-                m_handles[0]->format_title_from_external_info(*m_full_file_info, &tf_hook, temp, m_to, nullptr);
+                tracks[0]->format_title_from_external_info(*m_full_file_info, &tf_hook, temp, m_to, nullptr);
             } else {
                 request_full_file_info();
-                m_handles[0]->format_title(&tf_hook, temp, m_to, nullptr);
+                tracks[0]->format_title(&tf_hook, temp, m_to, nullptr);
             }
         }
 
@@ -496,94 +450,48 @@ void ItemDetails::reset_display_info()
     m_text_rect.reset();
 }
 
-void ItemDetails::on_playback_new_track(metadb_handle_ptr p_track) noexcept
-{
-    if (tracking_includes_playing_item())
-        m_playing_item = p_track;
-
-    if (m_nowplaying_active || tracking_prioritises_playing_item()
-        || (tracking_falls_back_to_playing_item() && m_handles.size() == 0)) {
-        m_nowplaying_active = true;
-        set_handles(pfc::list_single_ref_t(p_track));
-    }
-}
-
 void ItemDetails::on_playback_seek(double p_time) noexcept
 {
-    if (m_nowplaying_active)
+    if (m_context_tracker->is_playing_item())
         refresh_contents();
 }
+
 void ItemDetails::on_playback_pause(bool p_state) noexcept
 {
-    if (m_nowplaying_active)
+    if (m_context_tracker->is_playing_item())
         refresh_contents();
 }
+
 void ItemDetails::on_playback_edited(metadb_handle_ptr p_track) noexcept
 {
-    if (m_nowplaying_active)
+    if (m_context_tracker->is_playing_item())
         refresh_contents();
 }
+
 void ItemDetails::on_playback_dynamic_info(const file_info& p_info) noexcept
 {
-    if (m_nowplaying_active)
+    if (m_context_tracker->is_playing_item())
         refresh_contents();
 }
+
 void ItemDetails::on_playback_dynamic_info_track(const file_info& p_info) noexcept
 {
-    if (m_nowplaying_active)
+    if (m_context_tracker->is_playing_item())
         refresh_contents();
 }
+
 void ItemDetails::on_playback_time(double p_time) noexcept
 {
-    if (m_nowplaying_active)
+    if (m_context_tracker->is_playing_item())
         refresh_contents();
-}
-
-void ItemDetails::on_playback_stop(play_control::t_stop_reason p_reason) noexcept
-{
-    if (p_reason != play_control::stop_reason_starting_another)
-        m_playing_item.reset();
-
-    if (m_nowplaying_active && p_reason != play_control::stop_reason_starting_another
-        && p_reason != play_control::stop_reason_shutting_down) {
-        m_nowplaying_active = false;
-
-        metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
-        if (m_tracking_mode == track_auto_playing_item_or_playlist_selection) {
-            playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
-        } else if (m_tracking_mode == track_auto_playing_item_or_active_selection) {
-            handles = m_selection_handles;
-        }
-        set_handles(handles);
-    }
-}
-
-void ItemDetails::on_playlist_switch() noexcept
-{
-    if (tracking_includes_playlist_selection()
-        && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
-        metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
-        playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
-        set_selection_handles(handles);
-    }
-}
-
-void ItemDetails::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept
-{
-    if (tracking_includes_playlist_selection()
-        && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
-        metadb_handle_list_t<pfc::alloc_fast_aggressive> handles;
-        playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
-        set_selection_handles(handles);
-    }
 }
 
 void ItemDetails::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) noexcept
 {
-    if (m_nowplaying_active)
+    if (m_context_tracker->is_playing_item())
         return;
 
-    for (auto&& track : m_handles) {
+    for (auto&& track : m_context_tracker->get_tracks()) {
         if (size_t index{};
             p_items_sorted.bsearch_t(pfc::compare_t<metadb_handle_ptr, metadb_handle_ptr>, track, index)) {
             refresh_contents();
@@ -592,54 +500,9 @@ void ItemDetails::on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool
     }
 }
 
-bool ItemDetails::check_process_on_selection_changed()
-{
-    HWND wnd_focus = GetFocus();
-    if (wnd_focus == nullptr)
-        return false;
-
-    DWORD processid = NULL;
-    GetWindowThreadProcessId(wnd_focus, &processid);
-    return processid == GetCurrentProcessId();
-}
-
-void ItemDetails::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept
-{
-    if (check_process_on_selection_changed()) {
-        if (g_ui_selection_manager_is_now_playing_fallback())
-            m_selection_handles.remove_all();
-        else
-            m_selection_handles = p_selection;
-
-        if (tracking_includes_active_selection()
-            && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
-            set_selection_handles(m_selection_handles);
-        }
-    }
-}
-
 void ItemDetails::on_tracking_mode_change()
 {
-    metadb_handle_list handles;
-
-    m_nowplaying_active = false;
-
-    if (tracking_includes_playlist_selection()) {
-        playlist_manager_v3::get()->activeplaylist_get_selected_items(handles);
-    } else if (tracking_includes_active_selection()) {
-        handles = m_selection_handles;
-    }
-
-    if (tracking_includes_playing_item())
-        m_playback_control->get_now_playing(m_playing_item);
-
-    if ((tracking_prioritises_playing_item() || (tracking_falls_back_to_playing_item() && handles.size() == 0))
-        && m_playback_control->is_playing()) {
-        handles.add_item(m_playing_item);
-        m_nowplaying_active = true;
-    }
-
-    set_handles(handles);
+    m_context_tracker->set_tracking_mode(m_tracking_mode);
 }
 
 void ItemDetails::update_now()
@@ -867,11 +730,13 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             });
 
         set_window_theme();
+
         m_playback_control = playback_control::get();
-        register_callback();
-        play_callback_manager::get()->register_callback(
-            this, flag_on_playback_all & ~(flag_on_volume_change | flag_on_playback_starting), false);
-        playlist_manager_v3::get()->register_callback(this, playlist_callback_flags);
+        play_callback_manager::get()->register_callback(this,
+            flag_on_playback_all
+                & ~(flag_on_volume_change | flag_on_playback_starting | flag_on_playback_stop
+                    | flag_on_playback_new_track),
+            false);
         metadb_io_v3::get()->register_callback(this);
 
         m_use_hardware_acceleration_change_token = prefs::add_use_hardware_acceleration_changed_handler([this] {
@@ -889,14 +754,24 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (s_windows.empty())
             s_create_message_window();
 
-        s_windows.push_back(this);
-
         titleformat_compiler::get()->compile_safe(m_to, m_script);
+
+        m_context_tracker.emplace(m_tracking_mode, true, [&] {
+            if (m_full_file_info_request) {
+                m_full_file_info_request->abort();
+                m_aborting_full_file_info_requests.emplace_back(std::move(m_full_file_info_request));
+            }
+            m_full_file_info_requested = false;
+            m_full_file_info.reset();
+
+            refresh_contents(true, true);
+        });
+
+        s_windows.push_back(this);
 
         m_initialised = true;
 
         on_size();
-        on_tracking_mode_change();
         refresh_contents(true, true);
 
         m_power_notify_handle.reset(
@@ -912,16 +787,12 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (s_windows.empty())
             s_destroy_message_window();
 
+        m_context_tracker.reset();
         m_power_notify_handle.reset();
         m_use_hardware_acceleration_change_token.reset();
         play_callback_manager::get()->unregister_callback(this);
         metadb_io_v3::get()->unregister_callback(this);
-        playlist_manager_v3::get()->unregister_callback(this);
-        deregister_callback();
         release_all_full_file_info_requests();
-        m_handles.remove_all();
-        m_selection_handles.remove_all();
-        m_selection_holder.release();
         m_to.release();
         m_text_format.reset();
         m_text_layout.reset();
@@ -941,15 +812,6 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     }
     case WM_NCDESTROY:
         m_smooth_scroll_helper.reset();
-        break;
-    case WM_SETFOCUS:
-        deregister_callback();
-        m_selection_holder = ui_selection_manager::get()->acquire();
-        m_selection_holder->set_selection(m_handles);
-        break;
-    case WM_KILLFOCUS:
-        m_selection_holder.release();
-        register_callback();
         break;
     case WM_WINDOWPOSCHANGED: {
         auto lpwp = (LPWINDOWPOS)lp;
@@ -1294,7 +1156,7 @@ void ItemDetails::on_dark_mode_status_change()
 }
 
 ItemDetails::ItemDetails()
-    : m_tracking_mode(cfg_item_details_tracking_mode)
+    : m_tracking_mode(static_cast<utils::TrackingMode>(cfg_item_details_tracking_mode.get_value()))
     , m_script(default_item_details_script.data(), default_item_details_script.size())
     , m_horizontal_alignment(cfg_item_details_horizontal_alignment)
     , m_vertical_alignment(static_cast<VerticalAlignment>(cfg_item_details_vertical_alignment.get_value()))
@@ -1407,19 +1269,6 @@ void ItemDetails::set_horizontal_alignment(uint32_t horizontal_alignment)
     update_now();
 }
 
-bool ItemDetails::tracking_includes_active_selection() const
-{
-    return m_tracking_mode == track_auto_playing_item_or_active_selection || m_tracking_mode == track_active_selection
-        || m_tracking_mode == track_auto_active_selection_or_playing_item;
-}
-
-bool ItemDetails::tracking_includes_playlist_selection() const
-{
-    return m_tracking_mode == track_auto_playing_item_or_playlist_selection
-        || m_tracking_mode == track_playlist_selection
-        || m_tracking_mode == track_auto_playlist_selection_or_playing_item;
-}
-
 uie::container_window_v3_config ItemDetails::get_window_config()
 {
     uie::container_window_v3_config config(L"columns_ui_item_details_E0D8v091E", false);
@@ -1430,26 +1279,6 @@ uie::container_window_v3_config ItemDetails::get_window_config()
         config.extended_window_styles |= WS_EX_STATICEDGE;
 
     return config;
-}
-
-bool ItemDetails::tracking_prioritises_playing_item() const
-{
-    return m_tracking_mode == track_auto_playing_item_or_playlist_selection
-        || m_tracking_mode == track_auto_playing_item_or_active_selection || m_tracking_mode == track_playing_item;
-}
-
-bool ItemDetails::tracking_falls_back_to_playing_item() const
-{
-    return m_tracking_mode == track_auto_playlist_selection_or_playing_item
-        || m_tracking_mode == track_auto_active_selection_or_playing_item;
-}
-
-bool ItemDetails::tracking_includes_playing_item() const
-{
-    return m_tracking_mode == track_auto_playlist_selection_or_playing_item
-        || m_tracking_mode == track_auto_active_selection_or_playing_item
-        || m_tracking_mode == track_auto_playing_item_or_playlist_selection
-        || m_tracking_mode == track_auto_playing_item_or_active_selection || m_tracking_mode == track_playing_item;
 }
 
 uie::window_factory<ItemDetails> g_item_details;
@@ -1572,15 +1401,15 @@ const char* ItemDetails::MenuNodeAlignment::get_name(uint32_t source)
 
 ItemDetails::MenuNodeSourcePopup::MenuNodeSourcePopup(ItemDetails* p_wnd)
 {
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, track_auto_playing_item_or_active_selection));
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, track_auto_active_selection_or_playing_item));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, utils::TrackingMode::playing_item_or_active_selection));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, utils::TrackingMode::active_selection_or_playing_item));
     m_items.add_item(new uie::menu_node_separator_t());
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, track_auto_playing_item_or_playlist_selection));
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, track_auto_playlist_selection_or_playing_item));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, utils::TrackingMode::playing_item_or_playlist_selection));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, utils::TrackingMode::playlist_selection_or_playing_item));
     m_items.add_item(new uie::menu_node_separator_t());
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, track_playing_item));
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, track_active_selection));
-    m_items.add_item(new MenuNodeTrackMode(p_wnd, track_playlist_selection));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, utils::TrackingMode::playing_item));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, utils::TrackingMode::active_selection));
+    m_items.add_item(new MenuNodeTrackMode(p_wnd, utils::TrackingMode::playlist_selection));
 }
 
 void ItemDetails::MenuNodeSourcePopup::get_child(size_t p_index, uie::menu_node_ptr& p_out) const
@@ -1600,16 +1429,16 @@ bool ItemDetails::MenuNodeSourcePopup::get_display_data(pfc::string_base& p_out,
     return true;
 }
 
-ItemDetails::MenuNodeTrackMode::MenuNodeTrackMode(ItemDetails* p_wnd, uint32_t p_value)
+ItemDetails::MenuNodeTrackMode::MenuNodeTrackMode(ItemDetails* p_wnd, utils::TrackingMode p_value)
     : p_this(p_wnd)
-    , m_source(p_value)
+    , m_tracking_mode(p_value)
 {
 }
 
 void ItemDetails::MenuNodeTrackMode::execute()
 {
-    p_this->m_tracking_mode = m_source;
-    cfg_item_details_tracking_mode = m_source;
+    p_this->m_tracking_mode = m_tracking_mode;
+    cfg_item_details_tracking_mode = WI_EnumValue(m_tracking_mode);
     p_this->on_tracking_mode_change();
 }
 
@@ -1620,14 +1449,9 @@ bool ItemDetails::MenuNodeTrackMode::get_description(pfc::string_base& p_out) co
 
 bool ItemDetails::MenuNodeTrackMode::get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const
 {
-    p_out = get_name(m_source);
-    p_displayflags = (m_source == p_this->m_tracking_mode) ? state_radiochecked : 0;
+    p_out = utils::get_tracking_mode_name(m_tracking_mode).c_str();
+    p_displayflags = (m_tracking_mode == p_this->m_tracking_mode) ? state_radiochecked : 0;
     return true;
-}
-
-const char* ItemDetails::MenuNodeTrackMode::get_name(uint32_t source)
-{
-    return tracking_mode_labels.at(source).c_str();
 }
 
 } // namespace cui::panels::item_details

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pch.h"
+#include "context_tracker.h"
 #include "file_info_reader.h"
 #include "item_details_text.h"
 #include "window_resize_helper.h"
@@ -27,41 +28,22 @@ extern cfg_bool cfg_item_details_word_wrapping;
 
 class ItemDetails
     : public uie::container_uie_window_v3
-    , public ui_selection_callback
     , public play_callback
-    , public playlist_callback_single
     , public metadb_io_callback_dynamic {
     inline static std::unique_ptr<uie::container_window_v3> s_message_window;
 
     uie::container_window_v3_config get_window_config() override;
 
 public:
-    enum TrackingMode {
-        track_auto_playing_item_or_playlist_selection,
-        track_playlist_selection,
-        track_playing_item,
-        track_auto_playing_item_or_active_selection,
-        track_active_selection,
-        track_auto_playlist_selection_or_playing_item,
-        track_auto_active_selection_or_playing_item,
-    };
-
-    bool tracking_prioritises_playing_item() const;
-    bool tracking_falls_back_to_playing_item() const;
-    bool tracking_includes_playing_item() const;
-    bool tracking_includes_playlist_selection() const;
-    bool tracking_includes_active_selection() const;
-
     class MenuNodeTrackMode : public ui_extension::menu_node_command_t {
         service_ptr_t<ItemDetails> p_this;
-        uint32_t m_source;
+        utils::TrackingMode m_tracking_mode;
 
     public:
-        static const char* get_name(uint32_t source);
         bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override;
         bool get_description(pfc::string_base& p_out) const override;
         void execute() override;
-        MenuNodeTrackMode(ItemDetails* p_wnd, uint32_t p_value);
+        MenuNodeTrackMode(ItemDetails* p_wnd, utils::TrackingMode p_value);
     };
 
     class MenuNodeSourcePopup : public ui_extension::menu_node_popup_t {
@@ -141,13 +123,10 @@ public:
 
     void get_menu_items(ui_extension::menu_hook_t& p_hook) override;
 
-    // UI SEL API
-    void on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept override;
-
     // PC
     void on_playback_starting(play_control::t_track_command p_command, bool p_paused) override {}
-    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override;
-    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override;
+    void on_playback_new_track(metadb_handle_ptr p_track) noexcept override {}
+    void on_playback_stop(play_control::t_stop_reason p_reason) noexcept override {}
     void on_playback_seek(double p_time) noexcept override;
     void on_playback_pause(bool p_state) noexcept override;
     void on_playback_edited(metadb_handle_ptr p_track) noexcept override;
@@ -155,35 +134,6 @@ public:
     void on_playback_dynamic_info_track(const file_info& p_info) noexcept override;
     void on_playback_time(double p_time) noexcept override;
     void on_volume_change(float p_new_val) override {}
-
-    // PL
-    enum {
-        playlist_callback_flags = flag_on_items_selection_change | flag_on_playlist_switch
-    };
-    void on_playlist_switch() noexcept override;
-    void on_item_focus_change(size_t p_from, size_t p_to) override {}
-
-    void on_items_added(
-        size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override
-    {
-    }
-    void on_items_reordered(const size_t* p_order, size_t p_count) override {}
-    void on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
-    void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override {}
-    void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept override;
-    void on_items_modified(const bit_array& p_mask) override {}
-    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override {}
-    void on_items_replaced(const bit_array& p_mask,
-        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override
-    {
-    }
-    void on_item_ensure_visible(size_t p_idx) override {}
-
-    void on_playlist_renamed(const char* p_new_name, size_t p_new_name_len) override {}
-    void on_playlist_locked(bool p_locked) override {}
-
-    void on_default_format_changed() override {}
-    void on_playback_order_changed(size_t p_new_index) override {}
 
     // ML
     void on_changed_sorted(metadb_handle_list_cref p_items_sorted, bool p_fromhook) noexcept override;
@@ -213,12 +163,8 @@ private:
 
     LRESULT on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp) override;
 
-    void register_callback();
-    void deregister_callback();
     void on_app_activate(bool b_activated);
 
-    void set_selection_handles(const metadb_handle_list& handles);
-    void set_handles(const metadb_handle_list& handles);
     void refresh_contents(bool reset_vertical_scroll_position = false, bool reset_horizontal_scroll_position = false,
         bool force_update = false);
     void request_full_file_info();
@@ -229,7 +175,6 @@ private:
     void update_display_info();
     void reset_display_info();
     void on_tracking_mode_change();
-    bool check_process_on_selection_changed();
 
     void absolute_scroll(
         uih::ScrollAxis axis, int new_position, bool suppress_smooth_scroll = false, bool quick_animation = false);
@@ -263,18 +208,13 @@ private:
     bool m_initialised{};
     int m_last_cx{};
     int m_last_cy{};
+    std::optional<utils::ContextTracker> m_context_tracker;
     playback_control::ptr m_playback_control;
-    ui_selection_holder::ptr m_selection_holder;
-    metadb_handle_ptr m_playing_item;
-    metadb_handle_list m_handles;
-    metadb_handle_list m_selection_handles;
     std::shared_ptr<file_info_impl> m_full_file_info;
     std::shared_ptr<helpers::FullFileInfoRequest> m_full_file_info_request;
     std::vector<std::shared_ptr<helpers::FullFileInfoRequest>> m_aborting_full_file_info_requests;
     bool m_full_file_info_requested{};
-    bool m_callback_registered{};
-    bool m_nowplaying_active{};
-    uint32_t m_tracking_mode;
+    utils::TrackingMode m_tracking_mode;
 
     uih::direct_write::Context::Ptr m_direct_write_context;
     std::optional<uih::direct_write::TextFormat> m_text_format;


### PR DESCRIPTION
Relates to #57

This moves all the code to track items out of Item details and into a separate class. This is so that it can be reused in other built-in panels.

A bug where selected items being added or removed from the active playlist weren't correctly tracked in playlist tracking modes was also fixed.