### PR TITLE
Fix tracking of pre-existing selection in selection viewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
 - Artwork view and Item details now have two new automatic tracking modes
   prioritise the current or playlist selection over the playing item.
   [[#1842](https://github.com/reupen/columns_ui/pull/1842),
-  [#1848](https://github.com/reupen/columns_ui/pull/1848)]
+  [#1848](https://github.com/reupen/columns_ui/pull/1848),
+  [#1857](https://github.com/reupen/columns_ui/pull/1857)]
 
   Additionally, Item properties now has the same tracking modes as the artwork
   view and Item details.

--- a/foo_ui_columns/context_tracker.cpp
+++ b/foo_ui_columns/context_tracker.cpp
@@ -72,6 +72,7 @@ ContextTracker::ContextTracker(TrackingMode tracking_mode, bool track_single_ite
     , m_playback_control(playback_control_v3::get())
     , m_playlist_manager(playlist_manager_v4::get())
 {
+    ui_selection_manager_v2::get()->get_selection(m_ui_selection_tracks, ui_selection_manager_v2::flag_no_now_playing);
     refresh_tracks();
 }
 


### PR DESCRIPTION
This fixes a minor bug in `utils::ContextTracker` where it didn't retrieve the current selection on initialisation.

This caused built-in selection viewers to not show a pre-existing selection if the panel was added to the layout using live editing.