### PR TITLE
Format tracks in playlist context in Item details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,18 @@
   prioritise the current or playlist selection over the playing item.
   [[#1842](https://github.com/reupen/columns_ui/pull/1842),
   [#1848](https://github.com/reupen/columns_ui/pull/1848),
-  [#1857](https://github.com/reupen/columns_ui/pull/1857)]
+  [#1857](https://github.com/reupen/columns_ui/pull/1857),
+  [#1861](https://github.com/reupen/columns_ui/pull/1861)]
 
   Additionally, Item properties now has the same tracking modes as the artwork
   view and Item details.
   [[#1850](https://github.com/reupen/columns_ui/pull/1850)]
 
   All automatic tracking modes were renamed to make the priority order clearer.
+
+- Playlist-specific fields and dynamic track info are now available in playlist
+  selection tracking modes in Item details.
+  [[#1861](https://github.com/reupen/columns_ui/pull/1861)]
 
 - The following dialogues are now resizeable
   [[#1833](https://github.com/reupen/columns_ui/pull/1833),

--- a/foo_ui_columns/context_tracker.cpp
+++ b/foo_ui_columns/context_tracker.cpp
@@ -48,12 +48,13 @@ void ContextTracker::on_playback_stop(play_control::t_stop_reason p_reason) noex
     if (m_is_tracking_playing && p_reason != play_control::stop_reason_starting_another
         && p_reason != play_control::stop_reason_shutting_down) {
         metadb_handle_list tracks;
+        std::optional<size_t> playlist_selection_index;
         if (m_tracking_mode == TrackingMode::playing_item_or_playlist_selection) {
-            tracks = get_playlist_selection();
+            std::tie(playlist_selection_index, tracks) = get_playlist_selection();
         } else if (m_tracking_mode == TrackingMode::playing_item_or_active_selection) {
             tracks = m_ui_selection_tracks;
         }
-        set_tracks(tracks, false);
+        set_tracks(std::move(tracks), false, playlist_selection_index);
     }
 }
 
@@ -62,18 +63,28 @@ wil::zstring_view get_tracking_mode_name(TrackingMode mode)
     return tracking_mode_labels.at(mode);
 }
 
-ContextTracker::ContextTracker(TrackingMode tracking_mode, bool track_single_item, ContextTrackerCallback callback)
+ContextTracker::ContextTracker(TrackingMode tracking_mode, bool track_single_item,
+    ContextTrackerCallback tracks_change_callback, ContextTrackerCallback playlist_index_change_callback)
     : play_callback_impl_base(flag_on_playback_new_track | flag_on_playback_stop)
     , playlist_callback_single_impl_base(flag_on_items_added | flag_on_items_removing | flag_on_items_removed
-          | flag_on_items_selection_change | flag_on_playlist_switch)
+          | flag_on_items_reordered | flag_on_items_replaced | flag_on_items_selection_change | flag_on_playlist_switch)
     , m_tracking_mode(tracking_mode)
     , m_track_single_item(track_single_item)
-    , m_callback(std::move(callback))
+    , m_tracks_change_callback(std::move(tracks_change_callback))
+    , m_playlist_index_change_callback(std::move(playlist_index_change_callback))
     , m_playback_control(playback_control_v3::get())
     , m_playlist_manager(playlist_manager_v4::get())
 {
     ui_selection_manager_v2::get()->get_selection(m_ui_selection_tracks, ui_selection_manager_v2::flag_no_now_playing);
     refresh_tracks();
+}
+
+std::optional<size_t> ContextTracker::get_playlist_selection_index() const
+{
+    if (tracking_includes_playlist_selection() && (!m_is_tracking_playing || !tracking_prioritises_playing_item()))
+        return m_playlist_selection_index;
+
+    return {};
 }
 
 void ContextTracker::set_tracking_mode(TrackingMode tracking_mode, bool notify)
@@ -86,7 +97,7 @@ void ContextTracker::set_tracking_mode(TrackingMode tracking_mode, bool notify)
     refresh_tracks();
 
     if (notify)
-        m_callback();
+        m_tracks_change_callback();
 }
 
 void ContextTracker::on_selection_changed(const pfc::list_base_const_t<metadb_handle_ptr>& p_selection) noexcept
@@ -101,8 +112,7 @@ void ContextTracker::on_selection_changed(const pfc::list_base_const_t<metadb_ha
     else
         m_ui_selection_tracks.remove_all();
 
-    if (tracking_includes_active_selection()
-        && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
+    if (tracking_includes_active_selection() && (!tracking_prioritises_playing_item() || !m_is_tracking_playing)) {
         set_selection_tracks(m_ui_selection_tracks);
     }
 }
@@ -110,24 +120,29 @@ void ContextTracker::on_selection_changed(const pfc::list_base_const_t<metadb_ha
 void ContextTracker::on_items_added(
     size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection)
 {
-    if (!tracking_includes_playlist_selection()
-        || (tracking_prioritises_playing_item() && m_playback_control->is_playing()))
+    if (!tracking_includes_playlist_selection() || (tracking_prioritises_playing_item() && m_is_tracking_playing))
         return;
 
     for (const auto index : ranges::views::iota(size_t{}, p_data.size())) {
         if (p_selection[index]) {
-            set_selection_tracks(get_playlist_selection());
+            auto [playlist_index, tracks] = get_playlist_selection();
+            set_selection_tracks(std::move(tracks), playlist_index, true);
             return;
         }
     }
+
+    if (!m_playlist_selection_index)
+        return;
+
+    const auto new_index = *m_playlist_selection_index + (p_base <= *m_playlist_selection_index ? p_data.size() : 0);
+    set_playlist_selection_index(new_index, true);
 }
 
 void ContextTracker::on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
 {
     m_process_playlist_items_removed = false;
 
-    if (!tracking_includes_playlist_selection()
-        || (tracking_prioritises_playing_item() && m_playback_control->is_playing()))
+    if (!tracking_includes_playlist_selection() || (tracking_prioritises_playing_item() && m_is_tracking_playing))
         return;
 
     m_playlist_manager->activeplaylist_enum_items(
@@ -140,32 +155,81 @@ void ContextTracker::on_items_removing(const bit_array& p_mask, size_t p_old_cou
 
 void ContextTracker::on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count)
 {
-    if (!m_process_playlist_items_removed)
+    if (m_process_playlist_items_removed) {
+        m_process_playlist_items_removed = false;
+
+        if (!tracking_includes_playlist_selection() || (tracking_prioritises_playing_item() && m_is_tracking_playing))
+            return;
+
+        auto [playlist_index, tracks] = get_playlist_selection();
+        set_selection_tracks(std::move(tracks), playlist_index, true);
+        return;
+    }
+
+    if (!m_playlist_selection_index)
         return;
 
-    m_process_playlist_items_removed = false;
+    assert(*m_playlist_selection_index < p_old_count);
 
-    if (!tracking_includes_playlist_selection()
-        || (tracking_prioritises_playing_item() && m_playback_control->is_playing()))
+    if (*m_playlist_selection_index >= p_old_count) {
+        set_playlist_selection_index({}, true);
+        return;
+    }
+
+    if (p_mask[*m_playlist_selection_index]) {
+        auto [playlist_selection_index, _] = get_playlist_selection(true);
+        set_playlist_selection_index(playlist_selection_index, true);
+        return;
+    }
+
+    auto new_playlist_selection_index = m_playlist_selection_index;
+
+    for (const auto index : ranges::views::iota(size_t{}, *new_playlist_selection_index)) {
+        if (p_mask[index])
+            --*new_playlist_selection_index;
+    }
+
+    set_playlist_selection_index(new_playlist_selection_index, true);
+}
+
+void ContextTracker::on_items_reordered(const t_size* p_order, t_size p_count)
+{
+    if (!tracking_includes_playlist_selection() || (tracking_prioritises_playing_item() && m_is_tracking_playing))
         return;
 
-    set_selection_tracks(get_playlist_selection());
+    auto [playlist_selection_index, tracks] = get_playlist_selection();
+    set_selection_tracks(std::move(tracks), playlist_selection_index);
+}
+
+void ContextTracker::on_items_replaced(
+    const bit_array& p_mask, const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data)
+{
+    if (!tracking_includes_playlist_selection() || (tracking_prioritises_playing_item() && m_is_tracking_playing))
+        return;
+
+    if (m_playlist_selection_index && m_track_single_item && !p_mask[*m_playlist_selection_index])
+        return;
+
+    auto [playlist_selection_index, tracks] = get_playlist_selection();
+    set_selection_tracks(std::move(tracks), playlist_selection_index);
 }
 
 void ContextTracker::on_playlist_switch() noexcept
 {
-    if (tracking_includes_playlist_selection()
-        && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
-        set_selection_tracks(get_playlist_selection());
-    }
+    if (!tracking_includes_playlist_selection() || (tracking_prioritises_playing_item() && m_is_tracking_playing))
+        return;
+
+    auto [playlist_selection_index, tracks] = get_playlist_selection();
+    set_selection_tracks(std::move(tracks), playlist_selection_index, true);
 }
 
 void ContextTracker::on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept
 {
-    if (tracking_includes_playlist_selection()
-        && (!tracking_prioritises_playing_item() || !m_playback_control->is_playing())) {
-        set_selection_tracks(get_playlist_selection());
-    }
+    if (!tracking_includes_playlist_selection() || (tracking_prioritises_playing_item() && m_is_tracking_playing))
+        return;
+
+    auto [playlist_selection_index, tracks] = get_playlist_selection();
+    set_selection_tracks(std::move(tracks), playlist_selection_index);
 }
 
 void ContextTracker::refresh_tracks()
@@ -173,9 +237,11 @@ void ContextTracker::refresh_tracks()
     metadb_handle_list tracks;
 
     m_is_tracking_playing = false;
+    m_playlist_selection_index.reset();
+    std::optional<size_t> playlist_selection_index;
 
     if (tracking_includes_playlist_selection()) {
-        tracks = get_playlist_selection();
+        std::tie(playlist_selection_index, tracks) = get_playlist_selection();
     } else if (tracking_includes_active_selection()) {
         tracks = m_ui_selection_tracks;
     }
@@ -190,6 +256,9 @@ void ContextTracker::refresh_tracks()
     }
 
     m_tracks = std::move(tracks);
+
+    if (!m_is_tracking_playing)
+        m_playlist_selection_index = playlist_selection_index;
 }
 
 bool ContextTracker::tracking_prioritises_playing_item() const
@@ -228,52 +297,76 @@ bool ContextTracker::tracking_includes_active_selection() const
         || m_tracking_mode == TrackingMode::active_selection_or_playing_item;
 }
 
-metadb_handle_list ContextTracker::get_playlist_selection() const
+std::tuple<std::optional<size_t>, metadb_handle_list> ContextTracker::get_playlist_selection(bool index_only) const
 {
     metadb_handle_list tracks;
+    std::optional<size_t> playlist_selection_index{};
 
     if (m_track_single_item) {
         m_playlist_manager->activeplaylist_enum_items(
             [&](size_t index, const metadb_handle_ptr& item, bool is_selected) {
-                if (is_selected)
+                if (is_selected) {
                     tracks.add_item(item);
+                    playlist_selection_index = index;
+                }
 
                 return !is_selected;
             },
             bit_array_true());
-    } else {
+    } else if (!index_only) {
         m_playlist_manager->activeplaylist_get_selected_items(tracks);
     }
 
-    return tracks;
+    return std::make_tuple(playlist_selection_index, std::move(tracks));
 }
 
-void ContextTracker::set_selection_tracks(metadb_handle_list tracks)
+void ContextTracker::set_selection_tracks(
+    metadb_handle_list tracks, std::optional<size_t> playlist_selection_index, bool is_playlist_modification)
 {
     if (tracking_falls_back_to_playing_item() && tracks.size() == 0) {
         const auto is_playing = m_playback_control->is_playing();
 
         if (is_playing && !m_is_tracking_playing) {
-            set_tracks(pfc::list_single_ref_t(m_playing_item), true);
+            set_tracks(pfc::list_single_ref_t(m_playing_item), true, {}, is_playlist_modification);
         }
 
         if (m_is_tracking_playing)
             return;
     }
 
-    set_tracks(std::move(tracks), false);
+    set_tracks(std::move(tracks), false, playlist_selection_index, is_playlist_modification);
 }
 
-void ContextTracker::set_tracks(metadb_handle_list tracks, bool is_tracking_playing)
+void ContextTracker::set_tracks(metadb_handle_list tracks, bool is_tracking_playing,
+    std::optional<size_t> playlist_selection_index, bool is_playlist_modification)
 {
     const auto old_is_tracking_playing = m_is_tracking_playing;
     m_is_tracking_playing = is_tracking_playing;
 
-    if (!is_tracking_playing && !old_is_tracking_playing && m_track_single_item && tracks == m_tracks)
+    if (!is_tracking_playing && !old_is_tracking_playing && m_track_single_item && tracks == m_tracks) {
+        set_playlist_selection_index(playlist_selection_index, is_playlist_modification);
         return;
+    }
 
     m_tracks = std::move(tracks);
-    m_callback();
+    m_playlist_selection_index = !is_tracking_playing ? playlist_selection_index : std::nullopt;
+    m_tracks_change_callback();
+}
+
+void ContextTracker::set_playlist_selection_index(
+    std::optional<size_t> playlist_selection_index, bool is_playlist_modification)
+{
+    const auto old_playlist_selection_index = std::exchange(m_playlist_selection_index, playlist_selection_index);
+
+    if (!m_playlist_index_change_callback
+        || (!is_playlist_modification && old_playlist_selection_index == playlist_selection_index))
+        return;
+
+    if (!m_playlist_selection_index || !tracking_includes_playlist_selection()
+        || (m_is_tracking_playing && tracking_prioritises_playing_item()))
+        return;
+
+    m_playlist_index_change_callback();
 }
 
 } // namespace cui::utils

--- a/foo_ui_columns/context_tracker.h
+++ b/foo_ui_columns/context_tracker.h
@@ -21,10 +21,12 @@ class ContextTracker
     , public play_callback_impl_base
     , public playlist_callback_single_impl_base {
 public:
-    ContextTracker(TrackingMode tracking_mode, bool track_single_item, ContextTrackerCallback callback);
+    ContextTracker(TrackingMode tracking_mode, bool track_single_item, ContextTrackerCallback tracks_change_callback,
+        ContextTrackerCallback playlist_index_change_callback = {});
 
     bool is_playing_item() const { return m_is_tracking_playing; }
     const metadb_handle_list& get_tracks() const { return m_tracks; }
+    std::optional<size_t> get_playlist_selection_index() const;
 
     void activate_ui_selection_tracking() { ui_selection_callback_activate(true); }
     void deactivate_ui_selection_tracking() { ui_selection_callback_activate(false); }
@@ -41,8 +43,11 @@ protected:
         size_t p_base, const pfc::list_base_const_t<metadb_handle_ptr>& p_data, const bit_array& p_selection) override;
     void on_items_removing(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
     void on_items_removed(const bit_array& p_mask, size_t p_old_count, size_t p_new_count) override;
-    void on_playlist_switch() noexcept override;
+    void on_items_reordered(const t_size* p_order, t_size p_count) override;
+    void on_items_replaced(const bit_array& p_mask,
+        const pfc::list_base_const_t<playlist_callback::t_on_items_replaced_entry>& p_data) override;
     void on_items_selection_change(const bit_array& p_affected, const bit_array& p_state) noexcept override;
+    void on_playlist_switch() noexcept override;
 
     void refresh_tracks();
 
@@ -53,19 +58,25 @@ private:
     bool tracking_includes_playlist_selection() const;
     bool tracking_includes_active_selection() const;
 
-    metadb_handle_list get_playlist_selection() const;
+    std::tuple<std::optional<size_t>, metadb_handle_list> get_playlist_selection(bool index_only = false) const;
 
-    void set_selection_tracks(metadb_handle_list tracks);
-    void set_tracks(metadb_handle_list tracks, bool is_tracking_playing);
+    void set_selection_tracks(metadb_handle_list tracks, std::optional<size_t> playlist_selection_index = {},
+        bool is_playlist_modification = false);
+    void set_tracks(metadb_handle_list tracks, bool is_tracking_playing,
+        std::optional<size_t> playlist_selection_index = {}, bool is_playlist_modification = false);
+    void set_playlist_selection_index(
+        std::optional<size_t> playlist_selection_index, bool is_playlist_modification = false);
 
     TrackingMode m_tracking_mode;
     bool m_track_single_item{};
-    ContextTrackerCallback m_callback;
+    ContextTrackerCallback m_tracks_change_callback;
+    ContextTrackerCallback m_playlist_index_change_callback;
     playback_control_v3::ptr m_playback_control;
     playlist_manager_v4::ptr m_playlist_manager;
     metadb_handle_ptr m_playing_item;
     metadb_handle_list m_tracks;
     metadb_handle_list m_ui_selection_tracks;
+    std::optional<size_t> m_playlist_selection_index{};
     bool m_is_tracking_playing{};
     bool m_process_playlist_items_removed{};
 };

--- a/foo_ui_columns/item_details.cpp
+++ b/foo_ui_columns/item_details.cpp
@@ -5,6 +5,7 @@
 #include "item_details_text.h"
 #include "scroll.h"
 #include "tab_setup.h"
+#include "tf_splitter_hook.h"
 #include "tf_text_format.h"
 
 namespace cui::panels::item_details {
@@ -356,28 +357,40 @@ void ItemDetails::refresh_contents(
     bool reset_vertical_scroll_position, bool reset_horizontal_scroll_position, bool force_update)
 {
     const auto& tracks = m_context_tracker->get_tracks();
+    auto playlist_selection_index = m_context_tracker->get_playlist_selection_index();
 
     if (tracks.size() > 0) {
+        const auto& track = tracks[0];
         const auto font = fonts::get_font(g_guid_item_details_font_client);
         const auto font_size = uih::direct_write::dip_to_pt(font->size());
 
         const auto font_face = mmh::to_utf8({font->log_font().lfFaceName,
             wcsnlen_s(font->log_font().lfFaceName, std::size(font->log_font().lfFaceName))});
 
-        tf::TextFormatTitleformatHook tf_hook(font_size, font_face, true);
+        tf::TextFormatTitleformatHook text_format_tf_hook(font_size, font_face, true);
         pfc::string8_fast_aggressive temp;
         temp.prealloc(2048);
 
         if (m_context_tracker->is_playing_item()) {
             m_playback_control->playback_format_title(
-                &tf_hook, temp, m_to, nullptr, playback_control::display_level_all);
-        } else {
-            const auto handle = tracks[0];
+                &text_format_tf_hook, temp, m_to, nullptr, playback_control::display_level_all);
+        } else if (playlist_selection_index) {
             if (m_full_file_info) {
-                tracks[0]->format_title_from_external_info(*m_full_file_info, &tf_hook, temp, m_to, nullptr);
+                titleformat_hook_impl_file_info tf_file_info_hook(track->get_location(), &*m_full_file_info);
+                tf::SplitterTitleformatHook joined_tf_hook(&tf_file_info_hook, &text_format_tf_hook);
+                m_playlist_manager->activeplaylist_item_format_title(*playlist_selection_index, &joined_tf_hook, temp,
+                    m_to, nullptr, playback_control::display_level_all);
             } else {
                 request_full_file_info();
-                tracks[0]->format_title(&tf_hook, temp, m_to, nullptr);
+                m_playlist_manager->activeplaylist_item_format_title(*playlist_selection_index, &text_format_tf_hook,
+                    temp, m_to, nullptr, playback_control::display_level_all);
+            }
+        } else {
+            if (m_full_file_info) {
+                track->format_title_from_external_info(*m_full_file_info, &text_format_tf_hook, temp, m_to, nullptr);
+            } else {
+                request_full_file_info();
+                track->format_title(&text_format_tf_hook, temp, m_to, nullptr);
             }
         }
 
@@ -732,6 +745,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         set_window_theme();
 
         m_playback_control = playback_control::get();
+        m_playlist_manager = playlist_manager_v4::get();
         play_callback_manager::get()->register_callback(this,
             flag_on_playback_all
                 & ~(flag_on_volume_change | flag_on_playback_starting | flag_on_playback_stop
@@ -756,15 +770,24 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
         titleformat_compiler::get()->compile_safe(m_to, m_script);
 
-        m_context_tracker.emplace(m_tracking_mode, true, [&] {
-            if (m_full_file_info_request) {
-                m_full_file_info_request->abort();
-                m_aborting_full_file_info_requests.emplace_back(std::move(m_full_file_info_request));
-            }
-            m_full_file_info_requested = false;
-            m_full_file_info.reset();
+        m_context_tracker.emplace(
+            m_tracking_mode, true,
+            [&] {
+                if (m_full_file_info_request) {
+                    m_full_file_info_request->abort();
+                    m_aborting_full_file_info_requests.emplace_back(std::move(m_full_file_info_request));
+                }
+                m_full_file_info_requested = false;
+                m_full_file_info.reset();
 
-            refresh_contents(true, true);
+                refresh_contents(true, true);
+            },
+            [&] { refresh_contents(); });
+
+        m_playlist_item_modified_callback.emplace([this](const bit_array& mask) {
+            const auto index = m_context_tracker->get_playlist_selection_index();
+            if (index && mask[*index])
+                refresh_contents();
         });
 
         s_windows.push_back(this);
@@ -788,6 +811,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             s_destroy_message_window();
 
         m_context_tracker.reset();
+        m_playlist_item_modified_callback.reset();
         m_power_notify_handle.reset();
         m_use_hardware_acceleration_change_token.reset();
         play_callback_manager::get()->unregister_callback(this);
@@ -807,6 +831,7 @@ LRESULT ItemDetails::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_dxgi_factory.reset();
         m_smooth_scroll_helper->shut_down();
         m_autoscroll_helper.reset();
+        m_playlist_manager.reset();
         m_playback_control.reset();
         break;
     }

--- a/foo_ui_columns/item_details.h
+++ b/foo_ui_columns/item_details.h
@@ -26,6 +26,26 @@ extern cfg_uint cfg_item_details_horizontal_alignment;
 extern cfg_uint cfg_item_details_vertical_alignment;
 extern cfg_bool cfg_item_details_word_wrapping;
 
+class PlaylistItemModifiedCallback : public playlist_callback_single_impl_base {
+public:
+    PlaylistItemModifiedCallback(std::function<void(const bit_array& p_mask)> callback)
+        : playlist_callback_single_impl_base(flag_on_items_modified | flag_on_items_modified_fromplayback)
+        , m_callback(callback)
+    {
+    }
+
+protected:
+    void on_items_modified(const bit_array& p_mask) override { m_callback(p_mask); }
+
+    void on_items_modified_fromplayback(const bit_array& p_mask, play_control::t_display_level p_level) override
+    {
+        m_callback(p_mask);
+    }
+
+private:
+    std::function<void(const bit_array& p_mask)> m_callback;
+};
+
 class ItemDetails
     : public uie::container_uie_window_v3
     , public play_callback
@@ -209,7 +229,9 @@ private:
     int m_last_cx{};
     int m_last_cy{};
     std::optional<utils::ContextTracker> m_context_tracker;
+    std::optional<PlaylistItemModifiedCallback> m_playlist_item_modified_callback;
     playback_control::ptr m_playback_control;
+    playlist_manager_v4::ptr m_playlist_manager;
     std::shared_ptr<file_info_impl> m_full_file_info;
     std::shared_ptr<helpers::FullFileInfoRequest> m_full_file_info_request;
     std::vector<std::shared_ptr<helpers::FullFileInfoRequest>> m_aborting_full_file_info_requests;


### PR DESCRIPTION
Resolves #1847

This makes Item details format tracks in the context of the playlist when it's tracking the playlist selection.

This means playlist-specific fields are now available, including dynamic track info.

It also fixes a few bugs in the playlist selection tracking logic.