### PR TITLE
Save main window size and position in FCL files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Development version
+## 3.7.0-beta.1
 
 ### Features
 
@@ -17,6 +17,13 @@
   Presets with the option disabled share the same main window size and position
   as previously.
 
+  Layout preset-specific window sizes and positions are included with the preset
+  when exporting the current configuration to an FCL file.
+
+- The standard main window size and position can now be included in FCL
+  configuration exports.
+  [[#1862](https://github.com/reupen/columns_ui/pull/1862)]
+
 - Pressing Alt now shows the main menu as a pop-up menu in the top-left corner
   of the main window when there is no menu bar in the toolbar area or in the
   layout. [[#1816](https://github.com/reupen/columns_ui/pull/1816),
@@ -25,8 +32,8 @@
   This includes being able to directly access each top-level menu using their
   access keys (e.g. Alt+F for the File menu).
 
-- Artwork view and Item details now have two new automatic tracking modes
-  prioritise the current or playlist selection over the playing item.
+- Artwork view and Item details have two new automatic tracking modes prioritise
+  the current or playlist selection over the playing item.
   [[#1842](https://github.com/reupen/columns_ui/pull/1842),
   [#1848](https://github.com/reupen/columns_ui/pull/1848),
   [#1857](https://github.com/reupen/columns_ui/pull/1857),
@@ -44,7 +51,7 @@
 
 - The following dialogues are now resizeable
   [[#1833](https://github.com/reupen/columns_ui/pull/1833),
-  [#1835](https://github.com/reupen/columns_ui/pull/1835)],
+  [#1835](https://github.com/reupen/columns_ui/pull/1835),
   [#1836](https://github.com/reupen/columns_ui/pull/1836)]:
   - Add new group
   - Edit group
@@ -57,7 +64,7 @@
   - FCL import results
 
   Additionally, they now remember their size and position when next opened.
-  [[#1839](https://github.com/reupen/columns_ui/pull/1839)]]
+  [[#1839](https://github.com/reupen/columns_ui/pull/1839)]
 
 - The list of commands in the Buttons toolbar command picker can now be filtered
   using a search box. [[#1830](https://github.com/reupen/columns_ui/pull/1830)]
@@ -97,20 +104,22 @@
 - When opening a menu in the menu toolbar using the keyboard, the first menu
   item is now focused. [[#1826](https://github.com/reupen/columns_ui/pull/1826)]
 
-- Keyboard shortcuts are no longer triggered when typing capital letters or
-  symbols with the shift key in Filter search toolbar and in inline editing edit
-  boxes in the playlist view, playlist switcher, Filter panel and Item
-  properties. [[#1824](https://github.com/reupen/columns_ui/pull/1824)]
+- Keyboard shortcuts are no longer triggered when pressing character keys with
+  the shift key down in Filter search toolbar and in inline editing edit boxes
+  in the playlist view, playlist switcher, Filter panel and Item properties.
+  [[#1824](https://github.com/reupen/columns_ui/pull/1824)]
 
-- A bug where Item details did not correctly track items being added or removed
-  from the playlist in playlist selection tracking modes was fixed.
-  [[#1846](https://github.com/reupen/columns_ui/pull/1846)]
+- A bug where the Artwork view and Item details did not correctly track items
+  being added or removed from the playlist in playlist selection tracking modes
+  was fixed. [[#1846](https://github.com/reupen/columns_ui/pull/1846),
+  [#1848](https://github.com/reupen/columns_ui/pull/1848),
+  [#1861](https://github.com/reupen/columns_ui/pull/1861)]
 
 - A bug where some text labels in Quick setup were truncated at some display
   scales was fixed. [[#1845](https://github.com/reupen/columns_ui/pull/1845)
   (contributed by [@marc2k3](https://github.com/marc2k3))]
 
-- A bug where message box alert sounds may have played with an unexpected
+- A problem where message box alert sounds may have played with an unexpected
   spatial effect applied was fixed.
   [[#1812](https://github.com/reupen/columns_ui/pull/1812)]
 

--- a/foo_ui_columns/command_line.cpp
+++ b/foo_ui_columns/command_line.cpp
@@ -3,6 +3,8 @@
 #include "dark_mode_dialog.h"
 #include "fcl.h"
 
+namespace cui {
+
 static const char* g_help_text
     = "Available commands:\n\n"
       "/columnsui:help, /columnsui:?\t\tdisplay this command-line help\n"
@@ -25,8 +27,7 @@ public:
     {
         HWND parent = core_api::get_main_window();
         ui_control::get()->activate();
-        cui::dark::modeless_info_box(
-            parent, "Columns UI command-line help", g_help_text, uih::InfoBoxType::Neutral, true);
+        dark::modeless_info_box(parent, "Columns UI command-line help", g_help_text, uih::InfoBoxType::Neutral, true);
     }
 };
 
@@ -45,12 +46,12 @@ public:
         const auto main_window = core_api::get_main_window();
         if (m_files.empty()) {
             ui_control::get()->activate();
-            cui::dark::modeless_info_box(main_window, m_error_title, m_no_files_error, uih::InfoBoxType::Error);
+            dark::modeless_info_box(main_window, m_error_title, m_no_files_error, uih::InfoBoxType::Error);
             return false;
         }
         if (m_files.size() > 1) {
             ui_control::get()->activate();
-            cui::dark::modeless_info_box(main_window, m_error_title, m_too_many_files_error, uih::InfoBoxType::Error);
+            dark::modeless_info_box(main_window, m_error_title, m_too_many_files_error, uih::InfoBoxType::Error);
             return false;
         }
         return true;
@@ -108,11 +109,11 @@ public:
                 = fmt::format("Are you sure you want to import {}? Your current Columns UI configuration will be lost.",
                     pfc::string_filename_ext(path).c_str());
 
-            if (!cui::dark::modal_info_box(main_window, "Import configuration", message.c_str(),
-                    uih::InfoBoxType::Neutral, uih::InfoBoxModalType::YesNo))
+            if (!dark::modal_info_box(main_window, "Import configuration", message.c_str(), uih::InfoBoxType::Neutral,
+                    uih::InfoBoxModalType::YesNo))
                 return;
         }
-        g_import_layout(core_api::get_main_window(), path, is_quiet);
+        fcl::g_import_layout(core_api::get_main_window(), path, is_quiet);
     }
 };
 
@@ -154,10 +155,12 @@ public:
         if (!is_quiet) {
             ui_control::get()->activate();
         }
-        g_export_layout(core_api::get_main_window(), path, is_quiet);
+        fcl::g_export_layout(core_api::get_main_window(), path, is_quiet);
     }
 };
 
 static commandline_handler_factory_t<HelpCommandLineHandler> help_cli_handler;
 static commandline_handler_factory_t<ImportCommandLineHandler> import_cli_handler;
 static commandline_handler_factory_t<ExportCommandLineHandler> export_cli_handler;
+
+} // namespace cui

--- a/foo_ui_columns/fcl.cpp
+++ b/foo_ui_columns/fcl.cpp
@@ -7,6 +7,8 @@
 #include "main_window.h"
 #include "window_resize_helper.h"
 
+namespace cui::fcl {
+
 namespace {
 
 cfg_int last_export_mode({0xea0cd797, 0x9cf2, 0x4da4, {0x8b, 0x69, 0x08, 0x36, 0x90, 0x58, 0x70, 0x7b}}, 1);
@@ -19,14 +21,6 @@ constexpr GUID results_dialog_placement_id{
     0x72f08eae, 0x4e05, 0x4506, {0x8c, 0xca, 0x7b, 0xe6, 0x86, 0x26, 0xd1, 0x04}};
 
 } // namespace
-
-// {EBD87879-65A7-4242-821B-812AF9F68E8F}
-const GUID cui::fcl::groups::titles_playlist_view
-    = {0xebd87879, 0x65a7, 0x4242, {0x82, 0x1b, 0x81, 0x2a, 0xf9, 0xf6, 0x8e, 0x8f}};
-
-// {F17DDDF4-BB3E-4f36-B9E1-D626629F2C76}
-const GUID cui::fcl::groups::titles_common
-    = {0xf17dddf4, 0xbb3e, 0x4f36, {0xb9, 0xe1, 0xd6, 0x26, 0x62, 0x9f, 0x2c, 0x76}};
 
 enum {
     fcl_stream_version = 2
@@ -220,12 +214,13 @@ private:
     std::optional<cui::utils::WindowResizeHelper> m_resize_helper;
 };
 
-cui::fcl::group_impl_factory g_group_toolbars(cui::fcl::groups::toolbars, "Toolbar Layout", "The toolbar layout");
-cui::fcl::group_impl_factory g_group_layout(cui::fcl::groups::layout, "Main Layout", "The main layout");
+cui::fcl::group_impl_factory g_group_toolbars(cui::fcl::groups::toolbars, "Toolbar layout", "The toolbar layout");
+cui::fcl::group_impl_factory g_group_layout(
+    cui::fcl::groups::layout, "Layout presets", "The main layout including all layout presets");
 cui::fcl::group_impl_factory g_group_colours(
-    cui::fcl::groups::colours_and_fonts, "Colours and Fonts", "The colours and fonts");
+    cui::fcl::groups::colours_and_fonts, "Colours and fonts", "The colours and fonts");
 cui::fcl::group_impl_factory g_group_titles(
-    cui::fcl::groups::title_scripts, "Title Scripts", "The titleformatting scripts");
+    cui::fcl::groups::title_scripts, "Title formatting scripts", "The title formatting scripts");
 
 class PanelInfo {
 public:
@@ -571,3 +566,5 @@ void g_export_layout(HWND wnd, pfc::string8 path, bool is_quiet)
         popup_message::g_show(ex.what(), "Error");
     }
 }
+
+} // namespace cui::fcl

--- a/foo_ui_columns/fcl.h
+++ b/foo_ui_columns/fcl.h
@@ -1,13 +1,9 @@
 #pragma once
 
+namespace cui::fcl {
+
 void g_export_layout(HWND wnd, pfc::string8 path = {}, bool is_quiet = false);
 void g_import_layout(HWND wnd);
 void g_import_layout(HWND wnd, const char* path, bool quiet = false);
 
-namespace cui {
-namespace fcl {
-namespace groups {
-extern const GUID titles_playlist_view, titles_common;
-}
-} // namespace fcl
-} // namespace cui
+} // namespace cui::fcl

--- a/foo_ui_columns/fcl_titles.cpp
+++ b/foo_ui_columns/fcl_titles.cpp
@@ -1,15 +1,24 @@
 #include "pch.h"
-#include "fcl.h"
-#include "ng_playlist/ng_playlist_groups.h"
 #include "ng_playlist/ng_playlist.h"
 #include "status_pane.h"
+
+namespace cui::fcl::groups {
+
+namespace {
+
+constexpr GUID titles_playlist_view_id{0xebd87879, 0x65a7, 0x4242, {0x82, 0x1b, 0x81, 0x2a, 0xf9, 0xf6, 0x8e, 0x8f}};
+constexpr GUID titles_other_id{0xf17dddf4, 0xbb3e, 0x4f36, {0xb9, 0xe1, 0xd6, 0x26, 0x62, 0x9f, 0x2c, 0x76}};
+
+} // namespace
+
+} // namespace cui::fcl::groups
 
 namespace cui::panels::playlist_view {
 
 fcl::group_impl_factory fclgroupcolumns(
-    fcl::groups::titles_playlist_view, "Playlist Scripts", "Playlist Scripts", fcl::groups::title_scripts);
+    fcl::groups::titles_playlist_view_id, "Playlist view scripts", "Playlist view scripts", fcl::groups::title_scripts);
 fcl::group_impl_factory fclgroupcommon(
-    fcl::groups::titles_common, "Common Scripts", "Common Scripts", fcl::groups::title_scripts);
+    fcl::groups::titles_other_id, "Other scripts", "Other scripts", fcl::groups::title_scripts);
 
 class PlaylistViewColumnsDataSet : public fcl::dataset {
     enum ItemID {
@@ -32,7 +41,7 @@ class PlaylistViewColumnsDataSet : public fcl::dataset {
         identifier_width_dpi
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Columns"; }
-    const GUID& get_group() const override { return fcl::groups::titles_playlist_view; }
+    const GUID& get_group() const override { return fcl::groups::titles_playlist_view_id; }
     const GUID& get_guid() const override
     {
         // {2415AAE7-7F5E-4ad8-94E2-1E730A2139EF}
@@ -178,7 +187,7 @@ class PlaylistViewGroupsDataSet : public fcl::dataset {
         identifier_playlist_filter_string,
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Groups"; }
-    const GUID& get_group() const override { return fcl::groups::titles_playlist_view; }
+    const GUID& get_group() const override { return fcl::groups::titles_playlist_view_id; }
     const GUID& get_guid() const override
     {
         // {A89F68C6-B40A-4200-BA2A-68999F704FFD}
@@ -302,7 +311,7 @@ class PlaylistViewMiscDataSet : public fcl::dataset {
         identifier_use_globals,
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Colours"; }
-    const GUID& get_group() const override { return fcl::groups::titles_playlist_view; }
+    const GUID& get_group() const override { return fcl::groups::titles_playlist_view_id; }
     const GUID& get_guid() const override
     {
         // {190F4811-899A-4366-A181-FF5161FC1C77}
@@ -377,7 +386,7 @@ class TitlesDataSet : public fcl::dataset {
         identifier_status_pane,
     };
     void get_name(pfc::string_base& p_out) const override { p_out = "Titles"; }
-    const GUID& get_group() const override { return fcl::groups::titles_common; }
+    const GUID& get_group() const override { return fcl::groups::titles_other_id; }
     const GUID& get_guid() const override
     {
         // {9AF6A28B-3EFF-4d1a-AD81-FA1759F1D66C}

--- a/foo_ui_columns/fcl_window_placement.cpp
+++ b/foo_ui_columns/fcl_window_placement.cpp
@@ -1,0 +1,80 @@
+#include "pch.h"
+#include "main_window.h"
+
+namespace cui::fcl {
+namespace {
+
+namespace groups {
+
+constexpr GUID main_window_placement_id{0x9d612b71, 0x14f7, 0x4864, {0xa0, 0xb2, 0x17, 0x78, 0x31, 0x3a, 0x6f, 0xda}};
+
+group_impl_factory _main_window_placement_group(main_window_placement_id, "Main window size and position",
+    "The main window size and position (excluding layout preset-specific sizes and positions)");
+
+} // namespace groups
+
+class MainWindowPlacementDataSet : public dataset {
+    static constexpr auto main_window_placement_id = 1;
+
+    void get_name(pfc::string_base& p_out) const override { p_out = "Main window size and position"; }
+
+    const GUID& get_group() const override { return groups::main_window_placement_id; }
+
+    const GUID& get_guid() const override
+    {
+        static constexpr GUID id{0xab22bbed, 0x68ab, 0x4af8, {0xb7, 0x3e, 0x7c, 0xf5, 0x71, 0x96, 0xf6, 0x21}};
+        return id;
+    }
+
+    void get_data(
+        stream_writer* p_writer, uint32_t type, t_export_feedback& feedback, abort_callback& aborter) const override
+    {
+        stream_writer_memblock placement_writer;
+        cfg_window_placement_columns.get_data_raw(&placement_writer, aborter);
+
+        if (placement_writer.m_data.size() == 0)
+            return;
+
+        fbh::fcl::Writer fcl_writer(p_writer, aborter);
+        fcl_writer.write_item(main_window_placement_id, placement_writer.m_data.get_ptr(),
+            gsl::narrow<uint32_t>(placement_writer.m_data.size()));
+    }
+
+    void set_data(stream_reader* p_reader, size_t stream_size, uint32_t type, t_import_feedback& feedback,
+        abort_callback& aborter) override
+    {
+        fbh::fcl::Reader reader(p_reader, stream_size, aborter);
+        uint32_t element_id{};
+        uint32_t element_size{};
+
+        bool is_imported{};
+
+        while (reader.get_remaining()) {
+            reader.read_item(element_id);
+            reader.read_item(element_size);
+
+            switch (element_id) {
+            case main_window_placement_id: {
+                std::vector<uint8_t> data(element_size);
+                reader.read(data.data(), element_size);
+                stream_reader_memblock_ref placement_reader(data.data(), element_size);
+                cfg_window_placement_columns.set_data_raw(&placement_reader, element_size, aborter);
+                is_imported = true;
+                break;
+            }
+            default:
+                reader.skip(element_size);
+                break;
+            }
+        }
+
+        if (is_imported)
+            main_window.on_window_placement_imported();
+    }
+};
+
+dataset_factory<MainWindowPlacementDataSet> _main_window_placement_dataset;
+
+} // namespace
+
+} // namespace cui::fcl

--- a/foo_ui_columns/foo_ui_columns.vcxproj
+++ b/foo_ui_columns/foo_ui_columns.vcxproj
@@ -274,6 +274,7 @@
     <ClCompile Include="fallback_menu.cpp" />
     <ClCompile Include="fb2k_callbacks.cpp" />
     <ClCompile Include="fb2k_misc.cpp" />
+    <ClCompile Include="fcl_window_placement.cpp" />
     <ClCompile Include="file_info_utils.cpp" />
     <ClCompile Include="font_manager.cpp" />
     <ClCompile Include="font_manager_v3.cpp" />

--- a/foo_ui_columns/foo_ui_columns.vcxproj.filters
+++ b/foo_ui_columns/foo_ui_columns.vcxproj.filters
@@ -686,6 +686,9 @@
     <ClCompile Include="config_utils.cpp">
       <Filter>Config storage</Filter>
     </ClCompile>
+    <ClCompile Include="fcl_window_placement.cpp">
+      <Filter>FCL files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h">

--- a/foo_ui_columns/main_window.cpp
+++ b/foo_ui_columns/main_window.cpp
@@ -457,6 +457,19 @@ void cui::MainWindow::mark_window_placement_overridden()
     m_is_window_placement_overridden = true;
 }
 
+void cui::MainWindow::on_window_placement_imported()
+{
+    if (!m_wnd || is_window_placement_overridden() || cfg_layout.is_remember_window_placement_active())
+        return;
+
+    const auto placement = cfg_window_placement_columns.get_value();
+
+    if (!placement)
+        return;
+
+    set_window_placement(*placement);
+}
+
 void cui::MainWindow::update_window() const
 {
     if (m_wnd)

--- a/foo_ui_columns/main_window.h
+++ b/foo_ui_columns/main_window.h
@@ -51,6 +51,7 @@ public:
     void override_window_placement(const config::WindowPlacementAndDpi& placement_and_dpi);
     void restore_window_placement();
     void mark_window_placement_overridden();
+    void on_window_placement_imported();
     void update_window() const;
 
     /*

--- a/foo_ui_columns/tab_setup.cpp
+++ b/foo_ui_columns/tab_setup.cpp
@@ -62,10 +62,10 @@ public:
                 SendMessage(main_window.get_wnd(), MSG_RUN_INITIAL_SETUP, NULL, NULL);
                 break;
             case IDC_FCL_EXPORT:
-                g_export_layout(wnd);
+                fcl::g_export_layout(wnd);
                 break;
             case IDC_FCL_IMPORT:
-                g_import_layout(wnd);
+                fcl::g_import_layout(wnd);
                 break;
             case IDC_HARDWARE_ACCELERATION:
                 config::use_hardware_acceleration = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;


### PR DESCRIPTION
This adds an FCL group named ‘Main window size and position’ that contains the standard main window placement (i.e. the placement when a layout preset-specific placement isn’t in effect).

It also updates the names of the FCL groups (shown in the export and import dialogues) to use sentence case and more accurate names.

The change log was also tweaked for the 3.7.0-beta.1 release.