### PR TITLE
Remove message under ‘Show toolbars’ option in Preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 - Pressing Alt now shows the main menu as a pop-up menu in the top-left corner
   of the main window when there is no menu bar in the toolbar area or in the
-  layout. [[#1816](https://github.com/reupen/columns_ui/pull/1816)]
+  layout. [[#1816](https://github.com/reupen/columns_ui/pull/1816),
+  [#1860](https://github.com/reupen/columns_ui/pull/1860)]
 
   This includes being able to directly access each top-level menu using their
   access keys (e.g. Alt+F for the File menu).

--- a/foo_ui_columns/foo_ui_columns.rc
+++ b/foo_ui_columns/foo_ui_columns.rc
@@ -182,8 +182,7 @@ BEGIN
     EDITTEXT        IDC_STRING,7,59,313,64,ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL
     LTEXT           "Toolbars",IDC_TITLE2,7,145,313,14
     CONTROL         "Show toolbars",IDC_TOOLBARS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,169,64,10
-    LTEXT           "Before hiding the toolbars, ensure you have an alternative way of accessing preferences.",IDC_STATIC,7,185,299,8
-    PUSHBUTTON      "Reset toolbars",IDC_RESET_TOOLBARS,7,205,107,14
+    PUSHBUTTON      "Reset toolbars",IDC_RESET_TOOLBARS,7,190,107,14
 END
 
 IDD_SPECTRUM_ANALYSER_OPTIONS DIALOGEX 0, 0, 152, 280


### PR DESCRIPTION
This removes the ‘Before hiding the toolbars, ensure you have an alternative way of accessing preferences.’ message in Preferences on the Main window tab.

This is because the main menu can now always be opened using the Alt key and so it should be more difficult for people to get stuck after disabling the toolbars.